### PR TITLE
fix(calendar): event schedule updates now persist date and recurrence changes

### DIFF
--- a/src/client/components/logged_in/calendar/event_recurrence.vue
+++ b/src/client/components/logged_in/calendar/event_recurrence.vue
@@ -870,10 +870,14 @@ const updateStartDate = () => {
  * Handles start date input changes. Updates the start date and auto-syncs
  * the end date if the user has not manually overridden it.
  */
+let previousStartDate = initialDate;
 const onStartDateChange = () => {
-  if (!state.eventEndDateManuallySet && state.date) {
+  if (state.date && (!state.eventEndDateManuallySet || state.eventEndDate === previousStartDate)) {
+    // Auto-sync end date when it matched the previous start date (same-day event)
+    // or when the user hasn't manually changed the end date yet.
     state.eventEndDate = state.date;
   }
+  previousStartDate = state.date;
   updateStartDate();
 };
 

--- a/src/client/components/logged_in/calendar/event_recurrence.vue
+++ b/src/client/components/logged_in/calendar/event_recurrence.vue
@@ -839,6 +839,7 @@ const state = reactive({
   eventEndDate: initialEndDate,
   eventEndTime: initialEndTime,
   eventEndDateManuallySet: initialEndDateManuallySet,
+  previousStartDate: initialDate,
   timezone: getLocalTimezone(),
   endDate: props.schedule.endDate ? props.schedule.endDate.toISO() : '',
   // Restore end-type from existing schedule so the correct radio is selected
@@ -870,14 +871,13 @@ const updateStartDate = () => {
  * Handles start date input changes. Updates the start date and auto-syncs
  * the end date if the user has not manually overridden it.
  */
-let previousStartDate = initialDate;
 const onStartDateChange = () => {
-  if (state.date && (!state.eventEndDateManuallySet || state.eventEndDate === previousStartDate)) {
+  if (state.date && (!state.eventEndDateManuallySet || state.eventEndDate === state.previousStartDate)) {
     // Auto-sync end date when it matched the previous start date (same-day event)
     // or when the user hasn't manually changed the end date yet.
     state.eventEndDate = state.date;
   }
-  previousStartDate = state.date;
+  state.previousStartDate = state.date;
   updateStartDate();
 };
 

--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -391,7 +391,7 @@ class CalendarEventSchedule extends Model {
       start: this.startDate?.toISO() ?? null,
       end: this.endDate?.toISO() ?? null,
       eventEndTime: this.eventEndTime?.toISO() ?? null,
-      frequency: this.frequency as string ?? null,
+      frequency: (this.frequency as string) ?? null,
       interval: this.interval,
       count: this.count,
       byDay: this.byDay,

--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -388,10 +388,10 @@ class CalendarEventSchedule extends Model {
   toObject(): Record<string, any> {
     return {
       id: this.id,
-      start: this.startDate?.toISO(),
-      end: this.endDate?.toISO(),
-      eventEndTime: this.eventEndTime?.toISO(),
-      frequency: this.frequency as string,
+      start: this.startDate?.toISO() ?? null,
+      end: this.endDate?.toISO() ?? null,
+      eventEndTime: this.eventEndTime?.toISO() ?? null,
+      frequency: this.frequency as string ?? null,
       interval: this.interval,
       count: this.count,
       byDay: this.byDay,

--- a/src/common/test/model/event_schedule.test.ts
+++ b/src/common/test/model/event_schedule.test.ts
@@ -57,6 +57,21 @@ describe('CalendarEventSchedule.eventEndTime', () => {
     expect(schedule.eventEndTime).toBeNull();
   });
 
+  it('should serialize null startDate as null in toObject()', () => {
+    const schedule = new CalendarEventSchedule('s1');
+    expect(schedule.toObject().start).toBeNull();
+  });
+
+  it('should serialize null endDate as null in toObject()', () => {
+    const schedule = new CalendarEventSchedule('s1');
+    expect(schedule.toObject().end).toBeNull();
+  });
+
+  it('should serialize null frequency as null in toObject()', () => {
+    const schedule = new CalendarEventSchedule('s1');
+    expect(schedule.toObject().frequency).toBeNull();
+  });
+
   it('should round-trip eventEndTime through toObject and fromObject', () => {
     const schedule = new CalendarEventSchedule('s1');
     schedule.startDate = DateTime.fromISO('2026-04-03T10:00:00.000Z');

--- a/src/common/test/model/event_schedule.test.ts
+++ b/src/common/test/model/event_schedule.test.ts
@@ -18,12 +18,12 @@ describe('CalendarEventSchedule.eventEndTime', () => {
     expect(obj.eventEndTime).toBe(endTime.toISO());
   });
 
-  it('should serialize null eventEndTime as undefined in toObject()', () => {
+  it('should serialize null eventEndTime as null in toObject()', () => {
     const schedule = new CalendarEventSchedule('s1');
     schedule.eventEndTime = null;
 
     const obj = schedule.toObject();
-    expect(obj.eventEndTime).toBeUndefined();
+    expect(obj.eventEndTime).toBeNull();
   });
 
   it('should deserialize eventEndTime from ISO string in fromObject()', () => {

--- a/src/server/calendar/entity/event.ts
+++ b/src/server/calendar/entity/event.ts
@@ -228,21 +228,25 @@ class EventScheduleEntity extends Model {
     return schedule;
   }
 
+  /**
+   * Converts a Luxon DateTime to a JS Date for database storage,
+   * preserving local-time digit values as UTC digits.
+   * Sequelize SQLite appends "+00:00" to naive strings, treating stored values as UTC.
+   * By converting with keepLocalTime: true, toModel() can reverse this correctly.
+   */
+  static toStorageDate(dt: DateTime | null | undefined): Date | undefined {
+    if (!dt) return undefined;
+    return dt.setZone('UTC', { keepLocalTime: true }).toJSDate();
+  }
+
   static fromModel(schedule: CalendarEventSchedule): EventScheduleEntity {
     const tz = schedule.startDate?.zoneName ?? 'UTC';
-    // Store dates so that the local-time digit values are preserved as UTC digits.
-    // Sequelize SQLite appends "+00:00" to naive strings, treating stored values as UTC.
-    // By converting with keepLocalTime: true, toModel() can reverse this correctly.
-    const toStorageDate = (dt: DateTime | null | undefined): Date | undefined => {
-      if (!dt) return undefined;
-      return dt.setZone('UTC', { keepLocalTime: true }).toJSDate();
-    };
     return EventScheduleEntity.build({
       id: schedule.id,
       timezone: tz,
-      start_date: toStorageDate(schedule.startDate),
-      end_date: toStorageDate(schedule.endDate),
-      event_end_time: toStorageDate(schedule.eventEndTime),
+      start_date: EventScheduleEntity.toStorageDate(schedule.startDate),
+      end_date: EventScheduleEntity.toStorageDate(schedule.endDate),
+      event_end_time: EventScheduleEntity.toStorageDate(schedule.eventEndTime),
       frequency: schedule.frequency as string,
       interval: schedule.interval,
       count: schedule.count,

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -848,16 +848,19 @@ class EventService {
             ? parsed.byDay.join(',')
             : scheduleEntity.by_day;
 
+          // Use parsed model values for fields present in the request.
+          // For clearable fields (end_date, count, frequency), check the raw
+          // request to distinguish "explicitly cleared" from "not sent".
           await scheduleEntity.update({
             timezone: parsed.startDate?.zoneName ?? scheduleEntity.timezone,
             start_date: toStorageDate(parsed.startDate) ?? scheduleEntity.start_date,
-            end_date: toStorageDate(parsed.endDate) ?? scheduleEntity.end_date,
-            event_end_time: toStorageDate(parsed.eventEndTime) ?? scheduleEntity.event_end_time,
-            frequency: parsed.frequency ?? scheduleEntity.frequency,
-            interval: parsed.interval ?? scheduleEntity.interval,
-            count: parsed.count ?? scheduleEntity.count,
+            end_date: 'end' in schedule ? (toStorageDate(parsed.endDate) ?? null) : scheduleEntity.end_date,
+            event_end_time: 'eventEndTime' in schedule ? (toStorageDate(parsed.eventEndTime) ?? null) : scheduleEntity.event_end_time,
+            frequency: 'frequency' in schedule ? (parsed.frequency as string ?? null) : scheduleEntity.frequency,
+            interval: 'interval' in schedule ? (parsed.interval ?? 0) : scheduleEntity.interval,
+            count: 'count' in schedule ? (parsed.count ?? 0) : scheduleEntity.count,
             by_day: byDayValue,
-            is_exclusion: parsed.isExclusion ?? scheduleEntity.is_exclusion,
+            is_exclusion: 'isException' in schedule ? (parsed.isExclusion ?? false) : scheduleEntity.is_exclusion,
           });
           event.addSchedule(scheduleEntity.toModel());
         }

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import config from 'config';
 import axios from 'axios';
-import { DateTime } from 'luxon';
 
 import { Account } from "@/common/model/account";
 import { Calendar } from "@/common/model/calendar";
@@ -838,25 +837,21 @@ class EventService {
             parsed.endDate = parsed.eventEndTime;
           }
 
-          // Convert DateTime to storage format with timezone-aware conversion
-          const toStorageDate = (dt: DateTime | null | undefined): Date | undefined => {
-            if (!dt) return undefined;
-            return dt.setZone('UTC', { keepLocalTime: true }).toJSDate();
-          };
-
           const byDayValue = parsed.byDay !== undefined && parsed.byDay.length > 0
             ? parsed.byDay.join(',')
             : scheduleEntity.by_day;
 
           // Use parsed model values for fields present in the request.
           // For clearable fields (end_date, count, frequency), check the raw
-          // request to distinguish "explicitly cleared" from "not sent".
+          // request keys to distinguish "explicitly cleared" from "not sent".
+          // Raw key names: start/end/eventEndTime/frequency/interval/count/isException
+          const toStorage = EventScheduleEntity.toStorageDate;
           await scheduleEntity.update({
             timezone: parsed.startDate?.zoneName ?? scheduleEntity.timezone,
-            start_date: toStorageDate(parsed.startDate) ?? scheduleEntity.start_date,
-            end_date: 'end' in schedule ? (toStorageDate(parsed.endDate) ?? null) : scheduleEntity.end_date,
-            event_end_time: 'eventEndTime' in schedule ? (toStorageDate(parsed.eventEndTime) ?? null) : scheduleEntity.event_end_time,
-            frequency: 'frequency' in schedule ? (parsed.frequency as string ?? null) : scheduleEntity.frequency,
+            start_date: toStorage(parsed.startDate) ?? scheduleEntity.start_date,
+            end_date: 'end' in schedule ? (toStorage(parsed.endDate) ?? null) : scheduleEntity.end_date,
+            event_end_time: 'eventEndTime' in schedule ? (toStorage(parsed.eventEndTime) ?? null) : scheduleEntity.event_end_time,
+            frequency: 'frequency' in schedule ? ((parsed.frequency as string) ?? null) : scheduleEntity.frequency,
             interval: 'interval' in schedule ? (parsed.interval ?? 0) : scheduleEntity.interval,
             count: 'count' in schedule ? (parsed.count ?? 0) : scheduleEntity.count,
             by_day: byDayValue,

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import config from 'config';
 import axios from 'axios';
+import { DateTime } from 'luxon';
 
 import { Account } from "@/common/model/account";
 import { Calendar } from "@/common/model/calendar";
@@ -827,21 +828,36 @@ class EventService {
           }
 
           existingScheduleIds = existingScheduleIds.filter( id => id !== schedule.id );
-          // TODO: validate schedule data so we don't store junk
-          // Convert byDay array to comma-separated string for database storage
-          const byDayValue = schedule.byDay !== undefined
-            ? (Array.isArray(schedule.byDay) ? schedule.byDay.join(',') : (schedule.byDay || ''))
+
+          // Parse incoming data through the model to get proper DateTime objects
+          // and correct property name mapping (start → startDate, end → endDate)
+          const parsed = CalendarEventSchedule.fromObject(schedule);
+
+          // For non-recurring events, sync endDate to eventEndTime (same as createEventSchedule)
+          if (!parsed.frequency && parsed.eventEndTime) {
+            parsed.endDate = parsed.eventEndTime;
+          }
+
+          // Convert DateTime to storage format with timezone-aware conversion
+          const toStorageDate = (dt: DateTime | null | undefined): Date | undefined => {
+            if (!dt) return undefined;
+            return dt.setZone('UTC', { keepLocalTime: true }).toJSDate();
+          };
+
+          const byDayValue = parsed.byDay !== undefined && parsed.byDay.length > 0
+            ? parsed.byDay.join(',')
             : scheduleEntity.by_day;
 
           await scheduleEntity.update({
-            start_date: schedule.startDate ?? scheduleEntity.start_date,
-            end_date: schedule.endDate ?? scheduleEntity.end_date,
-            event_end_time: schedule.eventEndTime ?? scheduleEntity.event_end_time,
-            frequency: schedule.frequency ?? scheduleEntity.frequency,
-            interval: schedule.interval ?? scheduleEntity.interval,
-            count: schedule.count ?? scheduleEntity.count,
+            timezone: parsed.startDate?.zoneName ?? scheduleEntity.timezone,
+            start_date: toStorageDate(parsed.startDate) ?? scheduleEntity.start_date,
+            end_date: toStorageDate(parsed.endDate) ?? scheduleEntity.end_date,
+            event_end_time: toStorageDate(parsed.eventEndTime) ?? scheduleEntity.event_end_time,
+            frequency: parsed.frequency ?? scheduleEntity.frequency,
+            interval: parsed.interval ?? scheduleEntity.interval,
+            count: parsed.count ?? scheduleEntity.count,
             by_day: byDayValue,
-            is_exclusion: schedule.isExclusion ?? scheduleEntity.is_exclusion,
+            is_exclusion: parsed.isExclusion ?? scheduleEntity.is_exclusion,
           });
           event.addSchedule(scheduleEntity.toModel());
         }

--- a/src/server/calendar/test/EventService/update.test.ts
+++ b/src/server/calendar/test/EventService/update.test.ts
@@ -345,7 +345,113 @@ describe('updateEvent with schedules', () => {
     expect(updatedEvent.schedules[0].frequency).toBe(EventFrequency.DAILY);
   });
 
-  // TODO: test replacing an event schedule with another one
+  it('should update start_date when request sends "start" key (property name mapping)', async () => {
+    let scheduleEntity = EventScheduleEntity.build({
+      id: 'testScheduleId',
+      start_date: new Date('2026-01-01T10:00:00Z'),
+      end_date: new Date('2026-01-01T12:00:00Z'),
+      timezone: 'America/Los_Angeles',
+    });
+
+    let findEventStub = sandbox.stub(EventEntity, 'findByPk');
+    sandbox.stub(EventEntity.prototype, 'save');
+    let findSchedulesStub = sandbox.stub(EventScheduleEntity, 'findAll');
+    let updateScheduleStub = sandbox.stub(EventScheduleEntity.prototype, 'update');
+
+    findEventStub.resolves(EventEntity.build({ account_id: 'testAccountId', id: '11111111-1111-4111-8111-111111111111', calendar_id: 'testCalendarId' }));
+    findSchedulesStub.resolves([ scheduleEntity ]);
+    updateScheduleStub.callsFake(async (params) => {
+      for (let key in params) {
+        scheduleEntity.set(key, params[key]);
+      }
+      return scheduleEntity;
+    });
+
+    await service.updateEvent(new Account('testAccountId', 'testme', 'testme'), '11111111-1111-4111-8111-111111111111', {
+      schedules: [{
+        id: 'testScheduleId',
+        start: '2026-06-15T14:00:00',
+        end: '2026-06-15T16:00:00',
+        eventEndTime: '2026-06-15T16:00:00',
+      }],
+    });
+
+    const updateArgs = updateScheduleStub.firstCall.args[0];
+    expect(updateArgs.start_date).toBeInstanceOf(Date);
+    expect(updateArgs.start_date).not.toEqual(new Date('2026-01-01T10:00:00Z'));
+    expect(updateArgs.end_date).toBeInstanceOf(Date);
+  });
+
+  it('should preserve end_date when "end" key is absent from request', async () => {
+    const originalEndDate = new Date('2026-01-01T12:00:00Z');
+    let scheduleEntity = EventScheduleEntity.build({
+      id: 'testScheduleId',
+      start_date: new Date('2026-01-01T10:00:00Z'),
+      end_date: originalEndDate,
+      timezone: 'UTC',
+    });
+
+    let findEventStub = sandbox.stub(EventEntity, 'findByPk');
+    sandbox.stub(EventEntity.prototype, 'save');
+    let findSchedulesStub = sandbox.stub(EventScheduleEntity, 'findAll');
+    let updateScheduleStub = sandbox.stub(EventScheduleEntity.prototype, 'update');
+
+    findEventStub.resolves(EventEntity.build({ account_id: 'testAccountId', id: '11111111-1111-4111-8111-111111111111', calendar_id: 'testCalendarId' }));
+    findSchedulesStub.resolves([ scheduleEntity ]);
+    updateScheduleStub.callsFake(async (params) => {
+      for (let key in params) {
+        scheduleEntity.set(key, params[key]);
+      }
+      return scheduleEntity;
+    });
+
+    await service.updateEvent(new Account('testAccountId', 'testme', 'testme'), '11111111-1111-4111-8111-111111111111', {
+      schedules: [{
+        id: 'testScheduleId',
+        frequency: EventFrequency.DAILY,
+      }],
+    });
+
+    const updateArgs = updateScheduleStub.firstCall.args[0];
+    expect(updateArgs.end_date).toEqual(originalEndDate);
+  });
+
+  it('should clear end_date when "end" key is explicitly null', async () => {
+    let scheduleEntity = EventScheduleEntity.build({
+      id: 'testScheduleId',
+      start_date: new Date('2026-01-01T10:00:00Z'),
+      end_date: new Date('2026-06-01T00:00:00Z'),
+      count: 6,
+      timezone: 'UTC',
+    });
+
+    let findEventStub = sandbox.stub(EventEntity, 'findByPk');
+    sandbox.stub(EventEntity.prototype, 'save');
+    let findSchedulesStub = sandbox.stub(EventScheduleEntity, 'findAll');
+    let updateScheduleStub = sandbox.stub(EventScheduleEntity.prototype, 'update');
+
+    findEventStub.resolves(EventEntity.build({ account_id: 'testAccountId', id: '11111111-1111-4111-8111-111111111111', calendar_id: 'testCalendarId' }));
+    findSchedulesStub.resolves([ scheduleEntity ]);
+    updateScheduleStub.callsFake(async (params) => {
+      for (let key in params) {
+        scheduleEntity.set(key, params[key]);
+      }
+      return scheduleEntity;
+    });
+
+    await service.updateEvent(new Account('testAccountId', 'testme', 'testme'), '11111111-1111-4111-8111-111111111111', {
+      schedules: [{
+        id: 'testScheduleId',
+        end: null,
+        count: 0,
+      }],
+    });
+
+    const updateArgs = updateScheduleStub.firstCall.args[0];
+    expect(updateArgs.end_date).toBeNull();
+    expect(updateArgs.count).toBe(0);
+  });
+
   it('should remove an existing schedule and add a new one', async () => {
     let scheduleEntity = EventScheduleEntity.build({
       id: 'testScheduleId',


### PR DESCRIPTION
## Summary

- **Date changes silently discarded on save**: The backend update path read `schedule.startDate`/`schedule.endDate` but the frontend sends `start`/`end` keys. The nullish coalescing silently preserved original values. Fixed by routing through `CalendarEventSchedule.fromObject()` for correct key mapping and timezone-aware storage conversion.
- **"Ends: never" reverted on reload**: `toObject()` serialized null DateTime fields as `undefined`, which `JSON.stringify` strips. The backend couldn't distinguish "field cleared" from "field not sent". Fixed by emitting explicit `null` in `toObject()` and checking `'key' in schedule` on the backend.
- **QoL: auto-sync end date**: When start and end dates match (same-day event), changing the start date now automatically updates the end date.
- **Audit-driven cleanup**: Extracted `toStorageDate` to `EventScheduleEntity` static method, added regression tests, moved component state to reactive, added operator precedence parentheses.

## Test plan

- [x] All existing tests pass (368 passed, 2 pre-existing AP failures)
- [x] New regression tests: property name mapping, clearable field preservation, explicit null clearing
- [x] New serialization tests: null start/end/frequency in `toObject()`
- [x] Manual browser verification: date changes persist, "ends: never" persists, end date auto-syncs