### PR TITLE
feat: sticky unpost for reposted events (pv-xq9q)

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -354,3 +354,51 @@ The community funding model was chosen because:
 - API keys must be stored securely (encrypted at rest) adding operational complexity
 - Funding plan management adds UI and backend complexity to the calendar domain
 - Per-calendar funding configuration requires calendar owners to understand pricing options
+
+## 2026-04-11: Sticky Per-Calendar Unpost Dismissals
+
+**ID:** DEC-008
+**Status:** Accepted
+**Category:** Technical
+**Stakeholders:** Tech Lead, Development Team
+**Related Spec:** @docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
+
+### Decision
+
+When a calendar owner unposts a reposted event, the system writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. The inbox auto-repost handler checks this row before creating a new `SharedEventEntity`, skipping silently if present. Dismissals are strictly per-calendar: a dismissal on Calendar A never suppresses auto-reposts on Calendar B, even within the same instance. Dismissals only gate re-share creation — `Update(Event)` activities continue to flow through the inbox unmodified so the underlying `EventEntity` stays in sync for every calendar still sharing it.
+
+### Context
+
+Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound `Announce` recreated it. This undermined the community-control principle (DEC-001): followers had policy control over *future* follows but not over *this specific event I already said no to*.
+
+### Alternatives Considered
+
+1. **Block Update activities entirely for dismissed events**
+   - Pros: Dismissed events would stop updating on the calendar list, reinforcing the "it's gone" feeling.
+   - Cons: Breaks federation sync for every *other* calendar still sharing the event — a single dismissal would stale the event across the instance. Violates federation-first principles.
+
+2. **Global (per-instance) dismissals across all calendars an account owns**
+   - Pros: Simpler mental model for owners managing multiple calendars.
+   - Cons: Violates the community-control principle that each calendar owner speaks only for their own calendar. Multi-editor calendars would get a confusing blast radius.
+
+3. **Per-calendar sticky dismissal with Update sync preserved** (Selected)
+   - Pros: Respects community control, preserves federation sync for other reposters, survives source re-broadcast.
+   - Cons: Dismissal rows accumulate over time (mitigated by `ON DELETE CASCADE` on event deletion); no audit/undo UI yet (data preserved, surface can be added later).
+
+### Rationale
+
+Per-calendar scoping is the only option that keeps DEC-001's community-control promise intact while also preserving federation-first semantics. Every calendar speaks for itself; no calendar's dismissal leaks into another calendar's policy surface. The explicit choice to leave `Update` processing unblocked is a federation-correctness invariant: `EventEntity` is a globally-shared fact, and every calendar currently sharing the event must see edits, regardless of which calendars have opted out of auto-reposting it.
+
+### Consequences
+
+**Positive:**
+- Respects DEC-001 community-control principle: each calendar owner controls only their own calendar
+- Preserves federation sync: Update activities continue flowing to all other calendars that still share the event
+- Survives source re-broadcast: the dismissal is durable, not a one-time destructive delete
+- No new API surface: the existing `DELETE /api/v1/social/shares/:eventId` endpoint handles the dismissal write transparently
+- User-facing concept ("unpost") cleanly hides the implementation vocabulary ("dismissal")
+
+**Negative:**
+- `ap_repost_dismissal` rows accumulate over time, bounded by event lifetime via `ON DELETE CASCADE`
+- No UI yet to audit or undo dismissals — deferred to a future bead; data is preserved so the surface can be added later
+- Manual re-share of a dismissed event requires clearing the dismissal row (handled transparently by `shareEvent` inside the same transaction)

--- a/docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
+++ b/docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
@@ -1,0 +1,208 @@
+# Unpost Control for Reposted Events
+
+> Date: 2026-04-11
+> Status: Approved (design)
+
+## Problem
+
+Calendar owners have no way to remove a reposted event from their own calendar
+after the fact. The gap appears in two places:
+
+1. **Calendar event list** (`events-tab.vue`): reposted events render inline
+   with a "repost" badge and offer only Edit / Duplicate / Report actions. No
+   unpost action exists, regardless of whether the event was manually reposted
+   or auto-reposted.
+2. **Feed view** (`feed/events.vue`): manually reposted events show a clickable
+   "Reposted" label that calls `handleUnrepost`. Auto-reposted events render a
+   non-clickable `<span class="auto-posted-label">`, so there is no path to
+   unshare an auto-reposted event from the feed either.
+
+The backend can already unshare — `memberService.unshareEvent()` destroys the
+`SharedEventEntity`, emits an `Undo Announce`, and fires an `eventUnreposted`
+domain event. The frontend just never invokes it for auto-reposted events, and
+the calendar list view never invokes it at all.
+
+There is a second, subtler problem: because the auto-repost handler in
+`inbox.ts` only skips when a `SharedEventEntity` currently exists for the
+`(event_id, calendar_id)` pair, a naive unshare would be fragile — if the
+source calendar re-broadcasts or updates the event, the dismissed event would
+re-auto-post. Owners would have to unpost repeatedly, and the control would
+feel broken.
+
+## Goals
+
+- Give calendar owners a one-click, post-hoc way to remove a reposted event
+  from their calendar, from either the calendar event list or the feed.
+- Make the removal sticky: once dismissed, the event does not silently
+  re-auto-post when the source calendar re-broadcasts or updates it.
+- Preserve the existing federation behavior: an `Undo Announce` is emitted
+  and Update activities for the underlying event continue to process normally
+  so other consumers stay in sync.
+- Keep the unpost affordance visually and semantically distinct from destructive
+  delete — unposting a share is reversible by re-sharing; deleting an owned
+  event is not.
+
+## Non-goals
+
+- Changing how owned events are deleted. The existing bulk delete flow for
+  owned events stays as-is.
+- Bulk unpost. Row-level unpost only for v1; we can add bulk later if needed.
+- Blocking future Update activities. The dismissal only gates creation of a
+  new `SharedEventEntity` for the dismissing calendar. The underlying event
+  continues to sync so any other calendar still sharing it stays current.
+
+## Design
+
+### Data model
+
+A new entity and table:
+
+**`RepostDismissalEntity`** (`ap_repost_dismissal`)
+
+| Column         | Type      | Notes                                       |
+|----------------|-----------|---------------------------------------------|
+| `id`           | UUID PK   |                                             |
+| `event_id`     | UUID      | References the local `event` row            |
+| `calendar_id`  | UUID      | The calendar that dismissed the repost      |
+| `dismissed_at` | TIMESTAMP |                                             |
+
+Unique index on `(event_id, calendar_id)`.
+
+A row here means "calendar X has explicitly said this event should not appear
+on its calendar via auto-repost." It gates only auto-repost creation. Manual
+re-shares by the owner supersede the dismissal — see the service changes
+below.
+
+### Backend service changes
+
+**`memberService.unshareEvent()`** (`src/server/activitypub/service/members.ts`)
+
+For each `SharedEventEntity` the method destroys, upsert a
+`RepostDismissalEntity` row for `(event_id, calendar_id)` in the same
+transaction. Continue emitting the `Undo Announce` to the outbox and the
+`eventUnreposted` domain event exactly as today.
+
+**`memberService.shareEvent()`** (`src/server/activitypub/service/members.ts`)
+
+Before creating a new `SharedEventEntity`, delete any existing
+`RepostDismissalEntity` row for `(event_id, calendar_id)`. A manual share is
+an explicit opt-in that supersedes any prior dismissal.
+
+**`inboxService.handleAnnounceAutoRepost()`** (`src/server/activitypub/service/inbox.ts`)
+
+Add a dismissal check immediately before the existing duplicate-share guard
+(around line 888). If a `RepostDismissalEntity` exists for
+`(event_id, calendar_id)`, log a skip reason ("previously dismissed by calendar
+owner") and return without creating a `SharedEventEntity` or writing to the
+outbox. Update activities that modify the underlying `EventEntity` are
+unaffected — only the re-share step is gated.
+
+**`calendarEventsService.listEvents()`** (`src/server/calendar/service/events.ts`)
+
+Replace the plain `isRepost: boolean` assignment (currently line 207) with a
+`repostStatus: 'none' | 'manual' | 'auto'` field derived by joining against
+`SharedEventEntity.auto_posted`. This mirrors what the feed service already
+computes (`members.ts:695`) and keeps the two surfaces consistent. Keep
+`isRepost` as a derived getter (`repostStatus !== 'none'`) on the
+`CalendarEvent` model so existing call sites keep working without churn.
+
+### API
+
+No new endpoints. The existing
+`DELETE /api/v1/social/shares/:eventId?calendarId=...` is the correct entry
+point and will automatically gain the dismissal behavior via the service
+change above.
+
+### Frontend
+
+**Common model** (`src/common/model/event.ts`)
+
+Add an optional `repostStatus: 'none' | 'manual' | 'auto'` field to the
+`CalendarEvent` model's serialization. Keep `isRepost` as a computed getter
+derived from `repostStatus` so existing templates continue to work.
+
+**Calendar event list** (`src/client/components/logged_in/calendar-content/events-tab.vue`)
+
+Add a new row-level icon button — `Link2Off` from lucide — between the
+Duplicate and Report buttons. It renders only when
+`event.repostStatus !== 'none'`.
+
+Clicking the button opens a lightweight confirmation modal:
+
+> **Remove this reposted event from your calendar?**
+> It will not be automatically reposted again if the original calendar
+> re-broadcasts it.
+
+On confirm, call a new `calendarService.unshareReposted(calendarId, eventId)`
+wrapper that hits
+`DELETE /api/v1/social/shares/:eventId?calendarId=...`. On success, remove the
+event from the local events store and show a success toast. On failure, show
+an error toast and leave the row in place.
+
+**Feed view** (`src/client/components/logged_in/feed/events.vue`)
+
+Convert the `<span class="auto-posted-label">` element (around line 343) to a
+`<button>` with the same `handleUnrepost(event.id)` handler used by the manual
+case. Give it a distinct aria-label key (`unrepost_auto_aria_label`) so assistive
+tech announces the action accurately. Visual styling stays close to the current
+label, with a hover state added to signal interactivity.
+
+### i18n keys
+
+Add to the client translation files:
+
+- `events-tab.unpost_button_label`
+- `events-tab.unpost_aria_label`
+- `events-tab.unpost_confirm_title`
+- `events-tab.unpost_confirm_body`
+- `events-tab.unpost_confirm_action`
+- `events-tab.unpost_success_toast`
+- `events-tab.unpost_error_toast`
+- `feed.events.unrepost_auto_aria_label`
+
+## Testing
+
+### Unit (backend)
+
+- `unshareEvent` creates a `RepostDismissalEntity` row and leaves one behind
+  after the `SharedEventEntity` is destroyed.
+- `shareEvent` deletes any existing dismissal for the same
+  `(event_id, calendar_id)` before creating the new share.
+- `handleAnnounceAutoRepost` skips when a dismissal exists, creates no
+  `SharedEventEntity`, and writes nothing to the outbox. A matching log line
+  is emitted for observability.
+- `listEvents` sets `repostStatus` correctly for owned, manually-reposted, and
+  auto-reposted events.
+
+### Component (frontend)
+
+- `events-tab.vue`: the unpost button renders only when
+  `event.repostStatus !== 'none'`. Clicking opens the confirm modal. Confirming
+  calls `calendarService.unshareReposted` with the expected args. The store is
+  updated on success. A server error shows the error toast and leaves the row
+  in place.
+- `feed/events.vue`: the auto-posted label renders as a button, is keyboard
+  focusable, and triggers `handleUnrepost` on click. Existing manual-repost
+  click behavior is unchanged.
+
+### Integration / E2E
+
+One high-value E2E scenario: calendar A follows calendar B with auto-repost
+enabled. B posts event X. A auto-reposts it. A unposts X from the calendar
+event list. B then re-broadcasts X. A does not re-receive it as a
+`SharedEventEntity`, and the event does not reappear in A's calendar list.
+
+## Risks and open questions
+
+- **Dismissal cleanup.** If the underlying event is deleted upstream, we
+  should not leave orphaned `RepostDismissalEntity` rows. Either add an
+  `ON DELETE CASCADE` on `event_id`, or have the existing event-delete handler
+  clean up dismissals alongside other dependent rows. The migration should set
+  this up from the start.
+- **Event lookup semantics.** `memberService.unshareEvent()` currently resolves
+  the incoming event URL to a UUID via `EventObjectEntity`. The dismissal write
+  needs to use the same resolved UUID so it lines up with the inbox handler's
+  dismissal check (which queries by `event_id` UUID).
+- **Visibility of dismissed events.** For v1 we do not expose a "view dismissed
+  reposts" surface. If owners ever want to see what they've dismissed, that is
+  a follow-up feature — the data will be there when we need it.

--- a/migrations/0018_create_ap_repost_dismissal.ts
+++ b/migrations/0018_create_ap_repost_dismissal.ts
@@ -56,6 +56,14 @@ export default {
         allowNull: false,
         defaultValue: DataTypes.NOW,
       },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
     });
 
     // Unique index enforcing one dismissal per (event, calendar) pair.

--- a/migrations/0018_create_ap_repost_dismissal.ts
+++ b/migrations/0018_create_ap_repost_dismissal.ts
@@ -1,0 +1,75 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import {
+  createTableIfNotExists,
+  tableExists,
+} from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Create ap_repost_dismissal table.
+ *
+ * Stores sticky "do not auto-repost" markers so that once a calendar owner
+ * unposts a reposted event, the inbox auto-repost handler will not silently
+ * re-create a SharedEventEntity when the source calendar re-broadcasts the
+ * event. Manual re-shares by the owner supersede the dismissal.
+ *
+ * Design:
+ * - Unique index on (event_id, calendar_id) enforces one dismissal row per
+ *   (event, calendar) pair.
+ * - ON DELETE CASCADE on event_id cleans up dismissals automatically when
+ *   the underlying local event row is deleted.
+ *
+ * Reference: docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await createTableIfNotExists(queryInterface, 'ap_repost_dismissal', {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        allowNull: false,
+        defaultValue: DataTypes.UUIDV4,
+      },
+      event_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'event',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      calendar_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'calendar',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      dismissed_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    });
+
+    // Unique index enforcing one dismissal per (event, calendar) pair.
+    await queryInterface.addIndex('ap_repost_dismissal', ['event_id', 'calendar_id'], {
+      name: 'idx_ap_repost_dismissal_event_calendar',
+      unique: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    if (await tableExists(queryInterface, 'ap_repost_dismissal')) {
+      await queryInterface.dropTable('ap_repost_dismissal');
+    }
+  },
+};

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -9,7 +9,6 @@ import { useCalendarStore } from '@/client/stores/calendarStore';
 import { useCategoryStore } from '@/client/stores/categoryStore';
 import CalendarService from '@/client/service/calendar';
 import EventService from '@/client/service/event';
-import FeedService from '@/client/service/feed';
 import { useToast } from '@/client/composables/useToast';
 import { useBulkSelection } from '@/client/composables/useBulkSelection';
 import EventImage from '@/client/components/common/media/event-image.vue';
@@ -50,7 +49,6 @@ const { t: tReport } = useTranslation('system', {
 const { t: tFeed } = useTranslation('feed');
 
 const eventService = new EventService();
-const feedService = new FeedService();
 const calendarStore = useCalendarStore();
 const categoryStore = useCategoryStore();
 const toast = useToast();
@@ -367,7 +365,17 @@ const handleUnpostCancel = async () => {
 
 /**
  * Executes the unpost after the user confirms in the modal.
- * Calls feedService.unshareEvent and removes the event from local state on success.
+ *
+ * Uses eventService.unshareReposted (not feedService.unshareEvent directly) so
+ * this calendar-management surface depends only on EventService. The wrapper
+ * hits the same DELETE /api/v1/social/shares endpoint and also handles store
+ * removal, keeping the component free of feed-domain imports.
+ *
+ * This surface confirms-then-mutates (removes the event from the list on
+ * success). The feed view uses an optimistic-with-rollback pattern instead,
+ * which is intentional: the calendar list is a management surface where a
+ * destructive-feeling remove makes sense, while the feed is a browsing surface
+ * where the row should remain visible.
  */
 const handleUnpostConfirm = async () => {
   const targetEvent = unpostTargetEvent.value;
@@ -381,8 +389,7 @@ const handleUnpostConfirm = async () => {
   }
 
   try {
-    await feedService.unshareEvent(props.calendar.id, targetEvent.id);
-    store.removeEvent(props.calendar.id, targetEvent);
+    await eventService.unshareReposted(props.calendar.id, targetEvent);
     toast.success(t('event.unpost_success_toast'));
   }
   catch (error) {

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -896,6 +896,11 @@ initializeFiltersFromURL();
             color: var(--pav-color-orange-500);
           }
 
+          &:focus-visible {
+            outline: 2px solid var(--pav-color-focus-ring, var(--pav-color-orange-500));
+            outline-offset: 2px;
+          }
+
           @media (prefers-color-scheme: dark) {
             color: var(--pav-color-stone-400);
 

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -3,12 +3,13 @@ import { reactive, ref, computed, nextTick } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useTranslation } from 'i18next-vue';
 import { DateTime } from 'luxon';
-import { Plus, Calendar, Languages, Repeat, Pencil, Copy, Flag } from 'lucide-vue-next';
+import { Plus, Calendar, Languages, Repeat, Pencil, Copy, Flag, Link2Off } from 'lucide-vue-next';
 import { useEventStore } from '@/client/stores/eventStore';
 import { useCalendarStore } from '@/client/stores/calendarStore';
 import { useCategoryStore } from '@/client/stores/categoryStore';
 import CalendarService from '@/client/service/calendar';
 import EventService from '@/client/service/event';
+import FeedService from '@/client/service/feed';
 import { useToast } from '@/client/composables/useToast';
 import { useBulkSelection } from '@/client/composables/useBulkSelection';
 import EventImage from '@/client/components/common/media/event-image.vue';
@@ -49,6 +50,7 @@ const { t: tReport } = useTranslation('system', {
 const { t: tFeed } = useTranslation('feed');
 
 const eventService = new EventService();
+const feedService = new FeedService();
 const calendarStore = useCalendarStore();
 const categoryStore = useCategoryStore();
 const toast = useToast();
@@ -112,6 +114,11 @@ const repostModalTriggerEl = ref(null);
 // Delete confirmation modal state
 const showDeleteConfirmModal = ref(false);
 const deleteModalTriggerEl = ref(null);
+
+// Unpost confirmation modal state
+const showUnpostConfirmModal = ref(false);
+const unpostTargetEvent = ref<any>(null);
+const unpostModalTriggerEl = ref<HTMLElement | null>(null);
 
 /**
  * Initializes filter state from URL query parameters.
@@ -339,6 +346,56 @@ const handleReportDialogClose = () => {
   reportEventTitle.value = '';
 };
 
+/**
+ * Opens the unpost confirmation modal for a reposted event.
+ */
+const handleUnpostButtonClick = (event: any, domEvent: MouseEvent) => {
+  unpostModalTriggerEl.value = (domEvent?.currentTarget as HTMLElement) ?? null;
+  unpostTargetEvent.value = event;
+  showUnpostConfirmModal.value = true;
+};
+
+/**
+ * Cancels the unpost operation and closes the confirmation modal.
+ */
+const handleUnpostCancel = async () => {
+  showUnpostConfirmModal.value = false;
+  unpostTargetEvent.value = null;
+  await nextTick();
+  unpostModalTriggerEl.value?.focus();
+};
+
+/**
+ * Executes the unpost after the user confirms in the modal.
+ * Calls feedService.unshareEvent and removes the event from local state on success.
+ */
+const handleUnpostConfirm = async () => {
+  const targetEvent = unpostTargetEvent.value;
+  showUnpostConfirmModal.value = false;
+
+  if (!targetEvent || !props.calendar?.id) {
+    unpostTargetEvent.value = null;
+    await nextTick();
+    unpostModalTriggerEl.value?.focus();
+    return;
+  }
+
+  try {
+    await feedService.unshareEvent(props.calendar.id, targetEvent.id);
+    store.removeEvent(props.calendar.id, targetEvent);
+    toast.success(t('event.unpost_success_toast'));
+  }
+  catch (error) {
+    console.error('Error unposting reposted event:', error);
+    toast.error(t('event.unpost_error_toast'));
+  }
+  finally {
+    unpostTargetEvent.value = null;
+    await nextTick();
+    unpostModalTriggerEl.value?.focus();
+  }
+};
+
 // Format event date for display
 const formatEventDate = (event) => {
   if (!event.schedules || event.schedules.length === 0) {
@@ -539,6 +596,16 @@ initializeFiltersFromURL();
               <Copy :size="18" />
             </button>
             <button
+              v-if="event.isRepost"
+              type="button"
+              class="unpost-btn icon-btn"
+              @click.stop="handleUnpostButtonClick(event, $event)"
+              :aria-label="t('event.unpost_aria_label', { name: event.content('en').name })"
+              :title="t('event.unpost_button_label')"
+            >
+              <Link2Off :size="18" />
+            </button>
+            <button
               type="button"
               class="report-btn icon-btn"
               @click.stop="handleReportEvent(event)"
@@ -607,6 +674,34 @@ initializeFiltersFromURL();
             @click="handleDeleteConfirm"
           >
             {{ tBulk('delete_confirm_button') }}
+          </PillButton>
+        </div>
+      </div>
+    </ModalLayout>
+
+    <!-- Unpost Confirmation Modal -->
+    <ModalLayout
+      v-if="showUnpostConfirmModal"
+      :title="t('event.unpost_confirm_title')"
+      modal-class="unpost-event-modal"
+      @close="handleUnpostCancel"
+    >
+      <div class="unpost-event-dialog">
+        <p class="unpost-event-message">
+          {{ t('event.unpost_confirm_body') }}
+        </p>
+        <div class="unpost-event-actions">
+          <PillButton
+            variant="ghost"
+            @click="handleUnpostCancel"
+          >
+            {{ t('event.unpost_cancel') }}
+          </PillButton>
+          <PillButton
+            variant="danger"
+            @click="handleUnpostConfirm"
+          >
+            {{ t('event.unpost_confirm_action') }}
           </PillButton>
         </div>
       </div>
@@ -1025,6 +1120,40 @@ initializeFiltersFromURL();
   }
 
   .delete-events-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    padding-top: var(--pav-space-4, 1rem);
+    border-top: 1px solid var(--pav-color-stone-200);
+
+    @media (prefers-color-scheme: dark) {
+      border-top-color: var(--pav-color-stone-700);
+    }
+  }
+}
+
+// Constrain unpost event modal width
+:global(.unpost-event-modal > div) {
+  max-width: 480px !important;
+}
+
+.unpost-event-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pav-space-4, 1rem);
+
+  .unpost-event-message {
+    margin: 0;
+    color: var(--pav-color-stone-600);
+    font-size: 0.875rem;
+    line-height: 1.5;
+
+    @media (prefers-color-scheme: dark) {
+      color: var(--pav-color-stone-400);
+    }
+  }
+
+  .unpost-event-actions {
     display: flex;
     gap: 0.75rem;
     justify-content: flex-end;

--- a/src/client/components/logged_in/feed/events.vue
+++ b/src/client/components/logged_in/feed/events.vue
@@ -339,14 +339,17 @@ onUnmounted(() => {
             {{ t('reposted_button') }}
           </button>
 
-          <!-- Auto-posted - show non-clickable label -->
-          <span
+          <!-- Auto-posted - show clickable label to unrepost -->
+          <button
             v-else-if="event.repostStatus === 'auto'"
+            type="button"
             class="auto-posted-label"
             data-testid="auto-posted-label"
+            :aria-label="t('unrepost_auto_aria_label', { eventTitle: getEventTitle(event) })"
+            @click="handleUnrepost(event.id)"
           >
             {{ t('auto_posted_label') }}
-          </span>
+          </button>
 
           <button
             type="button"
@@ -556,13 +559,29 @@ div.events-container {
           }
         }
 
-        span.auto-posted-label {
+        button.auto-posted-label {
           padding: var(--pav-space-2) var(--pav-space-4);
           background: var(--pav-color-stone-500);
           color: var(--pav-color-text-inverse);
+          border: none;
           border-radius: var(--pav-border-radius-sm);
           font-size: var(--pav-font-size-xs);
           font-weight: var(--pav-font-weight-medium);
+          cursor: pointer;
+          transition: background 0.2s ease, box-shadow 0.2s ease;
+
+          &:hover {
+            background: var(--pav-color-stone-600);
+          }
+
+          &:focus-visible {
+            outline: 2px solid var(--pav-color-focus-ring, var(--pav-color-orange-500));
+            outline-offset: 2px;
+          }
+
+          &:active {
+            background: var(--pav-color-stone-700);
+          }
         }
 
         button.report-button {
@@ -613,8 +632,7 @@ div.events-container {
         div.event-actions {
           width: 100%;
 
-          button,
-          span {
+          button {
             width: 100%;
             text-align: center;
           }

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -59,7 +59,15 @@
         "no_events_filtered_description": "No events match your current search criteria. Try adjusting your filters or clearing them to see all events.",
         "event": {
             "edit_label": "Edit event: {{name}}",
-            "duplicate_label": "Duplicate event: {{name}}"
+            "duplicate_label": "Duplicate event: {{name}}",
+            "unpost_button_label": "Unpost",
+            "unpost_aria_label": "Remove repost of event: {{name}}",
+            "unpost_confirm_title": "Remove reposted event?",
+            "unpost_confirm_body": "Remove this reposted event from your calendar? It will not be automatically reposted again if the original calendar re-broadcasts it.",
+            "unpost_confirm_action": "Remove repost",
+            "unpost_cancel": "Cancel",
+            "unpost_success_toast": "Reposted event removed",
+            "unpost_error_toast": "Failed to remove reposted event"
         },
         "series_badge_label": "Series:",
         "tab_events": "Events",

--- a/src/client/locales/en/feed.json
+++ b/src/client/locales/en/feed.json
@@ -43,6 +43,7 @@
         "reposted_button": "Reposted",
         "unrepost_aria_label": "Remove repost for: {{eventTitle}}",
         "auto_posted_label": "Auto-posted",
+        "unrepost_auto_aria_label": "Remove auto-repost for: {{eventTitle}}",
         "loading_more": "Loading more events...",
         "untitled_event": "Untitled Event",
         "unknown_calendar": "Unknown",

--- a/src/client/service/event.ts
+++ b/src/client/service/event.ts
@@ -146,6 +146,26 @@ export default class EventService {
   }
 
   /**
+   * Remove a reposted event from a calendar (writes a sticky dismissal on the backend
+   * so the event is not silently re-auto-posted on the next broadcast). Thin wrapper
+   * over DELETE /api/v1/social/shares so calendar-management components do not need
+   * to reach into FeedService.
+   *
+   * @param calendarId The calendar holding the repost
+   * @param event The reposted event to remove
+   */
+  async unshareReposted(calendarId: string, event: CalendarEvent): Promise<void> {
+    try {
+      await ModelService.delete(`/api/v1/social/shares/${encodeURIComponent(event.id)}?calendarId=${calendarId}`);
+      this.store.removeEvent(calendarId, event);
+    }
+    catch (error) {
+      console.error('Error unsharing reposted event:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Strips IDs and auto-generated fields from an event to prepare for duplication.
    * Creates a copy of the event with all identifying fields cleared while preserving
    * content, location data, media data, schedules, and categories.

--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -55,18 +55,31 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
   categories: EventCategory[] = [];
   series: EventSeries | null = null;
   /**
-   * Whether this event was obtained via a repost (SharedEventEntity) rather than direct ownership.
+   * Repost status of this event relative to the querying calendar:
+   * - 'none': owned directly by the calendar (not a repost)
+   * - 'manual': reposted to the calendar via an explicit user action
+   * - 'auto':  reposted to the calendar automatically by auto-repost policy
    *
-   * Populated by: EventService.listEvents() — sets true when the event has a corresponding
-   * SharedEventEntity for the querying calendar.
+   * Populated by: EventService.listEvents() — resolved from SharedEventEntity.auto_posted
+   * for events shared to the querying calendar, or 'manual' for legacy EventRepostEntity
+   * entries, or 'none' for owned events.
    *
    * NOT populated by: EventService.getEventById(), EventService.updateEvent(), or
    * EventService.bulkAssignCategories() (which calls getEventById() internally). Events
-   * returned by those methods will always have isRepost=false regardless of actual repost state.
+   * returned by those methods will always have repostStatus='none' regardless of actual
+   * repost state.
    *
-   * Default: false. Must be explicitly set after retrieval if needed.
+   * Default: 'none'. Must be explicitly set after retrieval if needed.
    */
-  isRepost: boolean = false;
+  repostStatus: 'none' | 'manual' | 'auto' = 'none';
+
+  /**
+   * Derived flag: true when this event was obtained via a repost (auto or manual)
+   * rather than direct ownership. Backed by {@link repostStatus}.
+   */
+  get isRepost(): boolean {
+    return this.repostStatus !== 'none';
+  }
   /**
    * Source calendar information for reposted events.
    * Contains the originating calendar's urlName, host, and URL.
@@ -154,7 +167,17 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
     event.location = obj.location ? EventLocation.fromObject(obj.location) : null;
     event.media = obj.media ? Media.fromObject(obj.media) : null;
     event.mediaId = obj.mediaId || null;
-    event.isRepost = obj.isRepost ?? false;
+    // Prefer repostStatus when present; fall back to legacy isRepost boolean for
+    // backward compatibility with older serialized payloads.
+    if (obj.repostStatus === 'manual' || obj.repostStatus === 'auto' || obj.repostStatus === 'none') {
+      event.repostStatus = obj.repostStatus;
+    }
+    else if (obj.isRepost === true) {
+      event.repostStatus = 'manual';
+    }
+    else {
+      event.repostStatus = 'none';
+    }
     event.sourceCalendar = obj.sourceCalendar ?? null;
 
     if ( obj.content ) {
@@ -196,6 +219,8 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
       id: this.id,
       date: this.date,
       calendarId: this.calendarId,
+      repostStatus: this.repostStatus,
+      // Kept for backward compatibility with frontend code still reading isRepost.
       isRepost: this.isRepost,
       sourceCalendar: this.sourceCalendar,
       locationId: this.locationId,

--- a/src/common/test/model/calendar_event.test.ts
+++ b/src/common/test/model/calendar_event.test.ts
@@ -59,3 +59,89 @@ describe('CalendarEvent.sourceCalendar', () => {
     expect(restored.sourceCalendar).toEqual(event.sourceCalendar);
   });
 });
+
+describe('CalendarEvent.repostStatus', () => {
+
+  it('should default repostStatus to "none"', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    expect(event.repostStatus).toBe('none');
+  });
+
+  it('isRepost getter should return false when repostStatus is "none"', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'none';
+    expect(event.isRepost).toBe(false);
+  });
+
+  it('isRepost getter should return true when repostStatus is "manual"', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'manual';
+    expect(event.isRepost).toBe(true);
+  });
+
+  it('isRepost getter should return true when repostStatus is "auto"', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'auto';
+    expect(event.isRepost).toBe(true);
+  });
+
+  it('should include repostStatus in toObject() output', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'auto';
+
+    const obj = event.toObject();
+    expect(obj.repostStatus).toBe('auto');
+  });
+
+  it('should keep isRepost in toObject() for backward compatibility', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'manual';
+
+    const obj = event.toObject();
+    expect(obj.isRepost).toBe(true);
+  });
+
+  it('should deserialize repostStatus from fromObject()', () => {
+    const obj = {
+      id: 'evt-1',
+      calendarId: 'cal-1',
+      repostStatus: 'auto',
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+    expect(event.repostStatus).toBe('auto');
+    expect(event.isRepost).toBe(true);
+  });
+
+  it('should fall back to legacy isRepost=true as "manual" in fromObject()', () => {
+    const obj = {
+      id: 'evt-1',
+      calendarId: 'cal-1',
+      isRepost: true,
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+    expect(event.repostStatus).toBe('manual');
+    expect(event.isRepost).toBe(true);
+  });
+
+  it('should default repostStatus to "none" when neither field is present in fromObject()', () => {
+    const obj = {
+      id: 'evt-1',
+      calendarId: 'cal-1',
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+    expect(event.repostStatus).toBe('none');
+    expect(event.isRepost).toBe(false);
+  });
+
+  it('should round-trip repostStatus through toObject/fromObject', () => {
+    const event = new CalendarEvent('evt-1', 'cal-1');
+    event.repostStatus = 'auto';
+
+    const restored = CalendarEvent.fromObject(event.toObject());
+    expect(restored.repostStatus).toBe('auto');
+    expect(restored.isRepost).toBe(true);
+  });
+});

--- a/src/server/activitypub/entity/activitypub.ts
+++ b/src/server/activitypub/entity/activitypub.ts
@@ -1,9 +1,10 @@
-import { Model, Table, Column, PrimaryKey, BelongsTo, DataType, ForeignKey } from 'sequelize-typescript';
+import { Model, Table, Column, PrimaryKey, BelongsTo, DataType, ForeignKey, Index } from 'sequelize-typescript';
 
 import { event_activity } from '@/common/model/events';
 import { FollowingCalendar, FollowerCalendar } from '@/common/model/follow';
 import db from '@/server/common/entity/db';
 import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import { EventEntity } from '@/server/calendar/entity/event';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import { ActivityPubActivity } from '@/server/activitypub/model/base';
 import CreateActivity from '@/server/activitypub/model/action/create';
@@ -197,6 +198,51 @@ class SharedEventEntity extends Model {
 }
 
 /**
+ * Sticky dismissals of reposted events. A row here means "calendar X has
+ * explicitly said this event should not appear on its calendar via
+ * auto-repost." It gates only auto-repost creation; a manual re-share by
+ * the calendar owner supersedes the dismissal.
+ *
+ * The unique index on (event_id, calendar_id) enforces the one-row-per-pair
+ * invariant. The event_id FK cascades on delete so dismissals are cleaned
+ * up automatically when the underlying local event row is deleted.
+ */
+@Table({ tableName: 'ap_repost_dismissal' })
+class RepostDismissalEntity extends Model {
+
+  @PrimaryKey
+  @Column({
+    type: DataType.UUID,
+    defaultValue: DataType.UUIDV4,
+    allowNull: false,
+  })
+  declare id: string;
+
+  @ForeignKey(() => EventEntity)
+  @Index({ name: 'idx_ap_repost_dismissal_event_calendar', unique: true })
+  @Column({ type: DataType.UUID, allowNull: false })
+  declare event_id: string;
+
+  @ForeignKey(() => CalendarEntity)
+  @Index({ name: 'idx_ap_repost_dismissal_event_calendar', unique: true })
+  @Column({ type: DataType.UUID, allowNull: false })
+  declare calendar_id: string;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+  })
+  declare dismissed_at: Date;
+
+  @BelongsTo(() => EventEntity, { foreignKey: 'event_id', onDelete: 'CASCADE' })
+  declare event: EventEntity;
+
+  @BelongsTo(() => CalendarEntity, { foreignKey: 'calendar_id' })
+  declare calendar: CalendarEntity;
+}
+
+/**
  * A list of activities (shares, etc) that other calendars have done to a calendar's
  * own events.
  *
@@ -227,6 +273,7 @@ db.addModels([
   FollowingCalendarEntity,
   FollowerCalendarEntity,
   SharedEventEntity,
+  RepostDismissalEntity,
   EventActivityEntity,
 ]);
 
@@ -237,5 +284,6 @@ export {
   FollowingCalendarEntity,
   FollowerCalendarEntity,
   SharedEventEntity,
+  RepostDismissalEntity,
   EventActivityEntity,
 };

--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -274,6 +274,29 @@ export default class ActivityPubInterface {
   }
 
   /**
+   * Gets a map of shared event IDs to their repost status ('auto' or 'manual')
+   * for a given calendar. Derived from SharedEventEntity.auto_posted.
+   *
+   * Events NOT present in the returned map are not shared via SharedEventEntity
+   * for the given calendar and their repost status must be determined by other
+   * means (e.g., ownership or legacy EventRepostEntity).
+   *
+   * @param calendarId - The calendar UUID
+   * @returns Map from event_id (UUID string) to 'auto' | 'manual'
+   */
+  async getSharedEventStatusMap(calendarId: string): Promise<Map<string, 'auto' | 'manual'>> {
+    const sharedEvents = await SharedEventEntity.findAll({
+      where: { calendar_id: calendarId },
+      attributes: ['event_id', 'auto_posted'],
+    });
+    const result = new Map<string, 'auto' | 'manual'>();
+    for (const se of sharedEvents) {
+      result.set(se.event_id, se.auto_posted ? 'auto' : 'manual');
+    }
+    return result;
+  }
+
+  /**
    * Gets the IDs of all calendars that have shared (reposted) a given event.
    *
    * @param eventId - The event UUID

--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -285,15 +285,7 @@ export default class ActivityPubInterface {
    * @returns Map from event_id (UUID string) to 'auto' | 'manual'
    */
   async getSharedEventStatusMap(calendarId: string): Promise<Map<string, 'auto' | 'manual'>> {
-    const sharedEvents = await SharedEventEntity.findAll({
-      where: { calendar_id: calendarId },
-      attributes: ['event_id', 'auto_posted'],
-    });
-    const result = new Map<string, 'auto' | 'manual'>();
-    for (const se of sharedEvents) {
-      result.set(se.event_id, se.auto_posted ? 'auto' : 'manual');
-    }
-    return result;
+    return this.memberService.getSharedEventStatusMap(calendarId);
   }
 
   /**

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -14,7 +14,7 @@ import DeleteActivity from "@/server/activitypub/model/action/delete";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
-import { ActivityPubInboxMessageEntity, EventActivityEntity, FollowerCalendarEntity, FollowingCalendarEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
+import { ActivityPubInboxMessageEntity, EventActivityEntity, FollowerCalendarEntity, FollowingCalendarEntity, RepostDismissalEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
 import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
 import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
 import RemoteCalendarService from "@/server/activitypub/service/remote_calendar";
@@ -882,6 +882,21 @@ class ProcessInboxService {
     const localActorUrl = ActivityPubActor.actorUrl(calendar);
     if (eventObject.attributed_to === localActorUrl) {
       logger.info('Skip: Loop prevention - event originated from this calendar');
+      return;
+    }
+
+    // DISMISSAL GUARD: Check for sticky unpost dismissal by this calendar owner.
+    // If present, skip share creation entirely. Update activities that modify
+    // the underlying event still process normally elsewhere in the inbox.
+    const dismissal = await RepostDismissalEntity.findOne({
+      where: {
+        event_id: eventObject.event_id,
+        calendar_id: calendar.id,
+      },
+    });
+
+    if (dismissal) {
+      logger.info({ event_id: eventObject.event_id, calendar_id: calendar.id }, 'Skip: previously dismissed by calendar owner');
       return;
     }
 

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -420,26 +420,37 @@ class ActivityPubService {
    *
    * @param account The account performing the unsharing
    * @param calendar The calendar to remove the share from
-   * @param eventUrl ActivityPub URL of the event to unshare
+   * @param eventIdOrUrl Either the local EventEntity UUID or the ActivityPub URL of the event to unshare
    */
-  async unshareEvent(account: Account, calendar: Calendar, eventUrl: string) {
+  async unshareEvent(account: Account, calendar: Calendar, eventIdOrUrl: string) {
 
     if (!await this.calendarService.userCanModifyCalendar(account, calendar)) {
       throw new InsufficientCalendarPermissionsError('User does not have permission to modify calendar: ' + calendar.id);
     }
 
-    // Resolve AP URL to local event UUID via EventObjectEntity.
-    // SharedEventEntity.event_id stores UUIDs, not AP URLs.
-    const eventObject = await EventObjectEntity.findOne({
-      where: { ap_id: eventUrl },
-    });
-
-    if (!eventObject) {
-      // Event doesn't exist locally, nothing to unshare
-      return;
+    // Resolve input to a local event UUID. The production path (DELETE
+    // /api/v1/social/shares/:id) passes the local EventEntity UUID from the
+    // frontend; service-level callers historically passed a full ActivityPub
+    // URL and expected an EventObjectEntity lookup. Accept both so legacy
+    // tests and the production API share a single code path.
+    //
+    // SharedEventEntity.event_id and RepostDismissalEntity.event_id both store
+    // UUIDs, so we must resolve to a UUID before hitting either table.
+    const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    let localEventId: string;
+    if (UUID_REGEX.test(eventIdOrUrl)) {
+      localEventId = eventIdOrUrl;
     }
-
-    const localEventId = eventObject.event_id;
+    else {
+      const eventObject = await EventObjectEntity.findOne({
+        where: { ap_id: eventIdOrUrl },
+      });
+      if (!eventObject) {
+        // Event doesn't exist locally, nothing to unshare
+        return;
+      }
+      localEventId = eventObject.event_id;
+    }
 
     let shares = await SharedEventEntity.findAll({
       where: {

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -466,10 +466,6 @@ class ActivityPubService {
             event_id: share.event_id,
             calendar_id: calendar.id,
           },
-          defaults: {
-            event_id: share.event_id,
-            calendar_id: calendar.id,
-          },
           transaction: t,
         });
       });

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -12,11 +12,12 @@ import { FollowingCalendar, FollowerCalendar } from "@/common/model/follow";
 import { ActivityPubActivity } from "@/server/activitypub/model/base";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
-import { FollowingCalendarEntity, FollowerCalendarEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
+import { FollowingCalendarEntity, FollowerCalendarEntity, SharedEventEntity, RepostDismissalEntity } from "@/server/activitypub/entity/activitypub";
 import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
 import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
 import RemoteCalendarService from "@/server/activitypub/service/remote_calendar";
 import UndoActivity from "../model/action/undo";
+import db from "@/server/common/entity/db";
 import CalendarInterface from "@/server/calendar/interface";
 import { EventObject } from "@/server/activitypub/model/object/event";
 import { addToOutbox as addToOutboxHelper } from "@/server/activitypub/helper/outbox";
@@ -372,12 +373,27 @@ class ActivityPubService {
     let actor = await this.actorUrl(calendar);
     let shareActivity = new AnnounceActivity(actor, canonicalEventUrl);
 
-    await SharedEventEntity.create({
-      id: shareActivity.id,
-      event_id: localEventId,
-      calendar_id: calendar.id,
-      auto_posted: autoPosted,
+    // A manual (or auto) share is an explicit opt-in that supersedes any prior
+    // dismissal. Delete any existing RepostDismissalEntity for this
+    // (event_id, calendar_id) in the same transaction as the SharedEventEntity
+    // creation so partial failure rolls both changes back together.
+    await db.transaction(async (t) => {
+      await RepostDismissalEntity.destroy({
+        where: {
+          event_id: localEventId,
+          calendar_id: calendar.id,
+        },
+        transaction: t,
+      });
+
+      await SharedEventEntity.create({
+        id: shareActivity.id,
+        event_id: localEventId,
+        calendar_id: calendar.id,
+        auto_posted: autoPosted,
+      }, { transaction: t });
     });
+
     this.addToOutbox(calendar, shareActivity);
 
     // Assign categories to the shared event if provided
@@ -397,6 +413,10 @@ class ActivityPubService {
    * Remove a shared event from a calendar.
    * Resolves the AP URL to a local event UUID via EventObjectEntity before
    * querying SharedEventEntity, since event_id stores UUIDs not AP URLs.
+   *
+   * Writes a sticky RepostDismissalEntity row for (event_id, calendar_id) in
+   * the same transaction as the SharedEventEntity destroy so future auto-repost
+   * attempts can detect and skip the dismissal.
    *
    * @param account The account performing the unsharing
    * @param calendar The calendar to remove the share from
@@ -432,7 +452,27 @@ class ActivityPubService {
       this.addToOutbox(calendar, new UndoActivity(actorUrl, share.id));
       // Emit eventUnreposted before destroy so share.event_id is still accessible
       this.eventBus.emit('eventUnreposted', { eventId: share.event_id, calendarId: calendar.id });
-      await share.destroy();
+
+      // Destroy the SharedEventEntity and upsert a RepostDismissalEntity row
+      // for (event_id, calendar_id) in the same transaction so partial failure
+      // rolls both changes back together. findOrCreate is used for idempotency:
+      // a second unshareEvent call on an already-dismissed event is a no-op for
+      // the dismissal row (the unique index on event_id+calendar_id ensures no
+      // duplicate rows are created).
+      await db.transaction(async (t) => {
+        await share.destroy({ transaction: t });
+        await RepostDismissalEntity.findOrCreate({
+          where: {
+            event_id: share.event_id,
+            calendar_id: calendar.id,
+          },
+          defaults: {
+            event_id: share.event_id,
+            calendar_id: calendar.id,
+          },
+          transaction: t,
+        });
+      });
     }
   }
 

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -473,6 +473,29 @@ class ActivityPubService {
   }
 
   /**
+   * Gets a map of shared event IDs to their repost status ('auto' or 'manual')
+   * for a given calendar. Derived from SharedEventEntity.auto_posted.
+   *
+   * Events NOT present in the returned map are not shared via SharedEventEntity
+   * for the given calendar and their repost status must be determined by other
+   * means (e.g., ownership or legacy EventRepostEntity).
+   *
+   * @param calendarId - The calendar UUID
+   * @returns Map from event_id (UUID string) to 'auto' | 'manual'
+   */
+  async getSharedEventStatusMap(calendarId: string): Promise<Map<string, 'auto' | 'manual'>> {
+    const sharedEvents = await SharedEventEntity.findAll({
+      where: { calendar_id: calendarId },
+      attributes: ['event_id', 'auto_posted'],
+    });
+    const result = new Map<string, 'auto' | 'manual'>();
+    for (const se of sharedEvents) {
+      result.set(se.event_id, se.auto_posted ? 'auto' : 'manual');
+    }
+    return result;
+  }
+
+  /**
    * Get list of calendars that this calendar is following
    * @param calendar The calendar whose followings to retrieve
    * @returns Array of FollowingCalendar objects with human-readable calendarActorId

--- a/src/server/activitypub/test/auto-repost-category-assignment.test.ts
+++ b/src/server/activitypub/test/auto-repost-category-assignment.test.ts
@@ -22,7 +22,7 @@ vi.mock('@/server/activitypub/helper/outbox', () => ({
 }));
 
 import ProcessInboxService from '@/server/activitypub/service/inbox';
-import { FollowingCalendarEntity, SharedEventEntity } from '@/server/activitypub/entity/activitypub';
+import { FollowingCalendarEntity, SharedEventEntity, RepostDismissalEntity } from '@/server/activitypub/entity/activitypub';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import { EventCategoryAssignmentEntity } from '@/server/calendar/entity/event_category_assignment';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
@@ -124,6 +124,9 @@ describe('ProcessInboxService - auto-repost category assignment', () => {
       auto_repost_originals: true,
       auto_repost_reposts: false,
     } as any);
+
+    // Stub RepostDismissalEntity.findOne (no prior sticky dismissal → null)
+    sandbox.stub(RepostDismissalEntity, 'findOne').resolves(null);
 
     // Stub SharedEventEntity.findOne (duplicate check → null = not shared yet)
     sandbox.stub(SharedEventEntity, 'findOne').resolves(null);
@@ -345,6 +348,7 @@ describe('ProcessInboxService - auto-repost category assignment', () => {
         auto_repost_reposts: false,
       } as any);
 
+      sandbox.stub(RepostDismissalEntity, 'findOne').resolves(null);
       sandbox.stub(SharedEventEntity, 'findOne').resolves(null);
 
       const sharedEventCreateStub = sandbox.stub(SharedEventEntity, 'create').resolves({

--- a/src/server/activitypub/test/entity.test.ts
+++ b/src/server/activitypub/test/entity.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, assertType } from 'vitest';
+import { describe, it, expect, assertType, beforeEach } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
 
 import CreateActivity from '@/server/activitypub/model/action/create';
 import UpdateActivity from '@/server/activitypub/model/action/update';
@@ -6,7 +7,13 @@ import DeleteActivity from '@/server/activitypub/model/action/delete';
 import FollowActivity from '@/server/activitypub/model/action/follow';
 import AnnounceActivity from '@/server/activitypub/model/action/announce';
 import UndoActivity from '@/server/activitypub/model/action/undo';
-import { ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
+import {
+  ActivityPubInboxMessageEntity,
+  RepostDismissalEntity,
+} from '@/server/activitypub/entity/activitypub';
+import { EventEntity } from '@/server/calendar/entity/event';
+import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import db from '@/server/common/entity/db';
 
 describe('toModel', () => {
   it('should fail to make a message', async () => {
@@ -99,5 +106,79 @@ describe('toModel', () => {
     });
 
     assertType<UndoActivity>( testEntity.toModel() );
+  });
+});
+
+describe('RepostDismissalEntity', () => {
+  let calendarId: string;
+  let eventId: string;
+
+  beforeEach(async () => {
+    await db.sync({ force: true });
+    // Enable SQLite foreign-key enforcement so ON DELETE CASCADE is honored.
+    // (SQLite :memory: defaults to foreign_keys = OFF.)
+    await db.query('PRAGMA foreign_keys = ON');
+
+    calendarId = uuidv4();
+    await CalendarEntity.create({
+      id: calendarId,
+      url_name: 'dismissal_cal',
+      languages: 'en',
+    });
+
+    eventId = uuidv4();
+    await EventEntity.create({
+      id: eventId,
+      calendar_id: calendarId,
+    });
+  });
+
+  it('allows inserting a dismissal for a valid (event_id, calendar_id) pair', async () => {
+    const row = await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: calendarId,
+    });
+
+    expect(row.event_id).toBe(eventId);
+    expect(row.calendar_id).toBe(calendarId);
+    expect(row.dismissed_at).toBeInstanceOf(Date);
+  });
+
+  it('rejects a duplicate (event_id, calendar_id) pair via the unique index', async () => {
+    await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: calendarId,
+    });
+
+    await expect(
+      RepostDismissalEntity.create({
+        id: uuidv4(),
+        event_id: eventId,
+        calendar_id: calendarId,
+      }),
+    ).rejects.toThrow();
+
+    const count = await RepostDismissalEntity.count({
+      where: { event_id: eventId, calendar_id: calendarId },
+    });
+    expect(count).toBe(1);
+  });
+
+  it('cascades and removes the dismissal row when its event is deleted', async () => {
+    await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: calendarId,
+    });
+
+    const before = await RepostDismissalEntity.count({ where: { event_id: eventId } });
+    expect(before).toBe(1);
+
+    await EventEntity.destroy({ where: { id: eventId } });
+
+    const after = await RepostDismissalEntity.count({ where: { event_id: eventId } });
+    expect(after).toBe(0);
   });
 });

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ProcessInboxService from '@/server/activitypub/service/inbox';
 import * as remoteFetch from '@/server/activitypub/helper/remote-fetch';
-import { FollowerCalendarEntity, FollowingCalendarEntity, ActivityPubOutboxMessageEntity, EventActivityEntity } from '@/server/activitypub/entity/activitypub';
+import { FollowerCalendarEntity, FollowingCalendarEntity, ActivityPubOutboxMessageEntity, EventActivityEntity, SharedEventEntity, RepostDismissalEntity } from '@/server/activitypub/entity/activitypub';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import FollowActivity from '@/server/activitypub/model/action/follow';
@@ -618,6 +618,149 @@ describe('ProcessInboxService - checkAndPerformAutoRepost eventReposted emission
     expect(emittedEvents).toHaveLength(0);
   });
 
+});
+
+describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () => {
+  let sandbox: sinon.SinonSandbox;
+  let inboxService: ProcessInboxService;
+  let eventBus: EventEmitter;
+  let testCalendar: Calendar;
+  let calendarInterface: CalendarInterface;
+
+  const sourceActorUri = 'https://remote.instance/calendars/source-calendar';
+
+  beforeEach(async () => {
+    await setupActivityPubSchema();
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    inboxService = new ProcessInboxService(eventBus, calendarInterface);
+
+    testCalendar = new Calendar('test-calendar-id', 'test-calendar');
+    testCalendar.addContent('en', new CalendarContent('en'));
+    testCalendar.content('en').title = 'Test Calendar';
+
+    await CalendarEntity.create({
+      id: testCalendar.id,
+      url_name: testCalendar.urlName,
+      account_id: uuidv4(),
+      languages: 'en',
+    });
+
+    // Ensure FK enforcement is off for this describe — other test files may
+    // leave `PRAGMA foreign_keys = ON` set on the shared SQLite connection.
+    // setupActivityPubSchema() does not sync the full EventEntity graph.
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    sandbox.stub(console, 'log');
+    sandbox.stub(console, 'warn');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+  });
+
+  async function seedAutoRepostPrerequisites(eventId: string, eventApId: string) {
+    const remoteCalendarActorId = uuidv4();
+    await CalendarActorEntity.create({
+      id: remoteCalendarActorId,
+      actor_type: 'remote',
+      actor_uri: sourceActorUri,
+      remote_display_name: null,
+      remote_domain: 'remote.instance',
+      calendar_id: null,
+      private_key: null,
+    });
+
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: testCalendar.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: sourceActorUri,
+    });
+  }
+
+  it('skips SharedEventEntity creation and outbox write when a dismissal exists', async () => {
+    // Arrange
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedAutoRepostPrerequisites(eventId, eventApId);
+
+    // Sticky dismissal for this (event_id, calendar_id) pair
+    await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: testCalendar.id,
+    });
+
+    // Stubs for downstream calls that should NOT be reached
+    const sharedCreateSpy = sandbox.spy(SharedEventEntity, 'create');
+    const outboxCreateSpy = sandbox.spy(ActivityPubOutboxMessageEntity, 'create');
+    const categorySpy = sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    const getEventByIdSpy = sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(eventId, null));
+
+    const emittedEvents: any[] = [];
+    eventBus.on('eventReposted', (payload) => emittedEvents.push(payload));
+
+    // Act
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+
+    // Assert
+    expect(sharedCreateSpy.called).toBe(false);
+    expect(outboxCreateSpy.called).toBe(false);
+    expect(categorySpy.called).toBe(false);
+    expect(getEventByIdSpy.called).toBe(false);
+    expect(emittedEvents).toHaveLength(0);
+
+    // The dismissal row should still be present after the skip.
+    const remaining = await RepostDismissalEntity.count({
+      where: { event_id: eventId, calendar_id: testCalendar.id },
+    });
+    expect(remaining).toBe(1);
+
+    // And no SharedEventEntity row should have been persisted.
+    const shares = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: testCalendar.id },
+    });
+    expect(shares).toBe(0);
+  });
+
+  it('creates SharedEventEntity normally when no dismissal exists', async () => {
+    // Arrange
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedAutoRepostPrerequisites(eventId, eventApId);
+
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(eventId, null));
+
+    const emittedEvents: any[] = [];
+    eventBus.on('eventReposted', (payload) => emittedEvents.push(payload));
+
+    // Act
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+
+    // Assert - the existing behavior is preserved.
+    const shares = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: testCalendar.id },
+    });
+    expect(shares).toBe(1);
+
+    expect(emittedEvents).toHaveLength(1);
+  });
 });
 
 describe('ProcessInboxService - processUpdateEvent', () => {

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -660,6 +660,10 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
   afterEach(async () => {
     sandbox.restore();
     await teardownActivityPubSchema();
+    // Restore connection-wide pragma so neighboring test files are not
+    // affected by the OFF state set in beforeEach.
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = ON');
   });
 
   async function seedAutoRepostPrerequisites(eventId: string, eventApId: string) {
@@ -760,6 +764,111 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
     expect(shares).toBe(1);
 
     expect(emittedEvents).toHaveLength(1);
+  });
+
+  it('isolates dismissals per calendar: a dismissal on calendar A does not affect calendar B', async () => {
+    // Arrange — two calendars both follow the same remote source with
+    // auto_repost_originals: true. Only calendar A has a dismissal for the
+    // event. The inbox dismissal lookup MUST scope by calendar_id; otherwise
+    // calendar B would incorrectly skip the share.
+    const calendarA = testCalendar; // already set up in beforeEach
+    const calendarBId = uuidv4();
+    const calendarB = new Calendar(calendarBId, 'test-calendar-b');
+    calendarB.addContent('en', new CalendarContent('en'));
+    calendarB.content('en').title = 'Test Calendar B';
+
+    await CalendarEntity.create({
+      id: calendarB.id,
+      url_name: calendarB.urlName,
+      account_id: uuidv4(),
+      languages: 'en',
+    });
+
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+
+    // Seed the remote actor + EventObjectEntity once
+    const remoteCalendarActorId = uuidv4();
+    await CalendarActorEntity.create({
+      id: remoteCalendarActorId,
+      actor_type: 'remote',
+      actor_uri: sourceActorUri,
+      remote_display_name: null,
+      remote_domain: 'remote.instance',
+      calendar_id: null,
+      private_key: null,
+    });
+
+    // Both calendars follow the same remote actor
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: calendarA.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: calendarB.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: sourceActorUri,
+    });
+
+    // Dismissal exists ONLY for (eventId, calendarA)
+    await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: calendarA.id,
+    });
+
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(eventId, null));
+
+    // Act — calendar A first (should be skipped by dismissal guard)
+    await (inboxService as any).checkAndPerformAutoRepost(
+      calendarA, sourceActorUri, eventApId, true,
+    );
+
+    let sharesA = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: calendarA.id },
+    });
+    expect(sharesA).toBe(0);
+
+    // Act — calendar B next (no dismissal, should create the share)
+    await (inboxService as any).checkAndPerformAutoRepost(
+      calendarB, sourceActorUri, eventApId, true,
+    );
+
+    const sharesB = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: calendarB.id },
+    });
+    expect(sharesB).toBe(1);
+
+    // Re-confirm calendar A still has zero shares (calendar B's processing
+    // must not have leaked into calendar A's state).
+    sharesA = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: calendarA.id },
+    });
+    expect(sharesA).toBe(0);
+
+    // Calendar A's dismissal row should be untouched.
+    const dismissalsA = await RepostDismissalEntity.count({
+      where: { event_id: eventId, calendar_id: calendarA.id },
+    });
+    expect(dismissalsA).toBe(1);
+
+    // Calendar B should have NO dismissal row (sharing does not create one).
+    const dismissalsB = await RepostDismissalEntity.count({
+      where: { event_id: eventId, calendar_id: calendarB.id },
+    });
+    expect(dismissalsB).toBe(0);
   });
 });
 

--- a/src/server/activitypub/test/service/feed.test.ts
+++ b/src/server/activitypub/test/service/feed.test.ts
@@ -11,6 +11,7 @@ import {
   FollowingCalendarEntity,
   FollowerCalendarEntity,
   SharedEventEntity,
+  RepostDismissalEntity,
 } from '@/server/activitypub/entity/activitypub';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
@@ -52,6 +53,12 @@ describe("ActivityPub Feed Service Methods", () => {
 
     // Stub calendar service methods
     sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+
+    // shareEvent wraps its mutations in db.transaction(...) and destroys any
+    // existing RepostDismissalEntity for the (event_id, calendar_id) pair before
+    // creating the new share. These pure-stub tests never sync the ap_repost_dismissal
+    // table, so stub destroy to a no-op to keep the transaction callback hermetic.
+    sandbox.stub(RepostDismissalEntity, 'destroy').resolves(0);
   });
 
   afterEach(() => {
@@ -699,6 +706,10 @@ describe("shareEvent - local events without EventObjectEntity (seed events)", ()
     calendar = Calendar.fromObject({ id: 'test-calendar-id', urlName: 'testcalendar' });
 
     sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+
+    // shareEvent wraps mutations in db.transaction and destroys any prior dismissal
+    // row; these pure-stub tests do not sync ap_repost_dismissal, so no-op the destroy.
+    sandbox.stub(RepostDismissalEntity, 'destroy').resolves(0);
   });
 
   afterEach(() => {

--- a/src/server/activitypub/test/service/members-dismissal.test.ts
+++ b/src/server/activitypub/test/service/members-dismissal.test.ts
@@ -61,6 +61,9 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
   afterEach(async () => {
     sandbox.restore();
     await teardownActivityPubSchema();
+    // Restore connection-wide pragma so neighboring test files are not
+    // affected by the OFF state set in beforeEach.
+    await db.query('PRAGMA foreign_keys = ON');
   });
 
   it('creates a RepostDismissalEntity row after destroying the SharedEventEntity', async () => {
@@ -170,6 +173,55 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
     });
     expect(targetDismissal).not.toBeNull();
   });
+
+  it('rolls back the SharedEventEntity destroy if the dismissal write fails', async () => {
+    // Seed the AP URL → local event UUID lookup
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Seed a SharedEventEntity that unshareEvent would try to destroy
+    await SharedEventEntity.create({
+      id: 'share-activity-uuid-rollback',
+      event_id: localEventId,
+      calendar_id: calendarId,
+      auto_posted: false,
+    });
+
+    // Force the dismissal write inside the transaction to throw AFTER the
+    // SharedEventEntity destroy. The transaction wrapper must roll back the
+    // destroy. We use sinon.stub directly (not the sandbox) so we can restore
+    // it in finally even if the test assertion blows up.
+    const findOrCreateStub = sinon.stub(RepostDismissalEntity, 'findOrCreate')
+      .rejects(new Error('simulated dismissal write failure'));
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    try {
+      await expect(
+        service.unshareEvent(account, calendar, eventApUrl),
+      ).rejects.toThrow('simulated dismissal write failure');
+
+      // The SharedEventEntity row must still be present — the destroy was
+      // rolled back when findOrCreate threw inside the transaction callback.
+      const remainingShares = await SharedEventEntity.findAll({
+        where: { event_id: localEventId, calendar_id: calendarId },
+      });
+      expect(remainingShares).toHaveLength(1);
+
+      // And no dismissal row should have been written.
+      const dismissals = await RepostDismissalEntity.findAll({
+        where: { event_id: localEventId, calendar_id: calendarId },
+      });
+      expect(dismissals).toHaveLength(0);
+    }
+    finally {
+      findOrCreateStub.restore();
+    }
+  });
 });
 
 describe('shareEvent - RepostDismissalEntity deletion', () => {
@@ -199,6 +251,9 @@ describe('shareEvent - RepostDismissalEntity deletion', () => {
   afterEach(async () => {
     sandbox.restore();
     await teardownActivityPubSchema();
+    // Restore connection-wide pragma so neighboring test files are not
+    // affected by the OFF state set in beforeEach.
+    await db.query('PRAGMA foreign_keys = ON');
   });
 
   it('deletes any existing dismissal for (event_id, calendar_id) before creating the new share', async () => {
@@ -269,5 +324,52 @@ describe('shareEvent - RepostDismissalEntity deletion', () => {
     expect(d1).not.toBeNull();
     expect(d2).not.toBeNull();
     expect(d3).not.toBeNull();
+  });
+
+  it('rolls back the dismissal destroy if the SharedEventEntity create fails', async () => {
+    // Seed the AP URL → local event UUID lookup
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Seed a pre-existing dismissal that shareEvent would normally delete
+    await RepostDismissalEntity.create({
+      event_id: localEventId,
+      calendar_id: calendarId,
+    });
+
+    // Force the SharedEventEntity create inside the transaction to throw
+    // AFTER the dismissal destroy. The transaction wrapper must roll back
+    // the dismissal destroy. We use sinon.stub directly (not the sandbox)
+    // so we can restore it in finally even if the assertion blows up.
+    const createStub = sinon.stub(SharedEventEntity, 'create')
+      .rejects(new Error('simulated share create failure'));
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    try {
+      await expect(
+        service.shareEvent(account, calendar, eventApUrl),
+      ).rejects.toThrow('simulated share create failure');
+
+      // The dismissal row must still be present — the destroy was rolled
+      // back when create threw inside the transaction callback.
+      const dismissals = await RepostDismissalEntity.findAll({
+        where: { event_id: localEventId, calendar_id: calendarId },
+      });
+      expect(dismissals).toHaveLength(1);
+
+      // And no SharedEventEntity row should have been persisted.
+      const shares = await SharedEventEntity.findAll({
+        where: { event_id: localEventId, calendar_id: calendarId },
+      });
+      expect(shares).toHaveLength(0);
+    }
+    finally {
+      createStub.restore();
+    }
   });
 });

--- a/src/server/activitypub/test/service/members-dismissal.test.ts
+++ b/src/server/activitypub/test/service/members-dismissal.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sinon from 'sinon';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import ActivityPubService from '@/server/activitypub/service/members';
+import CalendarInterface from '@/server/calendar/interface';
+import {
+  SharedEventEntity,
+  RepostDismissalEntity,
+} from '@/server/activitypub/entity/activitypub';
+import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
+import db from '@/server/common/entity/db';
+import {
+  setupActivityPubSchema,
+  teardownActivityPubSchema,
+} from '@/server/test/helpers/database';
+
+/**
+ * Sticky-dismissal behavior for memberService.unshareEvent / shareEvent.
+ *
+ * These tests exercise the real ActivityPub ephemeral schema so we can
+ * assert that RepostDismissalEntity rows are written/deleted in the same
+ * transaction as the SharedEventEntity mutation.
+ *
+ * SQLite's `foreign_keys` pragma is disabled here because setupActivityPubSchema()
+ * does not sync the full EventEntity graph (LocationEntity, EventSeriesEntity, etc.).
+ * We use raw UUIDs for event_id rather than actual EventEntity rows — the
+ * service layer only cares that the EventObjectEntity lookup resolves to a UUID
+ * that matches SharedEventEntity.event_id and RepostDismissalEntity.event_id.
+ */
+
+describe('unshareEvent - RepostDismissalEntity upsert', () => {
+  let service: ActivityPubService;
+  let sandbox: sinon.SinonSandbox;
+
+  const calendarId = 'c00a0000-0000-4000-8000-000000000001';
+  const otherCalendarId = 'c00a0000-0000-4000-8000-000000000002';
+  const localEventId = 'e00a0000-0000-4000-8000-000000000001';
+  const otherEventId = 'e00a0000-0000-4000-8000-000000000002';
+  const eventApUrl = 'https://remote.example.com/events/event-dismissal';
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    await setupActivityPubSchema();
+    // Ensure FK enforcement is off — setupActivityPubSchema() does not sync
+    // the full EventEntity FK graph (LocationEntity, EventSeriesEntity, etc.).
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    const eventBus = new EventEmitter();
+    service = new ActivityPubService(eventBus, new CalendarInterface(eventBus));
+
+    // Allow permission checks
+    sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+    // Stub outbox so we don't try to resolve a real calendar actor record
+    sandbox.stub(service, 'addToOutbox').resolves();
+    sandbox.stub(service, 'actorUrl').resolves('https://local.example.com/calendars/test-calendar');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+  });
+
+  it('creates a RepostDismissalEntity row after destroying the SharedEventEntity', async () => {
+    // Seed an EventObjectEntity so the AP URL resolves to localEventId
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Seed a SharedEventEntity the service will destroy
+    await SharedEventEntity.create({
+      id: 'share-activity-uuid-1',
+      event_id: localEventId,
+      calendar_id: calendarId,
+      auto_posted: false,
+    });
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    await service.unshareEvent(account, calendar, eventApUrl);
+
+    // SharedEventEntity row should be gone
+    const remainingShares = await SharedEventEntity.findAll({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(remainingShares).toHaveLength(0);
+
+    // RepostDismissalEntity row should exist for (event_id, calendar_id)
+    const dismissals = await RepostDismissalEntity.findAll({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(dismissals).toHaveLength(1);
+    expect(dismissals[0].event_id).toBe(localEventId);
+    expect(dismissals[0].calendar_id).toBe(calendarId);
+  });
+
+  it('is idempotent: calling unshareEvent twice does not create duplicate dismissal rows', async () => {
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    await SharedEventEntity.create({
+      id: 'share-activity-uuid-1',
+      event_id: localEventId,
+      calendar_id: calendarId,
+      auto_posted: false,
+    });
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    // First call destroys the share and writes a dismissal
+    await service.unshareEvent(account, calendar, eventApUrl);
+
+    // Second call should NOT throw or duplicate the dismissal
+    await expect(
+      service.unshareEvent(account, calendar, eventApUrl),
+    ).resolves.not.toThrow();
+
+    const dismissals = await RepostDismissalEntity.findAll({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(dismissals).toHaveLength(1);
+  });
+
+  it('does not touch dismissal rows for other (event_id, calendar_id) combinations', async () => {
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Pre-existing dismissal for a different calendar+event
+    await RepostDismissalEntity.create({
+      event_id: otherEventId,
+      calendar_id: otherCalendarId,
+    });
+    // Pre-existing dismissal for same event but different calendar
+    await RepostDismissalEntity.create({
+      event_id: localEventId,
+      calendar_id: otherCalendarId,
+    });
+
+    await SharedEventEntity.create({
+      id: 'share-activity-uuid-1',
+      event_id: localEventId,
+      calendar_id: calendarId,
+      auto_posted: false,
+    });
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    await service.unshareEvent(account, calendar, eventApUrl);
+
+    // All three dismissal rows should now exist: the two pre-existing + the
+    // new one for (localEventId, calendarId). None should have been clobbered.
+    const all = await RepostDismissalEntity.findAll();
+    expect(all).toHaveLength(3);
+
+    const targetDismissal = await RepostDismissalEntity.findOne({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(targetDismissal).not.toBeNull();
+  });
+});
+
+describe('shareEvent - RepostDismissalEntity deletion', () => {
+  let service: ActivityPubService;
+  let sandbox: sinon.SinonSandbox;
+
+  const calendarId = 'c00b0000-0000-4000-8000-000000000001';
+  const otherCalendarId = 'c00b0000-0000-4000-8000-000000000002';
+  const localEventId = 'e00b0000-0000-4000-8000-000000000001';
+  const otherEventId = 'e00b0000-0000-4000-8000-000000000002';
+  const eventApUrl = 'https://remote.example.com/events/event-share';
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    await setupActivityPubSchema();
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    const eventBus = new EventEmitter();
+    service = new ActivityPubService(eventBus, new CalendarInterface(eventBus));
+
+    sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+    sandbox.stub(service.calendarService, 'getEventById').resolves(null as any);
+    sandbox.stub(service, 'addToOutbox').resolves();
+    sandbox.stub(service, 'actorUrl').resolves('https://local.example.com/calendars/test-calendar');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+  });
+
+  it('deletes any existing dismissal for (event_id, calendar_id) before creating the new share', async () => {
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Pre-existing dismissal — simulates a prior unshareEvent
+    await RepostDismissalEntity.create({
+      event_id: localEventId,
+      calendar_id: calendarId,
+    });
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    await service.shareEvent(account, calendar, eventApUrl);
+
+    // Dismissal should be gone
+    const dismissals = await RepostDismissalEntity.findAll({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(dismissals).toHaveLength(0);
+
+    // SharedEventEntity should have been created
+    const shares = await SharedEventEntity.findAll({
+      where: { event_id: localEventId, calendar_id: calendarId },
+    });
+    expect(shares).toHaveLength(1);
+  });
+
+  it('does not touch dismissals for other calendars or other events', async () => {
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Pre-existing dismissals that should NOT be affected by sharing
+    // localEventId on calendarId:
+    //   - same event, different calendar
+    //   - different event, same calendar
+    //   - different event, different calendar
+    await RepostDismissalEntity.create({ event_id: localEventId, calendar_id: otherCalendarId });
+    await RepostDismissalEntity.create({ event_id: otherEventId, calendar_id: calendarId });
+    await RepostDismissalEntity.create({ event_id: otherEventId, calendar_id: otherCalendarId });
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    await service.shareEvent(account, calendar, eventApUrl);
+
+    // All three pre-existing dismissals should still exist
+    const all = await RepostDismissalEntity.findAll();
+    expect(all).toHaveLength(3);
+
+    const d1 = await RepostDismissalEntity.findOne({
+      where: { event_id: localEventId, calendar_id: otherCalendarId },
+    });
+    const d2 = await RepostDismissalEntity.findOne({
+      where: { event_id: otherEventId, calendar_id: calendarId },
+    });
+    const d3 = await RepostDismissalEntity.findOne({
+      where: { event_id: otherEventId, calendar_id: otherCalendarId },
+    });
+    expect(d1).not.toBeNull();
+    expect(d2).not.toBeNull();
+    expect(d3).not.toBeNull();
+  });
+});

--- a/src/server/activitypub/test/service/members.test.ts
+++ b/src/server/activitypub/test/service/members.test.ts
@@ -15,7 +15,8 @@ import {
 import { InsufficientCalendarPermissionsError } from '@/common/exceptions/calendar';
 import { setupActivityPubSchema, teardownActivityPubSchema } from '@/server/test/helpers/database';
 import CalendarInterface from '@/server/calendar/interface';
-import { SharedEventEntity } from '@/server/activitypub/entity/activitypub';
+import { SharedEventEntity, RepostDismissalEntity } from '@/server/activitypub/entity/activitypub';
+import db from '@/server/common/entity/db';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 
 // Mock CalendarActor model for testing (remote type)
@@ -804,6 +805,11 @@ describe("shareEvent - eventReposted emission", () => {
   beforeEach(() => {
     eventBus = new EventEmitter();
     service = new ActivityPubService(eventBus, new CalendarInterface(eventBus));
+
+    // Fake transaction: execute callback directly with a stub transaction object
+    sandbox.stub(db, 'transaction').callsFake(async (callback: any) => callback({}));
+    // shareEvent deletes any existing dismissal before creating a SharedEventEntity
+    sandbox.stub(RepostDismissalEntity, 'destroy').resolves(0 as any);
   });
 
   afterEach(() => {
@@ -968,6 +974,10 @@ describe("unshareEvent - UUID resolution", () => {
 
     // Allow all permission checks
     sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+    // Fake transaction: execute callback directly with a stub transaction object
+    sandbox.stub(db, 'transaction').callsFake(async (callback: any) => callback({}));
+    // unshareEvent upserts a RepostDismissalEntity after destroying each share
+    sandbox.stub(RepostDismissalEntity, 'findOrCreate').resolves([{} as any, true]);
   });
 
   afterEach(() => {
@@ -1083,6 +1093,10 @@ describe("unshareEvent - eventUnreposted emission", () => {
 
     // Allow all permission checks
     sandbox.stub(service.calendarService, 'userCanModifyCalendar').resolves(true);
+    // Fake transaction: execute callback directly with a stub transaction object
+    sandbox.stub(db, 'transaction').callsFake(async (callback: any) => callback({}));
+    // unshareEvent upserts a RepostDismissalEntity after destroying each share
+    sandbox.stub(RepostDismissalEntity, 'findOrCreate').resolves([{} as any, true]);
   });
 
   afterEach(() => {
@@ -1261,6 +1275,10 @@ describe("ActivityPubService - shareEvent with injected CalendarInterface", () =
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    // Fake transaction: execute callback directly with a stub transaction object
+    sandbox.stub(db, 'transaction').callsFake(async (callback: any) => callback({}));
+    // shareEvent deletes any existing dismissal before creating a SharedEventEntity
+    sandbox.stub(RepostDismissalEntity, 'destroy').resolves(0 as any);
   });
 
   afterEach(() => {

--- a/src/server/calendar/helper/source_calendar.ts
+++ b/src/server/calendar/helper/source_calendar.ts
@@ -37,8 +37,12 @@ export async function resolveSourceCalendars(
 ): Promise<void> {
   for (const ctx of contexts) {
     if (ctx.eventCalendarId === null) {
-      // Remote repost — resolve via pre-resolved actor URI map
-      ctx.event.isRepost = true;
+      // Remote repost — resolve via pre-resolved actor URI map.
+      // Without SharedEventEntity context here we default to 'manual';
+      // callers that know the actual auto/manual distinction should set it.
+      if (ctx.event.repostStatus === 'none') {
+        ctx.event.repostStatus = 'manual';
+      }
       const attributedTo = remoteActorUriMap.get(ctx.event.id);
       if (attributedTo) {
         const parsed = parseAttributedToUri(attributedTo);
@@ -48,8 +52,11 @@ export async function resolveSourceCalendars(
       }
     }
     else if (ctx.eventCalendarId !== ctx.displayCalendarId) {
-      // Local repost — resolve from eager-loaded calendar data
-      ctx.event.isRepost = true;
+      // Local repost — resolve from eager-loaded calendar data.
+      // Default to 'manual' when no more specific status has been set.
+      if (ctx.event.repostStatus === 'none') {
+        ctx.event.repostStatus = 'manual';
+      }
       if (ctx.sourceCalendarUrlName) {
         const domain: string = config.get('domain');
         ctx.event.sourceCalendar = {

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -93,23 +93,39 @@ class EventService {
     categories?: string[];
   }): Promise<CalendarEvent[]> {
 
-    // Get event IDs that are reposted or shared by this calendar
+    // Get event IDs that are reposted or shared by this calendar.
+    //
+    // repostStatus resolution:
+    //   - SharedEventEntity (via AP interface) is the authoritative source and
+    //     carries auto_posted to distinguish 'auto' vs 'manual' shares.
+    //   - EventRepostEntity is a legacy direct-repost link with no auto/manual
+    //     distinction; when an event appears only there it is treated as 'manual'.
+    //   - Events not in either collection (owned by the calendar) report 'none'.
     const reposts = await EventRepostEntity.findAll({
       where: { calendar_id: calendar.id },
       attributes: ['event_id'],
     });
-    // Get shared event IDs via AP interface
-    // Filter to valid UUIDs for safety since old records may have AP URLs
+    // Get shared event id -> status map via AP interface (derived from auto_posted).
+    // Filter to valid UUIDs for safety since old records may have AP URLs.
     const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    const shareEventIds = (await this.activityPubInterface!.getSharedEventIds(calendar.id))
-      .filter(id => UUID_REGEX.test(id));
+    const sharedStatusMap = await this.activityPubInterface!.getSharedEventStatusMap(calendar.id);
 
-    const repostedEventIds = [
-      ...reposts.map(r => r.event_id),
-      ...shareEventIds,
-    ];
+    // Build a unified repostStatus map for O(1) lookup during mapping below.
+    // SharedEventEntity takes precedence (auto|manual); EventRepostEntity-only
+    // entries default to 'manual'.
+    const repostStatusByEventId = new Map<string, 'auto' | 'manual'>();
+    for (const [eventId, status] of sharedStatusMap.entries()) {
+      if (UUID_REGEX.test(eventId)) {
+        repostStatusByEventId.set(eventId, status);
+      }
+    }
+    for (const r of reposts) {
+      if (!repostStatusByEventId.has(r.event_id)) {
+        repostStatusByEventId.set(r.event_id, 'manual');
+      }
+    }
 
-    const repostedIdSet = new Set(repostedEventIds);
+    const repostedEventIds = Array.from(repostStatusByEventId.keys());
 
     // Query events owned by calendar OR reposted by calendar
     const queryOptions: any = {
@@ -204,7 +220,7 @@ class EventService {
         e.categories = categoryAssignments.map(assignment => assignment.category.toModel());
       }
 
-      e.isRepost = repostedIdSet.has(e.id);
+      e.repostStatus = repostStatusByEventId.get(e.id) ?? 'none';
 
       return e;
     });
@@ -1362,7 +1378,9 @@ class EventService {
     const updatedEvents = [];
     for (const eventId of eventIds) {
       const updatedEvent = await this.getEventById(eventId);
-      updatedEvent.isRepost = wasRepost;
+      // wasRepost is derived from resolveEffectiveCalendarId(); preserve the
+      // legacy boolean by mapping true → 'manual' (no auto/manual context here).
+      updatedEvent.repostStatus = wasRepost ? 'manual' : 'none';
       updatedEvents.push(updatedEvent);
     }
 
@@ -1469,7 +1487,9 @@ class EventService {
 
     // Return updated event (after successful commit)
     const updatedEvent = await this.getEventById(eventId);
-    updatedEvent.isRepost = wasRepost;
+    // wasRepost is derived from resolveEffectiveCalendarId(); map true → 'manual'
+    // (no auto/manual context available here).
+    updatedEvent.repostStatus = wasRepost ? 'manual' : 'none';
 
     return updatedEvent;
   }

--- a/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
+++ b/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
@@ -357,7 +357,7 @@ describe('EventService.bulkAssignCategories', () => {
     // getEventById returns an event with isRepost=false (as it always does, since it
     // doesn't know about the repost relationship)
     const returnedEvent = new CalendarEvent(eventId, reposterCalendarId);
-    returnedEvent.isRepost = false;
+    returnedEvent.repostStatus = 'none';
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
     getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
 
@@ -409,7 +409,7 @@ describe('EventService.bulkAssignCategories', () => {
     sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
     const returnedEvent = new CalendarEvent(eventId, calendarId);
-    returnedEvent.isRepost = false;
+    returnedEvent.repostStatus = 'none';
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
     getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
 

--- a/src/server/calendar/test/EventService/event_service.test.ts
+++ b/src/server/calendar/test/EventService/event_service.test.ts
@@ -9,11 +9,25 @@ import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
 import EventService from '@/server/calendar/service/events';
 
 /**
- * Creates a mock ActivityPubInterface with getSharedEventIds stubbed.
+ * Creates a mock ActivityPubInterface with getSharedEventIds and
+ * getSharedEventStatusMap stubbed.
+ *
+ * @param sharedEventIds - Array of event IDs reposted to the calendar.
+ * @param statusOverrides - Optional map of eventId -> 'auto'|'manual' to
+ *   control the repostStatus resolution. Any id in sharedEventIds not in
+ *   statusOverrides defaults to 'manual'.
  */
-function buildMockApInterface(sharedEventIds: string[] = []) {
+function buildMockApInterface(
+  sharedEventIds: string[] = [],
+  statusOverrides: Record<string, 'auto' | 'manual'> = {},
+) {
+  const statusMap = new Map<string, 'auto' | 'manual'>();
+  for (const id of sharedEventIds) {
+    statusMap.set(id, statusOverrides[id] ?? 'manual');
+  }
   return {
     getSharedEventIds: sinon.stub().resolves(sharedEventIds),
+    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
   } as any;
 }
 
@@ -103,6 +117,103 @@ describe('listEvents', () => {
       const reposted = events.find(e => e.id === 'reposted-id');
       expect(owned?.isRepost).toBe(false);
       expect(reposted?.isRepost).toBe(true);
+    });
+  });
+
+  describe('repostStatus field', () => {
+    it('should set repostStatus="none" for events owned by the calendar', async () => {
+      const entity = EventEntity.build({ id: 'owned-event-id', calendar_id: 'cal-id' });
+      sandbox.stub(EventEntity, 'findAll').resolves([entity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+      expect(events[0].repostStatus).toBe('none');
+      expect(events[0].isRepost).toBe(false);
+    });
+
+    it('should set repostStatus="manual" for events shared with auto_posted=false', async () => {
+      const manualRepostId = '550e8400-e29b-41d4-a716-446655440001';
+      service.setActivityPubInterface(
+        buildMockApInterface([manualRepostId], { [manualRepostId]: 'manual' }),
+      );
+
+      const entity = EventEntity.build({ id: manualRepostId });
+      sandbox.stub(EventEntity, 'findAll').resolves([entity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+      expect(events[0].repostStatus).toBe('manual');
+      expect(events[0].isRepost).toBe(true);
+    });
+
+    it('should set repostStatus="auto" for events shared with auto_posted=true', async () => {
+      const autoRepostId = '550e8400-e29b-41d4-a716-446655440002';
+      service.setActivityPubInterface(
+        buildMockApInterface([autoRepostId], { [autoRepostId]: 'auto' }),
+      );
+
+      const entity = EventEntity.build({ id: autoRepostId });
+      sandbox.stub(EventEntity, 'findAll').resolves([entity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+      expect(events[0].repostStatus).toBe('auto');
+      expect(events[0].isRepost).toBe(true);
+    });
+
+    it('should prefer SharedEventEntity status over legacy EventRepostEntity', async () => {
+      // An event present in both EventRepostEntity and SharedEventEntity
+      // should use the SharedEventEntity status (auto in this case).
+      const eventId = '550e8400-e29b-41d4-a716-446655440003';
+      (EventRepostEntity.findAll as sinon.SinonStub).resolves([
+        { event_id: eventId },
+      ]);
+      service.setActivityPubInterface(
+        buildMockApInterface([eventId], { [eventId]: 'auto' }),
+      );
+
+      const entity = EventEntity.build({ id: eventId });
+      sandbox.stub(EventEntity, 'findAll').resolves([entity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+      expect(events[0].repostStatus).toBe('auto');
+    });
+
+    it('should default legacy EventRepostEntity-only events to "manual"', async () => {
+      const legacyId = 'legacy-repost-id';
+      (EventRepostEntity.findAll as sinon.SinonStub).resolves([
+        { event_id: legacyId },
+      ]);
+
+      const entity = EventEntity.build({ id: legacyId });
+      sandbox.stub(EventEntity, 'findAll').resolves([entity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+      expect(events[0].repostStatus).toBe('manual');
+      expect(events[0].isRepost).toBe(true);
+    });
+
+    it('should resolve repost status via a single SharedEventEntity query (no N+1)', async () => {
+      // Verify the map is built once up front, not per-event.
+      const id1 = '550e8400-e29b-41d4-a716-446655440010';
+      const id2 = '550e8400-e29b-41d4-a716-446655440011';
+      const id3 = '550e8400-e29b-41d4-a716-446655440012';
+      const apMock = buildMockApInterface([id1, id2, id3], {
+        [id1]: 'auto',
+        [id2]: 'manual',
+        [id3]: 'auto',
+      });
+      service.setActivityPubInterface(apMock);
+
+      const entities = [
+        EventEntity.build({ id: id1 }),
+        EventEntity.build({ id: id2 }),
+        EventEntity.build({ id: id3 }),
+      ];
+      sandbox.stub(EventEntity, 'findAll').resolves(entities);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+
+      // getSharedEventStatusMap called exactly once regardless of event count
+      expect(apMock.getSharedEventStatusMap.callCount).toBe(1);
+      expect(events.map(e => e.repostStatus).sort()).toEqual(['auto', 'auto', 'manual']);
     });
   });
 

--- a/src/server/calendar/test/EventService/local_event_ap_identifier.test.ts
+++ b/src/server/calendar/test/EventService/local_event_ap_identifier.test.ts
@@ -32,6 +32,7 @@ describe('EventService - Calendar ID Storage', () => {
     // no real ActivityPub domain is wired up in these unit tests.
     (eventService as any).activityPubInterface = {
       getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
     };
 
     // Setup test account

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -237,7 +237,7 @@ describe('EventService.replaceEventCategories', () => {
     sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
     const returnedEvent = new CalendarEvent(validEventId, reposterCalendarId);
-    returnedEvent.isRepost = false;
+    returnedEvent.repostStatus = 'none';
     sandbox.stub(service, 'getEventById').resolves(returnedEvent);
 
     const result = await service.replaceEventCategories(
@@ -285,7 +285,7 @@ describe('EventService.replaceEventCategories', () => {
     sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
 
     const returnedEvent = new CalendarEvent(validEventId, calendarId);
-    returnedEvent.isRepost = false;
+    returnedEvent.repostStatus = 'none';
     sandbox.stub(service, 'getEventById').resolves(returnedEvent);
 
     const result = await service.replaceEventCategories(mockAccount, validEventId, []);

--- a/src/server/calendar/test/integration/event_deletion_authorization.test.ts
+++ b/src/server/calendar/test/integration/event_deletion_authorization.test.ts
@@ -57,6 +57,7 @@ describe('Event Deletion and Update Authorization - IDOR Prevention', () => {
     // environment; returning null/[] keeps local-only code paths correct.
     calendarInterface.setActivityPubInterface({
       getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);
     accountService = new AccountService(eventBus, configurationInterface, setupInterface);

--- a/src/server/calendar/test/integration/event_location_integration.test.ts
+++ b/src/server/calendar/test/integration/event_location_integration.test.ts
@@ -37,6 +37,7 @@ describe('EventService - Location Integration', () => {
     // no real ActivityPub domain is wired up in this test environment.
     calendarInterface.setActivityPubInterface({
       getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
     } as any);
 
     const configurationInterface = new ConfigurationInterface();

--- a/src/server/calendar/test/integration/event_search_sqlite.test.ts
+++ b/src/server/calendar/test/integration/event_search_sqlite.test.ts
@@ -33,6 +33,7 @@ describe('Event Search Integration (SQLite)', () => {
     // no real ActivityPub domain is wired up in this test environment.
     (eventService as any).activityPubInterface = {
       getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
     };
 
     // Create test account and calendar

--- a/src/server/test/helpers/database.ts
+++ b/src/server/test/helpers/database.ts
@@ -27,6 +27,7 @@ import {
   EventActivityEntity,
   ActivityPubInboxMessageEntity,
   ActivityPubOutboxMessageEntity,
+  RepostDismissalEntity,
 } from '@/server/activitypub/entity/activitypub';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
@@ -63,6 +64,9 @@ export async function setupActivityPubSchema(): Promise<void> {
 
   // Sync EventObjectEntity (ap_event_object) — links AP identity to local events
   await EventObjectEntity.sync({ force: true });
+
+  // Sync RepostDismissalEntity (ap_repost_dismissal) — FKs to EventEntity + CalendarEntity
+  await RepostDismissalEntity.sync({ force: true });
 }
 
 /**
@@ -73,6 +77,7 @@ export async function setupActivityPubSchema(): Promise<void> {
  */
 export async function teardownActivityPubSchema(): Promise<void> {
   // Drop tables in reverse order of dependencies
+  await RepostDismissalEntity.drop();
   await EventObjectEntity.drop();
   await EventActivityEntity.drop();
   await SharedEventEntity.drop();

--- a/tests/e2e/federation/unpost-sticky.spec.ts
+++ b/tests/e2e/federation/unpost-sticky.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Sticky Unpost of Auto-Reposted Events
+ *
+ * This test verifies the end-to-end sticky-unpost invariant for events
+ * that were auto-reposted via follow policy:
+ *
+ * 1. Beta follows Alpha with auto-repost originals enabled.
+ * 2. Alpha publishes a new event X. Beta auto-reposts X onto its calendar.
+ * 3. Beta's calendar owner unposts X (DELETE /api/v1/social/shares/:id).
+ *    This is the same endpoint invoked by the Link2Off unpost button in the
+ *    calendar event list, which opens a confirmation modal and then calls
+ *    `calendarService.unshareReposted`. We drive the endpoint directly since
+ *    the rest of the federation harness is API-driven.
+ * 4. Alpha re-broadcasts X by editing the event (which triggers an Update
+ *    activity to followers).
+ * 5. The underlying event on Beta still reflects the Update (the Update
+ *    activity is NOT gated — only re-share creation is), but the event does
+ *    NOT reappear in Beta's calendar event list because the dismissal row
+ *    blocks a new SharedEventEntity from being created.
+ *
+ * Prerequisites:
+ * - Federation environment running: npm run federation:start
+ * - /etc/hosts entries for alpha.federation.local and beta.federation.local
+ *
+ * Related bead: pv-xq9q.7
+ * Design reference: docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
+ */
+
+import { test, expect } from '@playwright/test';
+import https from 'https';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  formatRemoteCalendarId,
+  generateCalendarName,
+} from './helpers/instances';
+import {
+  getToken,
+  createCalendar,
+  createEvent,
+  followCalendar,
+  getFeed,
+  getCalendarEvents,
+  getFollows,
+  updateFollowPolicy,
+} from './helpers/api';
+
+// Accept self-signed certificates for the local federation instances
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+test.describe('Sticky Unpost of Auto-Reposted Events', () => {
+  let aliceToken: string;
+  let bobToken: string;
+
+  test.beforeAll(async () => {
+    aliceToken = await getToken(
+      INSTANCE_ALPHA,
+      INSTANCE_ALPHA.adminEmail,
+      INSTANCE_ALPHA.adminPassword,
+    );
+    bobToken = await getToken(
+      INSTANCE_BETA,
+      INSTANCE_BETA.adminEmail,
+      INSTANCE_BETA.adminPassword,
+    );
+  });
+
+  test('Owner unposts an auto-reposted event and it does not come back after Alpha re-broadcasts', async () => {
+    // --- Setup: create calendars on both instances -------------------------
+    const aliceCalendar = await createCalendar(INSTANCE_ALPHA, aliceToken, {
+      urlName: generateCalendarName('aus'),
+      content: {
+        en: { name: 'Alice Sticky Unpost Test' },
+      },
+    });
+
+    const bobCalendar = await createCalendar(INSTANCE_BETA, bobToken, {
+      urlName: generateCalendarName('bus'),
+      content: {
+        en: { name: 'Bob Sticky Unpost Test' },
+      },
+    });
+
+    // --- Beta follows Alpha and enables auto-repost originals --------------
+    const aliceCalendarId = formatRemoteCalendarId(aliceCalendar.urlName, INSTANCE_ALPHA);
+    await followCalendar(INSTANCE_BETA, bobToken, bobCalendar.id, aliceCalendarId);
+
+    // Wait for follow to establish
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    const follows = await getFollows(INSTANCE_BETA, bobToken, bobCalendar.id);
+    const aliceFollow = follows.find(
+      f => f.calendarActorId === aliceCalendarId ||
+           f.calendarActorId?.includes(aliceCalendar.urlName),
+    );
+    expect(aliceFollow).toBeDefined();
+
+    await updateFollowPolicy(
+      INSTANCE_BETA,
+      bobToken,
+      aliceFollow!.id,
+      bobCalendar.id,
+      true,  // auto-repost originals
+      false, // don't auto-repost reposts
+    );
+
+    // Wait for policy update to take effect
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // --- Alpha publishes event X ------------------------------------------
+    const originalTitle = `Sticky Unpost Event ${Date.now()}`;
+    await createEvent(INSTANCE_ALPHA, aliceToken, {
+      calendarId: aliceCalendar.id,
+      content: {
+        en: {
+          title: originalTitle,
+          description: 'This event should auto-repost to Bob, then be unposted.',
+        },
+      },
+      startTime: '2026-05-01T18:00:00Z',
+      endTime: '2026-05-01T20:00:00Z',
+    });
+
+    // Wait for federation propagation
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    // --- Verify X was auto-reposted into Beta's calendar list -------------
+    let bobCalendarEventsResponse = await getCalendarEvents(
+      INSTANCE_BETA,
+      bobToken,
+      bobCalendar.urlName,
+    );
+    let bobCalendarEvents = await bobCalendarEventsResponse.json();
+    const autoRepostedEvent = bobCalendarEvents.find(
+      (e: any) => e.content?.en?.title === originalTitle,
+    );
+    expect(autoRepostedEvent).toBeDefined();
+
+    // Where the API already computes it, assert the auto-repost status so we
+    // know we're unposting an auto-reposted row rather than an owned event.
+    // (The field may be omitted on older clients; fall back to isRepost.)
+    if (autoRepostedEvent.repostStatus !== undefined) {
+      expect(autoRepostedEvent.repostStatus).toBe('auto');
+    }
+    else {
+      expect(autoRepostedEvent.isRepost).toBe(true);
+    }
+
+    // Confirm the event is also visible in Beta's feed
+    const feedBefore = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
+    const feedEntryBefore = feedBefore.events.find(
+      e => e.content?.en?.title === originalTitle,
+    );
+    expect(feedEntryBefore).toBeDefined();
+
+    // --- Unpost X via the API the calendar event-list button invokes ------
+    // The new Link2Off button in events-tab.vue calls
+    // calendarService.unshareReposted(calendarId, eventId), which hits:
+    //   DELETE /api/v1/social/shares/:eventId?calendarId=...
+    const unpostResponse = await fetch(
+      `${INSTANCE_BETA.baseUrl}/api/v1/social/shares/${encodeURIComponent(autoRepostedEvent.id)}?calendarId=${encodeURIComponent(bobCalendar.id)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${bobToken}`,
+        },
+        // @ts-ignore - agent is not in the TypeScript types but works at runtime
+        agent: httpsAgent,
+      },
+    );
+    expect(unpostResponse.ok).toBe(true);
+
+    // Give the Undo(Announce) + dismissal write time to settle
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // --- Verify X disappeared from Beta's calendar list -------------------
+    bobCalendarEventsResponse = await getCalendarEvents(
+      INSTANCE_BETA,
+      bobToken,
+      bobCalendar.urlName,
+    );
+    bobCalendarEvents = await bobCalendarEventsResponse.json();
+    const afterUnpost = bobCalendarEvents.find(
+      (e: any) => e.content?.en?.title === originalTitle,
+    );
+    expect(afterUnpost).toBeUndefined();
+
+    // --- Alpha re-broadcasts X by editing it -----------------------------
+    // Fetch Alice's current copy of the event so we can grab its ID
+    const aliceCalendarEventsResponse = await getCalendarEvents(
+      INSTANCE_ALPHA,
+      aliceToken,
+      aliceCalendar.urlName,
+    );
+    const aliceCalendarEvents = await aliceCalendarEventsResponse.json();
+    const aliceOriginalEvent = aliceCalendarEvents.find(
+      (e: any) => e.content?.en?.title === originalTitle,
+    );
+    expect(aliceOriginalEvent).toBeDefined();
+
+    const updatedTitle = `${originalTitle} - UPDATED`;
+    const updateResponse = await fetch(
+      `${INSTANCE_ALPHA.baseUrl}/api/v1/events/${encodeURIComponent(aliceOriginalEvent.id)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${aliceToken}`,
+        },
+        body: JSON.stringify({
+          calendarId: aliceCalendar.id,
+          content: {
+            en: {
+              title: updatedTitle,
+              description: 'Re-broadcast after unpost',
+            },
+          },
+          startTime: '2026-05-01T18:00:00Z',
+          endTime: '2026-05-01T20:00:00Z',
+        }),
+        // @ts-ignore - agent is not in the TypeScript types but works at runtime
+        agent: httpsAgent,
+      },
+    );
+    expect(updateResponse.ok).toBe(true);
+
+    // Wait for Update(Event) to federate to Beta
+    await new Promise(resolve => setTimeout(resolve, 10000));
+
+    // --- Assert X is still NOT on Beta's calendar list (sticky) ----------
+    bobCalendarEventsResponse = await getCalendarEvents(
+      INSTANCE_BETA,
+      bobToken,
+      bobCalendar.urlName,
+    );
+    bobCalendarEvents = await bobCalendarEventsResponse.json();
+
+    // Neither the original nor the updated title should appear — dismissal
+    // gates re-creation of the SharedEventEntity for this calendar.
+    const stillUnpostedOriginal = bobCalendarEvents.find(
+      (e: any) => e.content?.en?.title === originalTitle,
+    );
+    expect(stillUnpostedOriginal).toBeUndefined();
+
+    const stillUnpostedUpdated = bobCalendarEvents.find(
+      (e: any) => e.content?.en?.title === updatedTitle,
+    );
+    expect(stillUnpostedUpdated).toBeUndefined();
+
+    // --- But the underlying event on Beta's feed DID sync the Update -----
+    // The Update activity is not gated by dismissal, so the federated event
+    // row still reflects the edit when consumed through the feed (which
+    // reads from EventEntity, not SharedEventEntity).
+    const feedAfter = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
+    const feedEntryAfter = feedAfter.events.find(
+      e => e.content?.en?.title === updatedTitle,
+    );
+    expect(feedEntryAfter).toBeDefined();
+
+    // And the stale-titled version should no longer be present in the feed
+    // (since it's the same underlying EventEntity that just got renamed).
+    const feedEntryStale = feedAfter.events.find(
+      e => e.content?.en?.title === originalTitle,
+    );
+    expect(feedEntryStale).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Sticky per-calendar unpost for reposted events. Owners can now remove an auto-reposted event from their calendar, and the system remembers the intent so the source calendar's next re-broadcast or `Update` doesn't silently re-share it — while still letting `Update` activities flow through so other calendars still sharing the event stay in sync.

**Spec:** `docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md`
**Epic:** `pv-xq9q` (all 7 beads closed)
**Decision:** `DEC-008` added to `agent-os/product/decisions.md`

## Changes by layer

### Backend
- New `RepostDismissalEntity` in activitypub domain + migration 0018 (`ap_repost_dismissal`) with unique `(event_id, calendar_id)` index and `ON DELETE CASCADE` on `event_id`
- `memberService.shareEvent` / `unshareEvent` wrap their mutations in `db.transaction` and write/delete dismissal rows atomically with the `SharedEventEntity` changes
- `inbox.checkAndPerformAutoRepost` adds a dismissal gate **immediately before** the existing duplicate-share check — the `Update(Event)` handler is explicitly untouched so underlying event sync is preserved for other reposters
- New `ActivityPubInterface.getSharedEventStatusMap(calendarId)` lets calendar's `EventService.listEvents` derive tri-state repost status without crossing domain boundaries (N+1-safe — map is built once before the `.map()`)

### Data model
- `CalendarEvent.repostStatus: 'none' | 'manual' | 'auto'` replaces the old `isRepost` boolean
- `isRepost` is kept as a derived getter (`repostStatus !== 'none'`) for back-compat — no existing call site needed to change
- `fromObject` / `toObject` handle both the new and legacy payload shapes

### Frontend
- New Link2Off unpost icon button + `ModalLayout` confirmation in `events-tab.vue` (calendar management surface)
- Feed view's auto-posted label converted from `<span>` to `<button>` with `:focus-visible` states (calls existing `handleUnrepost`)
- New `EventService.unshareReposted(calendarId, event)` wrapper keeps the calendar-management component free of `FeedService` imports (architectural cleanup caught by the end-of-epic audit)
- A11y fix: added `:focus-visible` to the shared `.icon-btn` class in `events-tab.vue`, benefiting all four icon buttons (edit/duplicate/report/unpost)

### Tests
- Unit: entity tests (unique constraint + cascade), listEvents repostStatus coverage with N+1 assertion, CalendarEvent model round-trips with legacy fallback
- Service: `members-dismissal.test.ts` covers write-side scoping **and** transaction rollback atomicity for both `shareEvent` and `unshareEvent`
- Inbox: dismissal gating skip path + baseline path + **per-calendar isolation** (calendar A dismissal must not suppress calendar B)
- Regression fixes: stubs added to `auto-repost-category-assignment.test.ts` and `feed.test.ts` that were exercising the new transactional code paths
- Federation E2E: new `tests/e2e/federation/unpost-sticky.spec.ts` proves the full chain — auto-repost → unpost → re-broadcast → event does NOT reappear but Update still syncs

## Verification

- ✅ `npm run lint` — 0 errors (267 pre-existing warnings unchanged)
- ✅ `npm test` (unit) — 5958 passing; 2 pre-existing AP service failures unchanged
- ✅ `npm run test:integration` — 377 passing; 8 pre-existing failures unchanged
- ✅ `npm run build` — frontend + widget SDK compile clean
- ✅ `npm run test:e2e` — 98 passing; 5 pre-existing email-timeout failures unchanged
- ✅ Federation spec compiles (`npx playwright test --list --config=playwright.federation.config.ts tests/e2e/federation/unpost-sticky.spec.ts`)
- ✅ **Zero new failures** attributable to any commit in this PR

## Audit trail

Every wave passed the full verification gauntlet: consistency, complexity, testing, stylesheet, accessibility, i18n, cross-bead integration, architecture, and build-guardian auditors. Two 🔴 findings were caught and fixed mid-epic (Wave 2 test gaps for per-calendar isolation and transaction rollback; Wave 3 accessibility `:focus-visible` gap). Non-blocking 🟡 findings are recorded in the epic notes for follow-up cleanup — none block this PR.

## Test plan

- [ ] Run `npm run lint && npm test && npm run test:integration && npm run build && npm run test:e2e` locally to confirm baseline
- [ ] Start federation environment: `npm run federation:start` (requires Docker + `/etc/hosts` entries for `alpha.federation.local` and `beta.federation.local`)
- [ ] Run the new federation spec: `npm run test:federation -- unpost-sticky` — verifies the full sticky-dismissal chain end-to-end (this is the one test that wasn't run in the implementation session because Docker wasn't available)
- [ ] Manual smoke: in dev environment, auto-repost an event from a followed calendar, click the new Link2Off button, confirm the modal, verify the row disappears. Then have the source calendar re-broadcast the event and confirm it does NOT reappear.