### PR TITLE
feat(activitypub): signed outbox delivery + notification UUID fix

### DIFF
--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -142,8 +142,9 @@ services:
       - DB_PASSWORD=devpassword
       # Reset database on each start for clean testing
       - DB_RESET=true
-      # Enforce HTTP signature verification on beta instance
-      - SKIP_SIGNATURES=false
+      # Disable HTTP signature verification for local testing.
+      # Re-enable once ALL federation code paths sign requests (not just outbox).
+      - SKIP_SIGNATURES=true
       # Allow federation between Docker containers that resolve to private IPs
       # WARNING: Never use in production — Docker bridge IPs are private RFC-1918 addresses
       - ALLOW_PRIVATE_FEDERATION=true

--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -142,8 +142,8 @@ services:
       - DB_PASSWORD=devpassword
       # Reset database on each start for clean testing
       - DB_RESET=true
-      # Disable HTTP signature verification for local testing
-      - SKIP_SIGNATURES=true
+      # Enforce HTTP signature verification on beta instance
+      - SKIP_SIGNATURES=false
       # Allow federation between Docker containers that resolve to private IPs
       # WARNING: Never use in production — Docker bridge IPs are private RFC-1918 addresses
       - ALLOW_PRIVATE_FEDERATION=true

--- a/src/server/activitypub/service/calendar_actor.ts
+++ b/src/server/activitypub/service/calendar_actor.ts
@@ -4,17 +4,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { Calendar } from '@/common/model/calendar';
 import { CalendarActorEntity, CalendarActor } from '@/server/activitypub/entity/calendar_actor';
 import CalendarInterface from '@/server/calendar/interface';
+import { HttpSignature } from '@/server/activitypub/types';
 
-/**
- * HTTP Signature object for ActivityPub requests
- */
-export interface HttpSignature {
-  keyId: string;
-  signature: string;
-  algorithm: string;
-  headers: string;
-  date: string;
-}
+export type { HttpSignature };
 
 /**
  * Service for managing Calendar ActivityPub Group actors with keypairs
@@ -151,13 +143,18 @@ export default class CalendarActorService {
    * @param actorUri - The actor URI performing the activity
    * @param activity - The ActivityPub activity object
    * @param targetUrl - The target URL (inbox) the activity is being sent to
+   * @param digest - Optional Digest header value to include in the signature
    * @returns Promise resolving to HttpSignature object
    */
-  async signActivity(actorUri: string, activity: any, targetUrl: string): Promise<HttpSignature> {
+  async signActivity(actorUri: string, activity: any, targetUrl: string, digest?: string): Promise<HttpSignature> {
     // Retrieve actor with private key
     const actor = await this.getActorByUri(actorUri);
     if (!actor) {
       throw new Error(`Calendar actor not found: ${actorUri}`);
+    }
+
+    if (!actor.privateKey) {
+      throw new Error(`Calendar actor ${actorUri} does not have a private key`);
     }
 
     // Parse target URL for host
@@ -170,11 +167,15 @@ export default class CalendarActorService {
 
     // Create signing string
     const requestTarget = `post ${path}`;
-    const signingString = [
+    const signingStringParts = [
       `(request-target): ${requestTarget}`,
       `host: ${host}`,
       `date: ${date}`,
-    ].join('\n');
+    ];
+    if (digest) {
+      signingStringParts.push(`digest: ${digest}`);
+    }
+    const signingString = signingStringParts.join('\n');
 
     // Sign the string with private key
     const signer = createSign('RSA-SHA256');
@@ -188,7 +189,7 @@ export default class CalendarActorService {
       keyId: `${actorUri}#main-key`,
       signature: signatureBase64,
       algorithm: 'rsa-sha256',
-      headers: '(request-target) host date',
+      headers: digest ? '(request-target) host date digest' : '(request-target) host date',
       date: date,
     };
   }

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import { DateTime } from "luxon";
 import { EventEmitter } from "events";
 import axios from "axios";
@@ -20,9 +21,22 @@ import FlagActivity from "@/server/activitypub/model/action/flag";
 import { ActivityPubActivity, ActivityPubObject } from "@/server/activitypub/model/base";
 import CalendarInterface from "@/server/calendar/interface";
 import CalendarActorService from "@/server/activitypub/service/calendar_actor";
+import UserActorService from "@/server/activitypub/service/user_actor";
 import ProcessInboxService from "@/server/activitypub/service/inbox";
 import { FEDERATION_HTTP_TIMEOUT_MS } from "@/server/common/constants";
 import { validateUrlNotPrivate } from "@/server/common/helper/ip-validation";
+import { HttpSignature } from "@/server/activitypub/types";
+
+/**
+ * Signed headers returned by buildSignedHeaders, ready to merge into an
+ * axios request. When signing fails the method returns null and the caller
+ * records a partial delivery error.
+ */
+interface SignedHeaders {
+  Signature: string;
+  Date: string;
+  Digest: string;
+}
 
 /**
  * Service responsible for processing and distributing outgoing ActivityPub messages.
@@ -31,6 +45,7 @@ import { validateUrlNotPrivate } from "@/server/common/helper/ip-validation";
 class ProcessOutboxService {
   calendarService: CalendarInterface;
   calendarActorService: CalendarActorService;
+  private userActorService: UserActorService;
   private inboxService: ProcessInboxService | null;
 
   /**
@@ -44,6 +59,7 @@ class ProcessOutboxService {
   constructor(eventBus: EventEmitter, inboxService?: ProcessInboxService) {
     this.calendarService = new CalendarInterface(eventBus);
     this.calendarActorService = new CalendarActorService(this.calendarService);
+    this.userActorService = new UserActorService(this.calendarService);
     this.inboxService = inboxService ?? null;
     if (!this.inboxService) {
       logger.warn('[OUTBOX] constructed without ProcessInboxService — local recipients will degrade to HTTP delivery (test-only path)');
@@ -238,11 +254,58 @@ class ProcessOutboxService {
   }
 
   /**
+   * Builds HTTP Signature headers for an outbound ActivityPub delivery.
+   * Auto-detects actor type by trying CalendarActorService first, then
+   * falling back to UserActorService.
+   *
+   * @param actorUri - The actor URI that will sign the request
+   * @param body - The JSON-stringified request body (used for Digest)
+   * @param targetUrl - The inbox URL the request will be POSTed to
+   * @param digest - Pre-computed SHA-256 Digest header value
+   * @returns Signed headers object, or null if signing fails for both actor types
+   * @private
+   */
+  private async buildSignedHeaders(
+    actorUri: string,
+    body: string,
+    targetUrl: string,
+    digest: string,
+  ): Promise<SignedHeaders | null> {
+    let sig: HttpSignature | null = null;
+
+    // Try calendar actor first (most common case for outbox deliveries)
+    try {
+      sig = await this.calendarActorService.signActivity(actorUri, JSON.parse(body), targetUrl, digest);
+    }
+    catch {
+      // Calendar actor signing failed, try user actor
+      try {
+        sig = await this.userActorService.signActivity(actorUri, JSON.parse(body), targetUrl, digest);
+      }
+      catch {
+        // Both actor types failed to sign
+        return null;
+      }
+    }
+
+    if (!sig) {
+      return null;
+    }
+
+    return {
+      Signature: `keyId="${sig.keyId}",algorithm="${sig.algorithm}",headers="${sig.headers}",signature="${sig.signature}"`,
+      Date: sig.date,
+      Digest: digest,
+    };
+  }
+
+  /**
    * Delivers an activity to a recipient via HTTP POST to their inbox.
    * Resolves the recipient's inbox URL, validates it against SSRF protection,
-   * and posts the activity payload. Errors are accumulated into the supplied
-   * deliveryErrors array rather than thrown, preserving the per-recipient
-   * partial-failure semantics of the parent loop.
+   * signs the request with HTTP Signatures, and posts the activity payload.
+   * Errors are accumulated into the supplied deliveryErrors array rather than
+   * thrown, preserving the per-recipient partial-failure semantics of the
+   * parent loop.
    *
    * SECURITY: validateUrlNotPrivate is called before every HTTP POST to
    * block delivery to private/internal IPs that a malicious actor profile
@@ -277,11 +340,23 @@ class ProcessOutboxService {
     try {
       logger.info({ activityType: message.type, inboxUrl }, 'Delivering activity');
       const activityData = activity.toObject();
-      await axios.post(inboxUrl, activityData, {
+      const bodyString = JSON.stringify(activityData);
+      const digest = 'SHA-256=' + createHash('sha256').update(bodyString).digest('base64');
+
+      const signedHeaders = await this.buildSignedHeaders(activity.actor, bodyString, inboxUrl, digest);
+      if (!signedHeaders) {
+        const errorMsg = `Signing failed for actor ${activity.actor} delivering to ${recipient}`;
+        logger.error({ actorUri: activity.actor, recipient }, 'Failed to sign outbound delivery');
+        deliveryErrors.push(errorMsg);
+        return;
+      }
+
+      await axios.post(inboxUrl, bodyString, {
         timeout: FEDERATION_HTTP_TIMEOUT_MS,
         maxRedirects: 0,
         headers: {
           'Content-Type': 'application/activity+json',
+          ...signedHeaders,
         },
       });
       logger.info({ activityType: message.type, recipient }, 'Successfully delivered activity');

--- a/src/server/activitypub/service/user_actor.ts
+++ b/src/server/activitypub/service/user_actor.ts
@@ -11,17 +11,9 @@ import { AccountEntity } from '@/server/common/entity/account';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import RemoteCalendarService from '@/server/activitypub/service/remote_calendar';
 import CalendarInterface from '@/server/calendar/interface';
+import { HttpSignature } from '@/server/activitypub/types';
 
-/**
- * HTTP Signature object for ActivityPub requests
- */
-export interface HttpSignature {
-  keyId: string;
-  signature: string;
-  algorithm: string;
-  headers: string;
-  date: string;
-}
+export type { HttpSignature };
 
 /**
  * Service for managing User ActivityPub Person actors with keypairs
@@ -166,9 +158,10 @@ export default class UserActorService {
    * @param actorUri - The actor URI performing the activity
    * @param activity - The ActivityPub activity object
    * @param targetUrl - The target URL (inbox) the activity is being sent to
+   * @param digest - Optional digest header value to include in the signature
    * @returns Promise resolving to HttpSignature object
    */
-  async signActivity(actorUri: string, activity: any, targetUrl: string): Promise<HttpSignature> {
+  async signActivity(actorUri: string, activity: any, targetUrl: string, digest?: string): Promise<HttpSignature> {
     // Retrieve actor with private key
     const actor = await this.getActorByUri(actorUri);
     if (!actor) {
@@ -189,11 +182,18 @@ export default class UserActorService {
 
     // Create signing string
     const requestTarget = `post ${path}`;
-    const signingString = [
+    const signingParts = [
       `(request-target): ${requestTarget}`,
       `host: ${host}`,
       `date: ${date}`,
-    ].join('\n');
+    ];
+
+    // Conditionally include digest in signing string
+    if (digest) {
+      signingParts.push(`digest: ${digest}`);
+    }
+
+    const signingString = signingParts.join('\n');
 
     // Sign the string with private key
     const signer = createSign('RSA-SHA256');
@@ -203,11 +203,16 @@ export default class UserActorService {
     const signatureBytes = signer.sign(actor.privateKey);
     const signatureBase64 = signatureBytes.toString('base64');
 
+    // Build headers list, conditionally including digest
+    const headersList = digest
+      ? '(request-target) host date digest'
+      : '(request-target) host date';
+
     return {
       keyId: `${actorUri}#main-key`,
       signature: signatureBase64,
       algorithm: 'rsa-sha256',
-      headers: '(request-target) host date',
+      headers: headersList,
       date: date,
     };
   }

--- a/src/server/activitypub/test/integration/flag-outbox.test.ts
+++ b/src/server/activitypub/test/integration/flag-outbox.test.ts
@@ -21,6 +21,17 @@ const LOCAL_ACTOR_URL = 'https://local.instance/calendars/test-calendar';
 const REMOTE_ACTOR_URI = 'https://remote.instance/calendars/remote-calendar';
 const REMOTE_INBOX_URL = 'https://remote.instance/calendars/remote-calendar/inbox';
 
+/** Stub signing so deliverViaHttp proceeds without real keypairs. */
+function stubSigning(service: ProcessOutboxService, sandbox: sinon.SinonSandbox) {
+  sandbox.stub(service.calendarActorService, 'signActivity').resolves({
+    keyId: `${LOCAL_ACTOR_URL}#main-key`,
+    signature: 'mock-signature-base64',
+    algorithm: 'rsa-sha256',
+    headers: '(request-target) host date digest',
+    date: new Date().toUTCString(),
+  });
+}
+
 describe('Flag activity outbox processing', () => {
   let service: ProcessOutboxService;
   let sandbox: sinon.SinonSandbox = sinon.createSandbox();
@@ -29,6 +40,7 @@ describe('Flag activity outbox processing', () => {
   beforeEach(() => {
     eventBus = new EventEmitter();
     service = new ProcessOutboxService(eventBus);
+    stubSigning(service, sandbox);
   });
 
   afterEach(() => {
@@ -73,13 +85,14 @@ describe('Flag activity outbox processing', () => {
     // Process the outbox message
     await service.processOutboxMessage(message);
 
-    // Verify HTTP POST was called with correct payload
+    // Verify HTTP POST was called with correct payload (body is JSON string after signing)
     expect(postStub.calledOnce).toBe(true);
     const postCall = postStub.getCall(0);
     expect(postCall.args[0]).toBe(REMOTE_INBOX_URL);
-    expect(postCall.args[1].type).toBe('Flag');
-    expect(postCall.args[1].actor).toBe(LOCAL_ACTOR_URL);
-    expect(postCall.args[1].content).toBe('Report description text');
+    const body = JSON.parse(postCall.args[1]);
+    expect(body.type).toBe('Flag');
+    expect(body.actor).toBe(LOCAL_ACTOR_URL);
+    expect(body.content).toBe('Report description text');
 
     // Verify outbox record was marked as processed
     expect(updateStub.calledOnce).toBe(true);
@@ -127,12 +140,13 @@ describe('Flag activity outbox processing', () => {
     // Process the outbox message
     await service.processOutboxMessage(message);
 
-    // Verify admin tags are preserved
+    // Verify admin tags are preserved (body is JSON string after signing)
     expect(postStub.calledOnce).toBe(true);
     const postCall = postStub.getCall(0);
-    expect(postCall.args[1].tag).toHaveLength(2);
-    expect(postCall.args[1].tag[0].name).toBe('#admin-flag');
-    expect(postCall.args[1].tag[1].name).toBe('#priority-high');
+    const body = JSON.parse(postCall.args[1]);
+    expect(body.tag).toHaveLength(2);
+    expect(body.tag[0].name).toBe('#admin-flag');
+    expect(body.tag[1].name).toBe('#priority-high');
   });
 
   it('should record delivery errors for failed Flag activities', async () => {

--- a/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
+++ b/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
@@ -51,6 +51,7 @@ import ActivityPubInterface from '@/server/activitypub/interface';
 import ActivityPubEventHandlers from '@/server/activitypub/events';
 import { TestEnvironment } from '@/server/test/lib/test_environment';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
+import CalendarActorService from '@/server/activitypub/service/calendar_actor';
 import { ActivityPubActor } from '@/server/activitypub/model/base';
 import {
   FollowingCalendarEntity,
@@ -220,6 +221,17 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
+    // Stub signing so deliverViaHttp proceeds without real keypairs.
+    // The manually-created CalendarActorEntity rows (A, B, C) lack private
+    // keys, so signing would fail and HTTP delivery would be skipped.
+    sandbox.stub(CalendarActorService.prototype, 'signActivity').callsFake(async (actorUri: string) => ({
+      keyId: `${actorUri}#main-key`,
+      signature: 'mock-signature-base64',
+      algorithm: 'rsa-sha256',
+      headers: '(request-target) host date digest',
+      date: new Date().toUTCString(),
+    }));
 
     // Prevent real HTTP delivery to remote.example. Both axios.post (inbox
     // delivery) and axios.get (actor profile fetch inside resolveInboxUrl)

--- a/src/server/activitypub/test/service/calendar_actor.test.ts
+++ b/src/server/activitypub/test/service/calendar_actor.test.ts
@@ -7,6 +7,36 @@ import CalendarActorService from '@/server/activitypub/service/calendar_actor';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import CalendarInterface from '@/server/calendar/interface';
 
+/**
+ * Helper to create a mock actor entity with a real RSA keypair
+ */
+function createMockActorWithKeypair(actorUri: string) {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  return {
+    id: 'actor-id-123',
+    calendar_id: 'calendar-id-123',
+    actor_uri: actorUri,
+    public_key: publicKey,
+    private_key: privateKey,
+    toModel: function() {
+      return {
+        id: this.id,
+        calendarId: this.calendar_id,
+        actorUri: this.actor_uri,
+        publicKey: this.public_key,
+        privateKey: this.private_key,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    },
+  };
+}
+
 describe('CalendarActorService', () => {
   let service: CalendarActorService;
   let sandbox: sinon.SinonSandbox;
@@ -182,36 +212,7 @@ describe('CalendarActorService', () => {
   describe('signActivity', () => {
     it('should produce valid HTTP signature format', async () => {
       const actorUri = 'https://events.example/calendars/community-events';
-      const mockData = {
-        id: 'actor-id-123',
-        calendar_id: 'calendar-id-123',
-        actor_uri: actorUri,
-        public_key: '-----BEGIN PUBLIC KEY-----\nKEY_DATA\n-----END PUBLIC KEY-----',
-        private_key: '-----BEGIN PRIVATE KEY-----\nKEY_DATA\n-----END PRIVATE KEY-----',
-      };
-
-      // Generate a real keypair for this test to make signing work
-      const { publicKey, privateKey } = generateKeyPairSync('rsa', {
-        modulusLength: 2048,
-        publicKeyEncoding: { type: 'spki', format: 'pem' },
-        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-      });
-
-      const mockEntity = {
-        ...mockData,
-        private_key: privateKey,
-        toModel: function() {
-          return {
-            id: this.id,
-            calendarId: this.calendar_id,
-            actorUri: this.actor_uri,
-            publicKey: this.public_key,
-            privateKey: this.private_key,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          };
-        },
-      };
+      const mockEntity = createMockActorWithKeypair(actorUri);
 
       sandbox.stub(CalendarActorEntity, 'findOne').resolves(mockEntity as any);
 
@@ -233,6 +234,70 @@ describe('CalendarActorService', () => {
       expect(signature.headers).toContain('(request-target)');
       expect(signature.headers).toContain('host');
       expect(signature.headers).toContain('date');
+      expect(signature.headers).not.toContain('digest');
+    });
+
+    it('should include digest in signed headers when provided', async () => {
+      const actorUri = 'https://events.example/calendars/community-events';
+      const mockEntity = createMockActorWithKeypair(actorUri);
+
+      sandbox.stub(CalendarActorEntity, 'findOne').resolves(mockEntity as any);
+
+      const activity = { type: 'Announce' };
+      const targetUrl = 'https://remote.example/inbox';
+      const digest = 'SHA-256=abc123def456';
+
+      const signature = await service.signActivity(actorUri, activity, targetUrl, digest);
+
+      expect(signature.headers).toBe('(request-target) host date digest');
+      expect(signature.signature).toBeDefined();
+    });
+
+    it('should not include digest in signed headers when omitted', async () => {
+      const actorUri = 'https://events.example/calendars/community-events';
+      const mockEntity = createMockActorWithKeypair(actorUri);
+
+      sandbox.stub(CalendarActorEntity, 'findOne').resolves(mockEntity as any);
+
+      const activity = { type: 'Announce' };
+      const targetUrl = 'https://remote.example/inbox';
+
+      const signature = await service.signActivity(actorUri, activity, targetUrl);
+
+      expect(signature.headers).toBe('(request-target) host date');
+      expect(signature.signature).toBeDefined();
+    });
+
+    it('should throw when actor has no private key', async () => {
+      const actorUri = 'https://events.example/calendars/community-events';
+
+      // Mock actor without a private key (remote actor)
+      const mockEntity = {
+        id: 'actor-id-123',
+        calendar_id: 'calendar-id-123',
+        actor_uri: actorUri,
+        public_key: '-----BEGIN PUBLIC KEY-----\nKEY_DATA\n-----END PUBLIC KEY-----',
+        private_key: null,
+        toModel: function() {
+          return {
+            id: this.id,
+            calendarId: this.calendar_id,
+            actorUri: this.actor_uri,
+            publicKey: this.public_key,
+            privateKey: this.private_key,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+        },
+      };
+
+      sandbox.stub(CalendarActorEntity, 'findOne').resolves(mockEntity as any);
+
+      const activity = { type: 'Announce' };
+      const targetUrl = 'https://remote.example/inbox';
+
+      await expect(service.signActivity(actorUri, activity, targetUrl))
+        .rejects.toThrow(`Calendar actor ${actorUri} does not have a private key`);
     });
   });
 

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -61,6 +61,17 @@ const REMOTE_PROFILE_URL = 'https://remotedomain.test/calendars/testcalendar';
 const REMOTE_INBOX_URL = 'https://remotedomain.test/calendars/testcalendar/inbox';
 const OBSERVER_CALENDAR_HANDLE = 'observercalendar@observerdomain.test';
 
+/** Stub signing on a service so deliverViaHttp can proceed without real keypairs. */
+function stubSigning(service: ProcessOutboxService, sandbox: sinon.SinonSandbox) {
+  sandbox.stub(service.calendarActorService, 'signActivity').resolves({
+    keyId: `${LOCAL_ACTOR_URL}#main-key`,
+    signature: 'mock-signature-base64',
+    algorithm: 'rsa-sha256',
+    headers: '(request-target) host date digest',
+    date: new Date().toUTCString(),
+  });
+}
+
 
 describe('resolveInbox', () => {
   let service: ProcessOutboxService;
@@ -370,7 +381,7 @@ describe('processOutboxMessage', () => {
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 
-  it('should send message to each recipient', async () => {
+  it('should send message to each recipient with signed headers', async () => {
     // Use Fedify helper to create a proper Create activity
     const activityMessage = createMockCreateActivity(LOCAL_ACTOR_URL, {
       type: 'Event',
@@ -389,6 +400,7 @@ describe('processOutboxMessage', () => {
     const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
     const getRecipientsStub = sandbox.stub(service, 'getRecipients');
     const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
 
     getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
     getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE, OBSERVER_CALENDAR_HANDLE]);
@@ -397,8 +409,133 @@ describe('processOutboxMessage', () => {
     await service.processOutboxMessage(message);
 
     expect(postStub.calledTwice).toBe(true);
+
+    // Verify signed headers are present on the POST request
+    const firstCallHeaders = postStub.getCalls()[0].args[2]?.headers;
+    expect(firstCallHeaders).toBeDefined();
+    expect(firstCallHeaders['Signature']).toMatch(/keyId=.*algorithm=.*headers=.*signature=/);
+    expect(firstCallHeaders['Date']).toBeDefined();
+    expect(firstCallHeaders['Digest']).toMatch(/^SHA-256=/);
+
     expect(updateStub.calledOnce).toBe(true);
     expect(updateStub.getCalls()[0].args[0]['processed_time']).toBeDefined();
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('should send JSON string body matching the Digest', async () => {
+    const activityMessage = createMockCreateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/456`,
+      name: 'Digest Test Event',
+    });
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Create',
+      message: activityMessage,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post');
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(postStub.calledOnce).toBe(true);
+
+    // Body should be a string (JSON.stringify'd), not an object
+    const bodyArg = postStub.getCalls()[0].args[1];
+    expect(typeof bodyArg).toBe('string');
+
+    // Verify the Digest matches the body bytes
+    const { createHash } = await import('crypto');
+    const expectedDigest = 'SHA-256=' + createHash('sha256').update(bodyArg as string).digest('base64');
+    const actualDigest = postStub.getCalls()[0].args[2]?.headers['Digest'];
+    expect(actualDigest).toBe(expectedDigest);
+  });
+
+  it('should record partial error when signing fails, not crash', async () => {
+    const activityMessage = createMockCreateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/789`,
+      name: 'Signing Failure Event',
+    });
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Create',
+      message: activityMessage,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post');
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    // Both signing services throw — simulates no matching actor
+    sandbox.stub(service.calendarActorService, 'signActivity').rejects(new Error('No calendar actor found'));
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    // Should NOT throw
+    await service.processOutboxMessage(message);
+
+    // HTTP POST should not have been called (signing failed before POST)
+    expect(postStub.called).toBe(false);
+    expect(updateStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toMatch(/^partial:.*Signing failed/);
+  });
+
+  it('should fall back to user actor signing when calendar actor fails', async () => {
+    const activityMessage = createMockCreateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/fallback`,
+      name: 'Fallback Signing Event',
+    });
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Create',
+      message: activityMessage,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post');
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    // Calendar actor fails, user actor succeeds
+    sandbox.stub(service.calendarActorService, 'signActivity').rejects(new Error('No calendar actor'));
+    // Access userActorService via type assertion to stub private property
+    const userActorStub = sandbox.stub(
+      (service as any).userActorService, 'signActivity',
+    ).resolves({
+      keyId: `${LOCAL_ACTOR_URL}/users/admin#main-key`,
+      signature: 'user-actor-signature',
+      algorithm: 'rsa-sha256',
+      headers: '(request-target) host date digest',
+      date: new Date().toUTCString(),
+    });
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(userActorStub.calledOnce).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 
@@ -523,6 +660,7 @@ describe('processOutboxMessage — local/remote dispatcher split', () => {
     const resolveLocalStub = sandbox
       .stub(service.calendarActorService, 'getLocalCalendarByActorUri')
       .resolves(null);
+    stubSigning(service, sandbox);
 
     const announceMessage = createMockAnnounceActivity(
       LOCAL_ACTOR_URL,

--- a/src/server/activitypub/test/service/user_actor.test.ts
+++ b/src/server/activitypub/test/service/user_actor.test.ts
@@ -182,25 +182,21 @@ describe('UserActorService', () => {
   });
 
   describe('signActivity', () => {
-    it('should produce valid HTTP signature format', async () => {
-      const actorUri = 'https://events.example/users/alice';
-      const mockData = {
-        id: 'actor-id-123',
-        account_id: 'account-id-123',
-        actor_uri: actorUri,
-        public_key: '-----BEGIN PUBLIC KEY-----\nKEY_DATA\n-----END PUBLIC KEY-----',
-        private_key: '-----BEGIN PRIVATE KEY-----\nKEY_DATA\n-----END PRIVATE KEY-----',
-      };
-
-      // Generate a real keypair for this test to make signing work
+    /**
+     * Helper to create a mock actor entity with a real RSA keypair
+     */
+    function createMockActorWithKeypair(actorUri: string) {
       const { publicKey, privateKey } = generateKeyPairSync('rsa', {
         modulusLength: 2048,
         publicKeyEncoding: { type: 'spki', format: 'pem' },
         privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
       });
 
-      const mockEntity = {
-        ...mockData,
+      return {
+        id: 'actor-id-123',
+        account_id: 'account-id-123',
+        actor_uri: actorUri,
+        public_key: publicKey,
         private_key: privateKey,
         toModel: function() {
           return {
@@ -214,6 +210,11 @@ describe('UserActorService', () => {
           };
         },
       };
+    }
+
+    it('should produce valid HTTP signature format', async () => {
+      const actorUri = 'https://events.example/users/alice';
+      const mockEntity = createMockActorWithKeypair(actorUri);
 
       sandbox.stub(UserActorEntity, 'findOne').resolves(mockEntity as any);
 
@@ -232,9 +233,52 @@ describe('UserActorService', () => {
       expect(signature.keyId).toBe(`${actorUri}#main-key`);
       expect(signature.signature).toBeDefined();
       expect(signature.algorithm).toBe('rsa-sha256');
-      expect(signature.headers).toContain('(request-target)');
-      expect(signature.headers).toContain('host');
-      expect(signature.headers).toContain('date');
+      expect(signature.headers).toBe('(request-target) host date');
+    });
+
+    it('should include digest in signed headers when digest is provided', async () => {
+      const actorUri = 'https://events.example/users/alice';
+      const mockEntity = createMockActorWithKeypair(actorUri);
+
+      sandbox.stub(UserActorEntity, 'findOne').resolves(mockEntity as any);
+
+      const activity = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'Create',
+        actor: actorUri,
+        object: { type: 'Note', content: 'Hello' },
+      };
+
+      const targetUrl = 'https://remote.example/inbox';
+      const digest = 'SHA-256=abc123digest';
+      const signature = await service.signActivity(actorUri, activity, targetUrl, digest);
+
+      // Verify digest is included in the headers list
+      expect(signature.headers).toBe('(request-target) host date digest');
+      // Signature should still be valid
+      expect(signature.signature).toBeDefined();
+      expect(signature.keyId).toBe(`${actorUri}#main-key`);
+    });
+
+    it('should not include digest in signed headers when digest is omitted', async () => {
+      const actorUri = 'https://events.example/users/alice';
+      const mockEntity = createMockActorWithKeypair(actorUri);
+
+      sandbox.stub(UserActorEntity, 'findOne').resolves(mockEntity as any);
+
+      const activity = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'Follow',
+        actor: actorUri,
+        object: 'https://remote.example/calendars/events',
+      };
+
+      const targetUrl = 'https://remote.example/inbox';
+      const signature = await service.signActivity(actorUri, activity, targetUrl);
+
+      // Verify digest is NOT in the headers list
+      expect(signature.headers).toBe('(request-target) host date');
+      expect(signature.headers).not.toContain('digest');
     });
   });
 });

--- a/src/server/activitypub/types.ts
+++ b/src/server/activitypub/types.ts
@@ -1,0 +1,10 @@
+/**
+ * HTTP Signature object for ActivityPub requests
+ */
+export interface HttpSignature {
+  keyId: string;
+  signature: string;
+  algorithm: string;
+  headers: string;
+  date: string;
+}

--- a/src/server/notifications/entity/notification.ts
+++ b/src/server/notifications/entity/notification.ts
@@ -89,7 +89,7 @@ class NotificationEntity extends Model {
    */
   static fromModel(notification: Notification, accountId: string): NotificationEntity {
     return NotificationEntity.build({
-      id: notification.id,
+      ...(notification.id ? { id: notification.id } : {}),
       account_id: accountId,
       type: notification.type,
       calendar_id: notification.calendarId,

--- a/src/server/notifications/test/notification_entity.test.ts
+++ b/src/server/notifications/test/notification_entity.test.ts
@@ -130,6 +130,21 @@ describe('NotificationEntity', () => {
       expect(model.seen).toBe(true);
     });
 
+    it('should auto-generate a valid UUID when notification has no id (empty string default)', () => {
+      const notification = new Notification(); // no id argument → id = '' from PrimaryModel
+      notification.type = 'repost';
+      notification.calendarId = uuidv4();
+      notification.actorName = 'Actor';
+
+      const entity = NotificationEntity.fromModel(notification, uuidv4());
+
+      // id must NOT be '' (PostgreSQL rejects empty string as UUID).
+      // Sequelize's defaultValue should generate a valid UUID.
+      const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      expect(entity.id).not.toBe('');
+      expect(entity.id).toMatch(UUID_REGEX);
+    });
+
     it('should not expose account_id in the returned model', () => {
       const notification = new Notification(uuidv4());
       notification.type = 'follow';

--- a/src/server/test/integration/create_event.test.ts
+++ b/src/server/test/integration/create_event.test.ts
@@ -14,6 +14,7 @@ import { EventEntity } from '@/server/calendar/entity/event';
 import { ActivityPubOutboxMessageEntity } from '@/server/activitypub/entity/activitypub';
 import ProcessInboxService from '@/server/activitypub/service/inbox';
 import FollowActivity from '@/server/activitypub/model/action/follow';
+import CalendarActorService from '@/server/activitypub/service/calendar_actor';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
 
@@ -74,6 +75,13 @@ describe('Event API', () => {
   it('createEvent: should succeed', async () => {
     let getStub = sinon.stub(axios, 'get');
     let postStub = sinon.stub(axios, 'post');
+    sinon.stub(CalendarActorService.prototype, 'signActivity').resolves({
+      keyId: 'https://local.test/calendars/testcalendar#main-key',
+      signature: 'mock-signature-base64',
+      algorithm: 'rsa-sha256',
+      headers: '(request-target) host date digest',
+      date: new Date().toUTCString(),
+    });
     env.stubRemoteCalendar(getStub, 'remotedomain', 'testcalendar');
 
     let authKey = await env.login(userEmail,userPassword);


### PR DESCRIPTION
## Summary

- **Signed outbox HTTP deliveries**: All outbox POST requests now include `Signature`, `Date`, and `Digest` headers using existing actor signing infrastructure. Auto-detects calendar vs user actor with fallback. Signing failure produces partial delivery error, not crash.
- **Notification UUID fix**: `NotificationEntity.fromModel` now omits empty-string IDs so PostgreSQL's UUID generator handles new notifications correctly.
- **Federation config revert**: Beta Docker instance reverted to `SKIP_SIGNATURES=true` — not all federation code paths sign requests yet (e.g. `createRemoteEvent`, editor grant notifications).

## Key Changes

- `buildSignedHeaders()` on ProcessOutboxService with actor auto-detection
- `signActivity()` extended with optional Digest on both CalendarActorService and UserActorService
- `HttpSignature` interface extracted to shared `activitypub/types.ts`
- `NotificationEntity.fromModel` guards against empty-string UUID
- Integration test stubs for HTTP signature signing

## Test plan

- [x] Unit tests: 5965 passing (2 pre-existing failures in server.test.ts)
- [x] Outbox signing tests: 25/25 passing
- [x] Federation e2e: 26 passing
- [x] Notification UUID regression test added
- [x] Lint: 0 errors
- [x] Build: passes