### PR TITLE
fix(db): correct ap_shared_event column types from VARCHAR to UUID

### DIFF
--- a/migrations/0020_fix_shared_event_column_types.ts
+++ b/migrations/0020_fix_shared_event_column_types.ts
@@ -1,0 +1,42 @@
+import { Sequelize, DataTypes } from 'sequelize';
+
+/**
+ * Fix type mismatch in ap_shared_event table.
+ *
+ * The initial migration (0001) created event_id and calendar_id as STRING,
+ * but these columns store UUIDs and are joined against UUID columns
+ * (event.id, calendar_actor.calendar_id). This causes "operator does not
+ * exist: character varying = uuid" on PostgreSQL.
+ *
+ * The entity (SharedEventEntity) already declares these as DataType.UUID,
+ * so this migration brings the schema in line with the entity definition.
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await queryInterface.changeColumn('ap_shared_event', 'event_id', {
+      type: DataTypes.UUID,
+      allowNull: true,
+    });
+
+    await queryInterface.changeColumn('ap_shared_event', 'calendar_id', {
+      type: DataTypes.UUID,
+      allowNull: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await queryInterface.changeColumn('ap_shared_event', 'calendar_id', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+
+    await queryInterface.changeColumn('ap_shared_event', 'event_id', {
+      type: DataTypes.STRING,
+      allowNull: true,
+    });
+  },
+};


### PR DESCRIPTION
## Summary

- Adds migration `0020` to alter `event_id` and `calendar_id` in `ap_shared_event` from VARCHAR to UUID
- Fixes `operator does not exist: character varying = uuid` error that breaks the feed endpoint on PostgreSQL
- The initial migration (0001) created these columns as STRING, but the entity declares UUID and the feed query joins them against UUID columns — SQLite silently ignored the mismatch, PostgreSQL does not

## Test plan

- [ ] Run migration on PostgreSQL instance (`npm run migrate`)
- [ ] Verify feed endpoint loads without errors
- [ ] Verify existing shared events are preserved after column type conversion