### PR TITLE
Fix reposted event categories showing source calendar's categories

### DIFF
--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -475,8 +475,8 @@ export default class CalendarInterface {
     return this.getEventById(eventId);
   }
 
-  async getEventCategories(eventId: string): Promise<EventCategory[]> {
-    return this.categoryService.getEventCategories(eventId);
+  async getEventCategories(eventId: string, calendarId?: string): Promise<EventCategory[]> {
+    return this.categoryService.getEventCategories(eventId, calendarId);
   }
 
   async getCategoryEvents(categoryId: string, calendarId?: string): Promise<string[]> {

--- a/src/server/calendar/service/categories.ts
+++ b/src/server/calendar/service/categories.ts
@@ -579,19 +579,28 @@ class CategoryService {
   }
 
   /**
-   * Get all categories assigned to an event
+   * Get all categories assigned to an event.
+   * When calendarId is provided, only returns categories that belong to that calendar.
+   * This is essential for public views of reposted events where only the display
+   * calendar's categories should be shown, not the source calendar's.
    */
-  async getEventCategories(eventId: string): Promise<EventCategory[]> {
+  async getEventCategories(eventId: string, calendarId?: string): Promise<EventCategory[]> {
     const assignments = await EventCategoryAssignmentEntity.findAll({
       where: { event_id: eventId },
       include: [{
         model: EventCategoryEntity,
-        as: 'category', // Required because association uses alias (see event.ts line 241)
+        as: 'category',
+        // When calendarId is provided, Sequelize applies a LEFT OUTER JOIN with
+        // this WHERE condition. Non-matching assignments still appear in results
+        // with category = null, so we filter those out below.
+        where: calendarId ? { calendar_id: calendarId } : undefined,
         include: [EventCategoryContentEntity],
       }],
     });
 
-    return assignments.map(assignment => assignment.category.toModel());
+    return assignments
+      .filter(assignment => assignment.category != null)
+      .map(assignment => assignment.category.toModel());
   }
 
   /**

--- a/src/server/calendar/service/event_instance.ts
+++ b/src/server/calendar/service/event_instance.ts
@@ -157,7 +157,7 @@ export default class EventInstanceService {
     }
 
     const instance = eventInstance.toModel();
-    instance.event.categories = await this.categoryService.getEventCategories(instance.event.id);
+    instance.event.categories = await this.categoryService.getEventCategories(instance.event.id, eventInstance.calendar_id);
     return instance;
   }
 
@@ -320,11 +320,12 @@ export default class EventInstanceService {
           instance.event.media = event.media.toModel();
         }
 
-        // Add categories
+        // Add categories, filtered to the display calendar so reposted events
+        // only show the display calendar's categories
         const categoryAssignments = event.getDataValue('categoryAssignments') as EventCategoryAssignmentEntity[] | undefined;
         if (categoryAssignments) {
           instance.event.categories = categoryAssignments
-            .filter(assignment => assignment.category != null)
+            .filter(assignment => assignment.category != null && assignment.category.calendar_id === calendar.id)
             .map(assignment => assignment.category.toModel());
         }
 
@@ -404,8 +405,9 @@ export default class EventInstanceService {
       instance.event.location = event.location.toModel();
     }
 
-    // Populate categories via the category service
-    instance.event.categories = await this.categoryService.getEventCategories(instance.event.id);
+    // Populate categories via the category service, filtered to the display calendar
+    // so reposted events only show the display calendar's categories
+    instance.event.categories = await this.categoryService.getEventCategories(instance.event.id, eventInstance.calendar_id);
 
     // Resolve source calendar information for reposted events
     const repostContext: RepostContext = {

--- a/src/server/calendar/test/categories_service.test.ts
+++ b/src/server/calendar/test/categories_service.test.ts
@@ -580,6 +580,60 @@ describe('CategoryService', () => {
 
       expect(categories).toHaveLength(0);
     });
+
+    it('should filter categories by calendarId when provided', async () => {
+      const findAllStub = sandbox.stub(EventCategoryAssignmentEntity, 'findAll').resolves([]);
+
+      await categoryService.getEventCategories('event-123', 'calendar-456');
+
+      expect(findAllStub.calledOnce).toBe(true);
+      const queryArgs = findAllStub.firstCall.args[0] as any;
+
+      // Verify the include has a where clause filtering by calendar_id
+      const categoryInclude = queryArgs.include[0];
+      expect(categoryInclude.where).toBeDefined();
+      expect(categoryInclude.where.calendar_id).toBe('calendar-456');
+    });
+
+    it('should not filter by calendarId when not provided', async () => {
+      const findAllStub = sandbox.stub(EventCategoryAssignmentEntity, 'findAll').resolves([]);
+
+      await categoryService.getEventCategories('event-123');
+
+      expect(findAllStub.calledOnce).toBe(true);
+      const queryArgs = findAllStub.firstCall.args[0] as any;
+
+      // Verify no where clause on the category include
+      const categoryInclude = queryArgs.include[0];
+      expect(categoryInclude.where).toBeUndefined();
+    });
+
+    it('should filter out null categories when calendarId filter excludes them', async () => {
+      // When calendarId filter is applied, Sequelize may return assignments
+      // where the category is null (filtered out by the WHERE)
+      const mockAssignments = [
+        { category: null },
+        {
+          category: {
+            toModel: () => {
+              const model = new EventCategory('cat-1', 'calendar-456');
+              const content = new EventCategoryContent('en');
+              content.name = 'Local Category';
+              model.addContent(content);
+              return model;
+            },
+          },
+        },
+      ];
+
+      sandbox.stub(EventCategoryAssignmentEntity, 'findAll').resolves(mockAssignments as any);
+
+      const categories = await categoryService.getEventCategories('event-123', 'calendar-456');
+
+      expect(categories).toHaveLength(1);
+      expect(categories[0].id).toBe('cat-1');
+      expect(categories[0].content('en').name).toBe('Local Category');
+    });
   });
 
   describe('getCategoryEvents', () => {

--- a/src/server/public/service/calendar.ts
+++ b/src/server/public/service/calendar.ts
@@ -36,8 +36,8 @@ export default class PublicCalendarService {
   async listEventInstances(calendar: Calendar): Promise<CalendarEventInstance[]> {
     const instances = await this.calendarInterface.listEventInstancesForCalendar(calendar);
 
-    // Populate category information for each event
-    await this.populateEventCategories(instances);
+    // Populate category information for each event, filtered to this calendar's categories
+    await this.populateEventCategories(instances, calendar.id);
 
     return instances;
   }
@@ -86,8 +86,8 @@ export default class PublicCalendarService {
     const allInstances = await this.calendarInterface.listEventInstancesForCalendar(calendar);
     const filteredInstances = allInstances.filter(instance => allEventIds.includes(instance.event.id));
 
-    // Populate category information for each event
-    await this.populateEventCategories(filteredInstances);
+    // Populate category information for each event, filtered to this calendar's categories
+    await this.populateEventCategories(filteredInstances, calendar.id);
 
     return filteredInstances;
   }
@@ -144,9 +144,11 @@ export default class PublicCalendarService {
   }
 
   /**
-   * Populate category information for events in instances
+   * Populate category information for events in instances.
+   * When calendarId is provided, only categories belonging to that calendar are included.
+   * This prevents source calendar categories from leaking into reposted event display.
    */
-  private async populateEventCategories(instances: CalendarEventInstance[]): Promise<void> {
+  private async populateEventCategories(instances: CalendarEventInstance[], calendarId?: string): Promise<void> {
     // Group instances by event ID to avoid duplicate category lookups
     const eventMap = new Map<string, CalendarEventInstance[]>();
 
@@ -158,11 +160,11 @@ export default class PublicCalendarService {
       eventMap.get(eventId)!.push(instance);
     }
 
-    // Fetch categories for each unique event
+    // Fetch categories for each unique event, filtered to the display calendar
     await Promise.all(
       Array.from(eventMap.entries()).map(async ([eventId, eventInstances]) => {
         try {
-          const categories = await this.calendarInterface.getEventCategories(eventId);
+          const categories = await this.calendarInterface.getEventCategories(eventId, calendarId);
 
           // Add categories to the event object for serialization
           for (const instance of eventInstances) {


### PR DESCRIPTION
## Summary

- Reposted events were displaying the source calendar's categories instead of the display calendar's categories in all public views and internal calendar listings
- Added optional `calendarId` parameter to `getEventCategories()` that filters categories at the Sequelize query level
- Threaded the display calendar ID through all affected code paths: public list views, filtered/search views, event detail pages, and internal instance lookups

## Root Cause

`EventCategoryAssignmentEntity` links `event_id` ↔ `category_id` with no calendar context. When `getEventCategories(eventId)` was called without filtering, it returned ALL categories assigned to the event globally — including categories from the source calendar that are meaningless in the display calendar's context.

## Changes

| File | Change |
|------|--------|
| `categories.ts` | Added optional `calendarId` param with Sequelize WHERE on `EventCategoryEntity.calendar_id` |
| `interface/index.ts` | Pass-through of new parameter |
| `public/service/calendar.ts` | `populateEventCategories()` now passes `calendar.id` |
| `event_instance.ts` | `getEventInstanceWithDetails()`, `getEventInstanceById()` pass `calendar_id`; `listEventInstancesWithFilters()` filters eager-loaded categories |
| `categories_service.test.ts` | 3 new tests for calendar-filtered behavior |

## Test plan

- [x] All 68 affected tests pass (category service + public API)
- [x] Full unit test suite: 5966 passed, 4 failed (pre-existing AP server test failures)
- [x] Lint clean on all changed files
- [x] Verified via Playwright on local dev: reposted "Morning Fitness Bootcamp" shows test_calendar's categories (Entertainment, Health, Sports) not testuser_calendar's (Music, Outdoors)
- [x] Verified source calendar still shows its own categories correctly