### PR TITLE
fix(db): use explicit USING cast for VARCHAR-to-UUID migration

### DIFF
--- a/.github/workflows/pr.ci.yaml
+++ b/.github/workflows/pr.ci.yaml
@@ -32,6 +32,8 @@ jobs:
     with:
       platform: linux/amd64
       runner: ubuntu-latest
+  migration_smoke_test:
+    uses: ./.github/workflows/run_migration_tests.yaml
   federation_tests:
     needs: x86_tests
     uses: ./.github/workflows/run_federation_tests.yaml

--- a/.github/workflows/run_migration_tests.yaml
+++ b/.github/workflows/run_migration_tests.yaml
@@ -1,0 +1,49 @@
+name: Migration Smoke Test
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: 'The runner to run the tests on'
+        required: false
+        type: string
+        default: ubuntu-latest
+
+jobs:
+  migrate:
+    runs-on: ${{ inputs.runner }}
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: pavillion_migrate_test
+          POSTGRES_USER: pavillion
+          POSTGRES_PASSWORD: testpassword
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pavillion -d pavillion_migrate_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - run: npm install
+
+      - name: Run migrations up then down against PostgreSQL
+        env:
+          DB_DIALECT: postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_NAME: pavillion_migrate_test
+          DB_USER: pavillion
+          DB_PASSWORD: testpassword
+        run: npx tsx scripts/test-migrations-pg.ts

--- a/migrations/0020_fix_shared_event_column_types.ts
+++ b/migrations/0020_fix_shared_event_column_types.ts
@@ -1,4 +1,4 @@
-import { Sequelize, DataTypes } from 'sequelize';
+import { Sequelize } from 'sequelize';
 
 /**
  * Fix type mismatch in ap_shared_event table.
@@ -10,33 +10,34 @@ import { Sequelize, DataTypes } from 'sequelize';
  *
  * The entity (SharedEventEntity) already declares these as DataType.UUID,
  * so this migration brings the schema in line with the entity definition.
+ *
+ * PostgreSQL requires an explicit USING cast when converting VARCHAR to UUID,
+ * so we use raw SQL instead of queryInterface.changeColumn.
  */
 export default {
   async up({ context: sequelize }: { context: Sequelize }) {
-    const queryInterface = sequelize.getQueryInterface();
+    const dialect = sequelize.getDialect();
 
-    await queryInterface.changeColumn('ap_shared_event', 'event_id', {
-      type: DataTypes.UUID,
-      allowNull: true,
-    });
-
-    await queryInterface.changeColumn('ap_shared_event', 'calendar_id', {
-      type: DataTypes.UUID,
-      allowNull: true,
-    });
+    if (dialect === 'postgres') {
+      await sequelize.query(`
+        ALTER TABLE "ap_shared_event"
+          ALTER COLUMN "event_id" TYPE UUID USING "event_id"::uuid,
+          ALTER COLUMN "calendar_id" TYPE UUID USING "calendar_id"::uuid;
+      `);
+    }
+    // SQLite has no strict column types; ALTER COLUMN is not supported.
+    // The entity already declares UUID, which SQLite stores as TEXT regardless.
   },
 
   async down({ context: sequelize }: { context: Sequelize }) {
-    const queryInterface = sequelize.getQueryInterface();
+    const dialect = sequelize.getDialect();
 
-    await queryInterface.changeColumn('ap_shared_event', 'calendar_id', {
-      type: DataTypes.STRING,
-      allowNull: true,
-    });
-
-    await queryInterface.changeColumn('ap_shared_event', 'event_id', {
-      type: DataTypes.STRING,
-      allowNull: true,
-    });
+    if (dialect === 'postgres') {
+      await sequelize.query(`
+        ALTER TABLE "ap_shared_event"
+          ALTER COLUMN "event_id" TYPE VARCHAR(255),
+          ALTER COLUMN "calendar_id" TYPE VARCHAR(255);
+      `);
+    }
   },
 };

--- a/scripts/test-migrations-pg.ts
+++ b/scripts/test-migrations-pg.ts
@@ -1,0 +1,65 @@
+/**
+ * Migration smoke test against PostgreSQL.
+ *
+ * Runs all migrations up, then all migrations down, against a real
+ * PostgreSQL instance. Catches dialect-specific issues (e.g. missing
+ * USING casts, unsupported ALTER syntax) that SQLite tests miss.
+ *
+ * Expects DB connection via environment variables:
+ *   DB_DIALECT=postgres DB_HOST=localhost DB_PORT=5432
+ *   DB_NAME=pavillion_migrate_test DB_USER=pavillion DB_PASSWORD=testpassword
+ *
+ * Usage:
+ *   npx tsx scripts/test-migrations-pg.ts
+ */
+import { Sequelize } from 'sequelize-typescript';
+import { createMigrationRunner } from '../src/server/common/migrations/runner.js';
+import path from 'path';
+
+async function main() {
+  const dialect = process.env.DB_DIALECT ?? 'postgres';
+  if (dialect !== 'postgres') {
+    console.error(`This script must run against PostgreSQL (got dialect="${dialect}")`);
+    process.exit(1);
+  }
+
+  const sequelize = new Sequelize({
+    dialect: 'postgres',
+    host: process.env.DB_HOST ?? 'localhost',
+    port: Number(process.env.DB_PORT ?? 5432),
+    database: process.env.DB_NAME ?? 'pavillion_migrate_test',
+    username: process.env.DB_USER ?? 'pavillion',
+    password: process.env.DB_PASSWORD ?? 'testpassword',
+    logging: false,
+  });
+
+  const migrationsPath = path.join(process.cwd(), 'migrations');
+  const umzug = createMigrationRunner(sequelize, migrationsPath);
+
+  try {
+    // Verify connection
+    await sequelize.authenticate();
+    console.log('Connected to PostgreSQL');
+
+    // Run all migrations up
+    console.log('Running migrations UP...');
+    const upResult = await umzug.up();
+    console.log(`  ${upResult.length} migration(s) applied`);
+
+    // Run all migrations down (in reverse)
+    console.log('Running migrations DOWN...');
+    const downResult = await umzug.down({ to: 0 });
+    console.log(`  ${downResult.length} migration(s) reverted`);
+
+    console.log('Migration smoke test passed');
+  }
+  catch (error) {
+    console.error('Migration smoke test FAILED:', error);
+    process.exit(1);
+  }
+  finally {
+    await sequelize.close();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Fix migration 0020 which failed on staging because PostgreSQL requires an explicit `USING column::uuid` cast when converting VARCHAR to UUID — Sequelize's `changeColumn` doesn't emit this clause
- Add a CI migration smoke test that runs all migrations up then down against a real PostgreSQL 17 service container on every PR, preventing this class of bug from reaching staging again

## Changes

- **`migrations/0020_fix_shared_event_column_types.ts`** — Replace `queryInterface.changeColumn()` with raw SQL using `USING` cast; dialect-aware (PostgreSQL runs ALTER, SQLite no-ops)
- **`scripts/test-migrations-pg.ts`** — Standalone script that connects to PostgreSQL, runs all migrations up then down, exits non-zero on failure
- **`.github/workflows/run_migration_tests.yaml`** — Reusable workflow that spins up a PostgreSQL 17 service container and runs the smoke test
- **`.github/workflows/pr.ci.yaml`** — Wire migration smoke test into the PR pipeline (runs in parallel, no added latency)

## Test plan

- [ ] Verify migration smoke test CI job passes (new PostgreSQL service container)
- [ ] Deploy to staging with DB reset to confirm migration 0020 applies cleanly on PostgreSQL
- [ ] Existing unit tests continue to pass (verified locally)