### PR TITLE
fix: reassign-categories dialog for reposted events

### DIFF
--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -230,6 +230,7 @@ const handleRepostCategoryUpdate = async (categoryIds) => {
     const updatedEvent = await calendarService.replaceEventCategories(
       repostEventForModal.value.id,
       categoryIds,
+      props.calendar?.id,
     );
     store.updateEvent(props.calendar?.id, updatedEvent);
   }

--- a/src/client/service/calendar.ts
+++ b/src/client/service/calendar.ts
@@ -322,11 +322,21 @@ export default class CalendarService {
    * Replace all category assignments for a single event
    * @param eventId The ID of the event to update
    * @param categoryIds Array of category IDs to assign (empty array clears all)
+   * @param calendarId Optional calendar context for disambiguating repost edits
+   *   when the user owns both the event's source calendar and a repost-target calendar.
    * @returns Promise<CalendarEvent> The updated event with its categories
    */
-  async replaceEventCategories(eventId: string, categoryIds: string[]): Promise<CalendarEvent> {
+  async replaceEventCategories(
+    eventId: string,
+    categoryIds: string[],
+    calendarId?: string,
+  ): Promise<CalendarEvent> {
     try {
-      const response = await axios.put(`/api/v1/events/${eventId}/categories`, { categoryIds });
+      const body: { categoryIds: string[]; calendarId?: string } = { categoryIds };
+      if (calendarId) {
+        body.calendarId = calendarId;
+      }
+      const response = await axios.put(`/api/v1/events/${eventId}/categories`, body);
       return CalendarEvent.fromObject(response.data);
     }
     catch (error: unknown) {

--- a/src/server/calendar/api/v1/events.ts
+++ b/src/server/calendar/api/v1/events.ts
@@ -316,7 +316,7 @@ export default class EventRoutes {
     }
 
     const eventId = req.params.id;
-    const { categoryIds } = req.body;
+    const { categoryIds, calendarId } = req.body;
 
     if (!Array.isArray(categoryIds)) {
       res.status(400).json({
@@ -326,8 +326,16 @@ export default class EventRoutes {
       return;
     }
 
+    if (calendarId !== undefined && typeof calendarId !== 'string') {
+      res.status(400).json({
+        "error": "calendarId must be a string when provided",
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
     try {
-      const event = await this.service.replaceEventCategories(account, eventId, categoryIds);
+      const event = await this.service.replaceEventCategories(account, eventId, categoryIds, calendarId);
       res.json(event.toObject());
     }
     catch (error) {

--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -495,8 +495,9 @@ export default class CalendarInterface {
     account: Account,
     eventId: string,
     categoryIds: string[],
+    calendarId?: string,
   ): Promise<CalendarEvent> {
-    return this.eventService.replaceEventCategories(account, eventId, categoryIds);
+    return this.eventService.replaceEventCategories(account, eventId, categoryIds, calendarId);
   }
 
   // Calendar settings operations

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1206,6 +1206,11 @@ class EventService {
    * @param calendarId - The calendar ID taken directly from the EventEntity rows
    * @param eventIds - The event IDs being operated on
    * @param transaction - Active Sequelize transaction
+   * @param preferredCalendarId - Optional caller-supplied context (e.g. the calendar
+   *   whose event list the user is viewing). When the account owns both the event's
+   *   source calendar and a repost target, this disambiguates which calendar the
+   *   operation is intended to modify. Used when the preferred calendar either matches
+   *   the source calendar or has an EventRepostEntity row for every event in the set.
    * @returns effectiveCalendarId (string), wasRepost flag, and pre-fetched userCalendars
    * @throws InsufficientCalendarPermissionsError when no owned calendar can be resolved
    */
@@ -1214,22 +1219,74 @@ class EventService {
     calendarId: string,
     eventIds: string[],
     transaction: Transaction,
+    preferredCalendarId?: string,
   ): Promise<{ effectiveCalendarId: string; wasRepost: boolean; userCalendars: Calendar[] }> {
     const userCalendars = await this.calendarService.editableCalendarsForUser(account);
     let effectiveCalendarId = calendarId;
     let wasRepost = false;
 
-    if (!userCalendars.some(cal => cal.id === effectiveCalendarId)) {
-      const reposts = await EventRepostEntity.findAll({
-        where: { event_id: eventIds },
-        transaction,
-      });
-      if (reposts.length === eventIds.length) {
-        const repostCalendarIds = [...new Set(reposts.map(r => r.calendar_id))];
-        if (repostCalendarIds.length === 1 && userCalendars.some(cal => cal.id === repostCalendarIds[0])) {
-          effectiveCalendarId = repostCalendarIds[0];
-          wasRepost = true;
+    // Fast path: caller doesn't need disambiguation and already owns the source
+    // calendar. No repost lookup required.
+    if (!preferredCalendarId && userCalendars.some(cal => cal.id === effectiveCalendarId)) {
+      return { effectiveCalendarId, wasRepost, userCalendars };
+    }
+
+    // Reposts are tracked in two tables: the legacy EventRepostEntity and the
+    // authoritative SharedEventEntity (populated by the auto-repost pipeline).
+    // Both must be consulted, otherwise repost targets created via auto-repost
+    // are invisible to this resolver.
+    const legacyReposts = await EventRepostEntity.findAll({
+      where: { event_id: eventIds },
+      transaction,
+    });
+    const sharedCalendarIdsByEvent = new Map<string, Set<string>>();
+    if (this.activityPubInterface) {
+      for (const eventId of eventIds) {
+        const calendarIds = await this.activityPubInterface.getCalendarIdsForSharedEvent(eventId);
+        sharedCalendarIdsByEvent.set(eventId, new Set(calendarIds));
+      }
+    }
+
+    const isRepostTarget = (candidateCalendarId: string): boolean => {
+      return eventIds.every((eventId) => {
+        if (legacyReposts.some(r => r.event_id === eventId && r.calendar_id === candidateCalendarId)) {
+          return true;
         }
+        return sharedCalendarIdsByEvent.get(eventId)?.has(candidateCalendarId) ?? false;
+      });
+    };
+
+    // When the caller provides the calendar context they're operating in, honor it
+    // if the account owns it and it has a valid relationship with the events. This
+    // disambiguates the case where the account owns both source and repost-target
+    // calendars (otherwise the source calendar wins and repost-target categories
+    // fail validation).
+    if (preferredCalendarId && userCalendars.some(cal => cal.id === preferredCalendarId)) {
+      if (preferredCalendarId === calendarId) {
+        return { effectiveCalendarId: preferredCalendarId, wasRepost: false, userCalendars };
+      }
+      if (isRepostTarget(preferredCalendarId)) {
+        return { effectiveCalendarId: preferredCalendarId, wasRepost: true, userCalendars };
+      }
+    }
+
+    if (!userCalendars.some(cal => cal.id === effectiveCalendarId)) {
+      // Gather all candidate repost targets across both legacy and shared tables.
+      const candidateCalendarIds = new Set<string>();
+      for (const r of legacyReposts) {
+        candidateCalendarIds.add(r.calendar_id);
+      }
+      for (const set of sharedCalendarIdsByEvent.values()) {
+        for (const id of set) {
+          candidateCalendarIds.add(id);
+        }
+      }
+      const ownedRepostTargets = [...candidateCalendarIds].filter(
+        (id) => userCalendars.some(cal => cal.id === id) && isRepostTarget(id),
+      );
+      if (ownedRepostTargets.length === 1) {
+        effectiveCalendarId = ownedRepostTargets[0];
+        wasRepost = true;
       }
       // If still not resolved, the permission check in the caller will throw
     }
@@ -1410,6 +1467,7 @@ class EventService {
     account: Account,
     eventId: string,
     categoryIds: string[],
+    calendarId?: string,
   ): Promise<CalendarEvent> {
     // Validate eventId is a valid UUID
     if (!this.isValidUUID(eventId)) {
@@ -1447,7 +1505,7 @@ class EventService {
         effectiveCalendarId,
         wasRepost: resolvedAsRepost,
         userCalendars,
-      } = await this.resolveEffectiveCalendarId(account, event.calendar_id, [eventId], transaction);
+      } = await this.resolveEffectiveCalendarId(account, event.calendar_id, [eventId], transaction, calendarId);
       wasRepost = resolvedAsRepost;
 
       // 3. Check user has permission

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -205,6 +205,56 @@ describe('EventService.replaceEventCategories', () => {
     expect((mockTransaction.rollback as sinon.SinonStub).calledOnce).toBe(true);
   });
 
+  it('should prefer the supplied calendarId over the source calendar when the account owns both', async () => {
+    // Regression: when a user owns both the event's source calendar and a repost
+    // target calendar, the resolver previously defaulted to the source calendar,
+    // which caused category validation to fail for categories belonging to the
+    // repost target. Passing calendarId from the client disambiguates.
+    const sourceCalendarId = 'source00-0000-4000-8000-000000000001';
+    const repostTargetCalendarId = 'repost00-0000-4000-8000-000000000001';
+
+    const mockEvent = EventEntity.build({
+      id: validEventId,
+      calendar_id: sourceCalendarId,
+      account_id: 'test-account-id',
+    });
+
+    const repostTargetCategory = EventCategoryEntity.build({
+      id: validCategoryId1,
+      calendar_id: repostTargetCalendarId,
+    });
+
+    const mockTransaction = stubCommonDependencies({
+      eventEntity: mockEvent,
+      categories: [repostTargetCategory],
+      userCalendars: [
+        new Calendar(sourceCalendarId, 'source-calendar'),
+        new Calendar(repostTargetCalendarId, 'repost-target-calendar'),
+      ],
+      repostEntity: [
+        EventRepostEntity.build({
+          id: 'repost-uuid',
+          event_id: validEventId,
+          calendar_id: repostTargetCalendarId,
+        }),
+      ],
+    });
+
+    sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
+    sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
+
+    const returnedEvent = new CalendarEvent(validEventId, repostTargetCalendarId);
+    sandbox.stub(service, 'getEventById').resolves(returnedEvent);
+
+    const result = await service.replaceEventCategories(
+      mockAccount, validEventId, [validCategoryId1], repostTargetCalendarId,
+    );
+
+    expect(result).toBeDefined();
+    expect(result.isRepost).toBe(true);
+    expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
+  });
+
   it('should resolve repost events to reposter calendar correctly', async () => {
     const originalCalendarId = 'original-0000-4000-8000-000000000001';
     const reposterCalendarId = 'reposter-0000-4000-8000-000000000001';

--- a/src/server/calendar/test/EventService/resolve_effective_calendar_id.test.ts
+++ b/src/server/calendar/test/EventService/resolve_effective_calendar_id.test.ts
@@ -154,6 +154,62 @@ describe('EventService.resolveEffectiveCalendarId', () => {
     expect(result.wasRepost).toBe(false);
   });
 
+  it('should honor preferredCalendarId when account owns both source and repost target', async () => {
+    const sourceCalendarId = 'source-calendar-uuid';
+    const repostTargetCalendarId = 'repost-target-uuid';
+    const eventIds = ['11111111-1111-4111-8111-111111111111'];
+
+    sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser')
+      .resolves([
+        new Calendar(sourceCalendarId, 'source-calendar'),
+        new Calendar(repostTargetCalendarId, 'repost-target-calendar'),
+      ]);
+
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([
+      EventRepostEntity.build({
+        id: 'repost-1',
+        event_id: eventIds[0],
+        calendar_id: repostTargetCalendarId,
+      }),
+    ]);
+
+    const result = await (service as any).resolveEffectiveCalendarId(
+      mockAccount,
+      sourceCalendarId,
+      eventIds,
+      mockTransaction,
+      repostTargetCalendarId,
+    );
+
+    // Without preferredCalendarId the resolver would return sourceCalendarId;
+    // passing the repost target should disambiguate in favor of the target.
+    expect(result.effectiveCalendarId).toBe(repostTargetCalendarId);
+    expect(result.wasRepost).toBe(true);
+  });
+
+  it('should ignore preferredCalendarId when the account does not own it', async () => {
+    const sourceCalendarId = 'source-calendar-uuid';
+    const unrelatedCalendarId = 'unrelated-calendar-uuid';
+    const eventIds = ['11111111-1111-4111-8111-111111111111'];
+
+    sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser')
+      .resolves([new Calendar(sourceCalendarId, 'source-calendar')]);
+
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([]);
+
+    const result = await (service as any).resolveEffectiveCalendarId(
+      mockAccount,
+      sourceCalendarId,
+      eventIds,
+      mockTransaction,
+      unrelatedCalendarId,
+    );
+
+    // User owns source; preferredCalendarId is ignored since user doesn't own it.
+    expect(result.effectiveCalendarId).toBe(sourceCalendarId);
+    expect(result.wasRepost).toBe(false);
+  });
+
   it('should return all user calendars in the result for downstream permission checks', async () => {
     const calendarId = 'owned-calendar-uuid';
     const anotherCalendarId = 'another-calendar-uuid';


### PR DESCRIPTION
## Summary

Fixes pv-pmra. When a user owns both the source calendar and a repost-target calendar, the reassign-categories dialog for reposted events silently failed — Save never closed the dialog and nothing was persisted.

## Root cause

- `PUT /api/v1/events/:id/categories` had no calendar context. `EventService.resolveEffectiveCalendarId` defaulted to the event's source calendar when the user owned it, so any categories from the repost-target calendar failed `CategoriesNotFoundError` validation. The handler collapses that into a unified 404 and the client's error map doesn't recognize `NotFoundError`, producing a silent `UnknownError`.
- The resolver only consulted the legacy `EventRepostEntity`, ignoring `SharedEventEntity` (the authoritative table populated by the auto-repost pipeline), so repost targets created via auto-repost were invisible to the resolver.

## Fix

- Add an optional `calendarId` to the API body, service, and interface. The client in `events-tab.vue` passes `props.calendar.id` so the server knows which calendar the user is editing in.
- `resolveEffectiveCalendarId` gains an optional `preferredCalendarId`. When the account owns it and the event has a source-or-repost relationship with it, the resolver honors it.
- The resolver now checks both `EventRepostEntity` and `SharedEventEntity` via `ActivityPubInterface.getCalendarIdsForSharedEvent`.

## Test plan

- [x] Added unit tests covering `preferredCalendarId` in `resolve_effective_calendar_id.test.ts` and `replace_event_categories.test.ts`.
- [x] `npx vitest run src/server/calendar/test/EventService/` — 105/105 passing.
- [x] Lint passes on all touched files (one pre-existing warning on an unrelated import).
- [x] Manual verification with Playwright on the dev server: open chain_b repost, toggle Music, Save → dialog closes, reopening shows the assignment persisted, and unchecking + saving also persists.