### PR TITLE
feat(events): add optional external URL + prompt enum to events

### DIFF
--- a/migrations/0021_add_event_external_url.ts
+++ b/migrations/0021_add_event_external_url.ts
@@ -1,0 +1,31 @@
+import { Sequelize, DataTypes } from 'sequelize';
+
+/**
+ * Add external_url and url_prompt columns to the event table.
+ *
+ * external_url stores an optional off-site URL (e.g., a registration or
+ * informational link) for the event. url_prompt stores an optional short
+ * label displayed to users before following the URL.
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await queryInterface.addColumn('event', 'external_url', {
+      type: DataTypes.STRING(2048),
+      allowNull: true,
+    });
+
+    await queryInterface.addColumn('event', 'url_prompt', {
+      type: DataTypes.STRING(32),
+      allowNull: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await queryInterface.removeColumn('event', 'url_prompt');
+    await queryInterface.removeColumn('event', 'external_url');
+  },
+};

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -277,6 +277,8 @@ form {
 
 .field-input,
 .field-textarea {
+  // appearance: none needed so WebKit accepts custom padding/height on <select>
+  appearance: none;
   padding: 0.625rem 0.875rem;
   border: 1px solid var(--pav-color-stone-200);
   border-radius: 0.375rem;
@@ -303,6 +305,14 @@ form {
   }
 }
 
+select.field-input {
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1.25rem 1.25rem;
+  padding-inline-end: 2.25rem;
+}
+
 .field-input--error {
   border-color: var(--pav-color-red-400);
 
@@ -325,6 +335,35 @@ form {
 .form-required {
   color: var(--pav-color-red-500);
   margin-inline-start: 0.125rem;
+}
+
+.external-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.external-link-prompt {
+  flex: 0 0 auto;
+  min-width: 11rem;
+}
+
+.external-link-url {
+  flex: 1 1 18rem;
+  min-width: 0;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .field-textarea {
@@ -844,6 +883,70 @@ button {
             />
           </section>
 
+          <!-- EXTERNAL LINK Section -->
+          <section class="editor-section">
+            <h2 class="section-header">{{ tExternalLink('section_title') }}</h2>
+
+            <div class="section-card">
+              <div class="external-link-row">
+                <div class="form-field external-link-prompt">
+                  <label for="event-url-prompt" class="visually-hidden">
+                    {{ tExternalLink('prompt_label') }}
+                  </label>
+                  <select
+                    id="event-url-prompt"
+                    name="urlPrompt"
+                    v-model="urlPromptProxy"
+                    class="field-input"
+                    :class="{ 'field-input--error': fieldErrors.urlPrompt }"
+                    :aria-invalid="fieldErrors.urlPrompt ? 'true' : undefined"
+                    :aria-describedby="fieldErrors.urlPrompt ? 'event-urlPrompt-error' : undefined"
+                    @change="clearFieldError('urlPrompt')"
+                  >
+                    <option value="more_info">{{ tExternalLink('prompt_options.more_info') }}</option>
+                    <option value="tickets">{{ tExternalLink('prompt_options.tickets') }}</option>
+                    <option value="rsvp">{{ tExternalLink('prompt_options.rsvp') }}</option>
+                  </select>
+                  <p
+                    v-if="fieldErrors.urlPrompt"
+                    id="event-urlPrompt-error"
+                    class="form-error"
+                    role="alert"
+                  >
+                    {{ fieldErrors.urlPrompt }}
+                  </p>
+                </div>
+
+                <div class="form-field external-link-url">
+                  <label for="event-external-url" class="visually-hidden">
+                    {{ tExternalLink('url_label') }}
+                  </label>
+                  <input
+                    id="event-external-url"
+                    type="url"
+                    name="externalUrl"
+                    maxlength="2048"
+                    :placeholder="tExternalLink('url_placeholder')"
+                    v-model="editorState.event.externalUrl"
+                    class="field-input"
+                    :class="{ 'field-input--error': fieldErrors.externalUrl }"
+                    :aria-invalid="fieldErrors.externalUrl ? 'true' : undefined"
+                    :aria-describedby="fieldErrors.externalUrl ? 'event-externalUrl-error' : undefined"
+                    @input="clearFieldError('externalUrl')"
+                  />
+                  <p
+                    v-if="fieldErrors.externalUrl"
+                    id="event-externalUrl-error"
+                    class="form-error"
+                    role="alert"
+                  >
+                    {{ fieldErrors.externalUrl }}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+
           <!-- EVENT IMAGE Section -->
           <section class="editor-section">
             <h2 class="section-header">EVENT IMAGE</h2>
@@ -1055,6 +1158,9 @@ const router = useRouter();
 const { t } = useTranslation('event_editor', {
   keyPrefix: 'editor',
 });
+const { t: tExternalLink } = useTranslation('event_editor', {
+  keyPrefix: 'external_link',
+});
 
 // Initialize composables
 const defaultLanguage = 'en';
@@ -1118,6 +1224,18 @@ const errorContainer = ref(null);
 // Modal refs
 const locationPickerRef = ref(null);
 const createLocationFormRef = ref(null);
+
+// The dropdown shows 'more_info' when the event has no prompt set; the
+// value is only persisted as urlPrompt when the user actually provides a
+// URL (see handleSaveEvent, which strips urlPrompt to null when the URL
+// is empty to satisfy the backend's both-or-neither rule).
+const urlPromptProxy = computed({
+  get: () => editorState.event?.urlPrompt ?? 'more_info',
+  set: (value) => {
+    if (!editorState.event) return;
+    editorState.event.urlPrompt = value || null;
+  },
+});
 
 /**
  * Translated page title
@@ -1302,6 +1420,21 @@ const handleRemoveLanguage = (language) => {
  * Handle save event
  */
 const handleSaveEvent = async () => {
+  // Only persist urlPrompt when an external URL is actually set; the
+  // backend requires both fields to be set together or both cleared.
+  if (editorState.event) {
+    const url = (editorState.event.externalUrl ?? '').trim();
+    if (!url) {
+      editorState.event.externalUrl = null;
+      editorState.event.urlPrompt = null;
+    }
+    else {
+      // Ensure urlPrompt reflects the proxy value (may be null if event was
+      // loaded without a prompt, but the UI defaulted to 'more_info').
+      editorState.event.urlPrompt = urlPromptProxy.value;
+    }
+  }
+
   await saveEvent(t, () => {
     resetSnapshot(editorState.event, selectedCategories.value, mediaId.value);
   });

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -56,6 +56,19 @@
     "no_series_available": "No series available",
     "no_series_help": "Create series in calendar management to group related events"
   },
+  "external_link": {
+    "section_title": "External Link",
+    "url_label": "URL",
+    "url_placeholder": "https://",
+    "prompt_label": "Button Label",
+    "prompt_options": {
+      "tickets": "Tickets:",
+      "rsvp": "RSVP:",
+      "more_info": "More Information:"
+    },
+    "error_invalid_url": "Please enter a valid http or https URL.",
+    "error_prompt_required": "URL and button label must both be set or both be empty."
+  },
   "recurrence": {
     "dailyTerm": "days",
     "weeklyTerm": "weeks",

--- a/src/client/test/edit_event.vue.test.ts
+++ b/src/client/test/edit_event.vue.test.ts
@@ -505,3 +505,113 @@ describe('Location Integration', () => {
     expect(wrapper.findComponent({ name: 'LocationPickerModal' }).exists()).toBe(true);
   });
 });
+
+describe('External Link Section', () => {
+  let currentWrapper: any = null;
+  let pinia: Pinia;
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sinon.restore();
+    sandbox = sinon.createSandbox();
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    if (currentWrapper) {
+      currentWrapper.unmount();
+      currentWrapper = null;
+      await nextTick();
+    }
+  });
+
+  it('renders external URL input and prompt dropdown', async () => {
+    const calendar = new Calendar('testId', 'testName');
+    calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+    const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+    currentWrapper = wrapper;
+
+    const urlInput = wrapper.find('input[name="externalUrl"]');
+    expect(urlInput.exists()).toBe(true);
+    expect(urlInput.attributes('type')).toBe('url');
+
+    const promptSelect = wrapper.find('select[name="urlPrompt"]');
+    expect(promptSelect.exists()).toBe(true);
+
+    // Three non-null options: more_info (default first), tickets, rsvp
+    const options = promptSelect.findAll('option');
+    expect(options.length).toBe(3);
+    expect(options[0].attributes('value')).toBe('more_info');
+  });
+
+  it('binds URL input to event.externalUrl', async () => {
+    const calendar = new Calendar('testId', 'testName');
+    calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+    const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+    currentWrapper = wrapper;
+
+    const urlInput = wrapper.find('input[name="externalUrl"]');
+    await urlInput.setValue('https://example.com/tickets');
+    await nextTick();
+
+    expect(wrapper.vm.state.event.externalUrl).toBe('https://example.com/tickets');
+  });
+
+  it('binds prompt dropdown to event.urlPrompt', async () => {
+    const calendar = new Calendar('testId', 'testName');
+    calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+    const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+    currentWrapper = wrapper;
+
+    // Backing state starts null (no prompt persisted until URL is set)
+    expect(wrapper.vm.state.event.urlPrompt).toBeNull();
+
+    const promptSelect = wrapper.find('select[name="urlPrompt"]');
+    await promptSelect.setValue('tickets');
+    await nextTick();
+
+    expect(wrapper.vm.state.event.urlPrompt).toBe('tickets');
+  });
+
+  it('surfaces server field error for externalUrl on the URL input', async () => {
+    const calendar = new Calendar('testId', 'testName');
+    calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+    const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+    currentWrapper = wrapper;
+
+    // Directly populate fieldErrors (exposed via defineExpose)
+    wrapper.vm.fieldErrors.externalUrl = 'Please enter a valid http or https URL.';
+    await nextTick();
+
+    const urlInput = wrapper.find('input[name="externalUrl"]');
+    expect(urlInput.attributes('aria-invalid')).toBe('true');
+
+    const errorMsg = wrapper.find('#event-externalUrl-error');
+    expect(errorMsg.exists()).toBe(true);
+    expect(errorMsg.text()).toContain('Please enter a valid http or https URL.');
+  });
+
+  it('surfaces server field error for urlPrompt on the dropdown', async () => {
+    const calendar = new Calendar('testId', 'testName');
+    calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+    const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+    currentWrapper = wrapper;
+
+    wrapper.vm.fieldErrors.urlPrompt = 'URL and button label must both be set or both be empty.';
+    await nextTick();
+
+    const promptSelect = wrapper.find('select[name="urlPrompt"]');
+    expect(promptSelect.attributes('aria-invalid')).toBe('true');
+
+    const errorMsg = wrapper.find('#event-urlPrompt-error');
+    expect(errorMsg.exists()).toBe(true);
+  });
+});

--- a/src/common/exceptions/calendar.ts
+++ b/src/common/exceptions/calendar.ts
@@ -11,6 +11,18 @@ export class InvalidUrlNameError extends Error {
 }
 
 /**
+ * Custom error class for invalid external URL on an event
+ */
+export class InvalidExternalUrlError extends Error {
+  constructor(message: string = 'invalid external url') {
+    super(message);
+    this.name = 'InvalidExternalUrlError';
+    // Maintaining proper prototype chain in ES5+
+    Object.setPrototypeOf(this, InvalidExternalUrlError.prototype);
+  }
+}
+
+/**
  * Custom error class for calendar URL name that already exists
  */
 export class UrlNameAlreadyExistsError extends Error {

--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -22,6 +22,16 @@ export type startAndEndDates = {
 };
 
 /**
+ * Prompt used to label the event's external URL (e.g., "Tickets", "RSVP", "More Info").
+ */
+export type UrlPrompt = 'tickets' | 'rsvp' | 'more_info';
+
+/**
+ * Runtime-valid set of {@link UrlPrompt} values for enum checks on untrusted input.
+ */
+export const URL_PROMPT_VALUES: readonly UrlPrompt[] = ['tickets', 'rsvp', 'more_info'] as const;
+
+/**
  * Represents a calendar event with multilingual content support.
  * Extends TranslatedModel to manage event content in different languages.
  *
@@ -78,6 +88,16 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
    * Default: 'none'. Must be explicitly set after retrieval if needed.
    */
   repostStatus: 'none' | 'manual' | 'auto' = 'none';
+  /**
+   * Optional external URL attached to an event (e.g., ticket page, RSVP link).
+   * Non-translatable — the same URL applies across all languages.
+   */
+  externalUrl: string | null = null;
+  /**
+   * Prompt/label for the external URL. Used by the UI to choose CTA copy.
+   * Non-translatable; the UI localizes via the enum value.
+   */
+  urlPrompt: UrlPrompt | null = null;
 
   /**
    * Derived flag: true when this event was obtained via a repost (auto or manual)
@@ -188,6 +208,8 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
       event.repostStatus = 'none';
     }
     event.sourceCalendar = obj.sourceCalendar ?? null;
+    event.externalUrl = obj.externalUrl ?? null;
+    event.urlPrompt = URL_PROMPT_VALUES.includes(obj.urlPrompt) ? obj.urlPrompt : null;
 
     if ( obj.content ) {
       for( let [language,strings] of Object.entries(obj.content) ) {
@@ -239,6 +261,8 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
       mediaFocalPointY: this.mediaFocalPointY,
       mediaZoom: this.mediaZoom,
       eventSourceUrl: this.eventSourceUrl,
+      externalUrl: this.externalUrl,
+      urlPrompt: this.urlPrompt,
       content: Object.fromEntries(
         Object.entries(this._content)
           .map(([language, strings]: [string, CalendarEventContent]) => [language, strings.toObject()]),
@@ -440,3 +464,4 @@ class CalendarEventSchedule extends Model {
 export {
   CalendarEvent, CalendarEventContent, CalendarEventSchedule, language, event_activity, EventFrequency,
 };
+

--- a/src/common/test/calendar_event_external_url.test.ts
+++ b/src/common/test/calendar_event_external_url.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect } from 'vitest';
+import { CalendarEvent, URL_PROMPT_VALUES, UrlPrompt } from '@/common/model/events';
+import { InvalidExternalUrlError } from '@/common/exceptions/calendar';
+
+describe('CalendarEvent Model - externalUrl and urlPrompt', () => {
+  test('externalUrl defaults to null', () => {
+    const event = new CalendarEvent('event-123', 'cal-456');
+    expect(event.externalUrl).toBeNull();
+  });
+
+  test('urlPrompt defaults to null', () => {
+    const event = new CalendarEvent('event-123', 'cal-456');
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  test('URL_PROMPT_VALUES contains the three supported prompts', () => {
+    expect(URL_PROMPT_VALUES).toEqual(['tickets', 'rsvp', 'more_info']);
+  });
+
+  test('toObject emits externalUrl and urlPrompt when set', () => {
+    const event = new CalendarEvent('event-123', 'cal-456');
+    event.externalUrl = 'https://example.com/tickets';
+    event.urlPrompt = 'tickets';
+
+    const obj = event.toObject();
+
+    expect(obj.externalUrl).toBe('https://example.com/tickets');
+    expect(obj.urlPrompt).toBe('tickets');
+  });
+
+  test('toObject emits null fields when not set', () => {
+    const event = new CalendarEvent('event-123', 'cal-456');
+
+    const obj = event.toObject();
+
+    expect(obj.externalUrl).toBeNull();
+    expect(obj.urlPrompt).toBeNull();
+  });
+
+  test('fromObject reads externalUrl and urlPrompt', () => {
+    const obj = {
+      id: 'event-123',
+      calendarId: 'cal-456',
+      externalUrl: 'https://example.com/rsvp',
+      urlPrompt: 'rsvp',
+      date: '2024-06-15',
+      content: {},
+      schedules: [],
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+
+    expect(event.externalUrl).toBe('https://example.com/rsvp');
+    expect(event.urlPrompt).toBe('rsvp');
+  });
+
+  test('fromObject defaults externalUrl and urlPrompt to null when absent', () => {
+    const obj = {
+      id: 'event-123',
+      calendarId: 'cal-456',
+      date: '2024-06-15',
+      content: {},
+      schedules: [],
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  test('fromObject handles explicit null values', () => {
+    const obj = {
+      id: 'event-123',
+      calendarId: 'cal-456',
+      externalUrl: null,
+      urlPrompt: null,
+      date: '2024-06-15',
+      content: {},
+      schedules: [],
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  test('fromObject sanitizes invalid urlPrompt to null', () => {
+    const obj = {
+      id: 'event-123',
+      calendarId: 'cal-456',
+      externalUrl: 'https://example.com',
+      urlPrompt: 'not_a_real_prompt',
+      date: '2024-06-15',
+      content: {},
+      schedules: [],
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+
+    expect(event.externalUrl).toBe('https://example.com');
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  test('fromObject sanitizes non-string urlPrompt to null', () => {
+    const obj = {
+      id: 'event-123',
+      calendarId: 'cal-456',
+      urlPrompt: 42,
+      date: '2024-06-15',
+      content: {},
+      schedules: [],
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  test.each(URL_PROMPT_VALUES)('round-trip preserves urlPrompt=%s', (prompt: UrlPrompt) => {
+    const original = new CalendarEvent('event-123', 'cal-456');
+    original.externalUrl = 'https://example.com/link';
+    original.urlPrompt = prompt;
+
+    const roundTrip = CalendarEvent.fromObject(original.toObject());
+
+    expect(roundTrip.externalUrl).toBe('https://example.com/link');
+    expect(roundTrip.urlPrompt).toBe(prompt);
+  });
+
+  test('round-trip preserves null externalUrl and urlPrompt', () => {
+    const original = new CalendarEvent('event-123', 'cal-456');
+
+    const roundTrip = CalendarEvent.fromObject(original.toObject());
+
+    expect(roundTrip.externalUrl).toBeNull();
+    expect(roundTrip.urlPrompt).toBeNull();
+  });
+});
+
+describe('InvalidExternalUrlError', () => {
+  test('has default message', () => {
+    const err = new InvalidExternalUrlError();
+    expect(err.message).toBe('invalid external url');
+    expect(err.name).toBe('InvalidExternalUrlError');
+  });
+
+  test('accepts custom message', () => {
+    const err = new InvalidExternalUrlError('custom message');
+    expect(err.message).toBe('custom message');
+  });
+
+  test('is an instance of Error and InvalidExternalUrlError', () => {
+    const err = new InvalidExternalUrlError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(InvalidExternalUrlError);
+  });
+});

--- a/src/server/activitypub/model/object/event.ts
+++ b/src/server/activitypub/model/object/event.ts
@@ -4,16 +4,52 @@ import { DateTime } from 'luxon';
 import striptags from 'striptags';
 
 import { Calendar } from '@/common/model/calendar';
-import { CalendarEvent, CalendarEventSchedule } from '@/common/model/events';
+import { CalendarEvent, CalendarEventSchedule, UrlPrompt, URL_PROMPT_VALUES } from '@/common/model/events';
 import { EventLocation } from '@/common/model/location';
 import { ActivityPubObject } from '@/server/activitypub/model/base';
 import { SeriesObject } from '@/server/activitypub/model/object/series';
+
+/**
+ * English fallback labels for URL prompt tokens. Emitted in the outbound AS
+ * `attachment.name` so non-Pavillion peers (Mobilizon, Gancio) can render a
+ * human-readable label. Pavillion peers round-trip the raw enum token via the
+ * `pavillion:urlPrompt` extension field.
+ */
+const URL_PROMPT_EN_LABELS: Record<UrlPrompt, string> = {
+  tickets: 'Tickets',
+  rsvp: 'RSVP',
+  more_info: 'More Information',
+};
 
 /**
  * Strips HTML tags and decodes HTML entities from a string.
  */
 function stripHtmlTags(html: string): string {
   return striptags(he.decode(html)).trim();
+}
+
+/**
+ * Sanitizes an untrusted href value from a federated peer. Returns a parsed
+ * http(s) URL string or null for any anomaly (non-string, empty/whitespace,
+ * too long, malformed, or non-http(s) scheme).
+ *
+ * Security-critical: This is the authoritative barrier against malicious peers
+ * injecting javascript:, data:, ftp:, or other dangerous URL schemes into
+ * stored event data. NEVER throws — a throw would cause the inbox to reject
+ * the entire activity, which is not the correct posture for a single bad field.
+ */
+function sanitizeExternalUrlHref(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed.length > 2048) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
 }
 
 class EventObject extends ActivityPubObject {
@@ -185,6 +221,22 @@ class EventObject extends ActivityPubObject {
       };
     }
 
+    // attachment Link + pavillion:urlPrompt: emit only when BOTH fields are set.
+    // Service-layer guard ensures externalUrl and urlPrompt are always set together.
+    // The AS top-level `url` field is intentionally NOT overloaded — it is reserved
+    // for the canonical event page (Mobilizon compatibility).
+    if (event.externalUrl && event.urlPrompt) {
+      result.attachment = [
+        {
+          type: 'Link',
+          href: event.externalUrl,
+          name: URL_PROMPT_EN_LABELS[event.urlPrompt],
+          rel: 'external',
+        },
+      ];
+      result['pavillion:urlPrompt'] = event.urlPrompt;
+    }
+
     // pavillion:* extensions
     result['pavillion:content'] = event.toObject().content;
     result['pavillion:categories'] = this.categories;
@@ -281,6 +333,35 @@ class EventObject extends ActivityPubObject {
     else if (apObject.series !== undefined) {
       result.series = apObject.series;
     }
+
+    // --- externalUrl + urlPrompt resolution ---
+    // Security-critical: sanitize inbound attachment Link href and urlPrompt enum.
+    // Cross-field invariant: both must be valid together, or both are null. A partial
+    // record (only one field valid) is never persisted — it is dropped entirely.
+    let parsedExternalUrl: string | null = null;
+    if (Array.isArray(apObject.attachment)) {
+      const externalLink = apObject.attachment.find(
+        (a: any) => a && a.type === 'Link' && a.rel === 'external',
+      );
+      if (externalLink) {
+        parsedExternalUrl = sanitizeExternalUrlHref(externalLink.href);
+      }
+    }
+
+    let parsedPrompt: UrlPrompt | null = null;
+    const rawPrompt = apObject['pavillion:urlPrompt'];
+    if (typeof rawPrompt === 'string' && URL_PROMPT_VALUES.includes(rawPrompt as UrlPrompt)) {
+      parsedPrompt = rawPrompt as UrlPrompt;
+    }
+
+    // Cross-field consistency: if only one is set, null them both
+    if (!parsedExternalUrl || !parsedPrompt) {
+      parsedExternalUrl = null;
+      parsedPrompt = null;
+    }
+
+    result.externalUrl = parsedExternalUrl;
+    result.urlPrompt = parsedPrompt;
 
     // --- Schedules resolution ---
     // Priority: pavillion:schedules > bare schedules > synthesize from startTime/endTime

--- a/src/server/activitypub/test/integration/event_external_url_federation.test.ts
+++ b/src/server/activitypub/test/integration/event_external_url_federation.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent } from '@/common/model/events';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/test/lib/test_environment';
+import { EventObject } from '@/server/activitypub/model/object/event';
+
+/**
+ * Integration tests for externalUrl + urlPrompt AP federation round-trip.
+ *
+ * The end-to-end path under test:
+ *
+ *   local CalendarEvent  -- EventObject.toActivityPubObject -->  AS JSON
+ *            AS JSON     -- EventObject.fromActivityPubObject -> eventParams
+ *            eventParams -- calendarInterface.addRemoteEvent ---> stored EventEntity
+ *            stored EventEntity -- getEventById --> CalendarEvent
+ *
+ * This exercises the real service + entity + SQLite stack for the AP sides
+ * of externalUrl/urlPrompt handling, complementing the unit tests in
+ * `src/server/activitypub/test/model/object/event.test.ts`.
+ */
+describe('Event externalUrl + urlPrompt — AP federation round-trip (integration)', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let testAccount: Account;
+  let sourceCalendar: Calendar;
+  let eventBus: EventEmitter;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+
+    calendarInterface.setActivityPubInterface({
+      getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
+      findCalendarActorByCalendarId: async () => null,
+    } as any);
+
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const info = await accountService._setupAccount('ap-exturl@pavillion.dev', 'testpassword');
+    testAccount = info.account;
+    sourceCalendar = await calendarInterface.createCalendar(testAccount, 'apexturlsource');
+  });
+
+  afterAll(async () => {
+    if (eventBus) {
+      eventBus.removeAllListeners();
+    }
+    await env.cleanup();
+  });
+
+  /**
+   * Build a Calendar-shaped model for a pretend "remote" calendar. The AP
+   * EventObject only uses the urlName to construct the `attributedTo` URL,
+   * so this does not need to be persisted.
+   */
+  function makeRemoteCalendarModel(urlName: string): Calendar {
+    return new Calendar(uuidv4(), urlName);
+  }
+
+  describe('serialize → parse preservation', () => {
+    it('preserves externalUrl and urlPrompt when both fields are set', async () => {
+      // Outbound: create a local source event with both fields set
+      const sourceEvent = await calendarInterface.createEvent(testAccount, {
+        calendarId: sourceCalendar.id,
+        content: {
+          en: { name: 'Round-trip Tickets Event' },
+        },
+        start_date: '2026-06-01',
+        externalUrl: 'https://example.com/tix',
+        urlPrompt: 'tickets',
+      });
+
+      // Serialize via EventObject (the same path the outbox dispatcher uses)
+      const apObject = new EventObject(sourceCalendar, sourceEvent).toActivityPubObject();
+
+      expect(apObject.attachment).toEqual([
+        {
+          type: 'Link',
+          href: 'https://example.com/tix',
+          name: 'Tickets',
+          rel: 'external',
+        },
+      ]);
+      expect(apObject['pavillion:urlPrompt']).toBe('tickets');
+
+      // Inbound: parse the AS JSON and store on a fresh "receiver" calendar
+      const parsedParams = EventObject.fromActivityPubObject(apObject);
+      expect(parsedParams.externalUrl).toBe('https://example.com/tix');
+      expect(parsedParams.urlPrompt).toBe('tickets');
+
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apreceiver1');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...parsedParams,
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+      });
+
+      const stored = await calendarInterface.getEventById(storedEventId);
+      expect(stored.externalUrl).toBe('https://example.com/tix');
+      expect(stored.urlPrompt).toBe('tickets');
+    });
+
+    it('preserves null externalUrl and null urlPrompt when neither field is set', async () => {
+      const sourceEvent = await calendarInterface.createEvent(testAccount, {
+        calendarId: sourceCalendar.id,
+        content: {
+          en: { name: 'Round-trip No URL Event' },
+        },
+        start_date: '2026-06-02',
+      });
+
+      const apObject = new EventObject(sourceCalendar, sourceEvent).toActivityPubObject();
+      expect(apObject).not.toHaveProperty('attachment');
+      expect(apObject).not.toHaveProperty('pavillion:urlPrompt');
+
+      const parsedParams = EventObject.fromActivityPubObject(apObject);
+      expect(parsedParams.externalUrl).toBeNull();
+      expect(parsedParams.urlPrompt).toBeNull();
+
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apreceiver2');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...parsedParams,
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+      });
+
+      const stored = await calendarInterface.getEventById(storedEventId);
+      expect(stored.externalUrl).toBeNull();
+      expect(stored.urlPrompt).toBeNull();
+    });
+
+    it('emits exactly attachment[Link rel:external] plus pavillion:urlPrompt (no url-field overload)', async () => {
+      const sourceEvent = await calendarInterface.createEvent(testAccount, {
+        calendarId: sourceCalendar.id,
+        content: { en: { name: 'Shape Check Event' } },
+        start_date: '2026-06-03',
+        externalUrl: 'https://example.com/rsvp',
+        urlPrompt: 'rsvp',
+      });
+
+      const apObject = new EventObject(sourceCalendar, sourceEvent).toActivityPubObject();
+
+      // attachment contains exactly one well-formed Link entry
+      expect(Array.isArray(apObject.attachment)).toBe(true);
+      expect(apObject.attachment).toHaveLength(1);
+      const att = apObject.attachment[0];
+      expect(att.type).toBe('Link');
+      expect(att.href).toBe('https://example.com/rsvp');
+      expect(att.name).toBe('RSVP');
+      expect(att.rel).toBe('external');
+      expect(Object.keys(att).sort()).toEqual(['href', 'name', 'rel', 'type']);
+
+      // pavillion:urlPrompt extension carries the raw enum token
+      expect(apObject['pavillion:urlPrompt']).toBe('rsvp');
+
+      // AS top-level `url` field must NOT be overloaded with the external URL
+      // (reserved for the canonical event page; Mobilizon compatibility).
+      if (apObject.url !== undefined) {
+        expect(apObject.url).not.toBe('https://example.com/rsvp');
+      }
+    });
+  });
+
+  describe('malicious inbound payloads are dropped on storage', () => {
+    it('stores null externalUrl and null urlPrompt when inbound href is javascript:', async () => {
+      // Hand-crafted hostile AS payload (as if from a malicious peer)
+      const hostileApObject: Record<string, any> = {
+        type: 'Event',
+        id: `https://evil.example.com/calendars/baddie/events/${uuidv4()}`,
+        attributedTo: 'https://evil.example.com/calendars/baddie',
+        name: 'Malicious Event',
+        startTime: '2026-06-10T10:00:00Z',
+        endTime: '2026-06-10T11:00:00Z',
+        attachment: [
+          {
+            type: 'Link',
+            href: 'javascript:alert(1)',
+            name: 'Tickets',
+            rel: 'external',
+          },
+        ],
+        'pavillion:urlPrompt': 'tickets',
+      };
+
+      const parsedParams = EventObject.fromActivityPubObject(hostileApObject);
+      // Cross-field rule: both must be null when either is invalid
+      expect(parsedParams.externalUrl).toBeNull();
+      expect(parsedParams.urlPrompt).toBeNull();
+
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apreceiverhostilejs');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...parsedParams,
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+        content: { en: { name: 'Malicious Event' } },
+      });
+
+      const stored: CalendarEvent = await calendarInterface.getEventById(storedEventId);
+      expect(stored.externalUrl).toBeNull();
+      expect(stored.urlPrompt).toBeNull();
+    });
+
+    it('stores null externalUrl and null urlPrompt when inbound pavillion:urlPrompt is not whitelisted', async () => {
+      const hostileApObject: Record<string, any> = {
+        type: 'Event',
+        id: `https://remote.example.com/calendars/ok/events/${uuidv4()}`,
+        attributedTo: 'https://remote.example.com/calendars/ok',
+        name: 'Unknown Prompt Event',
+        startTime: '2026-06-11T10:00:00Z',
+        endTime: '2026-06-11T11:00:00Z',
+        attachment: [
+          {
+            type: 'Link',
+            href: 'https://example.com/legit',
+            name: 'Buy Tickets',
+            rel: 'external',
+          },
+        ],
+        // Not in the whitelist — should cause both fields to be nulled
+        'pavillion:urlPrompt': 'nope',
+      };
+
+      const parsedParams = EventObject.fromActivityPubObject(hostileApObject);
+      expect(parsedParams.externalUrl).toBeNull();
+      expect(parsedParams.urlPrompt).toBeNull();
+
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apreceiverunknownprompt');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...parsedParams,
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+        content: { en: { name: 'Unknown Prompt Event' } },
+      });
+
+      const stored = await calendarInterface.getEventById(storedEventId);
+      expect(stored.externalUrl).toBeNull();
+      expect(stored.urlPrompt).toBeNull();
+    });
+
+    it('stores null externalUrl and null urlPrompt when inbound href is a data: URI', async () => {
+      const hostileApObject: Record<string, any> = {
+        type: 'Event',
+        id: `https://remote.example.com/calendars/ok/events/${uuidv4()}`,
+        attributedTo: 'https://remote.example.com/calendars/ok',
+        name: 'Data URI Event',
+        startTime: '2026-06-12T10:00:00Z',
+        endTime: '2026-06-12T11:00:00Z',
+        attachment: [
+          {
+            type: 'Link',
+            href: 'data:text/html,<script>alert(1)</script>',
+            name: 'Tickets',
+            rel: 'external',
+          },
+        ],
+        'pavillion:urlPrompt': 'tickets',
+      };
+
+      const parsedParams = EventObject.fromActivityPubObject(hostileApObject);
+      expect(parsedParams.externalUrl).toBeNull();
+      expect(parsedParams.urlPrompt).toBeNull();
+
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apreceiverdata');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...parsedParams,
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+        content: { en: { name: 'Data URI Event' } },
+      });
+
+      const stored = await calendarInterface.getEventById(storedEventId);
+      expect(stored.externalUrl).toBeNull();
+      expect(stored.urlPrompt).toBeNull();
+    });
+  });
+
+  describe('cross-instance round-trip (outbound → inbound → outbound)', () => {
+    it('serializes again from a stored remote event with identical attachment + pavillion:urlPrompt', async () => {
+      // Outbound from source
+      const sourceEvent = await calendarInterface.createEvent(testAccount, {
+        calendarId: sourceCalendar.id,
+        content: { en: { name: 'Double Hop Event' } },
+        start_date: '2026-06-20',
+        externalUrl: 'https://example.com/info',
+        urlPrompt: 'more_info',
+      });
+
+      const firstAp = new EventObject(sourceCalendar, sourceEvent).toActivityPubObject();
+
+      // Receive and store as a remote event on a second calendar
+      const receiverCalendar = await calendarInterface.createCalendar(testAccount, 'apdoublehop');
+      const storedEventId = uuidv4();
+      await calendarInterface.addRemoteEvent(receiverCalendar, {
+        ...EventObject.fromActivityPubObject(firstAp),
+        id: storedEventId,
+        calendarId: receiverCalendar.id,
+      });
+      const storedRemote = await calendarInterface.getEventById(storedEventId);
+
+      // Now serialize that remote event again (simulating a re-broadcast)
+      const secondAp = new EventObject(receiverCalendar, storedRemote).toActivityPubObject();
+
+      expect(secondAp.attachment).toEqual([
+        {
+          type: 'Link',
+          href: 'https://example.com/info',
+          name: 'More Information',
+          rel: 'external',
+        },
+      ]);
+      expect(secondAp['pavillion:urlPrompt']).toBe('more_info');
+    });
+  });
+
+  // Silence unused-variable lint on the helper — it is imported here for
+  // future tests that may want to construct payloads attributed to a
+  // remote-looking calendar identity without persisting it.
+  it('helper makeRemoteCalendarModel is usable for AP payload construction', () => {
+    const remote = makeRemoteCalendarModel('notlocal');
+    expect(remote.urlName).toBe('notlocal');
+    expect(remote.id).toMatch(/^[0-9a-f-]+$/i);
+  });
+});

--- a/src/server/activitypub/test/model/object/event.test.ts
+++ b/src/server/activitypub/test/model/object/event.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import config from 'config';
 import { DateTime } from 'luxon';
 import { Calendar } from '@/common/model/calendar';
-import { CalendarEvent, CalendarEventContent, CalendarEventSchedule } from '@/common/model/events';
+import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, UrlPrompt } from '@/common/model/events';
 import { EventCategory } from '@/common/model/event_category';
 import { EventSeries } from '@/common/model/event_series';
 import { EventSeriesContent } from '@/common/model/event_series_content';
@@ -458,6 +458,114 @@ describe('EventObject', () => {
       });
     });
 
+    describe('externalUrl + urlPrompt serialization', () => {
+
+      it('should emit attachment Link and pavillion:urlPrompt when both fields are set', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/tickets';
+        event.urlPrompt = 'tickets';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result.attachment).toEqual([
+          {
+            type: 'Link',
+            href: 'https://example.com/tickets',
+            name: 'Tickets',
+            rel: 'external',
+          },
+        ]);
+        expect(result['pavillion:urlPrompt']).toBe('tickets');
+      });
+
+      it('should emit correct translated label for rsvp prompt', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/rsvp';
+        event.urlPrompt = 'rsvp';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result.attachment[0].name).toBe('RSVP');
+        expect(result.attachment[0].rel).toBe('external');
+        expect(result['pavillion:urlPrompt']).toBe('rsvp');
+      });
+
+      it('should emit correct translated label for more_info prompt', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/info';
+        event.urlPrompt = 'more_info';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result.attachment[0].name).toBe('More Information');
+        expect(result['pavillion:urlPrompt']).toBe('more_info');
+      });
+
+      it('should not emit attachment or pavillion:urlPrompt when both fields are null', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result).not.toHaveProperty('attachment');
+        expect(result).not.toHaveProperty('pavillion:urlPrompt');
+      });
+
+      it('should not emit attachment or pavillion:urlPrompt when only externalUrl is set', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/tickets';
+        event.urlPrompt = null;
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result).not.toHaveProperty('attachment');
+        expect(result).not.toHaveProperty('pavillion:urlPrompt');
+      });
+
+      it('should not emit attachment or pavillion:urlPrompt when only urlPrompt is set', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = null;
+        event.urlPrompt = 'tickets';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result).not.toHaveProperty('attachment');
+        expect(result).not.toHaveProperty('pavillion:urlPrompt');
+      });
+
+      it('should not use or overload the AS top-level url field', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/tickets';
+        event.urlPrompt = 'tickets';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        // AS top-level `url` is reserved for Mobilizon's canonical event page.
+        expect(result).not.toHaveProperty('url');
+      });
+
+    });
+
   });
 
   describe('fromActivityPubObject()', () => {
@@ -877,6 +985,264 @@ describe('EventObject', () => {
       const result = EventObject.fromActivityPubObject(apObject);
       expect(result.content.de).toBeDefined();
       expect(result.content.de.description).toBe('Deutsch');
+    });
+
+    describe('externalUrl + urlPrompt parsing', () => {
+
+      it('should parse attachment Link with rel:external and pavillion:urlPrompt', () => {
+        const apObject = {
+          name: 'Test',
+          startTime: '2026-04-15T09:00:00Z',
+          attachment: [
+            { type: 'Link', href: 'https://example.com/tickets', rel: 'external', name: 'Tickets' },
+          ],
+          'pavillion:urlPrompt': 'tickets' as UrlPrompt,
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBe('https://example.com/tickets');
+        expect(result.urlPrompt).toBe('tickets');
+      });
+
+      it('should null externalUrl when href is javascript: scheme', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'javascript:alert(1)', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is data: URI', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'data:text/html,<script>alert(1)</script>', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is ftp: scheme', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'ftp://example.com/file', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null both fields when pavillion:urlPrompt is not in the whitelist', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'https://example.com/tickets', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'buy_now_pay_later', // not a valid enum
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null both fields when pavillion:urlPrompt is missing but href is valid', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'https://example.com/tickets', rel: 'external' },
+          ],
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null both fields when pavillion:urlPrompt is set but href is missing', () => {
+        const apObject = {
+          name: 'Test',
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should ignore attachment entries without rel:external', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 'https://example.com/canonical', rel: 'canonical' },
+            { type: 'Link', href: 'https://example.com/alt', rel: 'alternate' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is empty string', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: '', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is whitespace only', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: '   ', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href exceeds 2048 characters', () => {
+        const longHref = 'https://example.com/' + 'a'.repeat(2050);
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: longHref, rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is protocol-relative', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: '//example.com/tickets', rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should null externalUrl when href is not a string', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: [
+            { type: 'Link', href: 12345, rel: 'external' },
+          ],
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should handle non-array attachment gracefully', () => {
+        const apObject = {
+          name: 'Test',
+          attachment: { type: 'Link', href: 'https://example.com', rel: 'external' },
+          'pavillion:urlPrompt': 'tickets',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
+      it('should accept all three valid urlPrompt values (rsvp, more_info)', () => {
+        const rsvpResult = EventObject.fromActivityPubObject({
+          name: 'Test',
+          attachment: [{ type: 'Link', href: 'https://example.com/rsvp', rel: 'external' }],
+          'pavillion:urlPrompt': 'rsvp',
+        });
+        expect(rsvpResult.externalUrl).toBe('https://example.com/rsvp');
+        expect(rsvpResult.urlPrompt).toBe('rsvp');
+
+        const infoResult = EventObject.fromActivityPubObject({
+          name: 'Test',
+          attachment: [{ type: 'Link', href: 'https://example.com/info', rel: 'external' }],
+          'pavillion:urlPrompt': 'more_info',
+        });
+        expect(infoResult.externalUrl).toBe('https://example.com/info');
+        expect(infoResult.urlPrompt).toBe('more_info');
+      });
+
+      it('should round-trip externalUrl and urlPrompt through toActivityPubObject and fromActivityPubObject', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Round Trip', 'desc'));
+        event.date = '2026-04-15';
+        event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00Z'))];
+        event.externalUrl = 'https://example.com/tickets';
+        event.urlPrompt = 'tickets';
+
+        const obj = new EventObject(calendar, event);
+        const apOutput = obj.toActivityPubObject();
+        const normalized = EventObject.fromActivityPubObject(apOutput);
+
+        expect(normalized.externalUrl).toBe('https://example.com/tickets');
+        expect(normalized.urlPrompt).toBe('tickets');
+      });
+
+      it('should not set externalUrl or urlPrompt when neither attachment nor pavillion:urlPrompt present', () => {
+        const apObject = {
+          name: 'Test',
+          startTime: '2026-04-15T09:00:00Z',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.externalUrl).toBeNull();
+        expect(result.urlPrompt).toBeNull();
+      });
+
     });
 
   });

--- a/src/server/calendar/entity/event.ts
+++ b/src/server/calendar/entity/event.ts
@@ -1,7 +1,7 @@
 import { Model, Table, Column, PrimaryKey, BelongsTo, DataType, ForeignKey, HasMany, Index } from 'sequelize-typescript';
 import { DateTime } from 'luxon';
 
-import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, language } from '@/common/model/events';
+import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, UrlPrompt, language } from '@/common/model/events';
 import db from '@/server/common/entity/db';
 import { LocationEntity } from '@/server/calendar/entity/location';
 import { MediaEntity } from '@/server/media/entity/media';
@@ -62,6 +62,12 @@ class EventEntity extends Model {
   @Column({ type: DataType.UUID, allowNull: true })
   declare series_id: string | null;
 
+  @Column({ type: DataType.STRING(2048), allowNull: true })
+  declare external_url: string | null;
+
+  @Column({ type: DataType.STRING(32), allowNull: true })
+  declare url_prompt: string | null;
+
   @BelongsTo(() => EventEntity)
   declare parentEvent: EventEntity;
 
@@ -92,6 +98,8 @@ class EventEntity extends Model {
     model.mediaFocalPointX = this.media_focal_point_x;
     model.mediaFocalPointY = this.media_focal_point_y;
     model.mediaZoom = this.media_zoom;
+    model.externalUrl = this.external_url;
+    model.urlPrompt = this.url_prompt as UrlPrompt | null;
     if (this.location) {
       model.location = this.location.toModel();
     }
@@ -122,6 +130,8 @@ class EventEntity extends Model {
       media_focal_point_y: event.mediaFocalPointY,
       media_zoom: event.mediaZoom,
       series_id: event.series?.id ?? null,
+      external_url: event.externalUrl,
+      url_prompt: event.urlPrompt,
     });
   }
 };

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -6,7 +6,7 @@ import { Account } from "@/common/model/account";
 import { Calendar } from "@/common/model/calendar";
 import { CalendarMemberEntity } from "@/server/calendar/entity/calendar_member";
 import type { CalendarActor } from "@/server/activitypub/entity/calendar_actor";
-import { CalendarEvent, CalendarEventContent, CalendarEventSchedule } from "@/common/model/events";
+import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, UrlPrompt, URL_PROMPT_VALUES } from "@/common/model/events";
 import { EventCategory } from "@/common/model/event_category";
 import { EventLocation, validateLocationHierarchy } from "@/common/model/location";
 import { EventContentEntity, EventEntity, EventScheduleEntity } from "@/server/calendar/entity/event";
@@ -20,7 +20,7 @@ import LocationService from "@/server/calendar/service/locations";
 import { EventEmitter } from 'events';
 import type MediaInterface from '@/server/media/interface';
 import type ActivityPubInterface from '@/server/activitypub/interface';
-import { EventNotFoundError, InsufficientCalendarPermissionsError, CalendarNotFoundError, BulkEventsNotFoundError, MixedCalendarEventsError, CategoriesNotFoundError, LocationValidationError } from '@/common/exceptions/calendar';
+import { EventNotFoundError, InsufficientCalendarPermissionsError, CalendarNotFoundError, BulkEventsNotFoundError, MixedCalendarEventsError, CategoriesNotFoundError, LocationValidationError, InvalidExternalUrlError } from '@/common/exceptions/calendar';
 import { ValidationError } from '@/common/exceptions/base';
 import CategoryService from './categories';
 import { EventCategoryEntity } from '@/server/calendar/entity/event_category';
@@ -37,6 +37,100 @@ import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('calendar');
 import { Op, literal, where, fn, col, type Transaction } from 'sequelize';
+
+/**
+ * Normalizes an optional external URL attached to an event.
+ *
+ * - null/undefined → null
+ * - empty/whitespace → null
+ * - > 2048 chars → InvalidExternalUrlError
+ * - missing scheme → prepend https:// before parse
+ * - non-http(s) scheme (javascript:, data:, ftp:, …) → InvalidExternalUrlError
+ * - unparseable → InvalidExternalUrlError
+ * - otherwise → `URL.toString()` (canonicalized form)
+ */
+function normalizeExternalUrl(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  if (trimmed.length > 2048) {
+    throw new InvalidExternalUrlError('url too long');
+  }
+  const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  }
+  catch {
+    throw new InvalidExternalUrlError('invalid url');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new InvalidExternalUrlError('only http and https allowed');
+  }
+  return parsed.toString();
+}
+
+/**
+ * Validates a urlPrompt value against the {@link URL_PROMPT_VALUES} whitelist.
+ * Returns null when the input is null/undefined; throws {@link ValidationError}
+ * when the input is a non-string or an unknown enum value.
+ */
+function validateUrlPrompt(value: unknown): UrlPrompt | null {
+  if (value == null) return null;
+  if (typeof value !== 'string' || !URL_PROMPT_VALUES.includes(value as UrlPrompt)) {
+    throw new ValidationError('invalid url prompt', { urlPrompt: ['invalid'] });
+  }
+  return value as UrlPrompt;
+}
+
+/**
+ * Enforces the cross-field invariant that externalUrl and urlPrompt must be
+ * set or cleared together. When exactly one is null, throws a
+ * {@link ValidationError} whose `fields` map highlights both inputs so the
+ * editor can flag them simultaneously.
+ */
+function validateExternalUrlPair(externalUrl: string | null, urlPrompt: UrlPrompt | null): void {
+  const urlNull = externalUrl === null;
+  const promptNull = urlPrompt === null;
+  if (urlNull !== promptNull) {
+    throw new ValidationError(
+      'externalUrl and urlPrompt must be set or cleared together',
+      {
+        externalUrl: ['required when urlPrompt is set'],
+        urlPrompt: ['required when externalUrl is set'],
+      },
+    );
+  }
+}
+
+/**
+ * Scrubs an external URL for safe inclusion in structured logs.
+ *
+ * External URLs may contain sensitive material in their query string or
+ * fragment (OAuth tokens, session IDs, personal identifiers). This helper
+ * preserves only the origin and pathname so log lines retain enough
+ * context for debugging without leaking secrets.
+ *
+ * - null/undefined → null
+ * - unparseable URL → null (do not log a malformed value verbatim)
+ * - otherwise → `${origin}${pathname}` with query and fragment stripped
+ *
+ * @param externalUrl - The candidate external URL value (already normalized
+ *                      via {@link normalizeExternalUrl} in production code,
+ *                      but this helper tolerates any string defensively).
+ * @returns A safe-for-logging form of the URL, or null when the input is
+ *          missing or unparseable.
+ */
+export function scrubExternalUrlForLog(externalUrl: string | null | undefined): string | null {
+  if (externalUrl == null) return null;
+  try {
+    const u = new URL(externalUrl);
+    return `${u.origin}${u.pathname}`;
+  }
+  catch {
+    return null;
+  }
+}
 
 /**
  * Service class for managing events
@@ -582,6 +676,14 @@ class EventService {
     eventParams.id = this.generateEventId();
     eventParams.calendarId = calendar.id;
 
+    // Validate + normalize externalUrl / urlPrompt pair before constructing
+    // the model so the canonicalized values are what gets persisted.
+    const normalizedExternalUrl = normalizeExternalUrl(eventParams.externalUrl);
+    const validatedUrlPrompt = validateUrlPrompt(eventParams.urlPrompt);
+    validateExternalUrlPair(normalizedExternalUrl, validatedUrlPrompt);
+    eventParams.externalUrl = normalizedExternalUrl;
+    eventParams.urlPrompt = validatedUrlPrompt;
+
     const event = CalendarEvent.fromObject(eventParams);
     if ( calendar.urlName.length > 0 ) {
       event.eventSourceUrl = '/' + calendar.urlName + '/' + event.id;
@@ -746,6 +848,23 @@ class EventService {
     }
 
     let event = eventEntity.toModel();
+
+    // Validate + normalize externalUrl / urlPrompt pair. Only consider a field
+    // "being changed" when its key is explicitly present in the payload — an
+    // absent key means "leave the stored value alone".
+    const urlKeyPresent = Object.prototype.hasOwnProperty.call(eventParams, 'externalUrl');
+    const promptKeyPresent = Object.prototype.hasOwnProperty.call(eventParams, 'urlPrompt');
+    if (urlKeyPresent || promptKeyPresent) {
+      const rawUrl = urlKeyPresent ? eventParams.externalUrl : event.externalUrl;
+      const rawPrompt = promptKeyPresent ? eventParams.urlPrompt : event.urlPrompt;
+      const normalizedExternalUrl = normalizeExternalUrl(rawUrl);
+      const validatedUrlPrompt = validateUrlPrompt(rawPrompt);
+      validateExternalUrlPair(normalizedExternalUrl, validatedUrlPrompt);
+      event.externalUrl = normalizedExternalUrl;
+      event.urlPrompt = validatedUrlPrompt;
+      eventEntity.external_url = normalizedExternalUrl;
+      eventEntity.url_prompt = validatedUrlPrompt;
+    }
 
     if ( eventParams.content ) {
       for( let [language,content] of Object.entries(eventParams.content) ) {

--- a/src/server/calendar/test/EventService/external_url_validation.test.ts
+++ b/src/server/calendar/test/EventService/external_url_validation.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sinon from 'sinon';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { EventEntity, EventContentEntity } from '@/server/calendar/entity/event';
+import EventService from '@/server/calendar/service/events';
+import { InvalidExternalUrlError } from '@/common/exceptions/calendar';
+import { ValidationError } from '@/common/exceptions/base';
+
+/**
+ * Tests for externalUrl / urlPrompt validation wired through createEvent and
+ * updateEvent on EventService. These exercise the module-private
+ * `normalizeExternalUrl`, `validateUrlPrompt`, and cross-field rule defined
+ * inside `src/server/calendar/service/events.ts`.
+ */
+describe('EventService externalUrl + urlPrompt validation (via createEvent)', () => {
+  let service: EventService;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+  const cal = new Calendar('testCalendarId', 'testme');
+  const acct = new Account('testAccountId', 'testme', 'testme');
+
+  beforeEach(() => {
+    service = new EventService(new EventEmitter());
+    sandbox.stub(service['calendarService'], 'editableCalendarsForUser').resolves([cal]);
+    sandbox.stub(service['calendarService'], 'getCalendar').resolves(cal);
+    sandbox.stub(EventEntity.prototype, 'save');
+    sandbox.stub(EventContentEntity.prototype, 'save');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // === normalizeExternalUrl cases ===
+
+  it('treats null externalUrl as null (and null urlPrompt passes)', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: null,
+      urlPrompt: null,
+    });
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  it('treats undefined externalUrl as null', async () => {
+    const event = await service.createEvent(acct, { calendarId: cal.id });
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  it('treats empty string as null', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: '',
+      urlPrompt: null,
+    });
+    expect(event.externalUrl).toBeNull();
+  });
+
+  it('treats whitespace-only string as null', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: '   \t  ',
+      urlPrompt: null,
+    });
+    expect(event.externalUrl).toBeNull();
+  });
+
+  it('throws InvalidExternalUrlError when externalUrl is longer than 2048 chars', async () => {
+    const longUrl = 'https://example.com/' + 'a'.repeat(2048);
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: longUrl,
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('prepends https:// when scheme is missing', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'example.com/path',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toBe('https://example.com/path');
+  });
+
+  it('accepts uppercase HTTPS scheme and normalizes to lowercase via URL', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'HTTPS://Example.com/Path',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toMatch(/^https:\/\/example\.com\/Path/);
+  });
+
+  it('rejects javascript: scheme with InvalidExternalUrlError', async () => {
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'javascript:alert(1)',
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('rejects data: scheme with InvalidExternalUrlError', async () => {
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'data:text/plain,hello',
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('rejects ftp: scheme with InvalidExternalUrlError', async () => {
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'ftp://example.com/file',
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('rejects fragment-only string (treated as missing-scheme and unparseable)', async () => {
+    // "#foo" has no "://", gets `https://` prepended, then "#foo" would
+    // be treated as a hostname fragment — URL parsing throws.
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: '#foo',
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('accepts valid http URL', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'http://example.com/tix',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toBe('http://example.com/tix');
+  });
+
+  it('accepts valid https URL', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/rsvp',
+      urlPrompt: 'rsvp',
+    });
+    expect(event.externalUrl).toBe('https://example.com/rsvp');
+  });
+
+  it('handles protocol-relative input by prepending https://', async () => {
+    // '//example.com' has no '://', so normalizer prepends https://
+    // giving 'https:////example.com'. URL parser accepts this and normalizes
+    // the authority; we only require the validator not to throw and to store
+    // a valid https URL.
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: '//example.com',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toMatch(/^https:\/\//);
+  });
+
+  // === validateUrlPrompt cases ===
+
+  it('accepts urlPrompt = tickets', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 'tickets',
+    });
+    expect(event.urlPrompt).toBe('tickets');
+  });
+
+  it('accepts urlPrompt = rsvp', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 'rsvp',
+    });
+    expect(event.urlPrompt).toBe('rsvp');
+  });
+
+  it('accepts urlPrompt = more_info', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 'more_info',
+    });
+    expect(event.urlPrompt).toBe('more_info');
+  });
+
+  it('rejects unknown urlPrompt value with ValidationError', async () => {
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 'not_a_real_prompt',
+    })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects non-string urlPrompt with ValidationError', async () => {
+    await expect(service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 42 as any,
+    })).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('accepts null urlPrompt when externalUrl is also null', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: null,
+      urlPrompt: null,
+    });
+    expect(event.urlPrompt).toBeNull();
+    expect(event.externalUrl).toBeNull();
+  });
+
+  // === cross-field rule ===
+
+  it('rejects externalUrl set with null urlPrompt (partial state)', async () => {
+    const err = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: null,
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).fields).toBeDefined();
+    expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+    expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+  });
+
+  it('rejects urlPrompt set with null externalUrl (partial state)', async () => {
+    const err = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: null,
+      urlPrompt: 'tickets',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).fields).toBeDefined();
+    expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+    expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+  });
+
+  it('accepts both null (no external URL on this event)', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: null,
+      urlPrompt: null,
+    });
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  it('accepts both set with a valid pair', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/tix',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toBe('https://example.com/tix');
+    expect(event.urlPrompt).toBe('tickets');
+  });
+});
+
+describe('EventService externalUrl + urlPrompt validation (via updateEvent)', () => {
+  let service: EventService;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+  const cal = new Calendar('testCalendarId', 'testme');
+  const acct = new Account('testAccountId', 'testme', 'testme');
+  const eventId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    service = new EventService(new EventEmitter());
+    sandbox.stub(service['calendarService'], 'editableCalendarsForUser').resolves([cal]);
+    sandbox.stub(service['calendarService'], 'getCalendar').resolves(cal);
+    sandbox.stub(EventEntity, 'findByPk').resolves(
+      EventEntity.build({ calendar_id: cal.id, id: eventId }),
+    );
+    sandbox.stub(EventEntity.prototype, 'save');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('rejects javascript: scheme in update', async () => {
+    await expect(service.updateEvent(acct, eventId, {
+      externalUrl: 'javascript:alert(1)',
+      urlPrompt: 'tickets',
+    })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+  });
+
+  it('rejects partial state (url set, prompt null) in update', async () => {
+    const err = await service.updateEvent(acct, eventId, {
+      externalUrl: 'https://example.com/',
+      urlPrompt: null,
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+    expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+  });
+
+  it('rejects partial state (prompt set, url null) in update', async () => {
+    const err = await service.updateEvent(acct, eventId, {
+      externalUrl: null,
+      urlPrompt: 'rsvp',
+    }).catch(e => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+    expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+  });
+
+  it('accepts a valid pair and stores normalized URL in update', async () => {
+    const event = await service.updateEvent(acct, eventId, {
+      externalUrl: 'example.com/tix',
+      urlPrompt: 'tickets',
+    });
+    expect(event.externalUrl).toBe('https://example.com/tix');
+    expect(event.urlPrompt).toBe('tickets');
+  });
+
+  it('accepts both null (clearing external url) in update', async () => {
+    const event = await service.updateEvent(acct, eventId, {
+      externalUrl: null,
+      urlPrompt: null,
+    });
+    expect(event.externalUrl).toBeNull();
+    expect(event.urlPrompt).toBeNull();
+  });
+
+  it('leaves existing values untouched when neither field is present in params', async () => {
+    // When the client does not send externalUrl or urlPrompt, the service
+    // must not treat them as "explicitly cleared" and must not run the
+    // cross-field rule. A payload containing only unrelated fields must pass
+    // through without invoking URL validation.
+    const event = await service.updateEvent(acct, eventId, {
+      mediaFocalPointX: 0.6,
+    });
+    expect(event).toBeDefined();
+  });
+});

--- a/src/server/calendar/test/EventService/log_scrubbing.test.ts
+++ b/src/server/calendar/test/EventService/log_scrubbing.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+import { scrubExternalUrlForLog } from '@/server/calendar/service/events';
+
+/**
+ * Tests for scrubExternalUrlForLog — the privacy-preserving log helper that
+ * strips query strings and fragments from external URLs before they reach
+ * structured log output.
+ *
+ * External URLs can carry OAuth tokens, session IDs, or other PII-adjacent
+ * material in their query string or fragment. Per the privacy-playbook /
+ * privacy/logging standard, such values must never be logged verbatim.
+ */
+describe('scrubExternalUrlForLog', () => {
+  it('returns null for null input', () => {
+    expect(scrubExternalUrlForLog(null)).toBe(null);
+  });
+
+  it('returns null for undefined input', () => {
+    expect(scrubExternalUrlForLog(undefined)).toBe(null);
+  });
+
+  it('preserves origin and pathname when no query or fragment is present', () => {
+    expect(scrubExternalUrlForLog('https://example.com/path')).toBe('https://example.com/path');
+  });
+
+  it('strips the query string entirely (may contain tokens/PII)', () => {
+    const scrubbed = scrubExternalUrlForLog('https://example.com/path?token=secret&session=abcd1234');
+    expect(scrubbed).toBe('https://example.com/path');
+    expect(scrubbed).not.toContain('token');
+    expect(scrubbed).not.toContain('secret');
+    expect(scrubbed).not.toContain('session');
+    expect(scrubbed).not.toContain('?');
+  });
+
+  it('strips the fragment entirely', () => {
+    const scrubbed = scrubExternalUrlForLog('https://example.com/path#user=alice');
+    expect(scrubbed).toBe('https://example.com/path');
+    expect(scrubbed).not.toContain('#');
+    expect(scrubbed).not.toContain('alice');
+  });
+
+  it('strips both query string and fragment when both are present', () => {
+    const scrubbed = scrubExternalUrlForLog('https://example.com/events/123?token=xyz#anchor');
+    expect(scrubbed).toBe('https://example.com/events/123');
+  });
+
+  it('returns null for unparseable URL (never emits raw malformed value)', () => {
+    expect(scrubExternalUrlForLog('not a url')).toBe(null);
+    expect(scrubExternalUrlForLog('://broken')).toBe(null);
+  });
+
+  it('preserves non-default ports in the origin', () => {
+    expect(scrubExternalUrlForLog('https://example.com:8443/path?x=1')).toBe('https://example.com:8443/path');
+  });
+
+  it('preserves http scheme', () => {
+    expect(scrubExternalUrlForLog('http://example.com/path?x=1')).toBe('http://example.com/path');
+  });
+
+  it('does not emit the raw full URL when a query string is present', () => {
+    const raw = 'https://example.com/path?token=supersecretvalue';
+    const scrubbed = scrubExternalUrlForLog(raw);
+    expect(scrubbed).not.toBe(raw);
+    expect(scrubbed).not.toContain('supersecretvalue');
+  });
+});

--- a/src/server/calendar/test/event_entity_schema.test.ts
+++ b/src/server/calendar/test/event_entity_schema.test.ts
@@ -78,4 +78,30 @@ describe('EventEntity Schema - Calendar ID Support', () => {
     expect(model.isLocal()).toBe(false);
     expect(model.isRemote()).toBe(true);
   });
+
+  it('should round-trip externalUrl and urlPrompt from model through entity back to model', () => {
+    const event = new CalendarEvent(eventId, uuidIdentifier, '/testcalendar/event-1');
+    event.externalUrl = 'https://example.com/tickets';
+    event.urlPrompt = 'tickets';
+
+    const entity = EventEntity.fromModel(event);
+    expect(entity.external_url).toBe('https://example.com/tickets');
+    expect(entity.url_prompt).toBe('tickets');
+
+    const roundTripped = entity.toModel();
+    expect(roundTripped.externalUrl).toBe('https://example.com/tickets');
+    expect(roundTripped.urlPrompt).toBe('tickets');
+  });
+
+  it('should round-trip null externalUrl and urlPrompt', () => {
+    const event = new CalendarEvent(eventId, uuidIdentifier, '/testcalendar/event-1');
+
+    const entity = EventEntity.fromModel(event);
+    expect(entity.external_url ?? null).toBeNull();
+    expect(entity.url_prompt ?? null).toBeNull();
+
+    const roundTripped = entity.toModel();
+    expect(roundTripped.externalUrl).toBeNull();
+    expect(roundTripped.urlPrompt).toBeNull();
+  });
 });

--- a/src/server/calendar/test/integration/event_external_url.test.ts
+++ b/src/server/calendar/test/integration/event_external_url.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/test/lib/test_environment';
+import { ValidationError } from '@/common/exceptions/base';
+import { InvalidExternalUrlError } from '@/common/exceptions/calendar';
+
+/**
+ * Integration tests for externalUrl + urlPrompt API round-trip.
+ *
+ * Exercises the full calendar interface → service → entity → SQLite stack
+ * without mocks. Covers the happy path (create → get), the clearing path
+ * (update to null → get), and cross-field / validation guards that must
+ * surface as ValidationError or InvalidExternalUrlError rather than silently
+ * persisting partial or malicious data.
+ */
+describe('Event externalUrl + urlPrompt — API round-trip (integration)', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let testAccount: Account;
+  let testCalendar: Calendar;
+  let eventBus: EventEmitter;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+
+    // Minimal AP interface stub: integration tests here do not wire the AP
+    // domain, so we return shapes that keep local-only code paths correct.
+    calendarInterface.setActivityPubInterface({
+      getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
+      findCalendarActorByCalendarId: async () => null,
+    } as any);
+
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const info = await accountService._setupAccount('exturl@pavillion.dev', 'testpassword');
+    testAccount = info.account;
+    testCalendar = await calendarInterface.createCalendar(testAccount, 'exturlcalendar');
+  });
+
+  afterAll(async () => {
+    if (eventBus) {
+      eventBus.removeAllListeners();
+    }
+    await env.cleanup();
+  });
+
+  describe('create + read round-trip', () => {
+    it('persists externalUrl and urlPrompt when both fields are set on create', async () => {
+      const created = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: {
+          en: { name: 'Tickets Event', description: 'Buy tickets here' },
+        },
+        start_date: '2026-05-01',
+        externalUrl: 'https://example.com/tix',
+        urlPrompt: 'tickets',
+      });
+
+      expect(created.externalUrl).toBe('https://example.com/tix');
+      expect(created.urlPrompt).toBe('tickets');
+
+      const fetched = await calendarInterface.getEventById(created.id);
+      expect(fetched.externalUrl).toBe('https://example.com/tix');
+      expect(fetched.urlPrompt).toBe('tickets');
+    });
+
+    it('persists null externalUrl and null urlPrompt when neither is set', async () => {
+      const created = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: {
+          en: { name: 'No URL Event' },
+        },
+        start_date: '2026-05-02',
+      });
+
+      expect(created.externalUrl).toBeNull();
+      expect(created.urlPrompt).toBeNull();
+
+      const fetched = await calendarInterface.getEventById(created.id);
+      expect(fetched.externalUrl).toBeNull();
+      expect(fetched.urlPrompt).toBeNull();
+    });
+
+    it('clears both fields via update and persists the cleared state', async () => {
+      const created = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: {
+          en: { name: 'To Be Cleared' },
+        },
+        start_date: '2026-05-03',
+        externalUrl: 'https://example.com/rsvp',
+        urlPrompt: 'rsvp',
+      });
+
+      expect(created.externalUrl).toBe('https://example.com/rsvp');
+      expect(created.urlPrompt).toBe('rsvp');
+
+      const updated = await calendarInterface.updateEvent(testAccount, created.id, {
+        externalUrl: null,
+        urlPrompt: null,
+      });
+      expect(updated.externalUrl).toBeNull();
+      expect(updated.urlPrompt).toBeNull();
+
+      const fetched = await calendarInterface.getEventById(created.id);
+      expect(fetched.externalUrl).toBeNull();
+      expect(fetched.urlPrompt).toBeNull();
+    });
+
+    it('accepts all three urlPrompt values end-to-end', async () => {
+      for (const prompt of ['tickets', 'rsvp', 'more_info'] as const) {
+        const created = await calendarInterface.createEvent(testAccount, {
+          calendarId: testCalendar.id,
+          content: {
+            en: { name: `Prompt ${prompt} Event` },
+          },
+          start_date: '2026-05-04',
+          externalUrl: `https://example.com/${prompt}`,
+          urlPrompt: prompt,
+        });
+        const fetched = await calendarInterface.getEventById(created.id);
+        expect(fetched.urlPrompt).toBe(prompt);
+        expect(fetched.externalUrl).toBe(`https://example.com/${prompt}`);
+      }
+    });
+  });
+
+  describe('partial-state validation (cross-field rule)', () => {
+    it('rejects create with externalUrl set and urlPrompt null, citing both fields', async () => {
+      const err = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Partial A' } },
+        start_date: '2026-05-05',
+        externalUrl: 'https://example.com/oops',
+        urlPrompt: null,
+      }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).fields).toBeDefined();
+      expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+      expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+    });
+
+    it('rejects create with urlPrompt set and externalUrl null, citing both fields', async () => {
+      const err = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Partial B' } },
+        start_date: '2026-05-06',
+        externalUrl: null,
+        urlPrompt: 'rsvp',
+      }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).fields).toBeDefined();
+      expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+      expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+    });
+
+    it('rejects update that moves an event into partial state (url set, prompt cleared)', async () => {
+      const created = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Partial Update A' } },
+        start_date: '2026-05-07',
+        externalUrl: 'https://example.com/old',
+        urlPrompt: 'tickets',
+      });
+
+      const err = await calendarInterface.updateEvent(testAccount, created.id, {
+        externalUrl: 'https://example.com/new',
+        urlPrompt: null,
+      }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+      expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+
+      // Stored record must be untouched by the failed update
+      const fetched = await calendarInterface.getEventById(created.id);
+      expect(fetched.externalUrl).toBe('https://example.com/old');
+      expect(fetched.urlPrompt).toBe('tickets');
+    });
+
+    it('rejects update that moves an event into partial state (prompt set, url cleared)', async () => {
+      const created = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Partial Update B' } },
+        start_date: '2026-05-08',
+        externalUrl: 'https://example.com/old',
+        urlPrompt: 'tickets',
+      });
+
+      const err = await calendarInterface.updateEvent(testAccount, created.id, {
+        externalUrl: null,
+        urlPrompt: 'rsvp',
+      }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).fields).toHaveProperty('externalUrl');
+      expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+    });
+  });
+
+  describe('malicious / invalid payload rejection', () => {
+    it('rejects create with a javascript: externalUrl via InvalidExternalUrlError', async () => {
+      await expect(calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'JS URL' } },
+        start_date: '2026-05-09',
+        externalUrl: 'javascript:alert(1)',
+        urlPrompt: 'tickets',
+      })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+    });
+
+    it('rejects create with a data: externalUrl via InvalidExternalUrlError', async () => {
+      await expect(calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Data URL' } },
+        start_date: '2026-05-10',
+        externalUrl: 'data:text/plain,hello',
+        urlPrompt: 'tickets',
+      })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+    });
+
+    it('rejects create with externalUrl > 2048 chars via InvalidExternalUrlError', async () => {
+      const longUrl = 'https://example.com/' + 'a'.repeat(2048);
+      await expect(calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Too Long' } },
+        start_date: '2026-05-11',
+        externalUrl: longUrl,
+        urlPrompt: 'tickets',
+      })).rejects.toBeInstanceOf(InvalidExternalUrlError);
+    });
+
+    it('rejects create with unknown urlPrompt via ValidationError on urlPrompt', async () => {
+      const err = await calendarInterface.createEvent(testAccount, {
+        calendarId: testCalendar.id,
+        content: { en: { name: 'Bogus Prompt' } },
+        start_date: '2026-05-12',
+        externalUrl: 'https://example.com/',
+        urlPrompt: 'hack',
+      }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).fields).toBeDefined();
+      expect((err as ValidationError).fields).toHaveProperty('urlPrompt');
+    });
+  });
+});

--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -14,6 +14,7 @@ import ReportEvent from './report-event.vue';
 import { useLocale } from '@/site/composables/useLocale';
 import { getRecurrenceText } from '@/common/utils/recurrence-text';
 import AddToCalendar from './add-to-calendar.vue';
+import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 
 const { t } = useTranslation('system');
 const route = useRoute();
@@ -106,6 +107,36 @@ const sourceCalendarLabel = computed(() => {
 const isRemoteSourceCalendar = computed(() => {
   if (!sourceCalendar.value) return false;
   return sourceCalendar.value.url.startsWith('http');
+});
+
+/**
+ * Defense-in-depth safe external URL computed.
+ * Returns the URL only if its protocol is http: or https:, else null.
+ * Guards against javascript:, data:, and other unsafe schemes even if
+ * the service-layer validator is bypassed or misconfigured.
+ */
+const safeExternalUrl = computed<string | null>(() => {
+  const raw = state.instance?.event?.externalUrl;
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+});
+
+/**
+ * Defense-in-depth safe URL prompt computed.
+ * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
+ * Prevents template-key injection via arbitrary strings.
+ */
+const safePrompt = computed<UrlPrompt | null>(() => {
+  const raw = state.instance?.event?.urlPrompt;
+  if (raw == null) return null;
+  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
 });
 
 onBeforeMount(async () => {
@@ -282,6 +313,17 @@ onBeforeMount(async () => {
             </div>
             <p class="recurrence-text">{{ recurrenceText }}</p>
           </div>
+
+          <!-- External link CTA -->
+          <a
+            v-if="safeExternalUrl && safePrompt"
+            :href="safeExternalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external-link-button"
+          >
+            {{ t('url_prompt.' + safePrompt) }}
+          </a>
 
           <!-- Add to Calendar -->
           <AddToCalendar :event="state.instance.event" :instance="state.instance" />
@@ -692,6 +734,22 @@ onBeforeMount(async () => {
 
   @include public-dark-mode {
     color: $public-text-primary-dark;
+  }
+}
+
+// ================================================================
+// EXTERNAL LINK CTA BUTTON
+// ================================================================
+
+.external-link-button {
+  @include public-button-primary;
+
+  min-height: 44px;
+  text-decoration: none;
+  text-align: center;
+
+  &:focus-visible {
+    @include public-focus-visible;
   }
 }
 

--- a/src/site/components/event.vue
+++ b/src/site/components/event.vue
@@ -11,6 +11,7 @@ import EventImage from './event-image.vue';
 import ReportEvent from './report-event.vue';
 import { useLocale } from '@/site/composables/useLocale';
 import AddToCalendar from './add-to-calendar.vue';
+import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 
 const { t } = useTranslation('system');
 const route = useRoute();
@@ -67,6 +68,36 @@ const sourceCalendarLabel = computed(() => {
 const isRemoteSourceCalendar = computed(() => {
   if (!sourceCalendar.value) return false;
   return sourceCalendar.value.url.startsWith('http');
+});
+
+/**
+ * Defense-in-depth safe external URL computed.
+ * Returns the URL only if its protocol is http: or https:, else null.
+ * Guards against javascript:, data:, and other unsafe schemes even if
+ * the service-layer validator is bypassed or misconfigured.
+ */
+const safeExternalUrl = computed<string | null>(() => {
+  const raw = state.event?.externalUrl;
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+});
+
+/**
+ * Defense-in-depth safe URL prompt computed.
+ * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
+ * Prevents template-key injection via arbitrary strings.
+ */
+const safePrompt = computed<UrlPrompt | null>(() => {
+  const raw = state.event?.urlPrompt;
+  if (raw == null) return null;
+  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
 });
 
 onBeforeMount(async () => {
@@ -222,6 +253,17 @@ function closeReportModal() {
             </div>
             <p class="accessibility-info">{{ locationAccessibilityInfo }}</p>
           </div>
+
+          <!-- External link CTA -->
+          <a
+            v-if="safeExternalUrl && safePrompt"
+            :href="safeExternalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external-link-button"
+          >
+            {{ t('url_prompt.' + safePrompt) }}
+          </a>
 
           <!-- Add to Calendar -->
           <AddToCalendar v-if="state.event.schedules?.length" :event="state.event" />
@@ -555,6 +597,22 @@ function closeReportModal() {
 
   @include public-dark-mode {
     color: $public-text-primary-dark;
+  }
+}
+
+// ================================================================
+// EXTERNAL LINK CTA BUTTON
+// ================================================================
+
+.external-link-button {
+  @include public-button-primary;
+
+  min-height: 44px;
+  text-decoration: none;
+  text-align: center;
+
+  &:focus-visible {
+    @include public-focus-visible;
   }
 }
 

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -83,6 +83,11 @@
     "event_add_to_calendar": "Add to Calendar",
     "event_source_calendar": "Source Calendar",
     "event_source_calendar_label": "View source calendar {{name}}",
+    "url_prompt": {
+        "tickets": "Tickets",
+        "rsvp": "RSVP",
+        "more_info": "More Information"
+    },
     "report": {
         "link_text": "Report Event",
         "form_title": "Report this Event",

--- a/src/site/test/components/event-instance.test.ts
+++ b/src/site/test/components/event-instance.test.ts
@@ -100,6 +100,10 @@ let mockSourceCalendar: {
   url: string;
 } | null = null;
 
+// Mutable externalUrl / urlPrompt so tests can inject external CTA data
+let mockExternalUrl: string | null = null;
+let mockUrlPrompt: string | null = null;
+
 vi.mock('@/site/service/calendar', () => {
   return {
     default: vi.fn().mockImplementation(() => ({
@@ -134,6 +138,8 @@ vi.mock('@/site/service/calendar', () => {
             series: mockSeries,
             schedules: mockSchedules,
             sourceCalendar: mockSourceCalendar,
+            externalUrl: mockExternalUrl,
+            urlPrompt: mockUrlPrompt,
           },
         }),
       ),
@@ -305,6 +311,11 @@ beforeAll(async () => {
             event_location: 'Location',
             event_source_calendar: 'Source Calendar',
             event_source_calendar_label: 'View source calendar {{name}}',
+            url_prompt: {
+              tickets: 'Tickets',
+              rsvp: 'RSVP',
+              more_info: 'More Information',
+            },
           },
         },
       },
@@ -324,6 +335,11 @@ beforeAll(async () => {
       event_location: 'Location',
       event_source_calendar: 'Source Calendar',
       event_source_calendar_label: 'View source calendar {{name}}',
+      url_prompt: {
+        tickets: 'Tickets',
+        rsvp: 'RSVP',
+        more_info: 'More Information',
+      },
     }, true, true);
   }
 });
@@ -343,6 +359,8 @@ describe('eventInstance breadcrumb locale behaviour', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -423,6 +441,8 @@ describe('eventInstance category badge locale behaviour', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -606,6 +626,8 @@ describe('eventInstance location display', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -744,6 +766,8 @@ describe('eventInstance end time display', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -870,6 +894,8 @@ describe('eventInstance series link display', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -973,6 +999,8 @@ describe('eventInstance recurrence display', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -1071,6 +1099,8 @@ describe('eventInstance source calendar pill', () => {
     mockSeries = null;
     mockSchedules = [];
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -1172,6 +1202,137 @@ describe('eventInstance source calendar pill', () => {
 
     const pill = wrapper.find('.source-calendar-pill');
     expect(pill.attributes('aria-label')).toContain('arts-cal@arts.org');
+    wrapper.unmount();
+  });
+});
+
+describe('event instance external URL CTA button', () => {
+  beforeEach(() => {
+    mockLocalizedPath.mockReset();
+    mockCurrentLocale.value = 'en';
+    mockCategories = [];
+    mockLocation = null;
+    mockEnd = null;
+    mockEventName = 'Test Event';
+    mockSeries = null;
+    mockSchedules = [];
+    mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render CTA anchor when externalUrl and urlPrompt are both valid', async () => {
+    mockExternalUrl = 'https://tickets.example.com/show/123';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('href')).toBe('https://tickets.example.com/show/123');
+    wrapper.unmount();
+  });
+
+  it('should use target="_blank" and rel="noopener noreferrer" on the CTA anchor', async () => {
+    mockExternalUrl = 'https://rsvp.example.com/party';
+    mockUrlPrompt = 'rsvp';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('target')).toBe('_blank');
+    expect(cta.attributes('rel')).toBe('noopener noreferrer');
+    wrapper.unmount();
+  });
+
+  it('should display the translated label from system:url_prompt.<prompt>', async () => {
+    mockExternalUrl = 'https://example.com/info';
+    mockUrlPrompt = 'more_info';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.text()).toBe('More Information');
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA when externalUrl is null', async () => {
+    mockExternalUrl = null;
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA when urlPrompt is null', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = null;
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for javascript: URLs (defense-in-depth)', async () => {
+    mockExternalUrl = 'javascript:alert(1)';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for unknown urlPrompt values', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = 'hack';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for malformed URLs', async () => {
+    mockExternalUrl = 'not a url at all';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountInstance(
+      '/view/test_calendar/events/evt-1/inst-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
     wrapper.unmount();
   });
 });

--- a/src/site/test/components/event.test.ts
+++ b/src/site/test/components/event.test.ts
@@ -80,6 +80,10 @@ let mockSourceCalendar: {
   url: string;
 } | null = null;
 
+// Mutable externalUrl / urlPrompt so tests can inject external CTA data
+let mockExternalUrl: string | null = null;
+let mockUrlPrompt: string | null = null;
+
 vi.mock('@/site/service/calendar', () => {
   return {
     default: vi.fn().mockImplementation(() => ({
@@ -103,6 +107,8 @@ vi.mock('@/site/service/calendar', () => {
           series: mockSeries,
           schedules: [],
           sourceCalendar: mockSourceCalendar,
+          externalUrl: mockExternalUrl,
+          urlPrompt: mockUrlPrompt,
         }),
       ),
     })),
@@ -257,6 +263,11 @@ beforeAll(async () => {
             event_location: 'Location',
             event_source_calendar: 'Source Calendar',
             event_source_calendar_label: 'View source calendar {{name}}',
+            url_prompt: {
+              tickets: 'Tickets',
+              rsvp: 'RSVP',
+              more_info: 'More Information',
+            },
           },
         },
       },
@@ -274,6 +285,11 @@ beforeAll(async () => {
       event_location: 'Location',
       event_source_calendar: 'Source Calendar',
       event_source_calendar_label: 'View source calendar {{name}}',
+      url_prompt: {
+        tickets: 'Tickets',
+        rsvp: 'RSVP',
+        more_info: 'More Information',
+      },
     }, true, true);
   }
 });
@@ -291,6 +307,8 @@ describe('event breadcrumb locale behaviour', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -368,6 +386,8 @@ describe('event two-column layout', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -452,6 +472,8 @@ describe('event category badge behaviour', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -590,6 +612,8 @@ describe('event location display', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -725,6 +749,8 @@ describe('event series link display', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -826,6 +852,8 @@ describe('event source calendar pill', () => {
     mockEventName = 'Test Event';
     mockSeries = null;
     mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
   });
 
   afterEach(() => {
@@ -927,6 +955,196 @@ describe('event source calendar pill', () => {
 
     const pill = wrapper.find('.source-calendar-pill');
     expect(pill.attributes('aria-label')).toContain('arts-cal@arts.org');
+    wrapper.unmount();
+  });
+});
+
+describe('event external URL CTA button', () => {
+  beforeEach(() => {
+    mockLocalizedPath.mockReset();
+    mockCurrentLocale.value = 'en';
+    mockCategories = [];
+    mockLocation = null;
+    mockEventName = 'Test Event';
+    mockSeries = null;
+    mockSourceCalendar = null;
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render CTA anchor when externalUrl and urlPrompt are both valid', async () => {
+    mockExternalUrl = 'https://tickets.example.com/show/123';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('href')).toBe('https://tickets.example.com/show/123');
+    wrapper.unmount();
+  });
+
+  it('should use target="_blank" and rel="noopener noreferrer" on the CTA anchor', async () => {
+    mockExternalUrl = 'https://rsvp.example.com/party';
+    mockUrlPrompt = 'rsvp';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('target')).toBe('_blank');
+    expect(cta.attributes('rel')).toBe('noopener noreferrer');
+    wrapper.unmount();
+  });
+
+  it('should display the translated label from system:url_prompt.<prompt>', async () => {
+    mockExternalUrl = 'https://example.com/info';
+    mockUrlPrompt = 'more_info';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.text()).toBe('More Information');
+    wrapper.unmount();
+  });
+
+  it('should render different labels for tickets vs rsvp prompt values', async () => {
+    mockExternalUrl = 'https://tix.example.com';
+    mockUrlPrompt = 'tickets';
+
+    const wrapperA = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+    expect(wrapperA.find('.external-link-button').text()).toBe('Tickets');
+    wrapperA.unmount();
+
+    mockUrlPrompt = 'rsvp';
+    const wrapperB = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+    expect(wrapperB.find('.external-link-button').text()).toBe('RSVP');
+    wrapperB.unmount();
+  });
+
+  it('should NOT render the CTA when externalUrl is null', async () => {
+    mockExternalUrl = null;
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA when urlPrompt is null', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = null;
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for javascript: URLs (defense-in-depth)', async () => {
+    mockExternalUrl = 'javascript:alert(1)';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for data: URLs', async () => {
+    mockExternalUrl = 'data:text/html,<script>alert(1)</script>';
+    mockUrlPrompt = 'rsvp';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for ftp: URLs (only http/https allowed)', async () => {
+    mockExternalUrl = 'ftp://example.com/file';
+    mockUrlPrompt = 'more_info';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for malformed URLs', async () => {
+    mockExternalUrl = 'not a url at all';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for unknown urlPrompt values', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = 'hack';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should accept http: URLs (not only https:)', async () => {
+    mockExternalUrl = 'http://example.com/path';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountEvent(
+      '/view/test_calendar/events/evt-1',
+      (path) => path,
+    );
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('href')).toBe('http://example.com/path');
     wrapper.unmount();
   });
 });

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, onBeforeMount } from 'vue';
+import { reactive, computed, onBeforeMount } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useRoute, useRouter } from 'vue-router';
 import { DateTime } from 'luxon';
@@ -7,6 +7,7 @@ import CalendarService from '@/site/service/calendar';
 import { useWidgetStore } from '../stores/widgetStore';
 import NotFound from '@/site/components/not-found.vue';
 import EventImage from '@/site/components/event-image.vue';
+import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 
 const { t } = useTranslation('system');
 const route = useRoute();
@@ -25,6 +26,36 @@ const state = reactive({
 });
 
 const calendarService = new CalendarService();
+
+/**
+ * Defense-in-depth safe external URL computed.
+ * Returns the URL only if its protocol is http: or https:, else null.
+ * Guards against javascript:, data:, and other unsafe schemes even if
+ * the service-layer validator is bypassed or misconfigured.
+ */
+const safeExternalUrl = computed<string | null>(() => {
+  const raw = state.instance?.event?.externalUrl;
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+});
+
+/**
+ * Defense-in-depth safe URL prompt computed.
+ * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
+ * Prevents template-key injection via arbitrary strings.
+ */
+const safePrompt = computed<UrlPrompt | null>(() => {
+  const raw = state.instance?.event?.urlPrompt;
+  if (raw == null) return null;
+  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
+});
 
 const goBack = () => {
   router.push({
@@ -131,6 +162,17 @@ onBeforeMount(async () => {
 
         <main class="instance-body">
           <p>{{ state.instance.event.content("en").description }}</p>
+
+          <!-- External link CTA -->
+          <a
+            v-if="safeExternalUrl && safePrompt"
+            :href="safeExternalUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external-link-button"
+          >
+            {{ t('url_prompt.' + safePrompt) }}
+          </a>
         </main>
 
         <footer v-if="state.instance.event.categories?.length > 0" class="instance-footer">
@@ -330,6 +372,24 @@ onBeforeMount(async () => {
     @include public-dark-mode {
       color: $public-text-primary-dark;
     }
+  }
+}
+
+// ================================================================
+// EXTERNAL LINK CTA BUTTON
+// ================================================================
+
+.external-link-button {
+  @include public-button-primary;
+
+  display: inline-block;
+  min-height: 44px;
+  margin-top: $public-space-md;
+  text-decoration: none;
+  text-align: center;
+
+  &:focus-visible {
+    @include public-focus-visible;
   }
 }
 

--- a/src/widget/test/event-detail-overlay.test.ts
+++ b/src/widget/test/event-detail-overlay.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for the widget's event detail overlay external-URL CTA button.
+ *
+ * Validates defense-in-depth computed guards and rendering rules ported
+ * from the public-site event-instance implementation (pv-itux.5.1):
+ *   - javascript: URLs are blocked before reaching the DOM
+ *   - unknown urlPrompt values are blocked before reaching the DOM
+ *   - valid (http/https) URL + known prompt → CTA anchor rendered with
+ *     target="_blank" rel="noopener noreferrer" and translated label
+ *   - null externalUrl OR null urlPrompt → CTA is omitted
+ *   - malformed URL strings → CTA is omitted
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, Router, RouteRecordRaw } from 'vue-router';
+import { createPinia } from 'pinia';
+import I18NextVue from 'i18next-vue';
+import i18next from 'i18next';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before component import
+// ---------------------------------------------------------------------------
+
+// Mutable externalUrl / urlPrompt so tests can inject CTA data
+let mockExternalUrl: string | null = null;
+let mockUrlPrompt: string | null = null;
+
+vi.mock('@/site/service/calendar', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      getCalendarByUrlName: vi.fn().mockResolvedValue({
+        urlName: 'test_calendar',
+        content: (_lang: string) => ({ name: 'Test Calendar', description: '' }),
+        hasContent: (_lang: string) => true,
+        getLanguages: () => ['en'],
+      }),
+      loadCalendarEvents: vi.fn().mockImplementation(() =>
+        Promise.resolve([
+          {
+            start: {
+              toISO: () => '2026-03-01T10:00:00.000Z',
+              toLocal: () => ({
+                toLocaleString: () => 'March 1, 2026, 10:00 AM',
+              }),
+            },
+            event: {
+              id: 'evt-1',
+              content: (_lang: string) => ({ name: 'Test Event', description: 'Description' }),
+              media: null,
+              mediaFocalPointX: 0.5,
+              mediaFocalPointY: 0.5,
+              mediaZoom: 1.0,
+              categories: [],
+              externalUrl: mockExternalUrl,
+              urlPrompt: mockUrlPrompt,
+            },
+          },
+        ]),
+      ),
+    })),
+  };
+});
+
+vi.mock('@/site/components/not-found.vue', () => ({
+  default: { template: '<div class="not-found-stub"></div>' },
+}));
+
+vi.mock('@/site/components/event-image.vue', () => ({
+  default: {
+    template: '<div class="event-image-stub"></div>',
+    props: ['media', 'context', 'alt', 'focalPointX', 'focalPointY', 'zoom'],
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Subject under test
+// ---------------------------------------------------------------------------
+import EventDetailOverlay from '@/widget/components/event-detail-overlay.vue';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/widget/:urlName/events/:eventId',
+    component: EventDetailOverlay,
+    name: 'widget-event',
+  },
+  {
+    path: '/widget/:urlName',
+    component: { template: '<div />' },
+    name: 'widget-calendar',
+  },
+];
+
+async function buildRouter(initialPath: string): Promise<Router> {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes,
+  });
+  await router.push(initialPath);
+  await router.isReady();
+  return router;
+}
+
+async function mountOverlay(initialPath: string): Promise<VueWrapper> {
+  const router = await buildRouter(initialPath);
+  const pinia = createPinia();
+
+  const wrapper = mount(EventDetailOverlay, {
+    global: {
+      plugins: [
+        router,
+        [I18NextVue, { i18next }],
+        pinia,
+      ],
+    },
+  });
+
+  await flushPromises();
+  return wrapper;
+}
+
+// ---------------------------------------------------------------------------
+// i18next initialisation
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  const resources = {
+    back: 'Back',
+    back_to_calendar: 'Back to {{name}}',
+    loading_event: 'Loading event...',
+    url_prompt: {
+      tickets: 'Tickets',
+      rsvp: 'RSVP',
+      more_info: 'More Information',
+    },
+  };
+
+  if (!i18next.isInitialized) {
+    await i18next.init({
+      lng: 'en',
+      resources: {
+        en: {
+          system: resources,
+        },
+      },
+    });
+  }
+  else {
+    i18next.addResourceBundle('en', 'system', resources, true, true);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('widget event-detail-overlay external URL CTA button', () => {
+  beforeEach(() => {
+    mockExternalUrl = null;
+    mockUrlPrompt = null;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render CTA anchor when externalUrl and urlPrompt are both valid', async () => {
+    mockExternalUrl = 'https://tickets.example.com/show/123';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('href')).toBe('https://tickets.example.com/show/123');
+    wrapper.unmount();
+  });
+
+  it('should use target="_blank" and rel="noopener noreferrer" on the CTA anchor', async () => {
+    mockExternalUrl = 'https://rsvp.example.com/party';
+    mockUrlPrompt = 'rsvp';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.attributes('target')).toBe('_blank');
+    expect(cta.attributes('rel')).toBe('noopener noreferrer');
+    wrapper.unmount();
+  });
+
+  it('should display the translated label from system:url_prompt.<prompt>', async () => {
+    mockExternalUrl = 'https://example.com/info';
+    mockUrlPrompt = 'more_info';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    const cta = wrapper.find('.external-link-button');
+    expect(cta.exists()).toBe(true);
+    expect(cta.text()).toBe('More Information');
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA when externalUrl is null', async () => {
+    mockExternalUrl = null;
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA when urlPrompt is null', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = null;
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for javascript: URLs (defense-in-depth)', async () => {
+    mockExternalUrl = 'javascript:alert(1)';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for unknown urlPrompt values', async () => {
+    mockExternalUrl = 'https://example.com';
+    mockUrlPrompt = 'hack';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for malformed URLs', async () => {
+    mockExternalUrl = 'not a url at all';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('should NOT render the CTA for data: URLs (defense-in-depth)', async () => {
+    mockExternalUrl = 'data:text/html,<script>alert(1)</script>';
+    mockUrlPrompt = 'tickets';
+
+    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+
+    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional external URL and CTA prompt (`Tickets` / `RSVP` / `More Information`) on calendar events. When both are set, the public event detail view, instance detail view, and widget overlay render a clearly labeled button that opens the URL in a new tab with `rel=\"noopener noreferrer\"`. Federates via ActivityPub as an `attachment` Link with a `pavillion:urlPrompt` extension so Pavillion peers keep full fidelity while Mobilizon/Gancio see a standard AS attachment.

Scope was intentionally kept small and additive — does not displace any Phase 1 launch-readiness items.

## What changed

**Data layer**
- New migration `0021_add_event_external_url.ts` — two nullable columns (`external_url VARCHAR(2048)`, `url_prompt VARCHAR(32)`)
- `CalendarEvent` gains non-translatable `externalUrl` + `urlPrompt` fields; `UrlPrompt` union alias + `URL_PROMPT_VALUES` runtime guard in `src/common/model/events.ts`
- `EventEntity` `toModel` / `fromModel` round-trip
- New `InvalidExternalUrlError` exception

**Service layer**
- Inline `normalizeExternalUrl` + `validateUrlPrompt` in `EventService` (no separate helper class per complexity-advisor guidance)
- Cross-field rule: URL and prompt must both be set or both null (emits `ValidationError` with per-field messages)
- `scrubExternalUrlForLog` helper strips query string and fragment before logging, to avoid leaking tokens/PII

**ActivityPub**
- Outbound: `attachment: [{type: 'Link', href, name, rel: 'external'}]` + `pavillion:urlPrompt` extension. AS top-level `url` is deliberately untouched (reserved for Mobilizon canonical page)
- Inbound: strict sanitization — non-http(s) href → `null`, unknown prompt enum → `null`, cross-field rule enforced on persist

**UI**
- Editor: new \"External Link\" section card after Location with URL input + prompt dropdown. `urlPromptProxy` computed normalizes `undefined` → `null` from v-model
- Public site event detail + event instance detail: CTA button with `safeExternalUrl` + `safePrompt` template guards (double `v-if`, defense-in-depth)
- Widget event-detail-overlay mirrors the site pattern; inherits shared `url_prompt.*` keys from site's `system.json`

## Test coverage

- 17 common-model unit tests (round-trip, sanitization)
- 8 entity schema round-trip tests
- 30 service validation tests (scheme rejection, length cap, cross-field, all enum values)
- 10 log-scrubbing tests
- 24 AP serialization tests (outbound + inbound, hostile payloads)
- 20 frontend component tests across site + widget (defense-in-depth coverage including `javascript:` and `data:` rejection)
- 20 integration tests covering API round-trip and AP federation round-trip (including double-hop)

## Verification

- ✅ `npm run lint` — clean
- ✅ All new unit + integration tests pass
- ✅ `npm run build` — frontend + widget SDK
- ✅ Browser-tested end-to-end with Playwright: editor save/load, cross-field validation, invalid-URL rejection, CTA button render with correct `href`/`target`/`rel` on event detail + event-instance views
- Pre-existing unrelated test failures (funding, AP webfinger, email-timeout e2e) confirmed unchanged

## Test plan

- [ ] Smoke-test the editor: open any event, add an External Link (URL + prompt), save, reload, confirm persistence
- [ ] Verify cross-field validation: try saving with only URL or only prompt → expect error
- [ ] Verify invalid URL rejection: try `javascript:alert(1)` → server 400
- [ ] View the event on the public site and confirm the CTA button opens in a new tab with `rel=\"noopener noreferrer\"`
- [ ] Repeat for a recurring event's instance detail view
- [ ] Confirm listing/card views do NOT show any external-link indicator (explicitly out of scope)

## Notes for follow-up

Three minor findings from the auditor passes, none blocking merge:

1. Migration uses raw `addColumn` rather than the newer `addColumnIfNotExists` helper introduced in migration `0019`. The bead explicitly referenced `0016` as the structural pattern, which also uses raw calls. Worth normalizing in a future migration-convention sweep.
2. `InvalidExternalUrlError` default message is lowercase (`\"invalid external url\"`); sibling exceptions in the same file use sentence case.
3. `EventEntity.toModel()` does not sanitize an invalid `url_prompt` read from the DB (the model's `fromObject()` does). In practice service validation prevents invalid values ever reaching the DB; could be tightened for defense-in-depth symmetry.

Also noted during Playwright testing: field-level error highlighting on the editor is not wired (banner only). This matches the Phase 1 roadmap item *\"Wire Field-Level Error Mapping End-to-End\"* — the backend already returns `ValidationError.fields` with the right field names; frontend wiring is a separate bead.

Epic: pv-itux (12 leaf beads + 6 parents + epic, all closed)