### PR TITLE
feat(widget): persist widget display config server-side

### DIFF
--- a/migrations/0022_create_calendar_widget_config.ts
+++ b/migrations/0022_create_calendar_widget_config.ts
@@ -1,0 +1,82 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import {
+  createTableIfNotExists,
+  tableExists,
+} from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Create calendar_widget_config table.
+ *
+ * Stores per-calendar widget display configuration (view mode, accent color,
+ * color mode). Replaces the prior embed-snippet query-string approach so that
+ * calendar owners can change widget settings in the admin UI without editing
+ * the HTML on their embedding site.
+ *
+ * Design:
+ * - Unique FK on calendar_id enforces one config per calendar (lazy-created
+ *   when the owner first saves; no backfill for existing calendars).
+ * - ON DELETE CASCADE cleans up the config row automatically when the parent
+ *   calendar is deleted.
+ *
+ * Reference: docs/superpowers/specs/2026-04-14-server-side-widget-config-design.md
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await createTableIfNotExists(queryInterface, 'calendar_widget_config', {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        allowNull: false,
+        defaultValue: DataTypes.UUIDV4,
+      },
+      calendar_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: {
+          model: 'calendar',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      view: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      accent_color: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      color_mode: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    });
+
+    // Unique constraint on calendar_id enforces one config per calendar.
+    await queryInterface.addIndex('calendar_widget_config', ['calendar_id'], {
+      name: 'unique_calendar_widget_config_calendar',
+      unique: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    if (await tableExists(queryInterface, 'calendar_widget_config')) {
+      await queryInterface.dropTable('calendar_widget_config');
+    }
+  },
+};

--- a/src/client/components/logged_in/calendar-management/test/widget-admin.test.ts
+++ b/src/client/components/logged_in/calendar-management/test/widget-admin.test.ts
@@ -7,6 +7,7 @@ import axios from 'axios';
 import WidgetDomains from '../widget-domains.vue';
 import WidgetConfig from '../widget-config.vue';
 import WidgetEmbed from '../widget-embed.vue';
+import WidgetTab from '../widget-tab.vue';
 
 describe('Widget Admin UI Components', () => {
   let sandbox: sinon.SinonSandbox;
@@ -30,6 +31,12 @@ describe('Widget Admin UI Components', () => {
         en: {
           calendars: {
             widget: {
+              domains_section_title: 'Allowed Domains',
+              domains_section_intro: 'Manage allowed domains',
+              config_section_title: 'Configuration',
+              config_section_intro: 'Customize widget',
+              embed_section_title: 'Embed Code',
+              embed_section_intro: 'Copy this code',
               domains: {
                 loading: 'Loading...',
                 localhost_notice: 'Localhost is automatically allowed',
@@ -58,8 +65,14 @@ describe('Widget Admin UI Components', () => {
                 view_mode_label: 'View Mode',
                 view_mode_help: 'Choose view mode',
                 view_mode_list: 'List View',
+                view_mode_list_title: 'List View',
+                view_mode_list_description: 'Vertical list',
                 view_mode_week: 'Week View',
+                view_mode_week_title: 'Week View',
+                view_mode_week_description: 'Weekly grid',
                 view_mode_month: 'Month View',
+                view_mode_month_title: 'Month View',
+                view_mode_month_description: 'Monthly grid',
                 accent_color_label: 'Accent Color',
                 accent_color_help: 'Choose color',
                 color_mode_label: 'Color Mode',
@@ -69,6 +82,12 @@ describe('Widget Admin UI Components', () => {
                 color_mode_dark: 'Dark',
                 preview_title: 'Preview',
                 preview_description: 'Widget preview',
+                save_button: 'Save Configuration',
+                saving: 'Saving...',
+                save_success: 'Widget configuration saved.',
+                save_error: 'Failed to save widget configuration.',
+                save_validation_error: 'Please correct the errors below and try again.',
+                error_loading: 'Failed to load widget configuration.',
               },
               embed: {
                 title: 'Embed Code',
@@ -142,7 +161,12 @@ describe('Widget Admin UI Components', () => {
   });
 
   describe('WidgetConfig Component', () => {
+    // Default stub: component calls GET /api/v1/calendars/:id/widget/config on mount.
+    // Individual tests can override via axiosGetStub.resolves(...) before mount when needed.
+    const defaultConfig = { view: 'list', accentColor: '#ff9131', colorMode: 'auto' };
+
     it('should display configuration options', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
       const wrapper = mount(WidgetConfig, {
         props: {
           calendarId: 'test-calendar-id',
@@ -152,6 +176,8 @@ describe('Widget Admin UI Components', () => {
           plugins: [[I18NextVue, { i18next }]],
         },
       });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
 
       // Check for view mode selector (card buttons, not select dropdown)
       const viewModeCards = wrapper.findAll('button.view-mode-card');
@@ -169,6 +195,7 @@ describe('Widget Admin UI Components', () => {
     });
 
     it('should update configuration state when options change', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
       const wrapper = mount(WidgetConfig, {
         props: {
           calendarId: 'test-calendar-id',
@@ -178,6 +205,7 @@ describe('Widget Admin UI Components', () => {
           plugins: [[I18NextVue, { i18next }]],
         },
       });
+      await new Promise(resolve => setTimeout(resolve, 50));
 
       // Change view mode by clicking the week card button
       const weekCard = wrapper.findAll('button.view-mode-card')[1]; // list=0, week=1, month=2
@@ -194,6 +222,31 @@ describe('Widget Admin UI Components', () => {
     });
 
     it('should display preview iframe with current configuration', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
+      const wrapper = mount(WidgetConfig, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const iframe = wrapper.find('iframe.widget-preview');
+      expect(iframe.exists()).toBe(true);
+
+      const iframeSrc = iframe.attributes('src');
+      expect(iframeSrc).toContain('/widget/my-calendar');
+      expect(iframeSrc).toContain('view=list'); // default
+      expect(iframeSrc).toContain('colorMode=auto'); // default
+    });
+
+    it('should load config on mount and populate form state', async () => {
+      const storedConfig = { view: 'month', accentColor: '#00ff00', colorMode: 'dark' };
+      axiosGetStub.resolves({ data: storedConfig });
+
       const wrapper = mount(WidgetConfig, {
         props: {
           calendarId: 'test-calendar-id',
@@ -204,24 +257,150 @@ describe('Widget Admin UI Components', () => {
         },
       });
 
-      const iframe = wrapper.find('iframe.widget-preview');
-      expect(iframe.exists()).toBe(true);
+      await new Promise(resolve => setTimeout(resolve, 50));
 
-      const iframeSrc = iframe.attributes('src');
-      expect(iframeSrc).toContain('/widget/my-calendar');
-      expect(iframeSrc).toContain('view=list'); // default
-      expect(iframeSrc).toContain('colorMode=auto'); // default
+      // Verify GET was called with the correct URL
+      expect(axiosGetStub.calledOnce).toBe(true);
+      expect(axiosGetStub.getCall(0).args[0]).toBe('/api/v1/calendars/test-calendar-id/widget/config');
+
+      const vm = wrapper.vm as any;
+      expect(vm.state.viewMode).toBe('month');
+      expect(vm.state.accentColor).toBe('#00ff00');
+      expect(vm.state.colorMode).toBe('dark');
+    });
+
+    it('should disable Save button when clean and enable after edit', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
+
+      const wrapper = mount(WidgetConfig, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const saveButton = wrapper.find('button.save-button');
+      expect(saveButton.exists()).toBe(true);
+      // Clean state → disabled
+      expect(saveButton.attributes('disabled')).toBeDefined();
+
+      // Change a field
+      const weekCard = wrapper.findAll('button.view-mode-card')[1];
+      await weekCard.trigger('click');
+
+      // Dirty state → enabled
+      expect(saveButton.attributes('disabled')).toBeUndefined();
+    });
+
+    it('should PUT current state on Save and show success message, then disable Save again', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
+      const savedConfig = { view: 'week', accentColor: '#ff9131', colorMode: 'auto' };
+      axiosPutStub.resolves({ data: savedConfig });
+
+      const wrapper = mount(WidgetConfig, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Change view to week
+      const weekCard = wrapper.findAll('button.view-mode-card')[1];
+      await weekCard.trigger('click');
+
+      const saveButton = wrapper.find('button.save-button');
+      await saveButton.trigger('click');
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(axiosPutStub.calledOnce).toBe(true);
+      const [url, body] = axiosPutStub.getCall(0).args;
+      expect(url).toBe('/api/v1/calendars/test-calendar-id/widget/config');
+      expect(body).toEqual({ view: 'week', accentColor: '#ff9131', colorMode: 'auto' });
+
+      // Success alert rendered
+      expect(wrapper.html()).toContain('Widget configuration saved.');
+      // Save disabled again (clean snapshot)
+      expect(saveButton.attributes('disabled')).toBeDefined();
+    });
+
+    it('should render field-level error from 400 fields.accentColor next to the accent-color input', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
+      const error: any = new Error('Validation failed');
+      error.response = {
+        status: 400,
+        data: {
+          error: 'Validation failed',
+          errorName: 'ValidationError',
+          fields: { accentColor: 'Invalid hex' },
+        },
+      };
+      axiosPutStub.rejects(error);
+
+      const wrapper = mount(WidgetConfig, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Dirty the form so Save is enabled
+      const weekCard = wrapper.findAll('button.view-mode-card')[1];
+      await weekCard.trigger('click');
+
+      await wrapper.find('button.save-button').trigger('click');
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Inline error text rendered
+      const errorEl = wrapper.find('#accentColor-error');
+      expect(errorEl.exists()).toBe(true);
+      expect(errorEl.text()).toBe('Invalid hex');
+
+      // Input associated via aria-describedby (a11y)
+      const colorInput = wrapper.find('input#accentColor');
+      expect(colorInput.attributes('aria-describedby')).toBe('accentColor-error');
+      expect(colorInput.attributes('aria-invalid')).toBe('true');
+
+      // State holds the camelCase key, not snake_case
+      const vm = wrapper.vm as any;
+      expect(vm.state.fieldErrors.accentColor).toBe('Invalid hex');
+    });
+
+    it('should not include a Discard button (spec: reload is the escape hatch)', async () => {
+      axiosGetStub.resolves({ data: defaultConfig });
+      const wrapper = mount(WidgetConfig, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const html = wrapper.html();
+      expect(html).not.toContain('discard');
+      expect(html).not.toContain('Discard');
     });
   });
 
   describe('WidgetEmbed Component', () => {
-    it('should generate correct embed code', async () => {
+    it('should generate simplified embed code with only calendar and container keys', async () => {
       const wrapper = mount(WidgetEmbed, {
         props: {
           calendarUrlName: 'my-calendar',
-          viewMode: 'week',
-          accentColor: '#ff9131',
-          colorMode: 'auto',
         },
         global: {
           plugins: [[I18NextVue, { i18next }]],
@@ -231,11 +410,17 @@ describe('Widget Admin UI Components', () => {
       const codeBlock = wrapper.find('.embed-code');
       const codeText = codeBlock.text();
 
+      // Required content
+      expect(codeText).toContain('calendar');
+      expect(codeText).toContain('container');
       expect(codeText).toContain('my-calendar');
-      expect(codeText).toContain('week');
-      expect(codeText).toContain('#ff9131');
-      expect(codeText).toContain('auto');
+      expect(codeText).toContain('#calendar-widget');
       expect(codeText).toContain('pavillion-widget.js');
+
+      // Deprecated init keys must be absent from the snippet
+      expect(codeText).not.toContain('view');
+      expect(codeText).not.toContain('accentColor');
+      expect(codeText).not.toContain('colorMode');
     });
 
     it('should copy embed code to clipboard', async () => {
@@ -252,9 +437,6 @@ describe('Widget Admin UI Components', () => {
       const wrapper = mount(WidgetEmbed, {
         props: {
           calendarUrlName: 'my-calendar',
-          viewMode: 'month',
-          accentColor: '#0000ff',
-          colorMode: 'light',
         },
         global: {
           plugins: [[I18NextVue, { i18next }]],
@@ -267,7 +449,43 @@ describe('Widget Admin UI Components', () => {
       expect(mockWriteText).toHaveBeenCalled();
       const copiedText = mockWriteText.mock.calls[0][0];
       expect(copiedText).toContain('my-calendar');
-      expect(copiedText).toContain('month');
+      expect(copiedText).toContain('container');
+      expect(copiedText).not.toContain('view');
+      expect(copiedText).not.toContain('accentColor');
+      expect(copiedText).not.toContain('colorMode');
+    });
+  });
+
+  describe('WidgetTab Component', () => {
+    it('should render without ref-based plumbing between widget-config and widget-embed', async () => {
+      // API stubs needed because WidgetDomains calls GET on mount
+      axiosGetStub.resolves({ data: { domain: null } });
+
+      const wrapper = mount(WidgetTab, {
+        props: {
+          calendarId: 'test-calendar-id',
+          calendarUrlName: 'my-calendar',
+        },
+        global: {
+          plugins: [[I18NextVue, { i18next }]],
+        },
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // All three sections render
+      const sections = wrapper.findAll('section.widget-section');
+      expect(sections.length).toBe(3);
+
+      // WidgetEmbed renders with simplified snippet (no view/accentColor/colorMode)
+      const embedCode = wrapper.find('.embed-code');
+      expect(embedCode.exists()).toBe(true);
+      const embedText = embedCode.text();
+      expect(embedText).toContain('my-calendar');
+      expect(embedText).toContain('container');
+      expect(embedText).not.toContain('view');
+      expect(embedText).not.toContain('accentColor');
+      expect(embedText).not.toContain('colorMode');
     });
   });
 });

--- a/src/client/components/logged_in/calendar-management/widget-config.vue
+++ b/src/client/components/logged_in/calendar-management/widget-config.vue
@@ -5,14 +5,14 @@
       <p class="section-description">{{ t('configuration_description') }}</p>
 
       <div class="form-group view-mode-group">
-        <label class="form-label">{{ t('view_mode_label') }}</label>
-        <div class="view-mode-cards">
+        <p id="view-mode-group-label" class="form-label">{{ t('view_mode_label') }}</p>
+        <div class="view-mode-cards" role="group" aria-labelledby="view-mode-group-label">
           <button
             type="button"
             class="view-mode-card"
             :class="{ 'view-mode-card--selected': state.viewMode === 'list' }"
             :aria-pressed="state.viewMode === 'list'"
-            @click="state.viewMode = 'list'"
+            @click="setViewMode('list')"
           >
             <div class="view-mode-card__illustration">
               <div class="list-illustration">
@@ -46,7 +46,7 @@
             class="view-mode-card"
             :class="{ 'view-mode-card--selected': state.viewMode === 'week' }"
             :aria-pressed="state.viewMode === 'week'"
-            @click="state.viewMode = 'week'"
+            @click="setViewMode('week')"
           >
             <div class="view-mode-card__illustration">
               <div class="week-illustration">
@@ -84,7 +84,7 @@
             class="view-mode-card"
             :class="{ 'view-mode-card--selected': state.viewMode === 'month' }"
             :aria-pressed="state.viewMode === 'month'"
-            @click="state.viewMode = 'month'"
+            @click="setViewMode('month')"
           >
             <div class="view-mode-card__illustration">
               <div class="month-illustration">
@@ -139,8 +139,18 @@
               v-model="state.accentColor"
               type="color"
               class="color-input"
+              :aria-invalid="!!state.fieldErrors.accentColor"
+              :aria-describedby="state.fieldErrors.accentColor ? 'accentColor-error' : undefined"
+              @input="clearFieldError('accentColor')"
             />
             <span class="color-value">{{ state.accentColor }}</span>
+          </div>
+          <div
+            v-if="state.fieldErrors.accentColor"
+            id="accentColor-error"
+            class="field-error"
+            role="alert">
+            {{ state.fieldErrors.accentColor }}
           </div>
           <div class="description">{{ t('accent_color_help') }}</div>
         </div>
@@ -152,12 +162,54 @@
           <select
             id="colorMode"
             v-model="state.colorMode"
+            :aria-invalid="!!state.fieldErrors.colorMode"
+            :aria-describedby="state.fieldErrors.colorMode ? 'colorMode-error' : undefined"
+            @change="clearFieldError('colorMode')"
           >
             <option value="auto">{{ t('color_mode_auto') }}</option>
             <option value="light">{{ t('color_mode_light') }}</option>
             <option value="dark">{{ t('color_mode_dark') }}</option>
           </select>
+          <div
+            v-if="state.fieldErrors.colorMode"
+            id="colorMode-error"
+            class="field-error"
+            role="alert">
+            {{ state.fieldErrors.colorMode }}
+          </div>
           <div class="description">{{ t('color_mode_help') }}</div>
+        </div>
+      </div>
+
+      <div
+        v-if="state.fieldErrors.view"
+        id="view-error"
+        class="field-error"
+        role="alert">
+        {{ state.fieldErrors.view }}
+      </div>
+
+      <div class="form-actions">
+        <PillButton
+          variant="primary"
+          class="save-button"
+          :disabled="!isDirty || state.isSaving"
+          @click="save"
+        >
+          {{ state.isSaving ? t('saving') : t('save_button') }}
+        </PillButton>
+        <div
+          v-if="state.successMessage"
+          class="alert alert--success"
+          role="status"
+          aria-live="polite">
+          {{ state.successMessage }}
+        </div>
+        <div
+          v-if="state.errorMessage"
+          class="alert alert--error"
+          role="alert">
+          {{ state.errorMessage }}
         </div>
       </div>
     </div>
@@ -178,8 +230,12 @@
 </template>
 
 <script setup>
-import { reactive, computed, ref, watch } from 'vue';
+import { reactive, computed, ref, watch, onMounted } from 'vue';
 import { useTranslation } from 'i18next-vue';
+import axios from 'axios';
+import PillButton from '@/client/components/common/pill-button.vue';
+import { validateAndEncodeId } from '@/client/service/utils';
+import { WIDGET_CONFIG_DEFAULTS } from '@/common/model/widget_config';
 
 // Props
 const props = defineProps({
@@ -200,13 +256,35 @@ const { t } = useTranslation('calendars', {
 
 // Component state
 const state = reactive({
-  viewMode: 'list',
-  accentColor: '#ff9131',
-  colorMode: 'auto',
+  viewMode: WIDGET_CONFIG_DEFAULTS.view,
+  accentColor: WIDGET_CONFIG_DEFAULTS.accentColor,
+  colorMode: WIDGET_CONFIG_DEFAULTS.colorMode,
+  isSaving: false,
+  successMessage: '',
+  errorMessage: '',
+  fieldErrors: {
+    view: '',
+    accentColor: '',
+    colorMode: '',
+  },
+});
+
+// Snapshot of last loaded/saved state for dirty tracking
+const snapshot = reactive({
+  viewMode: WIDGET_CONFIG_DEFAULTS.view,
+  accentColor: WIDGET_CONFIG_DEFAULTS.accentColor,
+  colorMode: WIDGET_CONFIG_DEFAULTS.colorMode,
 });
 
 // Iframe ref
 const iframeRef = ref(null);
+
+// Dirty state: true when any field differs from the loaded snapshot
+const isDirty = computed(() => {
+  return state.viewMode !== snapshot.viewMode
+    || state.accentColor !== snapshot.accentColor
+    || state.colorMode !== snapshot.colorMode;
+});
 
 // Computed preview URL
 const previewUrl = computed(() => {
@@ -218,6 +296,96 @@ const previewUrl = computed(() => {
   });
   return `${baseUrl}/widget/${props.calendarUrlName}?${params.toString()}`;
 });
+
+/**
+ * Clear the inline error for a specific field when the user edits it.
+ */
+const setViewMode = (view) => {
+  state.viewMode = view;
+  clearFieldError('view');
+};
+
+const clearFieldError = (field) => {
+  if (state.fieldErrors[field]) {
+    state.fieldErrors[field] = '';
+  }
+};
+
+/**
+ * Capture the current loaded config as the snapshot used for dirty tracking.
+ */
+const refreshSnapshot = () => {
+  snapshot.viewMode = state.viewMode;
+  snapshot.accentColor = state.accentColor;
+  snapshot.colorMode = state.colorMode;
+};
+
+/**
+ * Load widget config for this calendar from the server.
+ * On failure, fall back to defaults (already initialized).
+ */
+const loadConfig = async () => {
+  try {
+    const encodedId = validateAndEncodeId(props.calendarId, 'Calendar ID');
+    const response = await axios.get(`/api/v1/calendars/${encodedId}/widget/config`);
+    const data = response.data ?? {};
+    state.viewMode = data.view ?? WIDGET_CONFIG_DEFAULTS.view;
+    state.accentColor = data.accentColor ?? WIDGET_CONFIG_DEFAULTS.accentColor;
+    state.colorMode = data.colorMode ?? WIDGET_CONFIG_DEFAULTS.colorMode;
+    refreshSnapshot();
+  }
+  catch (error) {
+    console.error('Error loading widget config:', error);
+    state.errorMessage = t('error_loading');
+  }
+};
+
+/**
+ * Save widget config to the server. On success, update the snapshot so the
+ * Save button disables again. On 400 with fields, surface inline errors.
+ */
+const save = async () => {
+  state.isSaving = true;
+  state.errorMessage = '';
+  state.successMessage = '';
+  state.fieldErrors.view = '';
+  state.fieldErrors.accentColor = '';
+  state.fieldErrors.colorMode = '';
+
+  try {
+    const encodedId = validateAndEncodeId(props.calendarId, 'Calendar ID');
+    const payload = {
+      view: state.viewMode,
+      accentColor: state.accentColor,
+      colorMode: state.colorMode,
+    };
+    const response = await axios.put(`/api/v1/calendars/${encodedId}/widget/config`, payload);
+    const saved = response.data ?? {};
+    state.viewMode = saved.view ?? state.viewMode;
+    state.accentColor = saved.accentColor ?? state.accentColor;
+    state.colorMode = saved.colorMode ?? state.colorMode;
+    refreshSnapshot();
+    state.successMessage = t('save_success');
+  }
+  catch (error) {
+    console.error('Error saving widget config:', error);
+    const fields = error?.response?.data?.fields;
+    if (fields && typeof fields === 'object') {
+      // Backend fields keyed by camelCase; value may be string or array
+      const coerce = (v) => Array.isArray(v) ? v.join(', ') : (typeof v === 'string' ? v : '');
+      if (fields.view) state.fieldErrors.view = coerce(fields.view);
+      if (fields.accentColor) state.fieldErrors.accentColor = coerce(fields.accentColor);
+      if (fields.colorMode) state.fieldErrors.colorMode = coerce(fields.colorMode);
+      state.errorMessage = t('save_validation_error');
+    }
+    else {
+      state.errorMessage = t('save_error');
+    }
+  }
+  finally {
+    state.isSaving = false;
+  }
+};
 
 // Watch for configuration changes and send updates to iframe
 watch(
@@ -239,9 +407,16 @@ watch(
   },
 );
 
+// Load config on mount and when calendar id changes
+onMounted(loadConfig);
+watch(() => props.calendarId, loadConfig);
+
 // Expose state to parent component
 defineExpose({
   state,
+  isDirty,
+  save,
+  loadConfig,
 });
 </script>
 
@@ -282,7 +457,7 @@ defineExpose({
       font-size: 0.875rem;
       font-weight: 500;
       color: var(--pav-color-stone-700);
-      margin-bottom: var(--pav-space-3);
+      margin: 0 0 var(--pav-space-3) 0;
 
       @media (prefers-color-scheme: dark) {
         color: var(--pav-color-stone-300);
@@ -482,6 +657,53 @@ defineExpose({
       font-family: monospace;
       color: var(--pav-text-primary);
       font-weight: 500;
+    }
+  }
+
+  .form-actions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pav-space-3);
+    margin-top: var(--pav-space-4);
+  }
+
+  .save-button {
+    align-self: flex-start;
+  }
+
+  .field-error {
+    margin-top: var(--pav-space-2);
+    font-size: 0.8125rem;
+    color: var(--pav-color-red-700);
+
+    @media (prefers-color-scheme: dark) {
+      color: var(--pav-color-red-400);
+    }
+  }
+
+  .alert {
+    padding: var(--pav-space-3);
+    border-radius: 0.75rem;
+    font-size: 0.875rem;
+
+    &.alert--error {
+      background-color: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.2);
+      color: var(--pav-color-red-700);
+
+      @media (prefers-color-scheme: dark) {
+        color: var(--pav-color-red-400);
+      }
+    }
+
+    &.alert--success {
+      background-color: rgba(34, 197, 94, 0.1);
+      border: 1px solid rgba(34, 197, 94, 0.2);
+      color: var(--pav-color-green-700);
+
+      @media (prefers-color-scheme: dark) {
+        color: var(--pav-color-green-400);
+      }
     }
   }
 

--- a/src/client/components/logged_in/calendar-management/widget-embed.vue
+++ b/src/client/components/logged_in/calendar-management/widget-embed.vue
@@ -4,6 +4,7 @@
       <button
         class="copy-btn"
         :disabled="state.copying"
+        :aria-disabled="state.copying"
         @click="copyToClipboard"
       >
         {{ state.copied ? t('copied') : t('copy_button') }}
@@ -12,11 +13,21 @@
 
     <pre class="embed-code"><code>{{ embedCode }}</code></pre>
 
-    <div v-if="state.error" class="error">
+    <div
+      v-if="state.error"
+      class="error"
+      role="alert"
+      aria-live="polite"
+    >
       {{ state.error }}
     </div>
 
-    <div v-if="state.copied" class="success">
+    <div
+      v-if="state.copied"
+      class="success"
+      role="status"
+      aria-live="polite"
+    >
       {{ t('copy_success') }}
     </div>
   </div>
@@ -31,18 +42,6 @@ const props = defineProps({
   calendarUrlName: {
     type: String,
     required: true,
-  },
-  viewMode: {
-    type: String,
-    default: 'list',
-  },
-  accentColor: {
-    type: String,
-    default: '#ff9131',
-  },
-  colorMode: {
-    type: String,
-    default: 'auto',
   },
 });
 
@@ -67,10 +66,7 @@ const embedCode = computed(() => {
   window.Pavillion = window.Pavillion || function(){(window.Pavillion.q=window.Pavillion.q||[]).push([].slice.call(arguments))};
   Pavillion('init', {
     calendar: '${props.calendarUrlName}',
-    container: '#calendar-widget',
-    view: '${props.viewMode}',
-    accentColor: '${props.accentColor}',
-    colorMode: '${props.colorMode}'
+    container: '#calendar-widget'
   });
 <\/script>`;
 });

--- a/src/client/components/logged_in/calendar-management/widget-embed.vue
+++ b/src/client/components/logged_in/calendar-management/widget-embed.vue
@@ -64,7 +64,7 @@ const embedCode = computed(() => {
   return `<div id="calendar-widget"></div>
 <script async src="${baseUrl}/widget/pavillion-widget.js"><\/script>
 <script>
-  window.Pavillion = window.Pavillion || { q: [] };
+  window.Pavillion = window.Pavillion || function(){(window.Pavillion.q=window.Pavillion.q||[]).push([].slice.call(arguments))};
   Pavillion('init', {
     calendar: '${props.calendarUrlName}',
     container: '#calendar-widget',

--- a/src/client/components/logged_in/calendar-management/widget-tab.vue
+++ b/src/client/components/logged_in/calendar-management/widget-tab.vue
@@ -13,7 +13,6 @@
         <h2>{{ t('config_section_title') }}</h2>
         <p class="section-intro">{{ t('config_section_intro') }}</p>
         <WidgetConfig
-          ref="widgetConfigRef"
           :calendar-id="calendarId"
           :calendar-url-name="calendarUrlName"
         />
@@ -23,26 +22,20 @@
       <section class="widget-section">
         <h2>{{ t('embed_section_title') }}</h2>
         <p class="section-intro">{{ t('embed_section_intro') }}</p>
-        <WidgetEmbed
-          :calendar-url-name="calendarUrlName"
-          :view-mode="widgetConfigState.viewMode"
-          :accent-color="widgetConfigState.accentColor"
-          :color-mode="widgetConfigState.colorMode"
-        />
+        <WidgetEmbed :calendar-url-name="calendarUrlName" />
       </section>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import WidgetDomains from './widget-domains.vue';
 import WidgetConfig from './widget-config.vue';
 import WidgetEmbed from './widget-embed.vue';
 
 // Props
-const props = defineProps({
+defineProps({
   calendarId: {
     type: String,
     required: true,
@@ -56,18 +49,6 @@ const props = defineProps({
 // Translations
 const { t } = useTranslation('calendars', {
   keyPrefix: 'widget',
-});
-
-// Ref to widget config component to access its state
-const widgetConfigRef = ref(null);
-
-// Computed property to reactively get widget config state
-const widgetConfigState = computed(() => {
-  return widgetConfigRef.value?.state || {
-    viewMode: 'list',
-    accentColor: '#ff9131',
-    colorMode: 'auto',
-  };
 });
 </script>
 

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -460,7 +460,13 @@
             "color_mode_light": "Light Mode (always use light theme)",
             "color_mode_dark": "Dark Mode (always use dark theme)",
             "preview_title": "Preview",
-            "preview_description": "See how your widget will look with the current settings."
+            "preview_description": "See how your widget will look with the current settings.",
+            "save_button": "Save Configuration",
+            "saving": "Saving...",
+            "save_success": "Widget configuration saved.",
+            "save_error": "Failed to save widget configuration.",
+            "save_validation_error": "Please correct the errors below and try again.",
+            "error_loading": "Failed to load widget configuration."
         },
         "embed": {
             "title": "Embed Code",

--- a/src/client/service/calendar.ts
+++ b/src/client/service/calendar.ts
@@ -3,6 +3,7 @@ import { Calendar, DefaultDateRange } from '@/common/model/calendar';
 import { CalendarEvent } from '@/common/model/events';
 import { CalendarEditor } from '@/common/model/calendar_editor';
 import { CalendarInfo } from '@/common/model/calendar_info';
+import { WidgetConfig } from '@/common/model/widget_config';
 import ModelService from '@/client/service/models';
 import { UrlNameAlreadyExistsError, InvalidUrlNameError, CalendarNotFoundError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError, EditorAlreadyExistsError, EditorNotFoundError } from '@/common/exceptions/editor';
@@ -373,5 +374,31 @@ export default class CalendarService {
       console.error('Error updating calendar settings:', error);
       handleApiError(error, errorMap);
     }
+  }
+
+  /**
+   * Fetch the widget display configuration for a calendar.
+   * Returns defaults if no stored configuration exists.
+   *
+   * @param calendarId - The ID of the calendar
+   * @returns The widget configuration
+   */
+  async getWidgetConfig(calendarId: string): Promise<WidgetConfig> {
+    const encodedId = validateAndEncodeId(calendarId, 'Calendar ID');
+    const response = await axios.get(`/api/v1/calendars/${encodedId}/widget/config`);
+    return WidgetConfig.fromObject(response.data);
+  }
+
+  /**
+   * Save the widget display configuration for a calendar.
+   *
+   * @param calendarId - The ID of the calendar
+   * @param config - The widget configuration to save
+   * @returns The saved widget configuration
+   */
+  async setWidgetConfig(calendarId: string, config: WidgetConfig): Promise<WidgetConfig> {
+    const encodedId = validateAndEncodeId(calendarId, 'Calendar ID');
+    const response = await axios.put(`/api/v1/calendars/${encodedId}/widget/config`, config.toObject());
+    return WidgetConfig.fromObject(response.data);
   }
 }

--- a/src/common/model/widget_config.ts
+++ b/src/common/model/widget_config.ts
@@ -1,0 +1,137 @@
+import { Model } from '@/common/model/model';
+
+/**
+ * Allowed values for the widget `view` field.
+ */
+export type WidgetView = 'list' | 'week' | 'month';
+
+/**
+ * Allowed values for the widget `colorMode` field.
+ */
+export type WidgetColorMode = 'auto' | 'light' | 'dark';
+
+/**
+ * Allowed view values (readonly, enumerated for validation + UI).
+ */
+export const WIDGET_CONFIG_ALLOWED_VIEWS: readonly WidgetView[] = ['list', 'week', 'month'];
+
+/**
+ * Allowed color mode values (readonly, enumerated for validation + UI).
+ */
+export const WIDGET_CONFIG_ALLOWED_COLOR_MODES: readonly WidgetColorMode[] = ['auto', 'light', 'dark'];
+
+/**
+ * Strict 6-digit hex color regex. No shorthand (#fff), no alpha (#rrggbbaa).
+ */
+const WIDGET_ACCENT_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Default widget configuration values.
+ * Used when no stored config exists and as fallbacks for missing/invalid fields.
+ */
+export const WIDGET_CONFIG_DEFAULTS: {
+  view: WidgetView;
+  accentColor: string;
+  colorMode: WidgetColorMode;
+} = {
+  view: 'list',
+  accentColor: '#ff9131',
+  colorMode: 'auto',
+};
+
+/**
+ * Checks whether a value is an allowed widget view.
+ *
+ * @param value - The value to check
+ * @returns True if the value is one of 'list', 'week', or 'month'
+ */
+export function isValidWidgetView(value: unknown): value is WidgetView {
+  return typeof value === 'string'
+    && (WIDGET_CONFIG_ALLOWED_VIEWS as readonly string[]).includes(value);
+}
+
+/**
+ * Checks whether a value is an allowed widget color mode.
+ *
+ * @param value - The value to check
+ * @returns True if the value is one of 'auto', 'light', or 'dark'
+ */
+export function isValidWidgetColorMode(value: unknown): value is WidgetColorMode {
+  return typeof value === 'string'
+    && (WIDGET_CONFIG_ALLOWED_COLOR_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * Checks whether a value is a valid widget accent color.
+ * Requires a strict 6-digit hex string with a leading '#'.
+ * Rejects shorthand (#fff) and alpha channel (#rrggbbaa) formats.
+ *
+ * @param value - The value to check
+ * @returns True if the value matches /^#[0-9a-fA-F]{6}$/
+ */
+export function isValidWidgetAccentColor(value: unknown): value is string {
+  return typeof value === 'string' && WIDGET_ACCENT_COLOR_REGEX.test(value);
+}
+
+/**
+ * Plain domain model for per-calendar widget display configuration.
+ *
+ * Stores three presentation-layer settings that used to live in embed-snippet
+ * query-string arguments: the default view mode, the accent color used by the
+ * widget, and the color-mode (auto/light/dark) preference.
+ *
+ * Usable from both frontend (admin UI, widget app) and backend (service layer).
+ */
+export class WidgetConfig extends Model {
+  view: WidgetView;
+  accentColor: string;
+  colorMode: WidgetColorMode;
+
+  /**
+   * Constructor for WidgetConfig.
+   *
+   * @param view - The default view mode for the widget
+   * @param accentColor - The accent color in 6-digit hex format
+   * @param colorMode - The color mode preference
+   */
+  constructor(
+    view: WidgetView = WIDGET_CONFIG_DEFAULTS.view,
+    accentColor: string = WIDGET_CONFIG_DEFAULTS.accentColor,
+    colorMode: WidgetColorMode = WIDGET_CONFIG_DEFAULTS.colorMode,
+  ) {
+    super();
+    this.view = view;
+    this.accentColor = accentColor;
+    this.colorMode = colorMode;
+  }
+
+  /**
+   * Convert to plain object for serialization.
+   * Returns camelCase keys matching the API request/response shape.
+   *
+   * @returns Plain object with view, accentColor, and colorMode
+   */
+  toObject(): Record<string, any> {
+    return {
+      view: this.view,
+      accentColor: this.accentColor,
+      colorMode: this.colorMode,
+    };
+  }
+
+  /**
+   * Create a WidgetConfig from a plain object.
+   * Applies default values for any missing fields.
+   *
+   * @param obj - Plain object, potentially containing view, accentColor, colorMode
+   * @returns A new WidgetConfig instance
+   */
+  static fromObject(obj: Record<string, any>): WidgetConfig {
+    return new WidgetConfig(
+      obj.view ?? WIDGET_CONFIG_DEFAULTS.view,
+      obj.accentColor ?? WIDGET_CONFIG_DEFAULTS.accentColor,
+      obj.colorMode ?? WIDGET_CONFIG_DEFAULTS.colorMode,
+    );
+  }
+
+}

--- a/src/common/test/widget_config.test.ts
+++ b/src/common/test/widget_config.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WidgetConfig,
+  WIDGET_CONFIG_DEFAULTS,
+  WIDGET_CONFIG_ALLOWED_VIEWS,
+  WIDGET_CONFIG_ALLOWED_COLOR_MODES,
+  isValidWidgetView,
+  isValidWidgetColorMode,
+  isValidWidgetAccentColor,
+} from '@/common/model/widget_config';
+
+describe('WidgetConfig', () => {
+  describe('defaults', () => {
+    it('exposes default values for view, accentColor, and colorMode', () => {
+      expect(WIDGET_CONFIG_DEFAULTS.view).toBe('list');
+      expect(WIDGET_CONFIG_DEFAULTS.accentColor).toBe('#ff9131');
+      expect(WIDGET_CONFIG_DEFAULTS.colorMode).toBe('auto');
+    });
+
+    it('constructs with default values when no args are provided', () => {
+      const config = new WidgetConfig();
+
+      expect(config.view).toBe('list');
+      expect(config.accentColor).toBe('#ff9131');
+      expect(config.colorMode).toBe('auto');
+    });
+
+    it('enumerates allowed view values', () => {
+      expect(WIDGET_CONFIG_ALLOWED_VIEWS).toEqual(['list', 'week', 'month']);
+    });
+
+    it('enumerates allowed color mode values', () => {
+      expect(WIDGET_CONFIG_ALLOWED_COLOR_MODES).toEqual(['auto', 'light', 'dark']);
+    });
+  });
+
+  describe('constructor', () => {
+    it('accepts all three fields', () => {
+      const config = new WidgetConfig('week', '#123abc', 'dark');
+
+      expect(config.view).toBe('week');
+      expect(config.accentColor).toBe('#123abc');
+      expect(config.colorMode).toBe('dark');
+    });
+  });
+
+  describe('toObject()', () => {
+    it('returns camelCase keys with current values', () => {
+      const config = new WidgetConfig('month', '#AABBCC', 'light');
+
+      expect(config.toObject()).toEqual({
+        view: 'month',
+        accentColor: '#AABBCC',
+        colorMode: 'light',
+      });
+    });
+
+    it('returns defaults when constructed with no args', () => {
+      const config = new WidgetConfig();
+
+      expect(config.toObject()).toEqual({
+        view: 'list',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+    });
+  });
+
+  describe('fromObject()', () => {
+    it('deserializes a complete object', () => {
+      const config = WidgetConfig.fromObject({
+        view: 'week',
+        accentColor: '#112233',
+        colorMode: 'dark',
+      });
+
+      expect(config.view).toBe('week');
+      expect(config.accentColor).toBe('#112233');
+      expect(config.colorMode).toBe('dark');
+    });
+
+    it('applies defaults for missing fields', () => {
+      const config = WidgetConfig.fromObject({});
+
+      expect(config.view).toBe('list');
+      expect(config.accentColor).toBe('#ff9131');
+      expect(config.colorMode).toBe('auto');
+    });
+
+    it('round-trips through toObject/fromObject', () => {
+      const original = new WidgetConfig('month', '#deadbe', 'light');
+      const roundTripped = WidgetConfig.fromObject(original.toObject());
+
+      expect(roundTripped.toObject()).toEqual(original.toObject());
+    });
+  });
+
+  describe('isValidWidgetView', () => {
+    it('accepts allowed values', () => {
+      expect(isValidWidgetView('list')).toBe(true);
+      expect(isValidWidgetView('week')).toBe(true);
+      expect(isValidWidgetView('month')).toBe(true);
+    });
+
+    it('rejects values outside the allowed set', () => {
+      expect(isValidWidgetView('day')).toBe(false);
+      expect(isValidWidgetView('')).toBe(false);
+      expect(isValidWidgetView('LIST')).toBe(false);
+      expect(isValidWidgetView('grid')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidWidgetView(undefined)).toBe(false);
+      expect(isValidWidgetView(null)).toBe(false);
+      expect(isValidWidgetView(42)).toBe(false);
+    });
+  });
+
+  describe('isValidWidgetColorMode', () => {
+    it('accepts allowed values', () => {
+      expect(isValidWidgetColorMode('auto')).toBe(true);
+      expect(isValidWidgetColorMode('light')).toBe(true);
+      expect(isValidWidgetColorMode('dark')).toBe(true);
+    });
+
+    it('rejects values outside the allowed set', () => {
+      expect(isValidWidgetColorMode('system')).toBe(false);
+      expect(isValidWidgetColorMode('')).toBe(false);
+      expect(isValidWidgetColorMode('AUTO')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidWidgetColorMode(undefined)).toBe(false);
+      expect(isValidWidgetColorMode(null)).toBe(false);
+      expect(isValidWidgetColorMode(0)).toBe(false);
+    });
+  });
+
+  describe('isValidWidgetAccentColor', () => {
+    it('accepts strict 6-digit hex with lowercase letters', () => {
+      expect(isValidWidgetAccentColor('#ff9131')).toBe(true);
+      expect(isValidWidgetAccentColor('#abcdef')).toBe(true);
+      expect(isValidWidgetAccentColor('#000000')).toBe(true);
+      expect(isValidWidgetAccentColor('#ffffff')).toBe(true);
+    });
+
+    it('accepts strict 6-digit hex with uppercase letters', () => {
+      expect(isValidWidgetAccentColor('#FF9131')).toBe(true);
+      expect(isValidWidgetAccentColor('#ABCDEF')).toBe(true);
+    });
+
+    it('accepts mixed-case 6-digit hex', () => {
+      expect(isValidWidgetAccentColor('#aAbBcC')).toBe(true);
+    });
+
+    it('rejects 3-digit shorthand hex', () => {
+      expect(isValidWidgetAccentColor('#fff')).toBe(false);
+      expect(isValidWidgetAccentColor('#f91')).toBe(false);
+    });
+
+    it('rejects 8-digit hex with alpha channel', () => {
+      expect(isValidWidgetAccentColor('#ff9131ff')).toBe(false);
+      expect(isValidWidgetAccentColor('#00000000')).toBe(false);
+    });
+
+    it('rejects hex without the leading #', () => {
+      expect(isValidWidgetAccentColor('ff9131')).toBe(false);
+      expect(isValidWidgetAccentColor('abcdef')).toBe(false);
+    });
+
+    it('rejects strings with invalid hex characters', () => {
+      expect(isValidWidgetAccentColor('#gggggg')).toBe(false);
+      expect(isValidWidgetAccentColor('#ff91zz')).toBe(false);
+    });
+
+    it('rejects named colors and non-hex formats', () => {
+      expect(isValidWidgetAccentColor('red')).toBe(false);
+      expect(isValidWidgetAccentColor('rgb(255, 145, 49)')).toBe(false);
+      expect(isValidWidgetAccentColor('')).toBe(false);
+    });
+
+    it('rejects values with surrounding whitespace', () => {
+      expect(isValidWidgetAccentColor(' #ff9131')).toBe(false);
+      expect(isValidWidgetAccentColor('#ff9131 ')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+      expect(isValidWidgetAccentColor(undefined)).toBe(false);
+      expect(isValidWidgetAccentColor(null)).toBe(false);
+      expect(isValidWidgetAccentColor(0xff9131)).toBe(false);
+    });
+  });
+});

--- a/src/server/calendar/api/v1/widget-config.ts
+++ b/src/server/calendar/api/v1/widget-config.ts
@@ -5,6 +5,7 @@ const logger = createLogger('calendar');
 
 import { Account } from '@/common/model/account';
 import ExpressHelper from '@/server/common/helper/express';
+import { ValidationError } from '@/common/exceptions/base';
 import { CalendarNotFoundError, InvalidDomainFormatError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
 import { SubscriptionRequiredError } from '@/common/exceptions/subscription';
@@ -27,6 +28,8 @@ class WidgetConfigRoutes {
     router.get('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.getDomain.bind(this));
     router.put('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.setDomain.bind(this));
     router.delete('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.clearDomain.bind(this));
+    router.get('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.getConfig.bind(this));
+    router.put('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.setConfig.bind(this));
     app.use(routePrefix, router);
   }
 
@@ -38,7 +41,7 @@ class WidgetConfigRoutes {
     const { calendarId } = req.params;
 
     if (!account) {
-      res.status(400).json({
+      res.status(401).json({
         "error": "missing account. Not logged in?",
         errorName: 'AuthenticationError',
       });
@@ -100,7 +103,7 @@ class WidgetConfigRoutes {
     const { domain } = req.body;
 
     if (!account) {
-      res.status(400).json({
+      res.status(401).json({
         "error": "missing account. Not logged in?",
         errorName: 'AuthenticationError',
       });
@@ -183,7 +186,7 @@ class WidgetConfigRoutes {
     const { calendarId } = req.params;
 
     if (!account) {
-      res.status(400).json({
+      res.status(401).json({
         "error": "missing account. Not logged in?",
         errorName: 'AuthenticationError',
       });
@@ -229,6 +232,134 @@ class WidgetConfigRoutes {
         logger.error({ err: error }, 'Error clearing widget domain');
         res.status(500).json({
           "error": "An error occurred while clearing widget domain",
+        });
+      }
+    }
+  }
+
+  /**
+   * Get the widget display configuration (view / accentColor / colorMode) for a calendar.
+   * Returns a fresh defaults object when no row exists, so the admin form always has
+   * something to populate from.
+   */
+  async getConfig(req: Request, res: Response) {
+    const account = req.user as Account;
+    const { calendarId } = req.params;
+
+    if (!account) {
+      res.status(401).json({
+        "error": "missing account. Not logged in?",
+        errorName: 'AuthenticationError',
+      });
+      return;
+    }
+
+    if (!calendarId) {
+      res.status(400).json({
+        "error": "missing calendarId",
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    if (!ExpressHelper.isValidUUID(calendarId)) {
+      res.status(400).json({
+        "error": "invalid calendarId format",
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    try {
+      const config = await this.service.getWidgetConfigForEditor(account, calendarId);
+      res.json(config.toObject());
+    }
+    catch (error) {
+      if (error instanceof CalendarNotFoundError) {
+        res.status(404).json({
+          "error": "Calendar not found",
+          "errorName": error.name,
+        });
+      }
+      else if (error instanceof CalendarEditorPermissionError) {
+        res.status(403).json({
+          "error": "Permission denied",
+          "errorName": error.name,
+        });
+      }
+      else {
+        logger.error({ err: error }, 'Error getting widget config');
+        res.status(500).json({
+          "error": "An error occurred while getting widget config",
+        });
+      }
+    }
+  }
+
+  /**
+   * Upsert the widget display configuration for a calendar.
+   * Request body: { view, accentColor, colorMode }. All fields validated in the service;
+   * invalid fields surface as a ValidationError with camelCase field keys.
+   */
+  async setConfig(req: Request, res: Response) {
+    const account = req.user as Account;
+    const { calendarId } = req.params;
+
+    if (!account) {
+      res.status(401).json({
+        "error": "missing account. Not logged in?",
+        errorName: 'AuthenticationError',
+      });
+      return;
+    }
+
+    if (!calendarId) {
+      res.status(400).json({
+        "error": "missing calendarId",
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    if (!ExpressHelper.isValidUUID(calendarId)) {
+      res.status(400).json({
+        "error": "invalid calendarId format",
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const configInput = {
+      view: body.view as any,
+      accentColor: body.accentColor as any,
+      colorMode: body.colorMode as any,
+    };
+
+    try {
+      const saved = await this.service.setWidgetConfig(account, calendarId, configInput);
+      res.json(saved.toObject());
+    }
+    catch (error) {
+      if (error instanceof ValidationError) {
+        ExpressHelper.sendValidationError(res, error);
+      }
+      else if (error instanceof CalendarNotFoundError) {
+        res.status(404).json({
+          "error": "Calendar not found",
+          "errorName": error.name,
+        });
+      }
+      else if (error instanceof CalendarEditorPermissionError) {
+        res.status(403).json({
+          "error": "Permission denied",
+          "errorName": error.name,
+        });
+      }
+      else {
+        logger.error({ err: error }, 'Error setting widget config');
+        res.status(500).json({
+          "error": "An error occurred while setting widget config",
         });
       }
     }

--- a/src/server/calendar/api/v1/widget.ts
+++ b/src/server/calendar/api/v1/widget.ts
@@ -42,6 +42,19 @@ class WidgetRoutes {
    */
   private async validateOrigin(req: Request, res: Response, next: NextFunction) {
     const origin = req.get('Origin');
+    const secFetchSite = req.get('Sec-Fetch-Site');
+
+    // Same-origin requests (e.g., the widget iframe fetching its own config
+    // from its own host) do not carry an Origin header per the Fetch spec —
+    // the browser only sends Origin on cross-origin GETs. The
+    // `Sec-Fetch-Site: same-origin` signal is browser-set and cannot be forged
+    // from web content, so it is safe to skip origin validation when the
+    // request is provably same-origin. Cross-origin requests still must
+    // supply an Origin header and pass the allow-list check below.
+    if (!origin && secFetchSite === 'same-origin') {
+      next();
+      return;
+    }
 
     // Require Origin header for all widget requests
     if (!origin) {
@@ -127,13 +140,25 @@ class WidgetRoutes {
         return;
       }
 
-      // Return calendar data
-      res.json(calendar.toObject());
+      // Fetch widget display configuration (lazy defaults when no row exists).
+      const widgetConfig = await this.service.getWidgetConfig(calendarUrlName);
+
+      // Cache headers on the 200 path only. Vary: Origin keys the cache per
+      // requesting origin so the CORS Access-Control-Allow-Origin echo stays
+      // correct across origins.
+      res.setHeader('Cache-Control', 'public, max-age=60');
+      res.setHeader('Vary', 'Origin');
+
+      // Return calendar data with widget config merged in
+      res.json({
+        ...calendar.toObject(),
+        widgetConfig: widgetConfig.toObject(),
+      });
     }
     catch (error: any) {
       if (error instanceof SubscriptionRequiredError) {
         // Return 402 with Cache-Control: no-store header
-        res.set('Cache-Control', 'no-store');
+        res.setHeader('Cache-Control', 'no-store');
         res.status(402).json({
           error: 'subscription_required',
           errorName: error.name,

--- a/src/server/calendar/entity/calendar_widget_config.ts
+++ b/src/server/calendar/entity/calendar_widget_config.ts
@@ -1,0 +1,102 @@
+import {
+  Model,
+  Column,
+  Table,
+  BelongsTo,
+  ForeignKey,
+  DataType,
+  PrimaryKey,
+  CreatedAt,
+  UpdatedAt,
+} from 'sequelize-typescript';
+
+import { WidgetConfig, WidgetView, WidgetColorMode } from '@/common/model/widget_config';
+import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import db from '@/server/common/entity/db';
+
+/**
+ * CalendarWidgetConfigEntity
+ *
+ * Stores per-calendar widget display configuration (view mode, accent color,
+ * color mode) that the widget SDK/iframe reads at render time. Replaces the
+ * previous approach of passing these settings as embed-snippet query-string
+ * arguments so that calendar owners can change them in the admin UI without
+ * touching the HTML on their embedding site.
+ *
+ * One row per calendar enforced via unique FK on calendar_id. No row is
+ * created until the owner explicitly saves a config; widget serving falls
+ * through to hardcoded defaults until then.
+ */
+@Table({
+  tableName: 'calendar_widget_config',
+  timestamps: true,
+  underscored: true,
+})
+class CalendarWidgetConfigEntity extends Model {
+  @PrimaryKey
+  @Column({ type: DataType.UUID, defaultValue: DataType.UUIDV4 })
+  declare id: string;
+
+  @ForeignKey(() => CalendarEntity)
+  @Column({ type: DataType.UUID, allowNull: false })
+  declare calendar_id: string;
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  declare view: string;
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  declare accent_color: string;
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  declare color_mode: string;
+
+  @CreatedAt
+  declare created_at: Date;
+
+  @UpdatedAt
+  declare updated_at: Date;
+
+  @BelongsTo(() => CalendarEntity, { foreignKey: 'calendar_id', onDelete: 'CASCADE' })
+  declare calendar: CalendarEntity;
+
+  /**
+   * Converts the entity to a WidgetConfig domain model.
+   */
+  toModel(): WidgetConfig {
+    return new WidgetConfig(
+      this.view as WidgetView,
+      this.accent_color,
+      this.color_mode as WidgetColorMode,
+    );
+  }
+
+  /**
+   * Creates a CalendarWidgetConfigEntity from a WidgetConfig domain model.
+   *
+   * The domain model only carries the three presentation fields (view,
+   * accentColor, colorMode). The entity's identity fields (id, calendar_id)
+   * must be supplied by the caller because they are not part of the domain
+   * model's concerns.
+   *
+   * @param model - WidgetConfig domain model to convert
+   * @param id - Entity row id (generated on creation, reused on update)
+   * @param calendarId - FK to the owning calendar
+   */
+  static fromModel(
+    model: WidgetConfig,
+    id: string,
+    calendarId: string,
+  ): CalendarWidgetConfigEntity {
+    return CalendarWidgetConfigEntity.build({
+      id,
+      calendar_id: calendarId,
+      view: model.view,
+      accent_color: model.accentColor,
+      color_mode: model.colorMode,
+    });
+  }
+}
+
+db.addModels([CalendarWidgetConfigEntity]);
+
+export { CalendarWidgetConfigEntity };

--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -14,6 +14,8 @@ import LocationService from '../service/locations';
 import CategoryService from '../service/categories';
 import CategoryMappingService from '@/server/calendar/service/category_mapping';
 import WidgetDomainService from '../service/widget_domain';
+import WidgetConfigService from '../service/widget_config';
+import { WidgetConfig } from '@/common/model/widget_config';
 import { EventEmitter } from 'events';
 import EventInstanceService from '../service/event_instance';
 import SeriesService from '../service/series';
@@ -43,6 +45,7 @@ export default class CalendarInterface {
   private eventInstanceService: EventInstanceService;
   private categoryService: CategoryService;
   private widgetDomainService: WidgetDomainService;
+  private widgetConfigService: WidgetConfigService;
   private categoryMappingService: CategoryMappingService;
   private seriesService: SeriesService;
 
@@ -58,6 +61,7 @@ export default class CalendarInterface {
     this.eventInstanceService = new EventInstanceService(eventBus);
     this.categoryService = new CategoryService(this.calendarService);
     this.widgetDomainService = new WidgetDomainService();
+    this.widgetConfigService = new WidgetConfigService(this.calendarService);
     this.categoryMappingService = new CategoryMappingService();
     this.seriesService = new SeriesService(this.calendarService, eventBus);
   }
@@ -559,6 +563,48 @@ export default class CalendarInterface {
     }
 
     return this.widgetDomainService.clearAllowedDomain(calendar);
+  }
+
+  // Widget config operations
+
+  /**
+   * Public widget-serving read. Returns stored widget config for the calendar
+   * identified by URL name, or a fresh defaults WidgetConfig when no row exists.
+   * No permission check — used by the anonymous widget iframe path.
+   *
+   * @param calendarUrlName - The calendar's URL name
+   * @returns The stored or default WidgetConfig
+   */
+  async getWidgetConfig(calendarUrlName: string): Promise<WidgetConfig> {
+    return this.widgetConfigService.getWidgetConfig(calendarUrlName);
+  }
+
+  /**
+   * Editor-permission-checked widget config read for the admin UI.
+   *
+   * @param account - The requesting account
+   * @param calendarId - The calendar UUID
+   * @returns The stored or default WidgetConfig
+   */
+  async getWidgetConfigForEditor(account: Account, calendarId: string): Promise<WidgetConfig> {
+    return this.widgetConfigService.getWidgetConfigForEditor(account, calendarId);
+  }
+
+  /**
+   * Upsert widget config for a calendar. Editor permission required; not
+   * subscription-gated.
+   *
+   * @param account - The requesting account
+   * @param calendarId - The calendar UUID
+   * @param config - Partial WidgetConfig; missing fields fall back to defaults
+   * @returns The persisted WidgetConfig
+   */
+  async setWidgetConfig(
+    account: Account,
+    calendarId: string,
+    config: Partial<WidgetConfig>,
+  ): Promise<WidgetConfig> {
+    return this.widgetConfigService.setWidgetConfig(account, calendarId, config);
   }
 
   // Category mapping operations

--- a/src/server/calendar/service/widget_config.ts
+++ b/src/server/calendar/service/widget_config.ts
@@ -1,0 +1,248 @@
+import { v4 as uuidv4 } from 'uuid';
+import pino from 'pino';
+
+import { Account } from '@/common/model/account';
+import {
+  WidgetConfig,
+  WIDGET_CONFIG_DEFAULTS,
+  isValidWidgetView,
+  isValidWidgetAccentColor,
+  isValidWidgetColorMode,
+  WidgetView,
+  WidgetColorMode,
+} from '@/common/model/widget_config';
+import { ValidationError } from '@/common/exceptions/base';
+import { CalendarNotFoundError } from '@/common/exceptions/calendar';
+import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
+import { CalendarWidgetConfigEntity } from '@/server/calendar/entity/calendar_widget_config';
+import { createLogger } from '@/server/common/helper/logger';
+import CalendarService from './calendar';
+
+const logger = createLogger('calendar');
+
+/**
+ * Service for managing per-calendar widget display configuration.
+ *
+ * Stores the widget view mode, accent color, and color mode that were
+ * previously passed as embed-snippet query-string arguments. Keeps the
+ * persistence concern out of CalendarService to avoid that service
+ * growing further.
+ */
+class WidgetConfigService {
+
+  constructor(private calendarService?: CalendarService, private logOverride?: pino.Logger) {
+    // calendarService is optional for backward compatibility.
+    // logOverride is used by tests to spy on warning emissions.
+  }
+
+  /**
+   * Get widget config for the public widget-serving path.
+   * Looks up by calendar URL name (what the iframe knows). Returns a
+   * fresh defaults WidgetConfig when no row exists — lazy creation means
+   * we never materialize a row until the owner saves one.
+   *
+   * NO permission check: this path is used anonymously by the widget
+   * iframe after origin validation has already happened at a higher layer.
+   *
+   * @param calendarUrlName - The calendar's URL name (as the iframe knows it)
+   * @returns The stored WidgetConfig, or a fresh defaults WidgetConfig
+   * @throws CalendarNotFoundError if no calendar matches the URL name
+   */
+  async getWidgetConfig(calendarUrlName: string): Promise<WidgetConfig> {
+    const calendar = await this.getCalendarByName(calendarUrlName);
+    if (!calendar) {
+      throw new CalendarNotFoundError();
+    }
+
+    const entity = await CalendarWidgetConfigEntity.findOne({
+      where: { calendar_id: calendar.id },
+    });
+
+    if (!entity) {
+      return new WidgetConfig();
+    }
+
+    return this.toSafeModel(entity, calendar.id);
+  }
+
+  /**
+   * Editor-permission-checked widget config read for the admin UI.
+   * Returns a fresh defaults WidgetConfig when no row exists so the admin
+   * form has something to populate from.
+   *
+   * @param account - The requesting account
+   * @param calendarId - The calendar UUID
+   * @returns The stored WidgetConfig, or a fresh defaults WidgetConfig
+   * @throws CalendarNotFoundError if the calendar does not exist
+   * @throws CalendarEditorPermissionError if the account lacks edit access
+   */
+  async getWidgetConfigForEditor(account: Account, calendarId: string): Promise<WidgetConfig> {
+    await this.assertEditorAccess(account, calendarId);
+
+    const entity = await CalendarWidgetConfigEntity.findOne({
+      where: { calendar_id: calendarId },
+    });
+
+    if (!entity) {
+      return new WidgetConfig();
+    }
+
+    return this.toSafeModel(entity, calendarId);
+  }
+
+  /**
+   * Upsert widget config for a calendar. Editor permission required.
+   * Not subscription-gated — owners can edit draft config even on a free
+   * instance; the subscription gate applies at the widget-serving boundary.
+   *
+   * Validates all three fields up front and throws ValidationError with a
+   * `fields` map keyed by the camelCase request-body names
+   * (view / accentColor / colorMode) — never the snake_case DB columns.
+   *
+   * @param account - The requesting account
+   * @param calendarId - The calendar UUID
+   * @param config - Partial WidgetConfig; missing fields fall back to defaults
+   * @returns The persisted WidgetConfig
+   * @throws CalendarNotFoundError if the calendar does not exist
+   * @throws CalendarEditorPermissionError if the account lacks edit access
+   * @throws ValidationError if any field is invalid
+   */
+  async setWidgetConfig(
+    account: Account,
+    calendarId: string,
+    config: Partial<WidgetConfig>,
+  ): Promise<WidgetConfig> {
+    await this.assertEditorAccess(account, calendarId);
+
+    const view = config.view ?? WIDGET_CONFIG_DEFAULTS.view;
+    const accentColor = config.accentColor ?? WIDGET_CONFIG_DEFAULTS.accentColor;
+    const colorMode = config.colorMode ?? WIDGET_CONFIG_DEFAULTS.colorMode;
+
+    const fieldErrors: Record<string, string[]> = {};
+
+    if (!isValidWidgetView(view)) {
+      fieldErrors.view = ['Invalid widget view'];
+    }
+    if (!isValidWidgetAccentColor(accentColor)) {
+      fieldErrors.accentColor = ['Invalid accent color'];
+    }
+    if (!isValidWidgetColorMode(colorMode)) {
+      fieldErrors.colorMode = ['Invalid color mode'];
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new ValidationError('Invalid widget configuration', fieldErrors);
+    }
+
+    const validConfig = new WidgetConfig(
+      view as WidgetView,
+      accentColor,
+      colorMode as WidgetColorMode,
+    );
+
+    const existing = await CalendarWidgetConfigEntity.findOne({
+      where: { calendar_id: calendarId },
+    });
+
+    if (existing) {
+      await existing.update({
+        view: validConfig.view,
+        accent_color: validConfig.accentColor,
+        color_mode: validConfig.colorMode,
+      });
+    }
+    else {
+      const entity = CalendarWidgetConfigEntity.fromModel(validConfig, uuidv4(), calendarId);
+      await entity.save();
+    }
+
+    return validConfig;
+  }
+
+  /**
+   * Convert a persisted entity to a WidgetConfig, re-validating each field
+   * on read. Any corrupt stored value falls back to the default for that
+   * field and emits a warning. This is defense-in-depth against a bad row
+   * (or a schema migration drift) reaching the widget DOM.
+   */
+  private toSafeModel(entity: CalendarWidgetConfigEntity, calendarId: string): WidgetConfig {
+    const warnings: Record<string, unknown> = {};
+
+    let view: WidgetView = WIDGET_CONFIG_DEFAULTS.view;
+    if (isValidWidgetView(entity.view)) {
+      view = entity.view;
+    }
+    else {
+      warnings.view = entity.view;
+    }
+
+    let accentColor: string = WIDGET_CONFIG_DEFAULTS.accentColor;
+    if (isValidWidgetAccentColor(entity.accent_color)) {
+      accentColor = entity.accent_color;
+    }
+    else {
+      warnings.accentColor = entity.accent_color;
+    }
+
+    let colorMode: WidgetColorMode = WIDGET_CONFIG_DEFAULTS.colorMode;
+    if (isValidWidgetColorMode(entity.color_mode)) {
+      colorMode = entity.color_mode;
+    }
+    else {
+      warnings.colorMode = entity.color_mode;
+    }
+
+    if (Object.keys(warnings).length > 0) {
+      this.getLogger().warn(
+        { calendarId, invalidFields: warnings },
+        'Corrupt widget config fields fell back to defaults',
+      );
+    }
+
+    return new WidgetConfig(view, accentColor, colorMode);
+  }
+
+  /**
+   * Verify the account has edit access to the calendar. Throws
+   * CalendarNotFoundError if missing and CalendarEditorPermissionError
+   * if the account lacks access.
+   */
+  private async assertEditorAccess(account: Account, calendarId: string): Promise<void> {
+    const calendar = await this.getCalendar(calendarId);
+    if (!calendar) {
+      throw new CalendarNotFoundError();
+    }
+
+    const canModify = this.calendarService
+      ? await this.calendarService.userCanModifyCalendar(account, calendar)
+      : false;
+
+    if (!canModify) {
+      throw new CalendarEditorPermissionError();
+    }
+  }
+
+  private async getCalendar(id: string) {
+    if (this.calendarService) {
+      return this.calendarService.getCalendar(id);
+    }
+    const { CalendarEntity } = await import('@/server/calendar/entity/calendar');
+    const entity = await CalendarEntity.findByPk(id);
+    return entity ? entity.toModel() : null;
+  }
+
+  private async getCalendarByName(urlName: string) {
+    if (this.calendarService) {
+      return this.calendarService.getCalendarByName(urlName);
+    }
+    const { CalendarEntity } = await import('@/server/calendar/entity/calendar');
+    const entity = await CalendarEntity.findOne({ where: { url_name: urlName } });
+    return entity ? entity.toModel() : null;
+  }
+
+  private getLogger(): pino.Logger {
+    return this.logOverride ?? logger;
+  }
+}
+
+export default WidgetConfigService;

--- a/src/server/calendar/test/WidgetAPI/widget_api.test.ts
+++ b/src/server/calendar/test/WidgetAPI/widget_api.test.ts
@@ -4,6 +4,7 @@ import express, { Application } from 'express';
 import supertest from 'supertest';
 
 import { Calendar } from '@/common/model/calendar';
+import { WidgetConfig } from '@/common/model/widget_config';
 import CalendarInterface from '@/server/calendar/interface';
 import WidgetDomainService from '@/server/calendar/service/widget_domain';
 import WidgetRoutes from '@/server/calendar/api/v1/widget';
@@ -25,6 +26,7 @@ describe('Widget API Routes', () => {
     mockInterface = {
       getCalendarByName: sandbox.stub(),
       getCalendarForWidget: sandbox.stub(),
+      getWidgetConfig: sandbox.stub().resolves(new WidgetConfig()),
     } as any;
 
     mockWidgetService = new WidgetDomainService();
@@ -113,6 +115,39 @@ describe('Widget API Routes', () => {
 
       const response = await supertest(app)
         .get('/api/widget/v1/calendars/test-calendar')
+        .expect(403);
+
+      expect(response.body).toHaveProperty('error');
+      expect(response.body.error).toContain('Origin header');
+    });
+
+    it('should bypass origin allowlist when Sec-Fetch-Site is same-origin and Origin is absent', async () => {
+      const getCalendarStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarStub.resolves(calendar);
+      getCalendarForWidgetStub.resolves(calendar);
+
+      // Browsers omit Origin on same-origin GETs but always set Sec-Fetch-Site,
+      // which cannot be forged by web content. The widget iframe self-fetch
+      // depends on this bypass branch.
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Sec-Fetch-Site', 'same-origin')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('id', calendar.id);
+      expect(response.body).toHaveProperty('urlName', calendar.urlName);
+    });
+
+    it('should still 403 when Sec-Fetch-Site indicates cross-site', async () => {
+      const getCalendarStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarStub.resolves(calendar);
+      getCalendarForWidgetStub.resolves(calendar);
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Sec-Fetch-Site', 'cross-site')
         .expect(403);
 
       expect(response.body).toHaveProperty('error');
@@ -255,6 +290,98 @@ describe('Widget API Routes', () => {
 
       expect(response.body).toHaveProperty('id', calendar.id);
       expect(response.body).toHaveProperty('urlName', calendar.urlName);
+    });
+  });
+
+  describe('Widget config in calendar response', () => {
+    it('should include widgetConfig with defaults when no saved config exists', async () => {
+      const getCalendarByNameStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      getCalendarByNameStub.resolves(calendar);
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarForWidgetStub.resolves(calendar);
+      // getWidgetConfig default stub returns new WidgetConfig() (defaults)
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Origin', 'http://localhost:3000')
+        .expect(200);
+
+      expect(response.body).toHaveProperty('widgetConfig');
+      expect(response.body.widgetConfig).toEqual({
+        view: 'list',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+    });
+
+    it('should include widgetConfig reflecting saved values when a row is saved', async () => {
+      const getCalendarByNameStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      getCalendarByNameStub.resolves(calendar);
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarForWidgetStub.resolves(calendar);
+
+      const savedConfig = new WidgetConfig('month', '#112233', 'dark');
+      (mockInterface.getWidgetConfig as sinon.SinonStub).resolves(savedConfig);
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Origin', 'http://localhost:3000')
+        .expect(200);
+
+      expect(response.body.widgetConfig).toEqual({
+        view: 'month',
+        accentColor: '#112233',
+        colorMode: 'dark',
+      });
+    });
+  });
+
+  describe('Cache headers on calendar response', () => {
+    it('should set Cache-Control: public, max-age=60 on 200 response', async () => {
+      const getCalendarByNameStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      getCalendarByNameStub.resolves(calendar);
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarForWidgetStub.resolves(calendar);
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Origin', 'http://localhost:3000')
+        .expect(200);
+
+      expect(response.headers['cache-control']).toBe('public, max-age=60');
+    });
+
+    it('should set Vary: Origin on 200 response', async () => {
+      const getCalendarByNameStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      getCalendarByNameStub.resolves(calendar);
+      const getCalendarForWidgetStub = mockInterface.getCalendarForWidget as sinon.SinonStub;
+      getCalendarForWidgetStub.resolves(calendar);
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Origin', 'http://localhost:3000')
+        .expect(200);
+
+      const varyHeader = response.headers['vary'];
+      expect(varyHeader).toBeDefined();
+      expect(varyHeader).toContain('Origin');
+    });
+
+    it('should set Cache-Control: no-store on 402 (subscription required) response', async () => {
+      const getCalendarByNameStub = mockInterface.getCalendarByName as sinon.SinonStub;
+      getCalendarByNameStub.resolves(calendar);
+
+      const { SubscriptionRequiredError } = await import('@/common/exceptions/subscription');
+      const getCalendarForWidgetStub = sandbox.stub();
+      getCalendarForWidgetStub.rejects(new SubscriptionRequiredError('widget_embedding'));
+      mockInterface.getCalendarForWidget = getCalendarForWidgetStub;
+
+      const response = await supertest(app)
+        .get('/api/widget/v1/calendars/test-calendar')
+        .set('Origin', 'http://localhost:3000')
+        .expect(402);
+
+      expect(response.headers['cache-control']).toBe('no-store');
     });
   });
 

--- a/src/server/calendar/test/entity/calendar_widget_config.test.ts
+++ b/src/server/calendar/test/entity/calendar_widget_config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+
+import { WidgetConfig } from '@/common/model/widget_config';
+import { CalendarWidgetConfigEntity } from '@/server/calendar/entity/calendar_widget_config';
+
+describe('CalendarWidgetConfigEntity', () => {
+
+  describe('fromModel', () => {
+    it('should create entity from a WidgetConfig domain model', () => {
+      const id = uuidv4();
+      const calendarId = uuidv4();
+      const model = new WidgetConfig('week', '#abcdef', 'dark');
+
+      const entity = CalendarWidgetConfigEntity.fromModel(model, id, calendarId);
+
+      expect(entity.id).toBe(id);
+      expect(entity.calendar_id).toBe(calendarId);
+      expect(entity.view).toBe('week');
+      expect(entity.accent_color).toBe('#abcdef');
+      expect(entity.color_mode).toBe('dark');
+    });
+  });
+
+  describe('toModel', () => {
+    it('should convert an entity to a WidgetConfig domain model', () => {
+      const id = uuidv4();
+      const calendarId = uuidv4();
+      const entity = CalendarWidgetConfigEntity.build({
+        id,
+        calendar_id: calendarId,
+        view: 'month',
+        accent_color: '#123456',
+        color_mode: 'light',
+      });
+
+      const model = entity.toModel();
+
+      expect(model).toBeInstanceOf(WidgetConfig);
+      expect(model.view).toBe('month');
+      expect(model.accentColor).toBe('#123456');
+      expect(model.colorMode).toBe('light');
+    });
+  });
+
+  describe('round-trip conversion', () => {
+    it('should maintain data integrity through model-entity-model', () => {
+      const id = uuidv4();
+      const calendarId = uuidv4();
+      const original = new WidgetConfig('list', '#ff9131', 'auto');
+
+      const entity = CalendarWidgetConfigEntity.fromModel(original, id, calendarId);
+      const roundTrip = entity.toModel();
+
+      expect(roundTrip.view).toBe(original.view);
+      expect(roundTrip.accentColor).toBe(original.accentColor);
+      expect(roundTrip.colorMode).toBe(original.colorMode);
+    });
+  });
+});

--- a/src/server/calendar/test/integration/widget-config.api.test.ts
+++ b/src/server/calendar/test/integration/widget-config.api.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import CalendarInterface from '@/server/calendar/interface';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import AccountService from '@/server/accounts/service/account';
+import { TestEnvironment } from '@/server/test/lib/test_environment';
+import { CalendarWidgetConfigEntity } from '@/server/calendar/entity/calendar_widget_config';
+import { WIDGET_CONFIG_DEFAULTS } from '@/common/model/widget_config';
+
+/**
+ * Integration tests for the admin widget-config REST endpoints:
+ *   GET  /api/v1/calendars/:calendarId/widget/config
+ *   PUT  /api/v1/calendars/:calendarId/widget/config
+ *
+ * These exercise the full Express pipeline (auth middleware, rate limiting,
+ * service validation, and error serialization) against an in-memory SQLite DB.
+ * The existing unit test in test/api/widget_config.test.ts covers the domain
+ * handler in isolation; this file covers the HTTP contract end-to-end.
+ */
+describe('Widget Config Admin API Integration Tests', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let eventBus: EventEmitter;
+
+  let ownerAccount: Account;
+  let ownedCalendar: Calendar;
+  let ownerToken: string;
+  let otherToken: string;
+
+  const ownerEmail = 'widgetcfg-owner@pavillion.dev';
+  const otherEmail = 'widgetcfg-other@pavillion.dev';
+  const password = 'testpassword';
+
+  const MISSING_UUID = '00000000-0000-4000-8000-000000000000';
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const ownerInfo = await accountService._setupAccount(ownerEmail, password);
+    ownerAccount = ownerInfo.account;
+    await accountService._setupAccount(otherEmail, password);
+
+    ownerToken = await env.login(ownerEmail, password);
+    otherToken = await env.login(otherEmail, password);
+
+    ownedCalendar = await calendarInterface.createCalendar(ownerAccount, 'widgetcfg-cal');
+  });
+
+  afterAll(async () => {
+    if (eventBus) {
+      eventBus.removeAllListeners();
+    }
+    await env.cleanup();
+  });
+
+  beforeEach(async () => {
+    // Reset widget config rows between tests so GET/PUT cases start clean.
+    await CalendarWidgetConfigEntity.destroy({
+      where: { calendar_id: ownedCalendar.id },
+    });
+  });
+
+  describe('GET /api/v1/calendars/:calendarId/widget/config', () => {
+    it('returns defaults when no row exists', async () => {
+      const response = await env.authGet(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        view: WIDGET_CONFIG_DEFAULTS.view,
+        accentColor: WIDGET_CONFIG_DEFAULTS.accentColor,
+        colorMode: WIDGET_CONFIG_DEFAULTS.colorMode,
+      });
+    });
+
+    it('returns stored values after PUT', async () => {
+      const putResponse = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'week', accentColor: '#123456', colorMode: 'dark' },
+      );
+      expect(putResponse.status).toBe(200);
+
+      const getResponse = await env.authGet(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+      );
+
+      expect(getResponse.status).toBe(200);
+      expect(getResponse.body).toEqual({
+        view: 'week',
+        accentColor: '#123456',
+        colorMode: 'dark',
+      });
+    });
+
+    it('returns 403 for a non-editor account', async () => {
+      const response = await env.authGet(
+        otherToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body.errorName).toBe('CalendarEditorPermissionError');
+    });
+
+    it('returns 400 for a malformed calendarId UUID', async () => {
+      const response = await env.authGet(
+        ownerToken,
+        '/api/v1/calendars/not-a-uuid/widget/config',
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+      expect(response.body.error).toContain('invalid calendarId format');
+    });
+
+    it('returns 404 when calendar does not exist', async () => {
+      const response = await env.authGet(
+        ownerToken,
+        `/api/v1/calendars/${MISSING_UUID}/widget/config`,
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('CalendarNotFoundError');
+    });
+  });
+
+  describe('PUT /api/v1/calendars/:calendarId/widget/config', () => {
+    it('returns 200 on first call (creates row)', async () => {
+      const response = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'month', accentColor: '#abcdef', colorMode: 'light' },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        view: 'month',
+        accentColor: '#abcdef',
+        colorMode: 'light',
+      });
+
+      const rowCount = await CalendarWidgetConfigEntity.count({
+        where: { calendar_id: ownedCalendar.id },
+      });
+      expect(rowCount).toBe(1);
+    });
+
+    it('returns 200 on second call with different values (updates row) and never creates a second row', async () => {
+      const firstResponse = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'list', accentColor: '#111111', colorMode: 'light' },
+      );
+      expect(firstResponse.status).toBe(200);
+
+      const secondResponse = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'week', accentColor: '#222222', colorMode: 'dark' },
+      );
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body).toEqual({
+        view: 'week',
+        accentColor: '#222222',
+        colorMode: 'dark',
+      });
+
+      // Assert exactly one row exists — upsert round-trip, no duplicates.
+      const rows = await CalendarWidgetConfigEntity.findAll({
+        where: { calendar_id: ownedCalendar.id },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].view).toBe('week');
+      expect(rows[0].accent_color).toBe('#222222');
+      expect(rows[0].color_mode).toBe('dark');
+    });
+
+    it('returns 403 for a non-editor account', async () => {
+      const response = await env.authPut(
+        otherToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'week', accentColor: '#abcdef', colorMode: 'dark' },
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.body.errorName).toBe('CalendarEditorPermissionError');
+    });
+
+    it('returns 400 with camelCase fields map for invalid payload', async () => {
+      const response = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'week', accentColor: 'not-a-hex', colorMode: 'dark' },
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+      expect(response.body.fields).toBeDefined();
+      expect(response.body.fields.accentColor).toBeDefined();
+      expect(Array.isArray(response.body.fields.accentColor)).toBe(true);
+      // Critical contract: camelCase keys only, never snake_case.
+      expect(response.body.fields).not.toHaveProperty('accent_color');
+    });
+
+    it('returns 400 with multiple invalid fields flagged in fields map', async () => {
+      const response = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${ownedCalendar.id}/widget/config`,
+        { view: 'bogus', accentColor: 'not-a-hex', colorMode: 'neon' },
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+      expect(response.body.fields.view).toBeDefined();
+      expect(response.body.fields.accentColor).toBeDefined();
+      expect(response.body.fields.colorMode).toBeDefined();
+      // Neither the snake_case DB column name nor the stringly-typed raw key should leak.
+      expect(response.body.fields).not.toHaveProperty('accent_color');
+      expect(response.body.fields).not.toHaveProperty('color_mode');
+    });
+
+    it('returns 400 for malformed calendarId UUID', async () => {
+      const response = await env.authPut(
+        ownerToken,
+        '/api/v1/calendars/not-a-uuid/widget/config',
+        { view: 'week', accentColor: '#abcdef', colorMode: 'dark' },
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+      expect(response.body.error).toContain('invalid calendarId format');
+    });
+
+    it('returns 404 when calendar does not exist', async () => {
+      const response = await env.authPut(
+        ownerToken,
+        `/api/v1/calendars/${MISSING_UUID}/widget/config`,
+        { view: 'week', accentColor: '#abcdef', colorMode: 'dark' },
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('CalendarNotFoundError');
+    });
+  });
+});

--- a/src/server/calendar/test/widget_config.service.test.ts
+++ b/src/server/calendar/test/widget_config.service.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sinon from 'sinon';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { WidgetConfig, WIDGET_CONFIG_DEFAULTS } from '@/common/model/widget_config';
+import { ValidationError } from '@/common/exceptions/base';
+import { CalendarNotFoundError } from '@/common/exceptions/calendar';
+import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
+import { CalendarWidgetConfigEntity } from '@/server/calendar/entity/calendar_widget_config';
+import CalendarService from '@/server/calendar/service/calendar';
+import WidgetConfigService from '@/server/calendar/service/widget_config';
+
+describe('WidgetConfigService', () => {
+  let sandbox: sinon.SinonSandbox;
+  let calendarService: sinon.SinonStubbedInstance<CalendarService>;
+  let service: WidgetConfigService;
+  let logger: { warn: sinon.SinonSpy; info: sinon.SinonSpy; debug: sinon.SinonSpy; error: sinon.SinonSpy };
+  let account: Account;
+  const calendarId = 'calendar-uuid-1';
+  const calendarUrlName = 'my-calendar';
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    calendarService = sandbox.createStubInstance(CalendarService);
+    logger = {
+      warn: sandbox.spy(),
+      info: sandbox.spy(),
+      debug: sandbox.spy(),
+      error: sandbox.spy(),
+    };
+    service = new WidgetConfigService(calendarService as unknown as CalendarService, logger as any);
+    account = new Account('account-id', 'tester', 'test@example.com');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getWidgetConfig (public widget path)', () => {
+    it('returns fresh defaults when no row exists', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendarByName.resolves(calendar);
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(null);
+
+      const config = await service.getWidgetConfig(calendarUrlName);
+
+      expect(config).toBeInstanceOf(WidgetConfig);
+      expect(config.view).toBe(WIDGET_CONFIG_DEFAULTS.view);
+      expect(config.accentColor).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(config.colorMode).toBe(WIDGET_CONFIG_DEFAULTS.colorMode);
+    });
+
+    it('returns stored config when row exists', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendarByName.resolves(calendar);
+      const entity = {
+        view: 'week',
+        accent_color: '#abcdef',
+        color_mode: 'dark',
+      } as any;
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(entity);
+
+      const config = await service.getWidgetConfig(calendarUrlName);
+
+      expect(config.view).toBe('week');
+      expect(config.accentColor).toBe('#abcdef');
+      expect(config.colorMode).toBe('dark');
+    });
+
+    it('throws CalendarNotFoundError when calendar does not exist', async () => {
+      calendarService.getCalendarByName.resolves(null);
+
+      await expect(service.getWidgetConfig('nope')).rejects.toThrow(CalendarNotFoundError);
+    });
+
+    it('falls back to defaults for corrupt fields and logs a warning (defense-in-depth)', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendarByName.resolves(calendar);
+      const entity = {
+        view: 'banana',
+        accent_color: '#ff9131',
+        color_mode: 'dark',
+      } as any;
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(entity);
+
+      const config = await service.getWidgetConfig(calendarUrlName);
+
+      expect(config.view).toBe(WIDGET_CONFIG_DEFAULTS.view);
+      expect(config.accentColor).toBe('#ff9131');
+      expect(config.colorMode).toBe('dark');
+      expect(logger.warn.calledOnce).toBe(true);
+
+      const [context, message] = logger.warn.firstCall.args;
+      expect(context.calendarId).toBe(calendarId);
+      expect(context.invalidFields).toHaveProperty('view', 'banana');
+      expect(context.invalidFields).not.toHaveProperty('accentColor');
+      expect(context.invalidFields).not.toHaveProperty('colorMode');
+      expect(message).toMatch(/Corrupt widget config fields/);
+    });
+  });
+
+  describe('getWidgetConfigForEditor', () => {
+    it('throws CalendarEditorPermissionError when account lacks edit access', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(false);
+
+      await expect(
+        service.getWidgetConfigForEditor(account, calendarId),
+      ).rejects.toThrow(CalendarEditorPermissionError);
+    });
+
+    it('throws CalendarNotFoundError when calendar does not exist', async () => {
+      calendarService.getCalendar.resolves(null);
+
+      await expect(
+        service.getWidgetConfigForEditor(account, calendarId),
+      ).rejects.toThrow(CalendarNotFoundError);
+    });
+
+    it('returns fresh defaults when the calendar has no stored row', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(null);
+
+      const config = await service.getWidgetConfigForEditor(account, calendarId);
+
+      expect(config.view).toBe(WIDGET_CONFIG_DEFAULTS.view);
+      expect(config.accentColor).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(config.colorMode).toBe(WIDGET_CONFIG_DEFAULTS.colorMode);
+    });
+
+    it('returns stored config when row exists', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+      const entity = {
+        view: 'month',
+        accent_color: '#123abc',
+        color_mode: 'light',
+      } as any;
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(entity);
+
+      const config = await service.getWidgetConfigForEditor(account, calendarId);
+
+      expect(config.view).toBe('month');
+      expect(config.accentColor).toBe('#123abc');
+      expect(config.colorMode).toBe('light');
+    });
+  });
+
+  describe('setWidgetConfig', () => {
+    it('throws CalendarEditorPermissionError when account lacks edit access', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(false);
+
+      await expect(
+        service.setWidgetConfig(account, calendarId, { view: 'list' }),
+      ).rejects.toThrow(CalendarEditorPermissionError);
+    });
+
+    it('throws ValidationError with camelCase field keys for invalid values', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+
+      try {
+        await service.setWidgetConfig(account, calendarId, {
+          view: 'bogus' as any,
+          accentColor: 'not-a-color',
+          colorMode: 'invisible' as any,
+        });
+        expect.fail('should have thrown ValidationError');
+      }
+      catch (err) {
+        expect(err).toBeInstanceOf(ValidationError);
+        const ve = err as ValidationError;
+        expect(ve.fields).toBeDefined();
+        expect(ve.fields).toHaveProperty('view');
+        expect(ve.fields).toHaveProperty('accentColor');
+        expect(ve.fields).toHaveProperty('colorMode');
+        // And NOT snake_case variants
+        expect(ve.fields).not.toHaveProperty('accent_color');
+        expect(ve.fields).not.toHaveProperty('color_mode');
+      }
+    });
+
+    it('rejects shorthand hex colors (#fff) via the strict regex', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+
+      try {
+        await service.setWidgetConfig(account, calendarId, {
+          view: 'list',
+          accentColor: '#fff',
+          colorMode: 'auto',
+        });
+        expect.fail('should have thrown ValidationError');
+      }
+      catch (err) {
+        expect(err).toBeInstanceOf(ValidationError);
+        const ve = err as ValidationError;
+        expect(ve.fields).toHaveProperty('accentColor');
+      }
+    });
+
+    it('persists a valid config by creating a new row when none exists', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(null);
+
+      const saveStub = sandbox.stub().resolves();
+      const buildStub = sandbox.stub(CalendarWidgetConfigEntity, 'build').returns({
+        save: saveStub,
+      } as any);
+
+      const result = await service.setWidgetConfig(account, calendarId, {
+        view: 'week',
+        accentColor: '#abcdef',
+        colorMode: 'dark',
+      });
+
+      expect(buildStub.calledOnce).toBe(true);
+      const buildArgs = buildStub.firstCall.args[0];
+      expect(buildArgs).toMatchObject({
+        calendar_id: calendarId,
+        view: 'week',
+        accent_color: '#abcdef',
+        color_mode: 'dark',
+      });
+      expect(saveStub.calledOnce).toBe(true);
+
+      expect(result.view).toBe('week');
+      expect(result.accentColor).toBe('#abcdef');
+      expect(result.colorMode).toBe('dark');
+    });
+
+    it('persists a valid config by updating an existing row', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+
+      const updateStub = sandbox.stub().resolves();
+      const existing = {
+        view: 'list',
+        accent_color: '#ff9131',
+        color_mode: 'auto',
+        update: updateStub,
+      } as any;
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').resolves(existing);
+
+      sandbox.stub(CalendarWidgetConfigEntity, 'build');
+
+      const result = await service.setWidgetConfig(account, calendarId, {
+        view: 'month',
+        accentColor: '#112233',
+        colorMode: 'light',
+      });
+
+      // Prove the update branch was taken (not the insert branch)
+      expect(updateStub.calledOnce).toBe(true);
+      expect(result.view).toBe('month');
+      expect(result.accentColor).toBe('#112233');
+      expect(result.colorMode).toBe('light');
+    });
+
+    it('happy-path round trip: write then read returns the same values', async () => {
+      const calendar = new Calendar(calendarId, calendarUrlName);
+      calendarService.getCalendar.resolves(calendar);
+      calendarService.userCanModifyCalendar.resolves(true);
+
+      let stored: any = null;
+      const updateStub = sandbox.stub().callsFake(async (patch: any) => {
+        Object.assign(stored, patch);
+      });
+      const saveStub = sandbox.stub().callsFake(async function (this: any) {
+        stored = {
+          view: this.view,
+          accent_color: this.accent_color,
+          color_mode: this.color_mode,
+          update: updateStub,
+        };
+      });
+
+      sandbox.stub(CalendarWidgetConfigEntity, 'findOne').callsFake(async () => stored);
+      sandbox.stub(CalendarWidgetConfigEntity, 'build').callsFake((attrs: any) => ({
+        ...attrs,
+        save: saveStub,
+      } as any));
+
+      await service.setWidgetConfig(account, calendarId, {
+        view: 'week',
+        accentColor: '#aabbcc',
+        colorMode: 'dark',
+      });
+
+      const read = await service.getWidgetConfigForEditor(account, calendarId);
+      expect(read.view).toBe('week');
+      expect(read.accentColor).toBe('#aabbcc');
+      expect(read.colorMode).toBe('dark');
+    });
+  });
+});

--- a/src/server/test/lib/test_environment.ts
+++ b/src/server/test/lib/test_environment.ts
@@ -10,6 +10,7 @@ import '@/server/common/entity/account';
 import '@/server/accounts/entity/account_invitation';
 import '@/server/calendar/entity/calendar';
 import '@/server/calendar/entity/calendar_member';
+import '@/server/calendar/entity/calendar_widget_config';
 import '@/server/calendar/entity/event_category';
 import '@/server/calendar/entity/event_category_content';
 import '@/server/calendar/entity/event';

--- a/src/widget-sdk/pavillion-widget.ts
+++ b/src/widget-sdk/pavillion-widget.ts
@@ -7,7 +7,7 @@
  * Usage:
  * <script async src="https://calendar.example.com/widget/pavillion-widget.js" data-lang="es"></script>
  * <script>
- *   window.Pavillion = window.Pavillion || { q: [] };
+ *   window.Pavillion = window.Pavillion || function(){(window.Pavillion.q=window.Pavillion.q||[]).push([].slice.call(arguments))};
  *   Pavillion('init', {
  *     calendar: 'my-calendar',
  *     container: '#calendar-widget',

--- a/src/widget-sdk/pavillion-widget.ts
+++ b/src/widget-sdk/pavillion-widget.ts
@@ -10,27 +10,27 @@
  *   window.Pavillion = window.Pavillion || function(){(window.Pavillion.q=window.Pavillion.q||[]).push([].slice.call(arguments))};
  *   Pavillion('init', {
  *     calendar: 'my-calendar',
- *     container: '#calendar-widget',
- *     view: 'week',
- *     accentColor: '#ff9131',
- *     colorMode: 'auto'
+ *     container: '#calendar-widget'
  *   });
  * </script>
  */
 
 import { isValidLanguageCode } from '@/common/i18n/languages';
 
-interface WidgetConfig {
+interface WidgetInitOptions {
   calendar: string;
   container: string;
-  view?: 'week' | 'month' | 'list';
-  accentColor?: string;
-  colorMode?: 'auto' | 'light' | 'dark';
   lang?: string;
   onResize?: (height: number) => void;
   onEventClick?: (eventId: string) => void;
   onNavigate?: (url: string) => void;
 }
+
+// Display options (view, accentColor, colorMode) are now stored server-side
+// and returned by the widget config API. They were previously accepted as SDK
+// init arguments; we warn once per init() call when old snippets still pass
+// any of them so embedders have a signal to update, then ignore the values.
+const DEPRECATED_CONFIG_KEYS = ['view', 'accentColor', 'colorMode'] as const;
 
 interface PavillionMessage {
   type: 'pavillion:resize' | 'pavillion:navigate' | 'pavillion:eventClick';
@@ -40,7 +40,7 @@ interface PavillionMessage {
 }
 
 class PavillionWidget {
-  private config: WidgetConfig | null = null;
+  private config: WidgetInitOptions | null = null;
   private iframe: HTMLIFrameElement | null = null;
   private container: HTMLElement | null = null;
   private widgetOrigin: string;
@@ -73,7 +73,12 @@ class PavillionWidget {
   /**
    * Initialize widget with configuration
    */
-  init(config: WidgetConfig): void {
+  init(config: WidgetInitOptions): void {
+    // Warn once if a legacy snippet still passes any of the deprecated display
+    // args. We aggregate into a single warning so three deprecated keys don't
+    // produce three console lines.
+    this.warnOnDeprecatedKeys(config);
+
     // Validate configuration
     const errors = this.validateConfig(config);
     if (errors.length > 0) {
@@ -81,11 +86,7 @@ class PavillionWidget {
       return;
     }
 
-    this.config = {
-      view: 'list',
-      colorMode: 'auto',
-      ...config,
-    };
+    this.config = { ...config };
 
     // Find container element
     this.container = document.querySelector(this.config.container);
@@ -99,9 +100,25 @@ class PavillionWidget {
   }
 
   /**
+   * Emit a single deprecation warning if the caller passed any of the
+   * legacy display args (view, accentColor, colorMode). The args are ignored;
+   * display settings are now sourced from server-side widget config.
+   */
+  private warnOnDeprecatedKeys(config: WidgetInitOptions): void {
+    const callerConfig = config as Record<string, unknown>;
+    const present = DEPRECATED_CONFIG_KEYS.filter(key => callerConfig[key] !== undefined);
+    if (present.length > 0) {
+      console.warn(
+        `[Pavillion Widget] The following init options are deprecated and ignored: ${present.join(', ')}. ` +
+        'Display settings (view, accent color, color mode) are now configured in the calendar admin UI.',
+      );
+    }
+  }
+
+  /**
    * Validate widget configuration
    */
-  private validateConfig(config: WidgetConfig): string[] {
+  private validateConfig(config: WidgetInitOptions): string[] {
     const errors: string[] = [];
 
     if (!config.calendar) {
@@ -109,12 +126,6 @@ class PavillionWidget {
     }
     if (!config.container) {
       errors.push('container is required');
-    }
-    if (config.view && !['week', 'month', 'list'].includes(config.view)) {
-      errors.push('view must be "week", "month", or "list"');
-    }
-    if (config.colorMode && !['auto', 'light', 'dark'].includes(config.colorMode)) {
-      errors.push('colorMode must be "auto", "light", or "dark"');
     }
 
     return errors;
@@ -129,16 +140,6 @@ class PavillionWidget {
     }
 
     const url = new URL(`/widget/${this.config.calendar}`, this.widgetOrigin);
-
-    if (this.config.view) {
-      url.searchParams.set('view', this.config.view);
-    }
-    if (this.config.accentColor) {
-      url.searchParams.set('accentColor', this.config.accentColor);
-    }
-    if (this.config.colorMode) {
-      url.searchParams.set('colorMode', this.config.colorMode);
-    }
 
     // Detect and set widget language
     const lang = detectWidgetLanguage(this.config.lang);
@@ -254,7 +255,7 @@ class PavillionWidget {
   // Create command processor function
   const Pavillion = function(command: string, ...args: any[]): void {
     if (command === 'init' && args[0]) {
-      widget.init(args[0] as WidgetConfig);
+      widget.init(args[0] as WidgetInitOptions);
     }
     else if (command === 'destroy') {
       widget.destroy();
@@ -318,5 +319,5 @@ export function detectWidgetLanguage(configLang?: string): string {
 }
 
 // Export for TypeScript consumers
-export type { WidgetConfig, PavillionMessage };
+export type { WidgetInitOptions, PavillionMessage };
 export { PavillionWidget };

--- a/src/widget-sdk/test/pavillion-widget.test.ts
+++ b/src/widget-sdk/test/pavillion-widget.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PavillionWidget } from '../pavillion-widget';
 
 describe('Pavillion Widget SDK', () => {
   let container: HTMLDivElement;
@@ -18,6 +19,7 @@ describe('Pavillion Widget SDK', () => {
     if (container && container.parentNode) {
       container.parentNode.removeChild(container);
     }
+    vi.restoreAllMocks();
   });
 
   describe('Async loading and command queue pattern', () => {
@@ -41,7 +43,6 @@ describe('Pavillion Widget SDK', () => {
       (window as any).Pavillion('init', {
         calendar: 'my-calendar',
         container: '#widget-container',
-        view: 'week',
       });
 
       expect((window as any).Pavillion.q.length).toBe(1);
@@ -50,7 +51,6 @@ describe('Pavillion Widget SDK', () => {
       expect((window as any).Pavillion.q[0][1]).toMatchObject({
         calendar: 'my-calendar',
         container: '#widget-container',
-        view: 'week',
       });
     });
   });
@@ -70,14 +70,14 @@ describe('Pavillion Widget SDK', () => {
         return errors;
       };
 
-      const invalidConfig = { view: 'week' };
+      const invalidConfig = {};
       const errors = validateConfig(invalidConfig);
 
       expect(errors).toContain('calendar is required');
       expect(errors).toContain('container is required');
     });
 
-    it('should accept valid config with optional parameters', () => {
+    it('should accept valid config with only calendar and container', () => {
       const validateConfig = (config: any): string[] => {
         const errors: string[] = [];
 
@@ -94,9 +94,6 @@ describe('Pavillion Widget SDK', () => {
       const validConfig = {
         calendar: 'my-calendar',
         container: '#widget-container',
-        view: 'month',
-        accentColor: '#ff9131',
-        colorMode: 'dark',
       };
 
       const errors = validateConfig(validConfig);
@@ -105,64 +102,123 @@ describe('Pavillion Widget SDK', () => {
   });
 
   describe('Iframe creation with URL parameters', () => {
-    it('should construct correct widget URL with parameters', () => {
-      const buildWidgetUrl = (
-        baseUrl: string,
-        calendar: string,
-        config: { view?: string; accentColor?: string; colorMode?: string },
-      ): string => {
-        const url = new URL(`/widget/${calendar}`, baseUrl);
+    it('should construct widget URL without deprecated display params', () => {
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+      });
 
-        if (config.view) {
-          url.searchParams.set('view', config.view);
-        }
-        if (config.accentColor) {
-          url.searchParams.set('accentColor', config.accentColor);
-        }
-        if (config.colorMode) {
-          url.searchParams.set('colorMode', config.colorMode);
-        }
+      const iframe = container.querySelector('iframe');
+      expect(iframe).not.toBeNull();
+      const src = iframe!.src;
 
-        return url.toString();
-      };
+      expect(src).toContain('/widget/my-calendar');
+      expect(src).toContain('lang=');
+      expect(src).not.toContain('view=');
+      expect(src).not.toContain('accentColor=');
+      expect(src).not.toContain('colorMode=');
 
-      const url = buildWidgetUrl('https://calendar.example.com', 'my-calendar', {
+      widget.destroy();
+    });
+
+    it('should not propagate deprecated args to widget URL even if passed', () => {
+      // Silence the expected deprecation warning for this test
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+        // @ts-expect-error — intentionally passing dropped args to verify they are ignored
         view: 'week',
         accentColor: '#ff9131',
         colorMode: 'dark',
       });
 
-      expect(url).toContain('/widget/my-calendar');
-      expect(url).toContain('view=week');
-      // URL encodes # as %25 in happy-dom, check for the color value
-      expect(url).toContain('accentColor');
-      expect(url).toContain('ff9131');
-      expect(url).toContain('colorMode=dark');
+      const iframe = container.querySelector('iframe');
+      expect(iframe).not.toBeNull();
+      const src = iframe!.src;
+
+      expect(src).not.toContain('view=week');
+      expect(src).not.toContain('accentColor');
+      expect(src).not.toContain('ff9131');
+      expect(src).not.toContain('colorMode=dark');
+
+      widget.destroy();
     });
 
     it('should create iframe with correct attributes', () => {
-      const createIframe = (url: string, container: HTMLElement): HTMLIFrameElement => {
-        const iframe = document.createElement('iframe');
-        iframe.src = url;
-        iframe.style.width = '100%';
-        iframe.style.border = 'none';
-        iframe.setAttribute('title', 'Pavillion Calendar Widget');
-        iframe.setAttribute('loading', 'lazy');
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+      });
 
-        container.appendChild(iframe);
-        return iframe;
-      };
+      const iframe = container.querySelector('iframe');
+      expect(iframe).not.toBeNull();
+      expect(iframe!.style.width).toBe('100%');
+      expect(iframe!.style.border).toContain('none');
+      expect(iframe!.getAttribute('title')).toBe('Pavillion Calendar Widget');
+      expect(iframe!.getAttribute('loading')).toBe('lazy');
 
-      const testContainer = document.getElementById('widget-container')!;
-      const iframe = createIframe('https://calendar.example.com/widget/test', testContainer);
+      widget.destroy();
+    });
+  });
 
-      expect(iframe.src).toContain('/widget/test');
-      expect(iframe.style.width).toBe('100%');
-      // Check that border style contains 'none' (happy-dom may add extra values)
-      expect(iframe.style.border).toContain('none');
-      expect(iframe.getAttribute('title')).toBe('Pavillion Calendar Widget');
-      expect(iframe.getAttribute('loading')).toBe('lazy');
-      expect(testContainer.contains(iframe)).toBe(true);
+  describe('Deprecated init arguments', () => {
+    it('should emit exactly one console.warn when all three deprecated args are passed simultaneously', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+        // @ts-expect-error — intentionally passing dropped args to verify deprecation warning
+        view: 'week',
+        accentColor: '#ff9131',
+        colorMode: 'dark',
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const firstCallArg = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(firstCallArg).toContain('view');
+      expect(firstCallArg).toContain('accentColor');
+      expect(firstCallArg).toContain('colorMode');
+
+      widget.destroy();
+    });
+
+    it('should emit one console.warn when only a subset of deprecated args is passed', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+        // @ts-expect-error — intentionally passing dropped arg to verify deprecation warning
+        view: 'month',
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const firstCallArg = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(firstCallArg).toContain('view');
+
+      widget.destroy();
+    });
+
+    it('should not emit a deprecation warning when no deprecated args are passed', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const widget = new PavillionWidget();
+      widget.init({
+        calendar: 'my-calendar',
+        container: '#widget-container',
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      widget.destroy();
     });
   });
 

--- a/src/widget-sdk/test/pavillion-widget.test.ts
+++ b/src/widget-sdk/test/pavillion-widget.test.ts
@@ -21,23 +21,21 @@ describe('Pavillion Widget SDK', () => {
   });
 
   describe('Async loading and command queue pattern', () => {
-    it('should create global Pavillion namespace with command queue', () => {
+    it('should create callable global Pavillion namespace with command queue', () => {
       // Simulate user code that runs before SDK loads
-      (window as any).Pavillion = (window as any).Pavillion || { q: [] };
-      (window as any).Pavillion.q = [];
+      (window as any).Pavillion = (window as any).Pavillion || function () {
+        ((window as any).Pavillion.q = (window as any).Pavillion.q || []).push([].slice.call(arguments));
+      };
 
       expect((window as any).Pavillion).toBeDefined();
-      expect((window as any).Pavillion.q).toBeInstanceOf(Array);
-      expect((window as any).Pavillion.q.length).toBe(0);
+      expect(typeof (window as any).Pavillion).toBe('function');
     });
 
     it('should buffer commands in queue before SDK loads', () => {
-      // Simulate user code
-      (window as any).Pavillion = (window as any).Pavillion || { q: [] };
-      const Pavillion = function(...args: any[]) {
-        (window as any).Pavillion.q.push(args);
+      // Simulate user code that runs before SDK loads
+      (window as any).Pavillion = (window as any).Pavillion || function () {
+        ((window as any).Pavillion.q = (window as any).Pavillion.q || []).push([].slice.call(arguments));
       };
-      (window as any).Pavillion = Object.assign(Pavillion, { q: [] });
 
       // User calls before SDK loads
       (window as any).Pavillion('init', {
@@ -47,6 +45,7 @@ describe('Pavillion Widget SDK', () => {
       });
 
       expect((window as any).Pavillion.q.length).toBe(1);
+      expect(Array.isArray((window as any).Pavillion.q[0])).toBe(true);
       expect((window as any).Pavillion.q[0][0]).toBe('init');
       expect((window as any).Pavillion.q[0][1]).toMatchObject({
         calendar: 'my-calendar',

--- a/src/widget/components/widget-container.vue
+++ b/src/widget/components/widget-container.vue
@@ -10,6 +10,11 @@ import WeekView from './week-view.vue';
 import MonthView from './month-view.vue';
 import ListView from './list-view.vue';
 import NotFound from '@/site/components/not-found.vue';
+import {
+  isValidWidgetView,
+  isValidWidgetColorMode,
+  isValidWidgetAccentColor,
+} from '@/common/model/widget_config';
 import type Config from '@/client/service/config';
 
 const { t } = useTranslation('system');
@@ -39,16 +44,21 @@ const handleMessage = (event: MessageEvent) => {
   if (event.data.type === 'pavillion:updateConfig') {
     const { config } = event.data;
 
-    // Update widget store with new configuration
-    // The app.vue component watches these values and will apply them automatically
-    if (config.view) {
-      widgetStore.viewMode = config.view;
-    }
-    if (config.accentColor) {
-      widgetStore.accentColor = config.accentColor;
-    }
-    if (config.colorMode) {
-      widgetStore.colorMode = config.colorMode;
+    // Update widget store with new configuration. Values are re-validated
+    // before being assigned; invalid values are silently ignored so a
+    // malformed postMessage cannot corrupt store state or (for accentColor)
+    // the CSS custom property the value ultimately reaches.
+    // The app.vue component watches these values and will apply them automatically.
+    if (config && typeof config === 'object') {
+      if (isValidWidgetView(config.view)) {
+        widgetStore.viewMode = config.view;
+      }
+      if (isValidWidgetAccentColor(config.accentColor)) {
+        widgetStore.accentColor = config.accentColor;
+      }
+      if (isValidWidgetColorMode(config.colorMode)) {
+        widgetStore.colorMode = config.colorMode;
+      }
     }
   }
 };
@@ -64,6 +74,34 @@ onBeforeMount(async () => {
       state.notFound = true;
       return;
     }
+
+    // Fetch widget display config from the widget-facing calendar endpoint.
+    // This endpoint returns calendar metadata merged with a `widgetConfig`
+    // property containing the authoritative server-stored view/accentColor/colorMode.
+    try {
+      const widgetApiResponse = await fetch(`/api/widget/v1/calendars/${encodeURIComponent(calendarUrlName)}`, {
+        credentials: 'omit',
+        headers: { 'Accept': 'application/json' },
+      });
+      if (widgetApiResponse.ok) {
+        const data = await widgetApiResponse.json();
+        widgetStore.applyServerConfig(data.widgetConfig);
+      }
+      else {
+        // Fall back to defaults if the widget endpoint is unavailable.
+        widgetStore.applyServerConfig(null);
+      }
+    }
+    catch (err) {
+      console.warn('[widget-container] Failed to load widget config from server, using defaults.', err);
+      widgetStore.applyServerConfig(null);
+    }
+
+    // Admin-preview override path: after the authoritative server config has
+    // been applied, any URL params present (view/accentColor/colorMode) take
+    // precedence. See `widgetStore.parseConfig` for the accepted-risk comment.
+    const urlParams = new URLSearchParams(window.location.search);
+    widgetStore.parseConfig(urlParams);
 
     // Set server-level default date range from site config before loading calendar
     if (siteConfig) {
@@ -84,7 +122,7 @@ onBeforeMount(async () => {
   }
   catch (error) {
     console.error('Error loading calendar data:', error);
-    state.err = 'Failed to load calendar data';
+    state.err = t('error_load_calendar');
   }
   finally {
     state.isLoading = false;

--- a/src/widget/router.ts
+++ b/src/widget/router.ts
@@ -11,9 +11,10 @@ const routes: RouteRecordRaw[] = [
     beforeEnter: (to) => {
       const store = useWidgetStore();
 
-      // Parse URL parameters for widget configuration
-      const urlParams = new URLSearchParams(window.location.search);
-      store.parseConfig(urlParams);
+      // Widget display config (view/accentColor/colorMode) is fetched from
+      // the server by widget-container.vue on mount. URL-param overrides
+      // for the admin preview iframe are also applied there, AFTER the
+      // authoritative server config, so they take precedence.
 
       // Set calendar URL name from route params
       if (typeof to.params.urlName === 'string') {

--- a/src/widget/stores/widgetStore.ts
+++ b/src/widget/stores/widgetStore.ts
@@ -1,8 +1,16 @@
 import { defineStore } from 'pinia';
 import { DateTime } from 'luxon';
+import {
+  WIDGET_CONFIG_DEFAULTS,
+  isValidWidgetView,
+  isValidWidgetColorMode,
+  isValidWidgetAccentColor,
+  type WidgetView,
+  type WidgetColorMode,
+} from '@/common/model/widget_config';
 
-export type ViewMode = 'week' | 'month' | 'list';
-export type ColorMode = 'auto' | 'light' | 'dark';
+export type ViewMode = WidgetView;
+export type ColorMode = WidgetColorMode;
 
 export interface WidgetState {
   // Configuration
@@ -18,9 +26,9 @@ export interface WidgetState {
 
 export const useWidgetStore = defineStore('widget', {
   state: (): WidgetState => ({
-    viewMode: 'list',
-    accentColor: '',
-    colorMode: 'auto',
+    viewMode: WIDGET_CONFIG_DEFAULTS.view,
+    accentColor: WIDGET_CONFIG_DEFAULTS.accentColor,
+    colorMode: WIDGET_CONFIG_DEFAULTS.colorMode,
     calendarUrlName: null,
     currentWeekStart: null,
     currentMonthStart: null,
@@ -28,26 +36,101 @@ export const useWidgetStore = defineStore('widget', {
 
   actions: {
     /**
-     * Parse configuration from URL parameters
+     * Apply widget configuration received from the server API response
+     * (`GET /api/widget/v1/calendars/:urlName` — `widgetConfig` property).
+     *
+     * This is the authoritative source of widget display configuration.
+     * Each field is re-validated at read time as defense-in-depth against
+     * corrupt or future-unknown enum values; invalid fields fall back to
+     * the default and emit a single console.warn per invalid field.
+     *
+     * @param widgetConfig - Plain object with view, accentColor, colorMode keys
+     */
+    applyServerConfig(widgetConfig: Record<string, unknown> | null | undefined) {
+      if (!widgetConfig || typeof widgetConfig !== 'object') {
+        this.viewMode = WIDGET_CONFIG_DEFAULTS.view;
+        this.accentColor = WIDGET_CONFIG_DEFAULTS.accentColor;
+        this.colorMode = WIDGET_CONFIG_DEFAULTS.colorMode;
+        return;
+      }
+
+      // view
+      if (isValidWidgetView(widgetConfig.view)) {
+        this.viewMode = widgetConfig.view;
+      }
+      else {
+        if (widgetConfig.view !== undefined) {
+          console.warn(
+            `[widgetStore] Invalid 'view' received from server: ${String(widgetConfig.view)}. Falling back to default.`,
+          );
+        }
+        this.viewMode = WIDGET_CONFIG_DEFAULTS.view;
+      }
+
+      // accentColor
+      if (isValidWidgetAccentColor(widgetConfig.accentColor)) {
+        this.accentColor = widgetConfig.accentColor;
+      }
+      else {
+        if (widgetConfig.accentColor !== undefined) {
+          console.warn(
+            `[widgetStore] Invalid 'accentColor' received from server: ${String(widgetConfig.accentColor)}. Falling back to default.`,
+          );
+        }
+        this.accentColor = WIDGET_CONFIG_DEFAULTS.accentColor;
+      }
+
+      // colorMode
+      if (isValidWidgetColorMode(widgetConfig.colorMode)) {
+        this.colorMode = widgetConfig.colorMode;
+      }
+      else {
+        if (widgetConfig.colorMode !== undefined) {
+          console.warn(
+            `[widgetStore] Invalid 'colorMode' received from server: ${String(widgetConfig.colorMode)}. Falling back to default.`,
+          );
+        }
+        this.colorMode = WIDGET_CONFIG_DEFAULTS.colorMode;
+      }
+    },
+
+    /**
+     * Parse configuration from URL parameters.
+     *
+     * NOTE: This URL-param override path is RETAINED SOLELY TO SUPPORT THE
+     * ADMIN PREVIEW IFRAME (so unsaved changes in the admin UI can be
+     * reflected in the embedded preview without a round-trip to the server).
+     * It is NOT part of the public SDK contract — the SDK does not emit
+     * these query-string arguments. Any embedder who appends these params
+     * to the public iframe URL gets a bounded, local-only override
+     * (cosmetic change on their own page only; does not affect stored
+     * config or other embeds). This risk is accepted per the spec
+     * (2026-04-14-server-side-widget-config-design.md — "Accepted risk").
+     *
+     * Values are validated with the common model helpers; invalid values
+     * are silently ignored (no warn — these arrive from untrusted callers).
+     *
+     * Should be invoked AFTER `applyServerConfig()` so URL params override
+     * the authoritative server values.
      *
      * @param urlParams - URLSearchParams object containing widget configuration
      */
     parseConfig(urlParams: URLSearchParams) {
       // Parse view mode
       const view = urlParams.get('view');
-      if (view === 'week' || view === 'month' || view === 'list') {
+      if (view !== null && isValidWidgetView(view)) {
         this.viewMode = view;
       }
 
-      // Parse accent color (URL decoded)
+      // Parse accent color (URL decoded by URLSearchParams)
       const accentColor = urlParams.get('accentColor');
-      if (accentColor) {
-        this.accentColor = decodeURIComponent(accentColor);
+      if (accentColor !== null && isValidWidgetAccentColor(accentColor)) {
+        this.accentColor = accentColor;
       }
 
       // Parse color mode
       const colorMode = urlParams.get('colorMode');
-      if (colorMode === 'auto' || colorMode === 'light' || colorMode === 'dark') {
+      if (colorMode !== null && isValidWidgetColorMode(colorMode)) {
         this.colorMode = colorMode;
       }
     },
@@ -62,7 +145,16 @@ export const useWidgetStore = defineStore('widget', {
     },
 
     /**
-     * Inject accent color as CSS custom property on root element
+     * Inject accent color as CSS custom property on root element.
+     *
+     * SECURITY: The accent color MUST reach the DOM only via
+     * `element.style.setProperty('--widget-accent-color', value)`. Never
+     * interpolate the value into a raw `<style>` block, `innerHTML`, or
+     * string-concatenated stylesheet — those paths enable CSS/HTML
+     * injection. Combined with the strict hex regex validation in
+     * `isValidWidgetAccentColor` and the re-validation in
+     * `applyServerConfig()`/`parseConfig()`, this closes the injection
+     * vector.
      *
      * @param rootElement - DOM element to inject CSS property on
      */

--- a/src/widget/test/integration/widget_integration.test.ts
+++ b/src/widget/test/integration/widget_integration.test.ts
@@ -11,6 +11,7 @@ import axios from 'axios';
 import { DateTime } from 'luxon';
 
 import { Calendar } from '@/common/model/calendar';
+import { WidgetConfig as WidgetConfigModel } from '@/common/model/widget_config';
 import CalendarInterface from '@/server/calendar/interface';
 import WidgetDomainService from '@/server/calendar/service/widget_domain';
 import WidgetRoutes from '@/server/calendar/api/v1/widget';
@@ -80,6 +81,7 @@ describe('Widget Integration Tests', () => {
     mockInterface = {
       getCalendarByName: sandbox.stub(),
       getCalendarForWidget: sandbox.stub(),
+      getWidgetConfig: sandbox.stub(),
     } as any;
     mockWidgetService = new WidgetDomainService();
 
@@ -90,6 +92,7 @@ describe('Widget Integration Tests', () => {
     // Stub the calendar lookup
     (mockInterface.getCalendarByName as sinon.SinonStub).resolves(calendar);
     (mockInterface.getCalendarForWidget as sinon.SinonStub).resolves(calendar);
+    (mockInterface.getWidgetConfig as sinon.SinonStub).resolves(new WidgetConfigModel());
   });
 
   afterEach(() => {
@@ -123,12 +126,12 @@ describe('Widget Integration Tests', () => {
       expect(configVm.state.accentColor).toBe('#ff9131');
 
       // Step 2: Generate embed code
+      // Per pv-jwgn.3.2, the snippet contains only `calendar` and `container` keys.
+      // Display config (view/accentColor/colorMode) lives server-side and is fetched
+      // by the widget at iframe-load time.
       const embedWrapper = mount(WidgetEmbed, {
         props: {
           calendarUrlName: 'my-calendar',
-          viewMode: 'week',
-          accentColor: '#ff9131',
-          colorMode: 'auto',
         },
         global: {
           plugins: [[I18NextVue, { i18next }]],
@@ -137,8 +140,10 @@ describe('Widget Integration Tests', () => {
 
       const embedCode = embedWrapper.find('.embed-code').text();
       expect(embedCode).toContain('my-calendar');
-      expect(embedCode).toContain('view: \'week\'');
-      expect(embedCode).toContain('accentColor: \'#ff9131\'');
+      expect(embedCode).toContain('container');
+      expect(embedCode).not.toContain('view');
+      expect(embedCode).not.toContain('accentColor');
+      expect(embedCode).not.toContain('colorMode');
 
       // Step 3: Validate widget loads with correct configuration
       const widgetStore = useWidgetStore();

--- a/src/widget/test/widgetApp.test.ts
+++ b/src/widget/test/widgetApp.test.ts
@@ -55,8 +55,9 @@ describe('Widget App Infrastructure', () => {
       const urlParams = new URLSearchParams('');
       store.parseConfig(urlParams);
 
+      // Defaults come from WIDGET_CONFIG_DEFAULTS (common/model/widget_config).
       expect(store.viewMode).toBe('list');
-      expect(store.accentColor).toBe('');
+      expect(store.accentColor).toBe('#ff9131');
       expect(store.colorMode).toBe('auto');
     });
   });
@@ -87,6 +88,8 @@ describe('Widget App Infrastructure', () => {
       document.body.appendChild(mockRoot);
 
       const store = useWidgetStore(pinia);
+      // Explicitly clear the default to simulate the empty case.
+      store.accentColor = '';
       store.injectAccentColor(mockRoot);
 
       expect(mockRoot.style.getPropertyValue('--widget-accent-color')).toBe('');

--- a/src/widget/test/widgetStore.test.ts
+++ b/src/widget/test/widgetStore.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useWidgetStore } from '../stores/widgetStore';
+import { WIDGET_CONFIG_DEFAULTS } from '@/common/model/widget_config';
+
+describe('widgetStore — server-side config + admin-preview override', () => {
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('applyServerConfig (API-sourced authoritative config)', () => {
+    it('loads view/accentColor/colorMode from API response when no URL params', () => {
+      const store = useWidgetStore();
+
+      store.applyServerConfig({
+        view: 'month',
+        accentColor: '#00ff00',
+        colorMode: 'dark',
+      });
+
+      expect(store.viewMode).toBe('month');
+      expect(store.accentColor).toBe('#00ff00');
+      expect(store.colorMode).toBe('dark');
+    });
+
+    it('falls back to defaults when widgetConfig is null/undefined', () => {
+      const store = useWidgetStore();
+
+      store.applyServerConfig(null);
+
+      expect(store.viewMode).toBe(WIDGET_CONFIG_DEFAULTS.view);
+      expect(store.accentColor).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(store.colorMode).toBe(WIDGET_CONFIG_DEFAULTS.colorMode);
+    });
+
+    it('falls back to default accentColor AND warns when server returns invalid value', () => {
+      const store = useWidgetStore();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      store.applyServerConfig({
+        view: 'week',
+        accentColor: 'zzzzzz', // invalid — not hex
+        colorMode: 'light',
+      });
+
+      expect(store.accentColor).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('accentColor');
+      // Other valid fields still take effect.
+      expect(store.viewMode).toBe('week');
+      expect(store.colorMode).toBe('light');
+    });
+
+    it('warns and falls back when server returns invalid view (unknown enum)', () => {
+      const store = useWidgetStore();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      store.applyServerConfig({
+        view: 'year', // future-unknown enum
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+
+      expect(store.viewMode).toBe(WIDGET_CONFIG_DEFAULTS.view);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy.mock.calls.some(call => String(call[0]).includes("'view'"))).toBe(true);
+    });
+
+    it('accepts shorthand hex as invalid (strict 6-digit hex only)', () => {
+      const store = useWidgetStore();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: '#fff', // shorthand — rejected
+        colorMode: 'auto',
+      });
+
+      expect(store.accentColor).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('parseConfig (URL-param override for admin preview)', () => {
+    it('URL params override API values when both present', () => {
+      const store = useWidgetStore();
+
+      // API says week view
+      store.applyServerConfig({
+        view: 'week',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+      expect(store.viewMode).toBe('week');
+
+      // Admin preview overrides via query string: view=month
+      const urlParams = new URLSearchParams('view=month');
+      store.parseConfig(urlParams);
+
+      expect(store.viewMode).toBe('month');
+      // Other fields untouched.
+      expect(store.accentColor).toBe('#ff9131');
+      expect(store.colorMode).toBe('auto');
+    });
+
+    it('URL override with all three fields present replaces server config', () => {
+      const store = useWidgetStore();
+
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: '#000000',
+        colorMode: 'light',
+      });
+
+      const urlParams = new URLSearchParams('view=week&accentColor=%23abcdef&colorMode=dark');
+      store.parseConfig(urlParams);
+
+      expect(store.viewMode).toBe('week');
+      expect(store.accentColor).toBe('#abcdef');
+      expect(store.colorMode).toBe('dark');
+    });
+
+    it('invalid URL params are silently ignored (server values preserved)', () => {
+      const store = useWidgetStore();
+
+      store.applyServerConfig({
+        view: 'week',
+        accentColor: '#ff9131',
+        colorMode: 'dark',
+      });
+
+      const urlParams = new URLSearchParams('view=bogus&accentColor=javascript:alert(1)&colorMode=purple');
+      store.parseConfig(urlParams);
+
+      // Server values preserved — invalid URL params rejected.
+      expect(store.viewMode).toBe('week');
+      expect(store.accentColor).toBe('#ff9131');
+      expect(store.colorMode).toBe('dark');
+    });
+  });
+
+  describe('safe accentColor DOM application', () => {
+    it('applies accent color via style.setProperty — not via innerHTML', () => {
+      const store = useWidgetStore();
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+
+      // Spy on the setProperty call to prove it's used.
+      const setPropertySpy = vi.spyOn(rootElement.style, 'setProperty');
+
+      store.injectAccentColor(rootElement);
+
+      expect(setPropertySpy).toHaveBeenCalledWith('--widget-accent-color', '#ff9131');
+
+      // The CSS custom property is readable from the style attribute, and
+      // the element's innerHTML remains empty (no <style> block injected).
+      expect(rootElement.style.getPropertyValue('--widget-accent-color')).toBe('#ff9131');
+      expect(rootElement.innerHTML).toBe('');
+
+      document.body.removeChild(rootElement);
+    });
+
+    it('a malicious-looking server value never reaches the DOM (falls back to default)', () => {
+      const store = useWidgetStore();
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Server returns an injection-style payload. Validation rejects it,
+      // store falls back to the default, and injection never happens.
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: 'red; } body { background: url(evil) } .x {',
+        colorMode: 'auto',
+      });
+
+      store.injectAccentColor(rootElement);
+
+      // Only the safe default hex reaches the DOM.
+      expect(rootElement.style.getPropertyValue('--widget-accent-color')).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+
+      document.body.removeChild(rootElement);
+    });
+  });
+});

--- a/tests/e2e/test-widget-embedding.html
+++ b/tests/e2e/test-widget-embedding.html
@@ -50,7 +50,6 @@
     var params = new URLSearchParams(window.location.search);
     var serverUrl = params.get('serverUrl') || 'http://localhost:3000';
     var calendarName = params.get('calendar') || 'test_calendar';
-    var viewMode = params.get('view') || 'list';
 
     console.log('[Test Page] Page origin:', window.location.origin);
     console.log('[Test Page] Widget server URL:', serverUrl);
@@ -73,9 +72,6 @@
     Pavillion('init', {
       calendar: calendarName,
       container: '#calendar-widget',
-      view: viewMode,
-      accentColor: '#ff9131',
-      colorMode: 'light',
       onResize: function(height) {
         console.log('[Test Page] Widget resized to:', height, 'px');
       },

--- a/tests/e2e/widget-config-roundtrip.spec.ts
+++ b/tests/e2e/widget-config-roundtrip.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+import { startTestServer, TestEnvironment } from './helpers/test-server';
+
+/**
+ * E2E Tests: Widget Configuration Roundtrip
+ *
+ * End-to-end verification that a calendar editor can save a widget view-mode
+ * preference in the admin tab and that the change is reflected in the widget's
+ * rendered DOM on a subsequent load.
+ *
+ * Flow:
+ *   1. Log in as admin (calendar editor).
+ *   2. Navigate to the calendar's widget admin tab.
+ *   3. Click the "Week View" card (default is "List").
+ *   4. Click Save. Assert:
+ *        - PUT response returns the saved config.
+ *        - Success message appears.
+ *        - Save button disables (dirty state cleared).
+ *   5. Open the cross-origin widget embedding page in a fresh browser context
+ *      and assert that the widget iframe renders the week view — proving the
+ *      saved server config flowed through the widget-facing endpoint and into
+ *      the widget's rendered DOM.
+ *
+ * Cross-origin is required for the widget-facing endpoint: `/api/widget/v1/...`
+ * requires an Origin header, which the browser only sets on cross-origin
+ * requests. The embedding fixture runs on port 8080, the server on 3100-3200.
+ *
+ * Bead: pv-jwgn.4 — depends on pv-jwgn.2.2, pv-jwgn.3.1, and pv-jwgn.3.2.
+ */
+
+let env: TestEnvironment;
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  env = await startTestServer();
+});
+
+test.afterAll(async () => {
+  await env.cleanup();
+});
+
+test('admin change to widget view mode is reflected in rendered widget', async ({ page, browser }) => {
+  // Step 1: Log in as admin.
+  await loginAsAdmin(page, env.baseURL);
+
+  // Step 2: Navigate directly to the calendar management page and open the widget tab.
+  await page.goto(env.baseURL + '/calendar/test_calendar/manage');
+  await page.waitForSelector('.calendar-management-root__tabs', { timeout: 15000 });
+
+  const widgetTabButton = page.locator('#widget-tab');
+  await widgetTabButton.click();
+
+  // Wait for widget config section to render and complete its initial load.
+  const widgetConfig = page.locator('.widget-config');
+  await expect(widgetConfig).toBeVisible({ timeout: 15000 });
+
+  // The list view card is the default selection. Confirm the starting state.
+  const listCard = widgetConfig.locator('button.view-mode-card').filter({ hasText: 'List View' });
+  await expect(listCard).toHaveAttribute('aria-pressed', 'true', { timeout: 10000 });
+
+  // Save button starts disabled because nothing is dirty after initial load.
+  const saveButton = widgetConfig.locator('button.save-button');
+  await expect(saveButton).toBeDisabled();
+
+  // Step 3: Click the Week View card.
+  const weekCard = widgetConfig.locator('button.view-mode-card').filter({ hasText: 'Week View' });
+  await weekCard.click();
+  await expect(weekCard).toHaveAttribute('aria-pressed', 'true');
+
+  // Save button becomes enabled once dirty.
+  await expect(saveButton).toBeEnabled();
+
+  // Step 4: Click Save and verify the PUT request persists the new view.
+  const savePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/widget/config')
+      && response.request().method() === 'PUT'
+      && response.ok(),
+    { timeout: 15000 },
+  );
+  await saveButton.click();
+  const saveResponse = await savePromise;
+  const savedBody = await saveResponse.json();
+  expect(savedBody.view).toBe('week');
+  expect(savedBody.accentColor).toBe('#ff9131');
+  expect(savedBody.colorMode).toBe('auto');
+
+  // Success message appears and Save button disables again (clean state).
+  await expect(widgetConfig.locator('.alert--success')).toBeVisible({ timeout: 10000 });
+  await expect(saveButton).toBeDisabled();
+
+  // Step 5: Open the cross-origin embedding page in a fresh context (no
+  // admin session, separate origin). The widget iframe will load from the
+  // server and must render the week view based on the server-persisted config.
+  //
+  // Note: The embedding fixture passes SDK args `view: 'list'` which the
+  // simplified SDK now ignores (deprecated). That means the iframe src has
+  // no `view=` query parameter and the rendered view is driven entirely by
+  // the server-stored widget config — exactly what we want to assert.
+  const embedContext = await browser.newContext();
+  const embedPage = await embedContext.newPage();
+
+  const embeddingUrl
+    = `http://localhost:8080/test-widget-embedding.html?serverUrl=${encodeURIComponent(env.baseURL)}&calendar=test_calendar`;
+  await embedPage.goto(embeddingUrl);
+
+  // Wait for the widget iframe to be created.
+  await embedPage.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
+  const iframe = embedPage.frameLocator('iframe[src*="/widget/"]');
+
+  // Assert the week-view container rendered inside the iframe. This proves the
+  // full roundtrip: admin save → DB → widget-facing endpoint → widgetStore →
+  // rendered DOM.
+  await expect(iframe.locator('.week-view')).toBeVisible({ timeout: 20000 });
+  await expect(iframe.locator('.week-grid')).toBeVisible();
+
+  // Make sure the list view did NOT render (proves the server config took
+  // precedence over the default, not the other way around).
+  await expect(iframe.locator('.list-view')).toHaveCount(0);
+
+  await embedContext.close();
+});

--- a/tests/e2e/widget-embedding.spec.ts
+++ b/tests/e2e/widget-embedding.spec.ts
@@ -18,14 +18,15 @@ import { startTestServer, TestEnvironment } from './helpers/test-server';
  * - Different ports = different origins = true cross-origin testing
  *
  * The embedding page (tests/e2e/test-widget-embedding.html) accepts
- * ?serverUrl=, ?calendar=, and ?view= query parameters.
+ * ?serverUrl= and ?calendar= query parameters. Display config (view,
+ * accentColor, colorMode) is sourced from server-side widget config; see
+ * widget-config-roundtrip.spec.ts for end-to-end view-mode coverage.
  */
 
 let env: TestEnvironment;
 
-function embeddingUrl(options?: { view?: string }): string {
-  const base = `http://localhost:8080/test-widget-embedding.html?serverUrl=${encodeURIComponent(env.baseURL)}&calendar=test_calendar`;
-  return options?.view ? `${base}&view=${options.view}` : base;
+function embeddingUrl(): string {
+  return `http://localhost:8080/test-widget-embedding.html?serverUrl=${encodeURIComponent(env.baseURL)}&calendar=test_calendar`;
 }
 
 // Configure tests to run serially since they share a test server
@@ -179,52 +180,21 @@ test.describe('Widget Embedding', () => {
     await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 10000 });
   });
 
-  test('theme parameters apply inside iframe', async ({ page }) => {
-    // The embedding HTML sets accentColor=#ff9131 and colorMode=light
+  test('default server config drives accent color CSS variable', async ({ page }) => {
+    // Display config (view, accentColor, colorMode) is now sourced from
+    // server-side widget config, not from SDK init args. With no admin
+    // override, the widget renders using WIDGET_CONFIG_DEFAULTS — verify the
+    // default accent color reaches the iframe DOM as a CSS custom property.
     await page.goto(embeddingUrl());
 
     await page.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
     const iframe = page.frameLocator('iframe[src*="/widget/"]');
     await expect(iframe.locator('body')).toBeVisible({ timeout: 20000 });
 
-    // Verify light theme class is applied
-    await expect(iframe.locator('.widget-root')).toHaveClass(/widget-theme-light/, { timeout: 10000 });
-
-    // Verify accent color CSS custom property is set (non-empty check, not exact value)
     const accentColor = await iframe.locator('.widget-root').evaluate(
       (el) => el.style.getPropertyValue('--widget-accent-color'),
     );
     expect(accentColor).toBeTruthy();
-  });
-
-  test('month view renders from view parameter', async ({ page }) => {
-    await page.goto(embeddingUrl({ view: 'month' }));
-
-    await page.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
-    const iframe = page.frameLocator('iframe[src*="/widget/"]');
-    await expect(iframe.locator('body')).toBeVisible({ timeout: 20000 });
-
-    // Verify month grid renders (Desktop Chrome guarantees desktop layout)
-    await expect(iframe.locator('.month-grid')).toBeVisible({ timeout: 15000 });
-
-    // Verify month title is displayed
-    await expect(iframe.locator('.month-title')).toBeVisible();
-    await expect(iframe.locator('.month-title')).not.toBeEmpty();
-  });
-
-  test('week view renders from view parameter', async ({ page }) => {
-    await page.goto(embeddingUrl({ view: 'week' }));
-
-    await page.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
-    const iframe = page.frameLocator('iframe[src*="/widget/"]');
-    await expect(iframe.locator('body')).toBeVisible({ timeout: 20000 });
-
-    // Verify week grid renders
-    await expect(iframe.locator('.week-grid')).toBeVisible({ timeout: 15000 });
-
-    // Verify week title (date range) is displayed
-    await expect(iframe.locator('.week-title')).toBeVisible();
-    await expect(iframe.locator('.week-title')).not.toBeEmpty();
   });
 
   test('postMessage resize events reach the embedding page', async ({ page }) => {


### PR DESCRIPTION
## Summary

Calendar owners can now change widget view mode, accent color, and color mode in the admin UI without re-editing the embed snippet on their site. The embed snippet simplifies to `calendar` + `container` only; the widget iframe fetches authoritative display config from the server on each load.

Bundled precursor: `a6cedf2` — fix(widget-sdk): make embed snippet stub a callable array-pushing queue.

Spec: `docs/superpowers/specs/2026-04-14-server-side-widget-config-design.md`
Beads epic: `pv-jwgn` (10 leaf beads, all closed)

## What changed

**Backend**
- New `calendar_widget_config` table (one row per calendar, lazy-created via `0022_create_calendar_widget_config.ts`)
- `WidgetConfig` domain model with strict hex validation (`/^#[0-9a-fA-F]{6}$/`) and view/colorMode enum guards
- `WidgetConfigService` with editor-permission-gated read/write and defense-in-depth read-time validation that falls back to defaults on corrupt stored values
- Admin endpoints `GET/PUT /api/v1/calendars/:calendarId/widget/config` with camelCase field-key error reporting (`view`, `accentColor`, `colorMode`) — never snake_case
- Widget-facing `GET /api/widget/v1/calendars/:urlName` extended to include `widgetConfig`; conditional `Cache-Control: public, max-age=60` + `Vary: Origin` on 200, `Cache-Control: no-store` preserved on 402
- `validateOrigin` middleware now allows the same-origin self-fetch when `Sec-Fetch-Site: same-origin` (browsers omit `Origin` on same-origin GETs); cross-origin requests still gate on the existing allowlist

**Frontend**
- Widget SDK drops `view` / `accentColor` / `colorMode` args with a single `console.warn` for backward compatibility; older snippets keep rendering
- Widget store reads server config first, then narrowly applies URL-param override for the admin preview iframe only (accepted risk documented in spec)
- Accent color reaches the DOM only via `element.style.setProperty('--widget-accent-color', value)` — no `innerHTML`, no raw `<style>`
- Admin `widget-config.vue` loads on mount, dirty-tracks form state, surfaces field-level validation errors with `aria-describedby`
- Embed snippet simplified to `calendar` + `container`

**Tests**
- 26 unit tests for `WidgetConfig` model
- 14 unit tests for `WidgetConfigService` (sinon)
- 12 integration tests for admin endpoints
- 10+ unit tests for `widgetStore` (DOM safety, URL override, defense-in-depth)
- 2 new tests for the same-origin bypass branch
- 1 new e2e roundtrip spec verifying admin → server → iframe DOM

## Test plan

- [ ] CI lint / unit / integration / build / e2e all green (modulo pre-existing AP/funding flakes)
- [ ] Migration 0022 applies cleanly on a fresh DB
- [ ] Manual: log in as calendar editor, open the Widget tab, change view mode, click Save, reload an embedded page, confirm the new view renders
- [ ] Manual: confirm an old embed snippet that still passes deprecated args (`view`, `accentColor`, `colorMode`) renders with one deprecation warning and ignores the args
- [ ] Manual: confirm `widget-embedding.spec.ts` legacy URL-param tests are obsolete (they relied on deprecated SDK args; superseded by `widget-config-roundtrip.spec.ts`)