### PR TITLE
feat(events): add 'register' external link prompt type

### DIFF
--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -64,7 +64,8 @@
     "prompt_options": {
       "tickets": "Tickets:",
       "rsvp": "RSVP:",
-      "more_info": "More Information:"
+      "more_info": "More Information:",
+      "register": "Register:"
     },
     "error_invalid_url": "Please enter a valid http or https URL.",
     "error_prompt_required": "URL and button label must both be set or both be empty."

--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -24,12 +24,12 @@ export type startAndEndDates = {
 /**
  * Prompt used to label the event's external URL (e.g., "Tickets", "RSVP", "More Info").
  */
-export type UrlPrompt = 'tickets' | 'rsvp' | 'more_info';
+export type UrlPrompt = 'tickets' | 'rsvp' | 'more_info' | 'register';
 
 /**
  * Runtime-valid set of {@link UrlPrompt} values for enum checks on untrusted input.
  */
-export const URL_PROMPT_VALUES: readonly UrlPrompt[] = ['tickets', 'rsvp', 'more_info'] as const;
+export const URL_PROMPT_VALUES: readonly UrlPrompt[] = ['tickets', 'rsvp', 'more_info', 'register'] as const;
 
 /**
  * Represents a calendar event with multilingual content support.

--- a/src/common/test/calendar_event_external_url.test.ts
+++ b/src/common/test/calendar_event_external_url.test.ts
@@ -13,8 +13,8 @@ describe('CalendarEvent Model - externalUrl and urlPrompt', () => {
     expect(event.urlPrompt).toBeNull();
   });
 
-  test('URL_PROMPT_VALUES contains the three supported prompts', () => {
-    expect(URL_PROMPT_VALUES).toEqual(['tickets', 'rsvp', 'more_info']);
+  test('URL_PROMPT_VALUES contains the four supported prompts', () => {
+    expect(URL_PROMPT_VALUES).toEqual(['tickets', 'rsvp', 'more_info', 'register']);
   });
 
   test('toObject emits externalUrl and urlPrompt when set', () => {

--- a/src/server/activitypub/model/object/event.ts
+++ b/src/server/activitypub/model/object/event.ts
@@ -19,6 +19,7 @@ const URL_PROMPT_EN_LABELS: Record<UrlPrompt, string> = {
   tickets: 'Tickets',
   rsvp: 'RSVP',
   more_info: 'More Information',
+  register: 'Register',
 };
 
 /**

--- a/src/server/activitypub/test/model/object/event.test.ts
+++ b/src/server/activitypub/test/model/object/event.test.ts
@@ -510,6 +510,20 @@ describe('EventObject', () => {
         expect(result['pavillion:urlPrompt']).toBe('more_info');
       });
 
+      it('should emit correct translated label for register prompt', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Event', ''));
+        event.externalUrl = 'https://example.com/register';
+        event.urlPrompt = 'register';
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result.attachment[0].name).toBe('Register');
+        expect(result['pavillion:urlPrompt']).toBe('register');
+      });
+
       it('should not emit attachment or pavillion:urlPrompt when both fields are null', () => {
         const calendar = new Calendar('calendar-uuid', 'mycal');
         const event = new CalendarEvent('event-uuid', 'calendar-uuid');
@@ -1196,7 +1210,7 @@ describe('EventObject', () => {
         expect(result.urlPrompt).toBeNull();
       });
 
-      it('should accept all three valid urlPrompt values (rsvp, more_info)', () => {
+      it('should accept all four valid urlPrompt values (rsvp, more_info, register)', () => {
         const rsvpResult = EventObject.fromActivityPubObject({
           name: 'Test',
           attachment: [{ type: 'Link', href: 'https://example.com/rsvp', rel: 'external' }],
@@ -1212,6 +1226,14 @@ describe('EventObject', () => {
         });
         expect(infoResult.externalUrl).toBe('https://example.com/info');
         expect(infoResult.urlPrompt).toBe('more_info');
+
+        const registerResult = EventObject.fromActivityPubObject({
+          name: 'Test',
+          attachment: [{ type: 'Link', href: 'https://example.com/register', rel: 'external' }],
+          'pavillion:urlPrompt': 'register',
+        });
+        expect(registerResult.externalUrl).toBe('https://example.com/register');
+        expect(registerResult.urlPrompt).toBe('register');
       });
 
       it('should round-trip externalUrl and urlPrompt through toActivityPubObject and fromActivityPubObject', () => {

--- a/src/server/calendar/test/EventService/external_url_validation.test.ts
+++ b/src/server/calendar/test/EventService/external_url_validation.test.ts
@@ -190,6 +190,15 @@ describe('EventService externalUrl + urlPrompt validation (via createEvent)', ()
     expect(event.urlPrompt).toBe('more_info');
   });
 
+  it('accepts urlPrompt = register', async () => {
+    const event = await service.createEvent(acct, {
+      calendarId: cal.id,
+      externalUrl: 'https://example.com/',
+      urlPrompt: 'register',
+    });
+    expect(event.urlPrompt).toBe('register');
+  });
+
   it('rejects unknown urlPrompt value with ValidationError', async () => {
     await expect(service.createEvent(acct, {
       calendarId: cal.id,

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -86,7 +86,8 @@
     "url_prompt": {
         "tickets": "Tickets",
         "rsvp": "RSVP",
-        "more_info": "More Information"
+        "more_info": "More Information",
+        "register": "Register"
     },
     "report": {
         "link_text": "Report Event",


### PR DESCRIPTION
## Summary
- Adds `'register'` to the `UrlPrompt` union type and `URL_PROMPT_VALUES` array in the common model
- Adds `"Register:"` option to the event editor dropdown (client locale) and `"Register"` label to the public site and widget locale
- Adds English fallback label in the ActivityPub serializer so federated peers see a human-readable name
- Adds tests for the new value: model round-trip, service validation, and AP serialization/deserialization

## Test Plan
- [ ] Unit tests pass: `npm run test:unit`
- [ ] Open the event editor, set an external URL, and confirm "Register:" appears in the button label dropdown
- [ ] Create an event with `urlPrompt = register`; verify the public event page shows a "Register" button