### PR TITLE
fix(widget): bring event detail page to parity with public site

### DIFF
--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -3,16 +3,23 @@ import { reactive, computed, onBeforeMount } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useRoute, useRouter } from 'vue-router';
 import { DateTime } from 'luxon';
+import i18next from 'i18next';
+import { ArrowLeft, Calendar, Clock, Repeat, MapPin, Accessibility } from 'lucide-vue-next';
+
 import CalendarService from '@/site/service/calendar';
 import { useWidgetStore } from '../stores/widgetStore';
+import { useLocalizedContent } from '@/site/composables/useLocalizedContent';
 import NotFound from '@/site/components/not-found.vue';
 import EventImage from '@/site/components/event-image.vue';
+import AddToCalendar from '@/site/components/add-to-calendar.vue';
+import { getRecurrenceText } from '@/common/utils/recurrence-text';
 import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 
 const { t } = useTranslation('system');
 const route = useRoute();
 const router = useRouter();
 const widgetStore = useWidgetStore();
+const { localizedContent } = useLocalizedContent();
 
 const calendarId = route.params.urlName;
 const eventId = route.params.eventId;
@@ -26,6 +33,43 @@ const state = reactive({
 });
 
 const calendarService = new CalendarService();
+
+/**
+ * Returns true when start and end fall on the same calendar day.
+ */
+function isSameDay(start: DateTime, end: DateTime): boolean {
+  return start.hasSame(end, 'day');
+}
+
+const recurrenceText = computed(() => {
+  if (!state.instance?.event?.schedules?.length) {
+    return '';
+  }
+  return getRecurrenceText(state.instance.event.schedules);
+});
+
+const locationAccessibilityInfo = computed(() => {
+  const location = state.instance?.event?.location;
+  if (!location || typeof location.hasContent !== 'function') {
+    return '';
+  }
+  try {
+    const content = localizedContent(location);
+    return content?.accessibilityInfo ?? '';
+  }
+  catch {
+    return '';
+  }
+});
+
+const sourceCalendar = computed(() => {
+  return state.instance?.event?.sourceCalendar ?? null;
+});
+
+const sourceCalendarLabel = computed(() => {
+  if (!sourceCalendar.value) return '';
+  return `${sourceCalendar.value.urlName}@${sourceCalendar.value.host}`;
+});
 
 /**
  * Defense-in-depth safe external URL computed.
@@ -68,7 +112,6 @@ onBeforeMount(async () => {
   try {
     state.isLoading = true;
 
-    // Load calendar by URL name
     state.calendar = await calendarService.getCalendarByUrlName(calendarId as string);
 
     if (!state.calendar) {
@@ -76,21 +119,25 @@ onBeforeMount(async () => {
       return;
     }
 
-    // For now, load the event's first instance
-    // TODO: Handle specific instance ID when available
+    // Widget routes carry only eventId (not instanceId), so list the
+    // calendar's instances and pick the first one whose event matches. The
+    // listing endpoint omits heavy fields like schedules for performance, so
+    // we then refetch that single instance to get the full detail shape
+    // (schedules, full location content, etc.) used by the detail template.
     const events = await calendarService.loadCalendarEvents(calendarId as string);
-    const event = events.find((e: any) => e.event.id === eventId);
+    const match = events.find((e: any) => e.event.id === eventId);
 
-    if (!event) {
+    if (!match) {
       state.notFound = true;
       return;
     }
 
-    state.instance = event;
+    const fullInstance = await calendarService.loadEventInstance(match.id);
+    state.instance = fullInstance ?? match;
   }
   catch (error) {
     console.error('Error loading event data:', error);
-    state.err = 'Failed to load event data';
+    state.err = t('error_load_event');
   }
   finally {
     state.isLoading = false;
@@ -120,72 +167,147 @@ onBeforeMount(async () => {
 
     <!-- Event Detail Content -->
     <div v-else-if="state.instance" class="event-detail-content">
-      <!-- Back Button -->
-      <header class="overlay-header">
+      <!-- Back link header -->
+      <header class="instance-back-header">
         <button type="button"
-                class="back-button"
+                class="back-link"
                 @click="goBack"
                 :aria-label="t('back_to_calendar', { name: widgetStore.calendarUrlName || '' })">
-          <svg width="24"
-               height="24"
-               viewBox="0 0 24 24"
-               fill="none">
-            <path
-              d="M15 18L9 12L15 6"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-          <span>{{ t('back') }}</span>
+          <ArrowLeft :size="16" class="back-arrow" aria-hidden="true" />
+          <span>{{ t('back_to_calendar', { name: widgetStore.calendarUrlName || '' }) }}</span>
         </button>
       </header>
 
-      <!-- Event Detail (based on site event-instance.vue) -->
-      <div class="instance-detail">
-        <div class="instance-header">
+      <main class="instance-main">
+        <!-- Hero image -->
+        <div class="hero-image-wrapper">
           <EventImage
             :media="state.instance.event.media"
+            context="feature"
+            :alt="localizedContent(state.instance.event).name"
             :focal-point-x="state.instance.event.mediaFocalPointX"
             :focal-point-y="state.instance.event.mediaFocalPointY"
             :zoom="state.instance.event.mediaZoom"
-            context="hero"
           />
-          <div class="instance-meta">
-            <h1>{{ state.instance.event.content("en").name }}</h1>
-            <time :datetime="state.instance.start.toISO()" class="event-datetime">
-              {{ state.instance.start.toLocal().toLocaleString(DateTime.DATETIME_MED) }}
-            </time>
-          </div>
         </div>
 
-        <main class="instance-body">
-          <p>{{ state.instance.event.content("en").description }}</p>
+        <!-- Recurrence badge -->
+        <div v-if="recurrenceText" class="recurrence-badge">
+          <Repeat :size="14" aria-hidden="true" />
+          <span>{{ recurrenceText }}</span>
+        </div>
 
-          <!-- External link CTA -->
-          <a
-            v-if="safeExternalUrl && safePrompt"
-            :href="safeExternalUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external-link-button"
-          >
-            {{ t('url_prompt.' + safePrompt) }}
-          </a>
-        </main>
+        <!-- Source calendar pill -->
+        <a
+          v-if="sourceCalendar"
+          :href="sourceCalendar.url"
+          class="source-calendar-pill"
+          :aria-label="t('event_source_calendar_label', { name: sourceCalendarLabel })"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Calendar :size="14" aria-hidden="true" />
+          <span>{{ sourceCalendarLabel }}</span>
+        </a>
 
-        <footer v-if="state.instance.event.categories?.length > 0" class="instance-footer">
-          <a
-            v-for="category in state.instance.event.categories"
-            :key="category.id"
-            class="event-category-badge"
-            @click.prevent="() => {}"
-          >
-            {{ category.content("en").name }}
-          </a>
-        </footer>
-      </div>
+        <!-- Event title -->
+        <h1 class="instance-title">{{ localizedContent(state.instance.event).name }}</h1>
+
+        <!-- Date + time row -->
+        <div class="datetime-row">
+          <div class="event-date">
+            <Calendar :size="16" class="datetime-icon datetime-icon--date" aria-hidden="true" />
+            <span>{{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY) }}</span>
+          </div>
+          <time :datetime="state.instance.start.toISO()" class="event-datetime">
+            <Clock :size="16" class="datetime-icon datetime-icon--time" aria-hidden="true" />
+            <span class="event-time-text">
+              {{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.TIME_SIMPLE) }}<template v-if="state.instance.end">
+                – {{ state.instance.end.toLocal().setLocale(i18next.language).toLocaleString(
+                  isSameDay(state.instance.start, state.instance.end) ? DateTime.TIME_SIMPLE : DateTime.DATETIME_MED
+                ) }}</template>
+            </span>
+          </time>
+        </div>
+
+        <!-- Two-column content grid -->
+        <div class="detail-grid">
+          <!-- Left column: description + categories -->
+          <div class="detail-main">
+            <h2 class="about-heading">{{ t('about_this_event') }}</h2>
+            <p class="event-description">{{ localizedContent(state.instance.event).description }}</p>
+
+            <div v-if="state.instance.event.categories && state.instance.event.categories.length" class="categories-section">
+              <h3 class="section-heading">{{ t('event_categories') }}</h3>
+              <div class="category-badges">
+                <span v-for="category in state.instance.event.categories"
+                      :key="category.id"
+                      class="event-category-badge"
+                >
+                  {{ localizedContent(category).name }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right sidebar: location, accessibility, recurrence cards -->
+          <aside class="detail-sidebar">
+            <!-- Location card -->
+            <div v-if="state.instance.event.location" class="sidebar-card event-location">
+              <div class="card-header">
+                <MapPin :size="16" class="card-icon" aria-hidden="true" />
+                <h3 class="card-heading">{{ t('event_location') }}</h3>
+              </div>
+              <p class="location-name">{{ state.instance.event.location.name }}</p>
+              <p v-if="state.instance.event.location.address" class="location-address">
+                <a :href="'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent([state.instance.event.location.address, state.instance.event.location.city, state.instance.event.location.state].filter(Boolean).join(', '))"
+                   target="_blank"
+                   rel="noopener"
+                   :aria-label="t('get_directions')"
+                >
+                  {{ state.instance.event.location.address }}
+                  <template v-if="state.instance.event.location.city">
+                    <br />{{ state.instance.event.location.city }}<template v-if="state.instance.event.location.state">, {{ state.instance.event.location.state }}</template>
+                    <template v-if="state.instance.event.location.postalCode">{{ ' ' + state.instance.event.location.postalCode }}</template>
+                  </template>
+                </a>
+              </p>
+            </div>
+
+            <!-- Accessibility card -->
+            <div v-if="locationAccessibilityInfo" class="sidebar-card accessibility-card">
+              <div class="card-header">
+                <Accessibility :size="16" class="card-icon" aria-hidden="true" />
+                <h3 class="card-heading">{{ t('event_accessibility') }}</h3>
+              </div>
+              <p class="accessibility-info">{{ locationAccessibilityInfo }}</p>
+            </div>
+
+            <!-- Recurrence details card -->
+            <div v-if="recurrenceText" class="sidebar-card recurrence-card">
+              <div class="card-header">
+                <Repeat :size="16" class="card-icon" aria-hidden="true" />
+                <h3 class="card-heading">{{ t('event_recurring') }}</h3>
+              </div>
+              <p class="recurrence-text">{{ recurrenceText }}</p>
+            </div>
+
+            <!-- External link CTA -->
+            <a
+              v-if="safeExternalUrl && safePrompt"
+              :href="safeExternalUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="external-link-button"
+            >
+              {{ t('url_prompt.' + safePrompt) }}
+            </a>
+
+            <!-- Add to Calendar -->
+            <AddToCalendar :event="state.instance.event" :instance="state.instance" />
+          </aside>
+        </div>
+      </main>
     </div>
   </div>
 </template>
@@ -217,161 +339,352 @@ onBeforeMount(async () => {
 }
 
 // ================================================================
-// OVERLAY HEADER WITH BACK BUTTON
+// BACK HEADER
 // ================================================================
 
-.overlay-header {
-  padding: $public-space-md;
+.instance-back-header {
+  padding: $public-space-md $public-space-lg;
   border-bottom: 1px solid $public-border-subtle-light;
+  margin-bottom: $public-space-2xl;
 
   @include public-dark-mode {
     border-bottom-color: $public-border-subtle-dark;
   }
 
-  .back-button {
-    @include public-button-base;
-
+  .back-link {
     display: inline-flex;
     align-items: center;
-    gap: $public-space-xs;
-    padding: $public-space-sm $public-space-md;
+    gap: $public-space-sm;
+    padding: 0;
     background: transparent;
-    border: 1px solid $public-border-medium-light;
-    border-radius: $public-radius-sm;
-    color: $public-text-primary-light;
+    border: 0;
+    font-family: $public-font-family;
     font-size: $public-font-size-base;
+    font-weight: $public-font-weight-medium;
+    color: $public-text-secondary-light;
+    cursor: pointer;
     transition: $public-transition-fast;
 
     &:hover {
-      background: $public-hover-overlay-light;
-      border-color: $public-border-strong-light;
-    }
-
-    @include public-dark-mode {
-      border-color: $public-border-medium-dark;
-      color: $public-text-primary-dark;
-
-      &:hover {
-        background: $public-hover-overlay-dark;
-        border-color: $public-border-strong-dark;
-      }
-    }
-
-    svg {
-      flex-shrink: 0;
-    }
-  }
-}
-
-// ================================================================
-// EVENT DETAIL (adapted from site event-instance.vue)
-// ================================================================
-
-.instance-detail {
-  flex: 1;
-  padding: $public-space-lg;
-  max-width: 800px;
-  margin: 0 auto;
-  width: 100%;
-
-  @include public-mobile-only {
-    padding: $public-space-md;
-  }
-}
-
-.instance-header {
-  display: flex;
-  flex-direction: column;
-  gap: $public-space-lg;
-  margin-bottom: $public-space-2xl;
-
-  // ============================================================
-  // HEADER WITHOUT IMAGE
-  // ============================================================
-
-  &:not(:has(.event-image)) .instance-meta {
-    padding-top: $public-space-lg;
-    border-top: 4px solid $public-accent-light;
-    max-width: 80%;
-
-    @include public-dark-mode {
-      border-top-color: $public-accent-dark;
-    }
-
-    @include public-mobile-only {
-      max-width: 100%;
-    }
-
-    h1 {
-      font-size: 40px;
-      font-weight: $public-font-weight-bold;
-      letter-spacing: $public-letter-spacing-tight;
-
-      @include public-mobile-only {
-        font-size: $public-font-size-2xl;
-      }
-    }
-
-    .event-datetime {
-      font-size: $public-font-size-lg;
-    }
-  }
-
-  // ============================================================
-  // HEADER WITH IMAGE
-  // ============================================================
-
-  &:has(.event-image) .instance-meta {
-    h1 {
-      font-size: $public-font-size-2xl;
-      font-weight: $public-font-weight-semibold;
-
-      @include public-mobile-only {
-        font-size: $public-font-size-xl;
-      }
-    }
-  }
-
-  .instance-meta {
-    display: flex;
-    flex-direction: column;
-    gap: $public-space-sm;
-
-    h1 {
-      margin: 0;
-      line-height: $public-line-height-tight;
-      color: $public-text-primary-light;
-
-      @include public-dark-mode {
-        color: $public-text-primary-dark;
-      }
-    }
-
-    .event-datetime {
-      display: inline-flex;
-      align-items: center;
-      gap: $public-space-sm;
-      font-size: $public-font-size-md;
-      font-weight: $public-font-weight-medium;
       color: $public-accent-light;
 
-      @include public-dark-mode {
+      .back-arrow {
+        transform: translateX(-3px);
+      }
+    }
+
+    &:focus-visible {
+      @include public-focus-visible;
+    }
+
+    @include public-dark-mode {
+      color: $public-text-secondary-dark;
+
+      &:hover {
         color: $public-accent-dark;
       }
     }
   }
+
+  .back-arrow {
+    display: inline-block;
+    transition: $public-transition-fast;
+    flex-shrink: 0;
+  }
 }
 
-.instance-body {
-  p {
-    font-size: $public-font-size-md;
-    line-height: $public-line-height-relaxed;
-    color: $public-text-primary-light;
-    margin: 0 0 $public-space-lg 0;
+// ================================================================
+// MAIN CONTENT
+// ================================================================
+
+.instance-main {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 $public-space-lg $public-space-2xl;
+  width: 100%;
+
+  @include public-tablet-up {
+    padding: 0 $public-space-xl $public-space-2xl;
+  }
+
+  @include public-desktop-up {
+    padding: 0 $public-space-2xl $public-space-2xl;
+  }
+}
+
+// ================================================================
+// HERO IMAGE
+// ================================================================
+
+.hero-image-wrapper {
+  @include public-hero-image;
+  margin-bottom: $public-space-2xl;
+
+  :deep(.event-image) {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+
+// ================================================================
+// RECURRENCE BADGE
+// ================================================================
+
+.recurrence-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: $public-space-sm;
+  padding: $public-space-xs $public-space-md;
+  border-radius: $public-radius-full;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: $public-text-primary-light;
+  font-size: $public-font-size-sm;
+  font-weight: $public-font-weight-medium;
+  margin-bottom: $public-space-md;
+
+  @include public-dark-mode {
+    background-color: rgba(30, 30, 35, 0.85);
+    color: $public-text-primary-dark;
+  }
+}
+
+// ================================================================
+// SOURCE CALENDAR PILL
+// ================================================================
+
+.source-calendar-pill {
+  @include public-source-calendar-pill;
+  margin-bottom: $public-space-md;
+}
+
+// ================================================================
+// TITLE
+// ================================================================
+
+.instance-title {
+  font-size: $public-font-size-2xl;
+  font-weight: $public-font-weight-bold;
+  letter-spacing: $public-letter-spacing-tight;
+  line-height: $public-line-height-tight;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-lg 0;
+
+  @include public-tablet-up {
+    font-size: 40px;
+  }
+
+  @include public-desktop-up {
+    font-size: 48px;
+  }
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+// ================================================================
+// DATE + TIME ROW
+// ================================================================
+
+.datetime-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $public-space-sm $public-space-xl;
+  margin-bottom: $public-space-2xl;
+}
+
+.event-date,
+.event-datetime {
+  display: inline-flex;
+  align-items: center;
+  gap: $public-space-sm;
+  font-size: $public-font-size-base;
+  font-weight: $public-font-weight-medium;
+  color: $public-text-secondary-light;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+.datetime-icon {
+  flex-shrink: 0;
+
+  &--date {
+    color: $public-accent-light;
 
     @include public-dark-mode {
-      color: $public-text-primary-dark;
+      color: $public-accent-dark;
     }
+  }
+
+  &--time {
+    color: $public-text-secondary-light;
+
+    @include public-dark-mode {
+      color: $public-text-secondary-dark;
+    }
+  }
+}
+
+// ================================================================
+// TWO-COLUMN DETAIL GRID
+// ================================================================
+
+.detail-grid {
+  @include public-detail-grid;
+  margin-bottom: $public-space-2xl;
+}
+
+// ================================================================
+// LEFT COLUMN: DESCRIPTION + CATEGORIES
+// ================================================================
+
+.detail-main {
+  min-width: 0;
+}
+
+.about-heading {
+  font-size: $public-font-size-md;
+  font-weight: $public-font-weight-semibold;
+  color: $public-text-secondary-light;
+  margin: 0 0 $public-space-md 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+.event-description {
+  font-size: $public-font-size-md;
+  line-height: $public-line-height-relaxed;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-xl 0;
+  white-space: pre-line;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+.categories-section {
+  margin-top: $public-space-lg;
+}
+
+.section-heading {
+  font-size: $public-font-size-xs;
+  font-weight: $public-font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: $public-letter-spacing-wide;
+  color: $public-text-secondary-light;
+  margin: 0 0 $public-space-sm 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+.category-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $public-space-sm;
+}
+
+.event-category-badge {
+  @include public-category-badge;
+
+  text-decoration: none;
+  cursor: default;
+}
+
+// ================================================================
+// RIGHT SIDEBAR: INFO CARDS
+// ================================================================
+
+.detail-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: $public-space-lg;
+}
+
+.sidebar-card {
+  @include public-sidebar-card;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: $public-space-sm;
+  margin-bottom: $public-space-md;
+}
+
+.card-icon {
+  color: $public-text-secondary-light;
+  flex-shrink: 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+.card-heading {
+  font-size: $public-font-size-xs;
+  font-weight: $public-font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: $public-letter-spacing-wide;
+  color: $public-text-secondary-light;
+  margin: 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+// Location card
+.location-name {
+  font-size: $public-font-size-base;
+  font-weight: $public-font-weight-medium;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-xs 0;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+.location-address {
+  font-size: $public-font-size-sm;
+  color: $public-text-secondary-light;
+  margin: 0;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+// Accessibility card
+.accessibility-info {
+  font-size: $public-font-size-base;
+  color: $public-text-primary-light;
+  margin: 0;
+  white-space: pre-line;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+// Recurrence card
+.recurrence-text {
+  font-size: $public-font-size-base;
+  color: $public-text-primary-light;
+  margin: 0;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
   }
 }
 
@@ -382,9 +695,7 @@ onBeforeMount(async () => {
 .external-link-button {
   @include public-button-primary;
 
-  display: inline-block;
   min-height: 44px;
-  margin-top: $public-space-md;
   text-decoration: none;
   text-align: center;
 
@@ -393,25 +704,9 @@ onBeforeMount(async () => {
   }
 }
 
-.instance-footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $public-space-sm;
-  margin-top: $public-space-xl;
-  padding-top: $public-space-lg;
-  border-top: 1px solid $public-border-subtle-light;
-
-  @include public-dark-mode {
-    border-top-color: $public-border-subtle-dark;
-  }
-}
-
-.event-category-badge {
-  @include public-category-badge;
-
-  text-decoration: none;
-  cursor: default;
-}
+// ================================================================
+// LOADING / ERROR STATES
+// ================================================================
 
 .loading {
   @include public-loading-state;

--- a/src/widget/test/event-detail-overlay.test.ts
+++ b/src/widget/test/event-detail-overlay.test.ts
@@ -34,29 +34,74 @@ vi.mock('@/site/service/calendar', () => {
         hasContent: (_lang: string) => true,
         getLanguages: () => ['en'],
       }),
-      loadCalendarEvents: vi.fn().mockImplementation(() =>
-        Promise.resolve([
+      loadCalendarEvents: vi.fn().mockImplementation(() => {
+        const localized = {
+          setLocale: () => ({
+            toLocaleString: () => 'March 1, 2026',
+          }),
+          toLocaleString: () => 'March 1, 2026, 10:00 AM',
+        };
+        return Promise.resolve([
           {
+            id: 'inst-1',
             start: {
               toISO: () => '2026-03-01T10:00:00.000Z',
-              toLocal: () => ({
-                toLocaleString: () => 'March 1, 2026, 10:00 AM',
-              }),
+              toLocal: () => localized,
+              hasSame: () => true,
             },
+            end: null,
             event: {
               id: 'evt-1',
               content: (_lang: string) => ({ name: 'Test Event', description: 'Description' }),
+              hasContent: (_lang: string) => true,
+              getLanguages: () => ['en'],
               media: null,
               mediaFocalPointX: 0.5,
               mediaFocalPointY: 0.5,
               mediaZoom: 1.0,
               categories: [],
+              schedules: [],
+              location: null,
+              sourceCalendar: null,
               externalUrl: mockExternalUrl,
               urlPrompt: mockUrlPrompt,
             },
           },
-        ]),
-      ),
+        ]);
+      }),
+      loadEventInstance: vi.fn().mockImplementation(() => {
+        const localized = {
+          setLocale: () => ({
+            toLocaleString: () => 'March 1, 2026',
+          }),
+          toLocaleString: () => 'March 1, 2026, 10:00 AM',
+        };
+        return Promise.resolve({
+          id: 'inst-1',
+          start: {
+            toISO: () => '2026-03-01T10:00:00.000Z',
+            toLocal: () => localized,
+            hasSame: () => true,
+          },
+          end: null,
+          event: {
+            id: 'evt-1',
+            content: (_lang: string) => ({ name: 'Test Event', description: 'Description' }),
+            hasContent: (_lang: string) => true,
+            getLanguages: () => ['en'],
+            media: null,
+            mediaFocalPointX: 0.5,
+            mediaFocalPointY: 0.5,
+            mediaZoom: 1.0,
+            categories: [],
+            schedules: [],
+            location: null,
+            sourceCalendar: null,
+            externalUrl: mockExternalUrl,
+            urlPrompt: mockUrlPrompt,
+          },
+        });
+      }),
     })),
   };
 });

--- a/tests/e2e/widget-embedding.spec.ts
+++ b/tests/e2e/widget-embedding.spec.ts
@@ -174,7 +174,7 @@ test.describe('Widget Embedding', () => {
     await expect(iframe.locator('.event-detail-overlay h1')).toBeVisible();
 
     // Click back button to return to list view
-    await iframe.locator('.back-button').first().click();
+    await iframe.locator('.back-link').first().click();
 
     // Verify list view is restored
     await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary

- Widget event detail overlay was missing several features the public site already renders: **location** (with map link), **accessibility**, **add-to-calendar (ICS)**, full **date/time range** with icons, **recurrence** badge + card, and **source calendar** pill.
- Rewrote `event-detail-overlay.vue` to mirror the site's `event-instance.vue` layout (two-column grid with sidebar cards), reusing `AddToCalendar` and `useLocalizedContent` from the site app instead of duplicating them.
- The public list endpoint (`/calendar/:name/events`) strips `schedules` for performance, so after finding the matching instance by event ID we now chain `loadEventInstance(instance.id)` to hydrate the full detail shape (schedules, full location content, etc.).

## Test plan

- [x] `npx vitest run src/widget/` — all 54 tests pass (test mocks updated for the new access patterns)
- [x] Lint clean on the changed file
- [x] Manually verified in dev against `test_calendar`:
  - Single-day non-recurring event shows Location card, date + time range, Add to Calendar
  - Recurring event (\"Outdoor Yoga Class\") shows \"Every week\" badge and Recurring Event sidebar card
- [x] Verified via a cross-origin embed host (separate HTTP server on port 8765 embedding the widget from `localhost:3000` via the SDK)

## Notes

No route/API changes — existing widget URLs (`/widget/:urlName/events/:eventId`) continue to work; no SDK contract changes.