### PR TITLE
feat(follow): accept bare urlName for local calendar follow lookup

### DIFF
--- a/src/client/components/logged_in/feed/add_calendar_modal.vue
+++ b/src/client/components/logged_in/feed/add_calendar_modal.vue
@@ -8,6 +8,7 @@ import { ADD_CATEGORY_VALUE } from '@/client/components/logged_in/category-mappi
 import { useFeedStore } from '@/client/stores/feedStore';
 import { useFeedFollows } from '@/client/composables/useFeedFollows';
 import FeedService, { type RemoteCalendarPreview, type CategoryEntry, type CategoryMappingEntry } from '@/client/service/feed';
+import { isValidCalendarUrlName } from '@/common/validation/calendarUrlName';
 import {
   InvalidRemoteCalendarIdentifierError,
   RemoteCalendarNotFoundError,
@@ -45,8 +46,18 @@ const pendingMappings = ref<CategoryMappingEntry[]>([]);
 const isSavingMappings = ref(false);
 const mappingStepRef = ref<HTMLElement | null>(null);
 
+// Mirrors server-side ActivityPubService.normalizeIdentifier.
+// Accepts `username@domain` for remote/qualified lookups, or a bare urlName
+// (validated against the shared calendar urlName rule) for a local lookup.
 const isValidIdentifier = computed(() => {
-  return identifier.value.includes('@') && identifier.value.split('@').length === 2;
+  const value = identifier.value.trim();
+  if (!value) {
+    return false;
+  }
+  if (value.includes('@')) {
+    return value.split('@').length === 2;
+  }
+  return isValidCalendarUrlName(value);
 });
 
 const canLookup = computed(() => {
@@ -87,7 +98,7 @@ const lookupRemoteCalendar = async () => {
 
   try {
     const feedService = new FeedService();
-    const result = await feedService.lookupRemoteCalendar(identifier.value);
+    const result = await feedService.lookupRemoteCalendar(identifier.value.trim());
 
     // Check for self-follow (local calendar matching selected calendar)
     if (result.calendarId && result.calendarId === feedStore.selectedCalendarId) {
@@ -145,7 +156,7 @@ const handleFollow = async () => {
   isFollowing.value = true;
 
   try {
-    const calendarActorId = await followCalendar(identifier.value, autoRepostOriginals.value, autoRepostReposts.value);
+    const calendarActorId = await followCalendar(identifier.value.trim(), autoRepostOriginals.value, autoRepostReposts.value);
     emit('follow-success');
 
     if (calendarActorId && feedStore.selectedCalendarId) {

--- a/src/client/components/logged_in/feed/test/add_calendar_modal.test.ts
+++ b/src/client/components/logged_in/feed/test/add_calendar_modal.test.ts
@@ -276,4 +276,27 @@ describe('AddCalendarModal — mapping step', () => {
     expect(wrapper.find('.mapping-step').exists()).toBe(false);
     expect(wrapper.emitted('close')).toBeTruthy();
   });
+
+  describe('identifier validation', () => {
+    const cases: [string, boolean, string][] = [
+      ['user@example.com', true, 'qualified identifier'],
+      ['mycal', true, 'bare urlName'],
+      ['MyCAL', true, 'mixed-case bare urlName (server lowercases)'],
+      ['my_cal_', true, 'bare urlName with trailing underscore'],
+      ['', false, 'empty string'],
+      ['ab', false, 'bare urlName too short'],
+      ['_leadunderscore', false, 'bare urlName with leading underscore'],
+      ['has spaces', false, 'bare urlName with spaces'],
+      ['user@domain@extra', false, 'identifier with multiple @'],
+    ];
+
+    for (const [input, expected, description] of cases) {
+      it(`${expected ? 'accepts' : 'rejects'} ${description}`, async () => {
+        const wrapper = mountModal();
+        wrapper.vm.identifier = input;
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.isValidIdentifier).toBe(expected);
+      });
+    }
+  });
 });

--- a/src/client/locales/en/feed.json
+++ b/src/client/locales/en/feed.json
@@ -75,8 +75,8 @@
     "add_calendar_modal": {
         "title": "Follow a Calendar",
         "identifier_label": "Calendar Identifier",
-        "identifier_placeholder": "calendar@domain.com",
-        "identifier_help": "Enter the ActivityPub identifier of the calendar you want to follow",
+        "identifier_placeholder": "calendar or calendar@domain.com",
+        "identifier_help": "Enter a local calendar name, or the ActivityPub identifier of a remote calendar you want to follow",
         "looking_up": "Looking up calendar...",
         "lookup_error": "Could not find calendar. Please check the identifier and try again.",
         "self_follow_error": "A calendar cannot follow itself.",

--- a/src/common/validation/calendarUrlName.ts
+++ b/src/common/validation/calendarUrlName.ts
@@ -1,0 +1,11 @@
+/**
+ * Canonical urlName validator shared by client and server.
+ *
+ * Server-side CalendarService.isValidUrlName and any client-side mirrors
+ * must delegate here so they can never drift.
+ */
+export const CALENDAR_URL_NAME_RE = /^[a-z0-9][a-z0-9_-]{1,22}[a-z0-9_]$/i;
+
+export function isValidCalendarUrlName(urlName: string): boolean {
+  return CALENDAR_URL_NAME_RE.test(urlName);
+}

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -23,6 +23,7 @@ import { EventObject } from "@/server/activitypub/model/object/event";
 import { addToOutbox as addToOutboxHelper } from "@/server/activitypub/helper/outbox";
 import { validateUrlNotPrivate } from "@/server/common/helper/ip-validation";
 import { PUBLIC_KEY_FETCH_TIMEOUT_MS } from "@/server/common/constants";
+import { isValidCalendarUrlName } from "@/common/validation/calendarUrlName";
 import {
   InvalidRemoteCalendarIdentifierError,
   InvalidSharedEventUrlError,
@@ -94,6 +95,35 @@ class ActivityPubService {
   }
 
   /**
+   * Normalize a calendar identifier to canonical `username@domain` form.
+   * Accepts either a fully qualified `username@domain` string or a bare
+   * urlName (no `@`), which is resolved against the local instance domain.
+   *
+   * Username and domain are lowercased so downstream equality checks
+   * (e.g. the self-follow guard) do not depend on input casing.
+   *
+   * @param identifier The user-supplied identifier
+   * @returns The canonical `username@domain` identifier, or null if the
+   *   identifier is not a valid form
+   */
+  static normalizeIdentifier(identifier: string): string | null {
+    if (identifier.includes('@')) {
+      if (!ActivityPubService.isValidOrgIdentifier(identifier)) {
+        return null;
+      }
+      const [username, domain] = identifier.split('@');
+      return `${username.toLowerCase()}@${domain.toLowerCase()}`;
+    }
+    // Bare urlName: must satisfy the canonical Calendar urlName rule so the
+    // client and server accept exactly the same set of inputs.
+    if (!isValidCalendarUrlName(identifier)) {
+      return null;
+    }
+    const localDomain = config.get('domain') as string;
+    return `${identifier.toLowerCase()}@${localDomain.toLowerCase()}`;
+  }
+
+  /**
    * Validate that repost policy settings are consistent.
    *
    * autoRepostReposts=true requires autoRepostOriginals=true because you cannot
@@ -120,7 +150,8 @@ class ActivityPubService {
     autoRepostOriginals: boolean = false,
     autoRepostReposts: boolean = false,
   ) {
-    if (!ActivityPubService.isValidOrgIdentifier(orgIdentifier)) {
+    const normalizedIdentifier = ActivityPubService.normalizeIdentifier(orgIdentifier);
+    if (!normalizedIdentifier) {
       throw new InvalidRemoteCalendarIdentifierError('Invalid remote calendar identifier: ' + orgIdentifier);
     }
 
@@ -131,15 +162,16 @@ class ActivityPubService {
     // Validate repost policy settings
     ActivityPubService.validateRepostPolicySettings(autoRepostOriginals, autoRepostReposts);
 
-    // Prevent self-follows
+    // Prevent self-follows. Both sides are lowercased so casing in the
+    // calendar's stored urlName or the user's input can't bypass the guard.
     const localDomain = config.get('domain') as string;
-    const selfIdentifier = `${calendar.urlName}@${localDomain}`;
-    if (orgIdentifier === selfIdentifier) {
+    const selfIdentifier = `${calendar.urlName.toLowerCase()}@${localDomain.toLowerCase()}`;
+    if (normalizedIdentifier === selfIdentifier) {
       throw new SelfFollowError('A calendar cannot follow itself');
     }
 
     // Resolve the ActivityPub actor URL from the WebFinger identifier first
-    const remoteProfile = await this.lookupRemoteCalendar(orgIdentifier);
+    const remoteProfile = await this.lookupRemoteCalendar(normalizedIdentifier);
     const remoteActorUrl = remoteProfile.actorUrl;
 
     // Get or create CalendarActorEntity
@@ -603,11 +635,12 @@ class ActivityPubService {
     actorUrl: string;
     calendarId?: string;
   }> {
-    if (!ActivityPubService.isValidOrgIdentifier(identifier)) {
+    const normalizedIdentifier = ActivityPubService.normalizeIdentifier(identifier);
+    if (!normalizedIdentifier) {
       throw new InvalidRemoteCalendarIdentifierError('Invalid calendar identifier format');
     }
 
-    const [username, domain] = identifier.split('@');
+    const [username, domain] = normalizedIdentifier.split('@');
     const localDomain = config.get('domain') as string;
 
     // Check if this is a local calendar
@@ -626,8 +659,10 @@ class ActivityPubService {
       };
     }
 
-    // Perform WebFinger lookup for remote calendars
-    const webfingerUrl = `https://${domain}/.well-known/webfinger?resource=acct:${identifier}`;
+    // Perform WebFinger lookup for remote calendars. Use the normalized
+    // identifier so the WebFinger resource parameter matches the values
+    // used for validation and local-domain comparison.
+    const webfingerUrl = `https://${domain}/.well-known/webfinger?resource=acct:${normalizedIdentifier}`;
     let webfingerResponse;
 
     try {

--- a/src/server/activitypub/test/service/members-exceptions.test.ts
+++ b/src/server/activitypub/test/service/members-exceptions.test.ts
@@ -51,7 +51,7 @@ describe('ActivityPubService Exception Handling', () => {
   describe('followCalendar', () => {
     it('throws InvalidRemoteCalendarIdentifierError for invalid identifier', async () => {
       await expect(
-        service.followCalendar(account, calendar, 'invalid-identifier'),
+        service.followCalendar(account, calendar, 'has spaces'),
       ).rejects.toThrow(InvalidRemoteCalendarIdentifierError);
     });
 
@@ -74,6 +74,33 @@ describe('ActivityPubService Exception Handling', () => {
 
       await expect(
         service.followCalendar(account, calendar, 'testcalendar@pavillion.dev'),
+      ).rejects.toThrow(SelfFollowError);
+    });
+
+    it('throws SelfFollowError when a bare urlName resolves to the calendar itself', async () => {
+      const userCanModifyStub = sandbox.stub(service.calendarService, 'userCanModifyCalendar');
+      userCanModifyStub.returns(true);
+
+      const configStub = sandbox.stub(require('config'), 'get');
+      configStub.withArgs('domain').returns('pavillion.dev');
+
+      await expect(
+        service.followCalendar(account, calendar, 'testcalendar'),
+      ).rejects.toThrow(SelfFollowError);
+    });
+
+    it('throws SelfFollowError for case-variant bare urlName matching the calendar', async () => {
+      const userCanModifyStub = sandbox.stub(service.calendarService, 'userCanModifyCalendar');
+      userCanModifyStub.returns(true);
+
+      const configStub = sandbox.stub(require('config'), 'get');
+      configStub.withArgs('domain').returns('pavillion.dev');
+
+      // Normalization lowercases both the user's input and the calendar's
+      // stored urlName before comparing, so TESTCALENDAR must still trip
+      // the self-follow guard regardless of collation behaviour.
+      await expect(
+        service.followCalendar(account, calendar, 'TESTCALENDAR'),
       ).rejects.toThrow(SelfFollowError);
     });
   });
@@ -144,13 +171,45 @@ describe('ActivityPubService Exception Handling', () => {
 
   describe('lookupRemoteCalendar', () => {
     it('throws InvalidRemoteCalendarIdentifierError for invalid identifier format', async () => {
+      // Whitespace is invalid in both qualified and bare-urlName forms.
       await expect(
-        service.lookupRemoteCalendar('invalid-format'),
+        service.lookupRemoteCalendar('has spaces'),
       ).rejects.toThrow(InvalidRemoteCalendarIdentifierError);
 
+      // Dots in a bare urlName aren't allowed, and without an `@` this can't
+      // be interpreted as a qualified identifier.
       await expect(
         service.lookupRemoteCalendar('no-at-sign.com'),
       ).rejects.toThrow(InvalidRemoteCalendarIdentifierError);
+    });
+
+    it('resolves a bare urlName as a local calendar lookup', async () => {
+      const configStub = sandbox.stub(require('config'), 'get');
+      configStub.withArgs('domain').returns('pavillion.dev');
+
+      const localCalendar = new Calendar('local-calendar-id', 'mycal');
+
+      const getCalendarByNameStub = sandbox.stub(service.calendarService, 'getCalendarByName');
+      getCalendarByNameStub.withArgs('mycal').resolves(localCalendar);
+
+      const result = await service.lookupRemoteCalendar('mycal');
+
+      expect(result.domain).toBe('pavillion.dev');
+      expect(result.calendarId).toBe('local-calendar-id');
+      expect(result.actorUrl).toBe('https://pavillion.dev/calendars/mycal');
+      expect(getCalendarByNameStub.calledWith('mycal')).toBe(true);
+    });
+
+    it('throws RemoteCalendarNotFoundError for a bare urlName with no matching local calendar', async () => {
+      const configStub = sandbox.stub(require('config'), 'get');
+      configStub.withArgs('domain').returns('pavillion.dev');
+
+      const getCalendarByNameStub = sandbox.stub(service.calendarService, 'getCalendarByName');
+      getCalendarByNameStub.resolves(null);
+
+      await expect(
+        service.lookupRemoteCalendar('missingcal'),
+      ).rejects.toThrow(RemoteCalendarNotFoundError);
     });
 
     it('throws RemoteCalendarNotFoundError when local calendar does not exist', async () => {
@@ -290,5 +349,51 @@ describe('ActivityPubService Exception Handling', () => {
         service.lookupRemoteCalendar('user@example.com'),
       ).rejects.toThrow(RemoteProfileFetchError);
     });
+  });
+});
+
+describe('ActivityPubService.normalizeIdentifier', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const configStub = sandbox.stub(require('config'), 'get');
+    configStub.withArgs('domain').returns('pavillion.dev');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns the qualified identifier lowercased when valid', () => {
+    expect(ActivityPubService.normalizeIdentifier('User@Example.Com')).toBe('user@example.com');
+  });
+
+  it('qualifies a bare urlName with the local domain', () => {
+    expect(ActivityPubService.normalizeIdentifier('mycal')).toBe('mycal@pavillion.dev');
+  });
+
+  it('lowercases a mixed-case bare urlName before qualifying', () => {
+    expect(ActivityPubService.normalizeIdentifier('MyCAL')).toBe('mycal@pavillion.dev');
+  });
+
+  it('accepts a bare urlName with a trailing underscore', () => {
+    // Calendar urlNames may end in `_` per isValidCalendarUrlName; the
+    // bare-urlName path must match that rule so client and server agree.
+    expect(ActivityPubService.normalizeIdentifier('my_cal_')).toBe('my_cal_@pavillion.dev');
+  });
+
+  it('returns null for a qualified identifier with an invalid domain', () => {
+    expect(ActivityPubService.normalizeIdentifier('user@not a domain')).toBeNull();
+  });
+
+  it('returns null for a bare string that is not a valid urlName', () => {
+    expect(ActivityPubService.normalizeIdentifier('has spaces')).toBeNull();
+    expect(ActivityPubService.normalizeIdentifier('_leadunderscore')).toBeNull();
+    expect(ActivityPubService.normalizeIdentifier('ab')).toBeNull(); // too short
+  });
+
+  it('returns null for an identifier with more than one @', () => {
+    expect(ActivityPubService.normalizeIdentifier('user@domain@extra')).toBeNull();
   });
 });

--- a/src/server/activitypub/test/service/members.test.ts
+++ b/src/server/activitypub/test/service/members.test.ts
@@ -177,7 +177,9 @@ describe("followCalendar", () => {
     let addToOutboxStub = sandbox.stub(service, 'addToOutbox');
     addToOutboxStub.resolves();
 
-    await expect( service.followCalendar(account, calendar,'invalidUserIdentifier') ).rejects.toThrow(InvalidRemoteCalendarIdentifierError);
+    // Whitespace is invalid in both qualified (`user@domain`) and bare-urlName
+    // forms, so normalizeIdentifier rejects before any DB lookup.
+    await expect( service.followCalendar(account, calendar,'invalid user') ).rejects.toThrow(InvalidRemoteCalendarIdentifierError);
     expect( buildFollowStub.called ).toBe(false);
     expect( saveFollowStub.called ).toBe(false);
     expect( addToOutboxStub.called ).toBe(false);

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -16,6 +16,7 @@ import { CalendarMember } from '@/common/model/calendar_member';
 import { AccountEntity } from '@/server/common/entity/account';
 import AccountInvitation from '@/common/model/invitation';
 import { UrlNameAlreadyExistsError, InvalidUrlNameError, CalendarNotFoundError } from '@/common/exceptions/calendar';
+import { isValidCalendarUrlName } from '@/common/validation/calendarUrlName';
 import { ValidationError } from '@/common/exceptions/base';
 import { MediaNotFoundError } from '@/common/exceptions/media';
 import { CalendarEditorPermissionError, EditorAlreadyExistsError, EditorNotFoundError } from '@/common/exceptions/editor';
@@ -92,7 +93,7 @@ class CalendarService {
   }
 
   isValidUrlName(username: string): boolean {
-    return username.match(/^[a-z0-9][a-z0-9_-]{1,22}[a-z0-9_]$/i) ? true : false;
+    return isValidCalendarUrlName(username);
   }
 
   async setUrlName(account: Account, calendar: Calendar, urlName: string): Promise<boolean> {

--- a/src/server/calendar/service/series.ts
+++ b/src/server/calendar/service/series.ts
@@ -18,6 +18,7 @@ import {
 } from '@/common/exceptions/series';
 import CalendarService from './calendar';
 import db from '@/server/common/entity/db';
+import { isValidCalendarUrlName } from '@/common/validation/calendarUrlName';
 
 /**
  * Service for managing event series within calendars.
@@ -38,14 +39,15 @@ class SeriesService {
   }
 
   /**
-   * Validate a series URL name against the allowed pattern.
-   * Same regex as Calendar.isValidUrlName: /^[a-z0-9][a-z0-9_-]{1,22}[a-z0-9_]$/i
+   * Validate a series URL name against the allowed pattern. Shares the
+   * canonical rule with CalendarService.isValidUrlName via the common
+   * validator so series and calendar urlNames cannot drift.
    *
    * @param urlName - The URL name to validate
    * @returns true if valid, false otherwise
    */
   isValidUrlName(urlName: string): boolean {
-    return /^[a-z0-9][a-z0-9_-]{1,22}[a-z0-9_]$/i.test(urlName);
+    return isValidCalendarUrlName(urlName);
   }
 
   /**


### PR DESCRIPTION
## Summary

- The Follow-a-Calendar modal previously required a fully qualified `calendar@domain.com` identifier even when the target was on the same instance. Users can now type just the bare urlName (e.g. `mycal`) and the server resolves it against the local instance. Qualified identifiers continue to work unchanged for remote federation.
- Extract a shared `isValidCalendarUrlName` helper into `src/common/validation/calendarUrlName.ts` so client and server use one authoritative urlName rule (replaces three drifted copies). `CalendarService`, `SeriesService`, the AP service's new `normalizeIdentifier`, and the modal all go through it.
- New `ActivityPubService.normalizeIdentifier` returns a canonical lowercased `username@domain` form. `lookupRemoteCalendar` and `followCalendar` normalize up front. Self-follow guard lowercases both sides so case-insensitive collation can't bypass it. WebFinger URL uses the normalized identifier.

## Test plan

- [x] `src/server/activitypub/test/service/members-exceptions.test.ts` — bare urlName local lookup success, not-found, self-follow, case-variant self-follow, and a direct `normalizeIdentifier` suite (qualified/lowercased, bare qualified, mixed-case, trailing `_`, invalid forms)
- [x] `src/server/activitypub/test/service/members.test.ts` — updated pre-existing invalid-input case (old string legitimately matched bare urlName pattern)
- [x] `src/client/components/logged_in/feed/test/add_calendar_modal.test.ts` — parameterized `isValidIdentifier` table covering qualified, bare, mixed-case, trailing underscore, empty, too-short, leading-underscore, spaces, and multi-`@` inputs
- [x] `src/server/calendar/test/series_service.test.ts` — 56 existing tests still green after routing through the shared validator
- [x] Lint clean on changed files (pre-existing unrelated warning in `calendar.ts:418` untouched)
- [ ] Manual verification: type a local calendar's urlName in the Follow modal → preview renders with correct domain and local calendarId

## Auditor review

Ran architecture, consistency, complexity, security, and testing auditors before and after the fix round. Final verdicts: complexity PASS; consistency PASS (one pre-existing inline regex copy in `CreateCalendarForm.vue` intentionally left out of scope). Original MEDIUM findings (regex drift, case bypass, missing direct tests) resolved in this PR.