### PR TITLE
feat(events): inline category creation in event editor

### DIFF
--- a/src/client/components/logged_in/calendar/category-selector.vue
+++ b/src/client/components/logged_in/calendar/category-selector.vue
@@ -14,39 +14,63 @@
 
     <!-- Error State -->
     <div
-      v-if="state.error"
+      v-else-if="state.error"
       class="error"
       role="alert"
     >
       {{ state.error }}
     </div>
 
-    <!-- Categories Selection -->
-    <div v-else-if="state.availableCategories.length > 0" class="categories-list">
-      <ToggleChip
-        v-for="category in state.availableCategories"
-        :key="category.id"
-        :model-value="state.selectedCategoryIds.includes(category.id)"
-        :label="category.content(currentLanguage)?.name || 'Unnamed Category'"
-        variant="orange"
-        @update:model-value="() => toggleCategory(category.id)"
-      />
-    </div>
+    <template v-else>
+      <!-- Categories Selection -->
+      <div v-if="state.availableCategories.length > 0" class="categories-list">
+        <ToggleChip
+          v-for="category in state.availableCategories"
+          :key="category.id"
+          :model-value="state.selectedCategoryIds.includes(category.id)"
+          :label="category.content(currentLanguage)?.name || 'Unnamed Category'"
+          variant="orange"
+          @update:model-value="() => toggleCategory(category.id)"
+        />
+      </div>
 
-    <!-- No Categories State -->
-    <div v-else class="no-categories">
-      <p>{{ t('no_categories_available') }}</p>
-      <p class="help-text">{{ t('no_categories_help') }}</p>
-    </div>
+      <!-- No Categories State -->
+      <div v-else class="no-categories">
+        <p>{{ t('no_categories_available') }}</p>
+        <p class="help-text">{{ t('no_categories_help') }}</p>
+      </div>
+
+      <!-- Inline Create Category Trigger -->
+      <button
+        ref="addCategoryButtonRef"
+        type="button"
+        class="btn btn--ghost add-category-button"
+        data-test="add-category-button"
+        @click="openCreateCategory"
+      >
+        {{ t('add_category_button') }}
+      </button>
+    </template>
+
+    <!-- Inline Create Category Modal -->
+    <CategoryEditor
+      v-if="state.showCategoryEditor && state.newCategory"
+      :category="state.newCategory"
+      @saved="onCategorySaved"
+      @close="closeCategoryEditor"
+    />
   </div>
 </template>
 
 <script setup>
-import { reactive, computed, onMounted, watch } from 'vue';
+import { reactive, computed, onMounted, ref, nextTick, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import i18next from 'i18next';
+import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
 import CategoryService from '@/client/service/category';
 import ToggleChip from '@/client/components/common/toggle-chip.vue';
+import CategoryEditor from '@/client/components/logged_in/calendar-content/category-editor.vue';
 
 const props = defineProps({
   calendarId: {
@@ -68,12 +92,56 @@ const { t } = useTranslation('event_editor', {
 const categoryService = new CategoryService();
 const currentLanguage = computed(() => i18next.language);
 
+// Template ref to the "+ New category" trigger button; used to restore focus
+// when the CategoryEditor modal closes (WCAG 2.4.3 Focus Order, 2.4.7 Focus Visible).
+const addCategoryButtonRef = ref(null);
+
 const state = reactive({
   availableCategories: [],
   selectedCategoryIds: [],
   isLoading: false,
   error: '',
+  showCategoryEditor: false,
+  newCategory: null,
 });
+
+/**
+ * Construct a fresh EventCategory scoped to the current calendar and open
+ * the CategoryEditor modal in create mode. The 'en' default matches
+ * category-editor.vue's internal defaultLanguage constant — if either
+ * changes, both must change in lock-step.
+ */
+function openCreateCategory() {
+  const fresh = new EventCategory('', props.calendarId);
+  fresh.addContent(new EventCategoryContent('en', ''));
+  state.newCategory = fresh;
+  state.showCategoryEditor = true;
+}
+
+/**
+ * Handle the CategoryEditor modal's 'saved' emit: append to the available
+ * list, auto-select the new category, and notify the parent editor.
+ */
+function onCategorySaved(savedCategory) {
+  state.availableCategories = [...state.availableCategories, savedCategory];
+  if (!state.selectedCategoryIds.includes(savedCategory.id)) {
+    state.selectedCategoryIds.push(savedCategory.id);
+    emit('categoriesChanged', [...state.selectedCategoryIds]);
+  }
+}
+
+/**
+ * Close the CategoryEditor modal without applying any state changes.
+ * Restores keyboard focus to the trigger button for WCAG 2.4.3 / 2.4.7
+ * compliance so sighted keyboard users are not dropped onto document.body.
+ */
+function closeCategoryEditor() {
+  state.showCategoryEditor = false;
+  state.newCategory = null;
+  nextTick(() => {
+    addCategoryButtonRef.value?.focus();
+  });
+}
 
 /**
  * Load categories for the calendar
@@ -223,5 +291,9 @@ onMounted(async () => {
       }
     }
   }
+}
+
+.add-category-button {
+  margin-block-start: var(--pav-space-3);
 }
 </style>

--- a/src/client/components/logged_in/calendar/category-selector.vue
+++ b/src/client/components/logged_in/calendar/category-selector.vue
@@ -123,7 +123,18 @@ function openCreateCategory() {
  * list, auto-select the new category, and notify the parent editor.
  */
 function onCategorySaved(savedCategory) {
-  state.availableCategories = [...state.availableCategories, savedCategory];
+  // Why: CategoryService.loadCategories() returns the same array reference that
+  // Pinia stores in categoryStore.categories[calendarId]. CategoryService.saveCategory()
+  // then mutates that same array via store.addCategory(...).push(savedCategory) before
+  // emitting 'saved'. As a result, state.availableCategories has already grown by one
+  // when this handler runs, so a naive [...state.availableCategories, savedCategory]
+  // would render the new chip twice. Dedupe by id to stay correct regardless of whether
+  // the saved category is already present (defensive — fixing the broader service/store
+  // coupling is out of scope for this bead; see pv-asqb).
+  const existingIds = new Set(state.availableCategories.map(c => c.id));
+  if (!existingIds.has(savedCategory.id)) {
+    state.availableCategories = [...state.availableCategories, savedCategory];
+  }
   if (!state.selectedCategoryIds.includes(savedCategory.id)) {
     state.selectedCategoryIds.push(savedCategory.id);
     emit('categoriesChanged', [...state.selectedCategoryIds]);

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -46,7 +46,8 @@
     "loading_categories": "Loading categories...",
     "error_loading_categories": "Error loading categories",
     "no_categories_available": "No categories available",
-    "no_categories_help": "Create categories in calendar management to organize your events"
+    "no_categories_help": "Create categories in calendar management to organize your events",
+    "add_category_button": "+ New category"
   },
   "series": {
     "series_label": "Series",

--- a/src/client/test/components/calendar/category-selector.test.ts
+++ b/src/client/test/components/calendar/category-selector.test.ts
@@ -4,6 +4,7 @@ import { RouteRecordRaw } from 'vue-router';
 import { nextTick } from 'vue';
 import { mountComponent } from '@/client/test/lib/vue';
 import CategorySelector from '@/client/components/logged_in/calendar/category-selector.vue';
+import CategoryEditor from '@/client/components/logged_in/calendar-content/category-editor.vue';
 import CategoryService from '@/client/service/category';
 import { EventCategory } from '@/common/model/event_category';
 import { EventCategoryContent } from '@/common/model/event_category_content';
@@ -206,6 +207,236 @@ describe('CategorySelector', () => {
       // Others should not be selected
       const musicChip = chips.find((c: any) => c.text() === 'Music');
       expect(musicChip?.attributes('aria-checked')).toBe('false');
+    });
+  });
+
+  describe('Inline category creation', () => {
+    it('should render the "+ New category" button below the chips when categories exist', async () => {
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      const button = wrapper.find('[data-test="add-category-button"]');
+      expect(button.exists()).toBe(true);
+      expect(button.attributes('type')).toBe('button');
+    });
+
+    it('should render the "+ New category" button alongside the empty-state message when no categories exist', async () => {
+      // Override the mock to return an empty list
+      mockLoadCategories.mockResolvedValue([]);
+
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      // The no-categories empty-state message is still present
+      expect(wrapper.find('.no-categories').exists()).toBe(true);
+
+      // And the button is present as well
+      const button = wrapper.find('[data-test="add-category-button"]');
+      expect(button.exists()).toBe(true);
+    });
+
+    it('should mount the CategoryEditor modal when the button is clicked', async () => {
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      // Modal should not be mounted initially
+      expect(wrapper.findComponent(CategoryEditor).exists()).toBe(false);
+
+      const button = wrapper.find('[data-test="add-category-button"]');
+      await button.trigger('click');
+      await nextTick();
+
+      // Modal should now be mounted
+      const modal = wrapper.findComponent(CategoryEditor);
+      expect(modal.exists()).toBe(true);
+
+      // The category passed to the modal should have calendarId set and be scoped for creation (no id)
+      const categoryProp = modal.props('category') as EventCategory;
+      expect(categoryProp).toBeTruthy();
+      expect(categoryProp.calendarId).toBe('calendar-123');
+      expect(categoryProp.id).toBeFalsy();
+      // And it should have default 'en' content registered
+      expect(categoryProp.getLanguages()).toContain('en');
+    });
+
+    it('should append the saved category chip to the DOM, auto-select it, and emit categoriesChanged', async () => {
+      wrapper = createWrapper({
+        selectedCategories: ['cat-1'],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      // Open the modal
+      const button = wrapper.find('[data-test="add-category-button"]');
+      await button.trigger('click');
+      await nextTick();
+
+      // Find the modal and simulate a successful save by emitting 'saved'
+      const modal = wrapper.findComponent(CategoryEditor);
+      expect(modal.exists()).toBe(true);
+
+      const newCategory = createTestCategory('cat-new', 'Festivals');
+
+      // Step 1: Emit 'saved' first. The design contract requires the chip append,
+      // auto-select, and categoriesChanged emit to happen as a result of 'saved' —
+      // not 'close'. Assert the DOM and emission reflect that before the modal closes.
+      modal.vm.$emit('saved', newCategory);
+      await nextTick();
+
+      // New chip rendered in the DOM
+      let chips = wrapper.findAll('.toggle-chip');
+      let festivalsChip = chips.find((c: any) => c.text() === 'Festivals');
+      expect(festivalsChip).toBeTruthy();
+
+      // Auto-selected
+      expect(festivalsChip?.attributes('aria-checked')).toBe('true');
+
+      // categoriesChanged emitted with both existing and new id
+      const emittedAfterSave = wrapper.emitted('categoriesChanged');
+      expect(emittedAfterSave).toBeTruthy();
+      const lastEmitAfterSave = emittedAfterSave[emittedAfterSave.length - 1][0];
+      expect(lastEmitAfterSave).toContain('cat-new');
+      expect(lastEmitAfterSave).toContain('cat-1');
+
+      // Modal is still mounted at this point (close hasn't been emitted yet)
+      expect(wrapper.findComponent(CategoryEditor).exists()).toBe(true);
+
+      // Step 2: Emit 'close'. Only now should the modal unmount.
+      modal.vm.$emit('close');
+      await nextTick();
+
+      expect(wrapper.findComponent(CategoryEditor).exists()).toBe(false);
+
+      // Chip and selection persist after close
+      chips = wrapper.findAll('.toggle-chip');
+      festivalsChip = chips.find((c: any) => c.text() === 'Festivals');
+      expect(festivalsChip).toBeTruthy();
+      expect(festivalsChip?.attributes('aria-checked')).toBe('true');
+    });
+
+    it('should hide the "+ New category" button during loading', async () => {
+      // Make loadCategories return a never-resolving promise so the component
+      // stays in its loading state.
+      let resolveLoad: (categories: EventCategory[]) => void = () => {};
+      mockLoadCategories.mockImplementation(
+        () => new Promise<EventCategory[]>((resolve) => {
+          resolveLoad = resolve;
+        }),
+      );
+
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      // Let onMounted kick off loadCategories but do NOT resolve yet.
+      await nextTick();
+
+      // The loading indicator should be visible
+      expect(wrapper.find('.loading').exists()).toBe(true);
+
+      // And the add-category button should NOT be in the DOM
+      expect(wrapper.find('[data-test="add-category-button"]').exists()).toBe(false);
+
+      // Clean up the pending promise so the test doesn't leak
+      resolveLoad([]);
+      await nextTick();
+      await nextTick();
+    });
+
+    it('should hide the "+ New category" button during the error state', async () => {
+      // Make loadCategories reject so the component transitions to the error state.
+      mockLoadCategories.mockRejectedValue(new Error('network failure'));
+
+      // Silence the expected console.error from the catch block
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      // Wait for the rejection to flow through
+      await nextTick();
+      await nextTick();
+      await nextTick();
+
+      // Error region is present
+      expect(wrapper.find('.error').exists()).toBe(true);
+
+      // Add-category button is NOT present
+      expect(wrapper.find('[data-test="add-category-button"]').exists()).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return focus to the "+ New category" button after the modal closes', async () => {
+      wrapper = createWrapper(
+        { selectedCategories: [] },
+      );
+
+      // Attach the wrapper's root to the document so document.activeElement
+      // reflects real focus state in happy-dom.
+      document.body.appendChild(wrapper.element);
+
+      await nextTick();
+      await nextTick();
+
+      const buttonEl = wrapper.find('[data-test="add-category-button"]').element as HTMLButtonElement;
+      expect(buttonEl).toBeTruthy();
+
+      // Open the modal
+      await wrapper.find('[data-test="add-category-button"]').trigger('click');
+      await nextTick();
+
+      const modal = wrapper.findComponent(CategoryEditor);
+      expect(modal.exists()).toBe(true);
+
+      // Close without saving — focus should return to the button
+      modal.vm.$emit('close');
+      await nextTick();
+      await nextTick();
+
+      expect(document.activeElement).toBe(buttonEl);
+    });
+
+    it('should close the modal without emitting categoriesChanged when closed without saving', async () => {
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      // Open the modal
+      const button = wrapper.find('[data-test="add-category-button"]');
+      await button.trigger('click');
+      await nextTick();
+
+      const modal = wrapper.findComponent(CategoryEditor);
+      expect(modal.exists()).toBe(true);
+
+      // Close without saving
+      modal.vm.$emit('close');
+      await nextTick();
+
+      // Modal unmounted
+      expect(wrapper.findComponent(CategoryEditor).exists()).toBe(false);
+
+      // No categoriesChanged emitted
+      const emitted = wrapper.emitted('categoriesChanged');
+      expect(emitted).toBeFalsy();
     });
   });
 });

--- a/src/client/test/components/calendar/category-selector.test.ts
+++ b/src/client/test/components/calendar/category-selector.test.ts
@@ -327,6 +327,52 @@ describe('CategorySelector', () => {
       expect(festivalsChip?.attributes('aria-checked')).toBe('true');
     });
 
+    it('should not duplicate the chip when the saved category is already in availableCategories', async () => {
+      // Why: CategoryService.loadCategories() returns the same array reference that
+      // Pinia's categoryStore holds, and CategoryService.saveCategory() mutates that
+      // shared array via store.addCategory(...).push(savedCategory) BEFORE emitting
+      // 'saved'. This test simulates that real-world condition by mutating the
+      // returned array between mount and the 'saved' emit. Without the dedupe-by-id
+      // guard in onCategorySaved, the chip would render twice.
+      const sharedArray = [...testCategories];
+      mockLoadCategories.mockResolvedValue(sharedArray);
+
+      wrapper = createWrapper({
+        selectedCategories: [],
+      });
+
+      await nextTick();
+      await nextTick();
+
+      // Baseline: 3 seeded chips
+      expect(wrapper.findAll('.toggle-chip').length).toBe(3);
+
+      // Open modal
+      await wrapper.find('[data-test="add-category-button"]').trigger('click');
+      await nextTick();
+
+      const modal = wrapper.findComponent(CategoryEditor);
+      const newCategory = createTestCategory('cat-new', 'Festivals');
+
+      // Simulate the service mutating the shared array (as the real
+      // CategoryService.saveCategory does via store.addCategory) BEFORE
+      // emitting 'saved'.
+      sharedArray.push(newCategory);
+      modal.vm.$emit('saved', newCategory);
+      await nextTick();
+
+      // Exactly ONE new chip rendered (3 existing + 1 new = 4), not two
+      const chips = wrapper.findAll('.toggle-chip');
+      expect(chips.length).toBe(4);
+
+      // And exactly one chip with the new category's label
+      const festivalsChips = chips.filter((c: any) => c.text() === 'Festivals');
+      expect(festivalsChips.length).toBe(1);
+
+      // Still auto-selected
+      expect(festivalsChips[0].attributes('aria-checked')).toBe('true');
+    });
+
     it('should hide the "+ New category" button during loading', async () => {
       // Make loadCategories return a never-resolving promise so the component
       // stays in its loading state.


### PR DESCRIPTION
## Summary

Adds a "+ New category" button to the event editor's category selector that opens the existing CategoryEditor modal. On save, the new category is appended to the available list and auto-selected. Reuses the existing modal, service, and `POST /api/v1/calendars/:calendarId/categories` endpoint — no backend changes.

Closes pv-asqb.

## Changes

- **New trigger button** below the chip grid (and below the empty-state message), hidden during loading and error states
- **Reuses CategoryEditor modal** unchanged from the calendar-admin Categories page
- **Auto-selects** the new category and emits `categoriesChanged` so the parent event editor sees the change immediately
- **Restores focus** to the trigger button when the modal closes (WCAG 2.4.3 / 2.4.7)
- **Defensive dedupe** in `onCategorySaved` to compensate for `CategoryService.saveCategory()` already mutating the shared categoryStore array before the `saved` emit arrives

## Test plan

- [x] Unit tests pass (15/15 in category-selector.test.ts including new regression test for the dedupe)
- [x] Regression tests pass (edit_event.vue, edit-event-screen — 27/27)
- [x] Lint clean on changed files
- [x] Production build succeeds
- [x] Full E2E suite: 117/123 passing (only pre-existing email-related failures, unrelated)
- [x] Manual browser smoke test (Playwright MCP) verified:
  - Happy path: open editor → click button → modal opens → type name → save → exactly one chip added → auto-selected → focus returns to button
  - Cancel path: open modal → escape → no chip added → focus restored
  - Persistence: save event, reload, category persists and is still selected
  - Empty state: button renders below "No categories available" message
  - No listener accumulation across multiple inline creates

## Out of scope

Two follow-up beads filed for stylesheet drift cleanup that this change deliberately does not address:
- `pv-8yty` — consolidate ghost text-button into `_buttons.scss`
- `pv-zbk3` — semantic tokens + `[data-theme=dark]` migration for `category-selector.vue` and `category-editor.vue`