### PR TITLE
fix(orchestrators): drop --bare flag so subagents reuse OAuth creds (pv-7bgc)

### DIFF
--- a/.claude/orchestrators/README.md
+++ b/.claude/orchestrators/README.md
@@ -36,12 +36,15 @@ tsx .claude/orchestrators/process-backlog.ts
 
 Every `claude -p` invocation uses:
 
-- `--bare` — skip SessionStart hooks
 - `--permission-mode bypassPermissions` — autonomous execution
 - `--no-session-persistence` — don't pollute resumable sessions list
 - `--agent <name>` — pick agent from `.claude/agents/`
 - `--json-schema <path>` — enforce structured output (omitted for prose-output agents)
 - `--max-budget-usd <N>` — per-dispatch cost ceiling
+
+`--bare` is intentionally **not** used. It disables keychain reads, forcing
+`ANTHROPIC_API_KEY` auth only. Without the flag, subagents reuse the parent
+session's OAuth credentials (e.g. Claude Max), which is what most users want.
 
 ## Logs
 

--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -313,7 +313,6 @@ function buildArgs(params: {
   isRetry: boolean;
 }): string[] {
   const args = [
-    '--bare',
     '--permission-mode', 'bypassPermissions',
     '--no-session-persistence',
     '--agent', params.agent,

--- a/.claude/orchestrators/test/unit/dispatch.test.ts
+++ b/.claude/orchestrators/test/unit/dispatch.test.ts
@@ -151,7 +151,7 @@ describe('dispatch', () => {
     expect(mockSpawnFn).toHaveBeenCalledTimes(1);
     const [bin, args] = mockSpawnFn.mock.calls[0];
     expect(bin).toContain('claude');
-    expect(args).toContain('--bare');
+    expect(args).not.toContain('--bare');
     expect(args).toContain('--permission-mode');
     expect(args).toContain('bypassPermissions');
     expect(args).toContain('--no-session-persistence');


### PR DESCRIPTION
## Summary

- The `/process-backlog` orchestrator was dispatching every subagent with `--bare`, which per `claude --help` explicitly disables keychain reads and forces `ANTHROPIC_API_KEY`-only auth.
- For users authenticated through the Claude Max OAuth flow (credentials in `security find-generic-password -s "Claude Code-credentials"`), every dispatched agent immediately bailed with `Not logged in · Please run /login` — the orchestrator halted before completing Phase 3.
- Removing `--bare` lets subagents inherit the parent session's OAuth credentials. Trade-off: the subagent sees SessionStart hooks, plugins, and `CLAUDE.md` auto-discovery. Worth it to make the orchestrator actually run on a Max subscription.

## Repro

```
$ echo hi | claude --bare -p -
Not logged in · Please run /login
$ echo hi | claude -p -
ok
```

Run log from the failed session: `.claude/orchestrators/logs/20260417T055515-a3c2/phase-3-shape.log`.

## Test plan

- [x] `npx vitest run .claude/orchestrators/test/unit/dispatch.test.ts` — 42/42 pass
- [ ] Re-run `/process-backlog` end-to-end with a bead to confirm subagents authenticate and Phase 3 completes