### PR TITLE
fix(orchestrators): parse raw advisor dispatch output (pv-p08z)

### DIFF
--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -574,8 +574,10 @@ export function buildAdvisorPrompt(
     '',
     '## Output format',
     '',
-    'Respond with JSON matching the advisor-verdict schema:',
-    '```json',
+    'Respond with ONLY a single JSON object matching the advisor-verdict schema.',
+    'Do not include prose, explanations, or markdown fences — the orchestrator parses your full stdout as JSON.',
+    '',
+    'Schema:',
     '{',
     `  "agent": "${advisorName}",`,
     '  "verdict": "clean" | "refinement-needed" | "escalate",',
@@ -583,8 +585,53 @@ export function buildAdvisorPrompt(
     '  "recommendations": ["..."],',
     `  "shapedBeadId": "${beadId}"`,
     '}',
-    '```',
   ].join('\n');
+}
+
+/**
+ * Extract and parse an AdvisorVerdict from raw dispatch output.
+ *
+ * Advisors are dispatched without a --json-schema, so dispatch() resolves
+ * with raw stdout (a string). Agents often return prose followed by a
+ * ```json fenced block; this helper tolerates both pure JSON and
+ * prose-wrapped JSON, using the last fenced block when present.
+ *
+ * Returns the parsed verdict, or null if nothing parseable was found.
+ */
+export function parseAdvisorVerdict(raw: unknown): AdvisorVerdict | null {
+  if (raw && typeof raw === 'object' && 'verdict' in (raw as Record<string, unknown>)) {
+    return raw as AdvisorVerdict;
+  }
+  if (typeof raw !== 'string') return null;
+
+  const candidates: string[] = [];
+  const fenceRegex = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRegex.exec(raw)) !== null) {
+    candidates.push(match[1].trim());
+  }
+  candidates.push(raw.trim());
+
+  for (const candidate of candidates.reverse()) {
+    if (!candidate) continue;
+    try {
+      const parsed = JSON.parse(candidate) as unknown;
+      if (parsed && typeof parsed === 'object' && 'verdict' in (parsed as Record<string, unknown>)) {
+        const verdict = parsed as Partial<AdvisorVerdict>;
+        return {
+          agent: typeof verdict.agent === 'string' ? verdict.agent : 'unknown',
+          verdict: (verdict.verdict ?? 'refinement-needed') as AdvisorVerdict['verdict'],
+          concerns: Array.isArray(verdict.concerns) ? verdict.concerns : [],
+          recommendations: Array.isArray(verdict.recommendations) ? verdict.recommendations : [],
+          ...(verdict.shapedBeadId ? { shapedBeadId: verdict.shapedBeadId } : {}),
+        };
+      }
+    }
+    catch {
+      // try next candidate
+    }
+  }
+  return null;
 }
 
 /**
@@ -636,12 +683,32 @@ export async function fanOutAdvisors(
     const advisorName = advisors[i].name;
 
     if (result.status === 'fulfilled') {
+      const parsed = parseAdvisorVerdict(result.value);
+      if (parsed) {
+        const normalized: AdvisorVerdict = {
+          ...parsed,
+          agent: advisorName,
+        };
+        ctx.logger.appendRunJson({
+          event: 'advisor_verdict_received',
+          agent: advisorName,
+          verdict: normalized.verdict,
+        });
+        return normalized;
+      }
+
+      const reason = `Advisor "${advisorName}" returned unparseable output`;
       ctx.logger.appendRunJson({
-        event: 'advisor_verdict_received',
+        event: 'advisor_dispatch_failed',
         agent: advisorName,
-        verdict: result.value.verdict,
+        reason,
       });
-      return result.value;
+      return {
+        agent: advisorName,
+        verdict: 'escalate' as const,
+        concerns: [reason],
+        recommendations: [],
+      };
     }
 
     // Failed dispatch: create a synthetic escalate verdict

--- a/.claude/orchestrators/test/unit/dispatch.test.ts
+++ b/.claude/orchestrators/test/unit/dispatch.test.ts
@@ -12,6 +12,7 @@ import {
   spawnCmd,
   fanOutAdvisors,
   buildAdvisorPrompt,
+  parseAdvisorVerdict,
   ADVISOR_BUDGET_DEFAULT,
   ADVISOR_TIMEOUT_MS,
   type DispatchOptions,
@@ -778,5 +779,152 @@ describe('fanOutAdvisors', () => {
     );
 
     expect(report.phase).toBe('phase-5-analyze');
+  });
+
+  // Regression: production dispatch() returns raw stdout strings for prose
+  // agents. Before the fix, fanOutAdvisors assumed parsed objects and crashed
+  // on `.concerns.map(...)` when any verdict was non-clean.
+  it('should parse raw JSON string output from fulfilled dispatch', async () => {
+    const ctx = makeCtx(logStub);
+    const advisors = [makeAdvisor('security-advisor')];
+    const rawJson = JSON.stringify({
+      agent: 'security-advisor',
+      verdict: 'refinement-needed',
+      concerns: ['token leak risk'],
+      recommendations: ['rotate keys'],
+    });
+    const deps: FanOutDeps = { dispatchFn: vi.fn().mockResolvedValue(rawJson) };
+
+    const report = await fanOutAdvisors(
+      advisors, 'pv-test-1', 'context', 'phase-3-shape', ctx, PhaseName.ShapeAdvisors, deps,
+    );
+
+    expect(report.overallVerdict).toBe('refinement-needed');
+    expect(report.advisors[0].verdict).toBe('refinement-needed');
+    expect(report.advisors[0].concerns).toEqual(['token leak risk']);
+    expect(report.summary).toContain('token leak risk');
+  });
+
+  it('should tolerate prose-wrapped JSON fenced block in advisor output', async () => {
+    const ctx = makeCtx(logStub);
+    const advisors = [makeAdvisor('stylesheet-advisor')];
+    const proseWithFence = [
+      '**Stylesheet Standards Consulted:** `structure.md`',
+      '',
+      'Evaluation summary: the spec looks clean.',
+      '',
+      '```json',
+      '{',
+      '  "agent": "stylesheet-advisor",',
+      '  "verdict": "clean",',
+      '  "concerns": [],',
+      '  "recommendations": []',
+      '}',
+      '```',
+    ].join('\n');
+    const deps: FanOutDeps = { dispatchFn: vi.fn().mockResolvedValue(proseWithFence) };
+
+    const report = await fanOutAdvisors(
+      advisors, 'pv-test-1', 'context', 'phase-3-shape', ctx, PhaseName.ShapeAdvisors, deps,
+    );
+
+    expect(report.overallVerdict).toBe('clean');
+    expect(report.advisors[0].verdict).toBe('clean');
+  });
+
+  it('should synthesize escalate verdict when output is unparseable', async () => {
+    const ctx = makeCtx(logStub);
+    const advisors = [makeAdvisor('consistency-advisor')];
+    const deps: FanOutDeps = { dispatchFn: vi.fn().mockResolvedValue('just some prose with no json') };
+
+    const report = await fanOutAdvisors(
+      advisors, 'pv-test-1', 'context', 'phase-3-shape', ctx, PhaseName.ShapeAdvisors, deps,
+    );
+
+    expect(report.advisors[0].verdict).toBe('escalate');
+    expect(report.advisors[0].concerns[0]).toMatch(/unparseable/i);
+    const failedEntry = logStub.runJsonEntries.find(
+      e => e.event === 'advisor_dispatch_failed' && e.agent === 'consistency-advisor',
+    );
+    expect(failedEntry).toBeDefined();
+  });
+
+  // Regression: repro of the pv-404l run crash. One advisor times out
+  // (Promise.allSettled rejection -> synthetic escalate) while sibling
+  // advisors return prose strings. Aggregation must not throw.
+  it('should not crash when mixing fulfilled string verdicts and a timeout', async () => {
+    const ctx = makeCtx(logStub);
+    const advisors = [
+      makeAdvisor('complexity-advisor'),
+      makeAdvisor('consistency-advisor'),
+      makeAdvisor('testing-advisor'),
+    ];
+    const cleanProse = [
+      'Quick note before the JSON:',
+      '```json',
+      '{"agent":"complexity-advisor","verdict":"clean","concerns":[],"recommendations":[]}',
+      '```',
+    ].join('\n');
+    const refinementProse = [
+      '```json',
+      '{"agent":"testing-advisor","verdict":"refinement-needed","concerns":["add a test"],"recommendations":["write it"]}',
+      '```',
+    ].join('\n');
+    const dispatchFn = vi.fn()
+      .mockResolvedValueOnce(cleanProse)
+      .mockRejectedValueOnce(new DispatchTimeoutError('consistency-advisor', 120_000))
+      .mockResolvedValueOnce(refinementProse);
+
+    const report = await fanOutAdvisors(
+      advisors, 'pv-404l', 'context', 'phase-3-shape', ctx, PhaseName.ShapeAdvisors, { dispatchFn },
+    );
+
+    expect(report.overallVerdict).toBe('refinement-needed');
+    expect(report.advisors).toHaveLength(3);
+    expect(report.advisors[0].verdict).toBe('clean');
+    expect(report.advisors[1].verdict).toBe('escalate');
+    expect(report.advisors[2].verdict).toBe('refinement-needed');
+  });
+});
+
+describe('parseAdvisorVerdict', () => {
+  it('returns a verdict object unchanged when passed a parsed object', () => {
+    const input: AdvisorVerdict = {
+      agent: 'security-advisor',
+      verdict: 'clean',
+      concerns: [],
+      recommendations: [],
+    };
+    expect(parseAdvisorVerdict(input)).toEqual(input);
+  });
+
+  it('parses pure JSON string output', () => {
+    const raw = '{"agent":"a","verdict":"clean","concerns":[],"recommendations":[]}';
+    const parsed = parseAdvisorVerdict(raw);
+    expect(parsed?.verdict).toBe('clean');
+  });
+
+  it('parses JSON wrapped in prose and a fenced block', () => {
+    const raw = 'Preamble prose.\n```json\n{"verdict":"clean","concerns":[],"recommendations":[]}\n```\nTrailing';
+    const parsed = parseAdvisorVerdict(raw);
+    expect(parsed?.verdict).toBe('clean');
+  });
+
+  it('defaults missing arrays to empty when parsing partial verdicts', () => {
+    const raw = '{"verdict":"refinement-needed"}';
+    const parsed = parseAdvisorVerdict(raw);
+    expect(parsed?.verdict).toBe('refinement-needed');
+    expect(parsed?.concerns).toEqual([]);
+    expect(parsed?.recommendations).toEqual([]);
+  });
+
+  it('returns null for unparseable strings', () => {
+    expect(parseAdvisorVerdict('just prose, no json')).toBeNull();
+  });
+
+  it('returns null for non-string, non-verdict objects', () => {
+    expect(parseAdvisorVerdict(42)).toBeNull();
+    expect(parseAdvisorVerdict({ foo: 'bar' })).toBeNull();
+    expect(parseAdvisorVerdict(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `fanOutAdvisors` assumed `dispatch()` resolved with parsed `AdvisorVerdict` objects, but since advisors dispatch without a `schemaPath`, `dispatch()` actually resolves with raw stdout strings. A timed-out sibling advisor pushed aggregation past the `'clean'` filter, and `.flatMap(v => v.concerns.map(...))` crashed on the strings (no `.concerns` property). This was the `Cannot read properties of undefined (reading 'map')` seen in the pv-404l run.
- Adds a `parseAdvisorVerdict` helper that accepts parsed objects or extracts the last fenced ```json``` block from prose output, with a whole-string fallback. Parse failures become synthetic `escalate` verdicts with real `concerns`, so nothing downstream ever sees `undefined`.
- Tightens the advisor prompt to request a single bare JSON object (no prose, no fences).

## Test plan

- [x] `npx vitest run .claude/orchestrators/test/unit/dispatch.test.ts` — 52/52 pass (10 new)
- [x] Regression test reproduces the pv-404l failure mode (one timeout + two prose-wrapped string verdicts) and confirms the aggregated report is now correctly `refinement-needed` instead of throwing
- [x] New tests cover: pure-JSON output, prose-wrapped fenced JSON, partial verdicts (missing arrays), unparseable prose, non-string/non-object inputs, and the mixed timeout/string scenario

Closes pv-p08z.