### PR TITLE
fix(orchestrators): plumb advisor feedback to re-shape + cap refinement loop (pv-jm78)

### DIFF
--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -47,7 +47,12 @@ import {
 export interface PhaseCtx extends RunContext {
   dryRun: boolean;
   refinementReport?: RefinementReport;
+  /** Per-phase refinement-loop counter, keyed by logTag (e.g. 'phase-3.5-advisors'). */
+  refinementRounds?: Record<string, number>;
 }
+
+/** Max refinement rounds before an advisor loop escalates to needs-human. */
+export const REFINEMENT_ROUND_CAP_DEFAULT = 2;
 
 /** Return type of every phase runner. */
 export interface PhaseReturn {
@@ -361,10 +366,31 @@ async function runAdvisorPass(
     return { next: 'halt', ctx };
   }
 
-  // Refinement needed -> loop back
+  // Refinement needed -> increment round counter, escalate if cap exceeded.
+  const cap = parseInt(process.env.ORCH_REFINEMENT_ROUND_CAP ?? '', 10) || REFINEMENT_ROUND_CAP_DEFAULT;
+  ctx.refinementRounds = ctx.refinementRounds ?? {};
+  const previousRounds = ctx.refinementRounds[config.logTag] ?? 0;
+  const nextRound = previousRounds + 1;
+  ctx.refinementRounds[config.logTag] = nextRound;
+
+  if (nextRound >= cap) {
+    const reason = `unresolved after ${nextRound} refinement round(s): ${report.summary}`;
+    ctx.logger.appendRunJson({
+      event: `${config.logTag.replace(/\./g, '_')}_cap_exceeded`,
+      beadId: ctx.beadId,
+      round: nextRound,
+      cap,
+      reason,
+    });
+    escalate(ctx.beadId, reason, config.escalateTag, config.logTag, deps, ctx);
+    return { next: 'halt', ctx };
+  }
+
   ctx.logger.appendRunJson({
     event: `${config.logTag.replace(/\./g, '_')}_refinement_needed`,
     beadId: ctx.beadId,
+    round: nextRound,
+    cap,
     summary: report.summary,
   });
   ctx.refinementReport = report;
@@ -417,7 +443,40 @@ export function routeToExecution(issueType: string): PhaseName {
 // Prompt builders
 // =============================================================================
 
-export function buildShapePrompt(beadId: string): string {
+/**
+ * Render a RefinementReport as a markdown section to splice into a re-dispatch
+ * prompt. Returns empty string when the report is absent or clean (belt +
+ * braces — callers only pass non-clean reports).
+ */
+export function formatRefinementFeedback(report?: RefinementReport): string {
+  if (!report || report.overallVerdict === 'clean') return '';
+  const nonClean = report.advisors.filter(v => v.verdict !== 'clean');
+  if (nonClean.length === 0) return '';
+
+  const lines: string[] = ['## Refinement feedback from prior review', ''];
+  lines.push(
+    'Your previous output was reviewed by advisors and flagged for refinement.',
+    'Address each concern below when re-running — update the relevant `bd` fields',
+    '(design, acceptance, notes) so the next advisor pass can approve.',
+    '',
+  );
+  for (const v of nonClean) {
+    lines.push(`### [${v.agent}] verdict: ${v.verdict}`);
+    if (v.concerns.length > 0) {
+      lines.push('', 'Concerns:');
+      for (const c of v.concerns) lines.push(`- ${c}`);
+    }
+    if (v.recommendations.length > 0) {
+      lines.push('', 'Recommendations:');
+      for (const r of v.recommendations) lines.push(`- ${r}`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function buildShapePrompt(beadId: string, refinementReport?: RefinementReport): string {
+  const feedback = formatRefinementFeedback(refinementReport);
   return [
     `# Shape bead: ${beadId}`,
     '',
@@ -436,6 +495,7 @@ export function buildShapePrompt(beadId: string): string {
     '  actionable signal (no verb, no object, no clear outcome), do NOT',
     '  fabricate a design. Return status `escalate` with the reason.',
     '- On success, return status `shaped` with a one-line summary.',
+    ...(feedback ? ['', feedback] : []),
     '',
     '## Output format',
     '',
@@ -462,7 +522,12 @@ export function buildDecomposePrompt(beadId: string, reasons: string[]): string 
   ].join('\n');
 }
 
-export function buildAnalyzePrompt(epicId: string, unenrichedIds: string[]): string {
+export function buildAnalyzePrompt(
+  epicId: string,
+  unenrichedIds: string[],
+  refinementReport?: RefinementReport,
+): string {
+  const feedback = formatRefinementFeedback(refinementReport);
   return [
     `Read \`.claude/commands/analyze-bead.md\` and run its full process for \`${epicId}\` autonomously.`,
     '',
@@ -471,6 +536,7 @@ export function buildAnalyzePrompt(epicId: string, unenrichedIds: string[]): str
     'Skip Phase 1.5 (decomposition is already complete); start from Phase 2 (Map Hierarchy) through Phase 5 (Store Analysis).',
     '',
     'No AskUserQuestion -- flag issues rather than pausing.',
+    ...(feedback ? ['', feedback] : []),
     '',
     'Report execution waves and confirm every leaf\'s notes contains an `Implementation Context` block.',
   ].join('\n');
@@ -577,7 +643,7 @@ export async function assessState(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<
  * Phase 3 — Auto-shape if needed (dispatches shape-bead subagent).
  */
 export async function shape(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<PhaseReturn> {
-  const prompt = buildShapePrompt(ctx.beadId);
+  const prompt = buildShapePrompt(ctx.beadId, ctx.refinementReport);
 
   ctx.logger.appendRunJson({
     event: 'shape_dispatched',
@@ -739,7 +805,7 @@ export async function analyze(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phas
   }
 
   // Step 4: Dispatch analyze-bead subagent
-  const prompt = buildAnalyzePrompt(ctx.beadId, unenrichedIds);
+  const prompt = buildAnalyzePrompt(ctx.beadId, unenrichedIds, ctx.refinementReport);
 
   const { result: report, escalated } = await dispatchAgent<AnalyzeReport>(ctx, {
     agent: 'analyze-bead',

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -12,6 +12,10 @@ import {
   analyze,
   analyzeAdvisors,
   branch,
+  buildShapePrompt,
+  buildAnalyzePrompt,
+  formatRefinementFeedback,
+  REFINEMENT_ROUND_CAP_DEFAULT,
   PREFLIGHT_MESSAGES,
   GIT_SAFE_MESSAGES,
   type PhaseCtx,
@@ -20,7 +24,7 @@ import {
   type ShapeVerdict,
 } from '../../lib/phases.js';
 import { PhaseName, type RunLogger } from '../../lib/types.js';
-import { DispatchTimeoutError } from '../../lib/dispatch.js';
+import { DispatchTimeoutError, type RefinementReport, type DispatchOptions } from '../../lib/dispatch.js';
 
 // =============================================================================
 // Shared helpers
@@ -419,6 +423,40 @@ describe('shape', () => {
 
     expect(result.next).toBe('halt');
   });
+
+  // Regression: shape() used to build its prompt from beadId only,
+  // ignoring ctx.refinementReport. That made the refinement loop
+  // re-dispatch the agent with identical input each round.
+  it('threads ctx.refinementReport into the shape prompt on re-dispatch', async () => {
+    const report: RefinementReport = {
+      beadId: 'pv-test-1',
+      phase: 'phase-3-shape',
+      advisors: [{
+        agent: 'testing-advisor',
+        verdict: 'refinement-needed',
+        concerns: ['no tests planned for register.vue'],
+        recommendations: ['add register.vue.test.ts'],
+      }],
+      overallVerdict: 'refinement-needed',
+      summary: '1 concern from testing-advisor',
+    };
+
+    let capturedPrompt = '';
+    const spawn = seqSpawn(fakeSpawn(beadTextShaped(), '', 0));
+
+    await shape(makeCtx({ refinementReport: report }), {
+      dispatchFn: (async (opts: DispatchOptions) => {
+        capturedPrompt = opts.prompt;
+        return { beadId: 'pv-test-1', status: 'shaped', summary: 'ok' } as never;
+      }) as PhaseDeps['dispatchFn'],
+      spawnFn: spawn,
+    });
+
+    expect(capturedPrompt).toContain('Refinement feedback');
+    expect(capturedPrompt).toContain('testing-advisor');
+    expect(capturedPrompt).toContain('no tests planned for register.vue');
+    expect(capturedPrompt).toContain('add register.vue.test.ts');
+  });
 });
 
 // =============================================================================
@@ -740,5 +778,85 @@ describe('message constants', () => {
     for (const msg of Object.values(PREFLIGHT_MESSAGES)) {
       expect(msg).toContain('\u2014');
     }
+  });
+});
+
+// =============================================================================
+// Prompt builders + refinement feedback plumbing
+// =============================================================================
+
+function refinementReportFixture(): RefinementReport {
+  return {
+    beadId: 'pv-test-1',
+    phase: 'phase-3-shape',
+    advisors: [
+      { agent: 'testing-advisor', verdict: 'refinement-needed', concerns: ['missing test A'], recommendations: ['write test A'] },
+      { agent: 'stylesheet-advisor', verdict: 'clean', concerns: [], recommendations: [] },
+    ],
+    overallVerdict: 'refinement-needed',
+    summary: '1 concern from testing-advisor',
+  };
+}
+
+describe('formatRefinementFeedback', () => {
+  it('returns empty string when report is absent', () => {
+    expect(formatRefinementFeedback(undefined)).toBe('');
+  });
+
+  it('returns empty string when overallVerdict is clean', () => {
+    const clean: RefinementReport = {
+      beadId: 'pv-x', phase: 'phase-3-shape', advisors: [], overallVerdict: 'clean', summary: 'ok',
+    };
+    expect(formatRefinementFeedback(clean)).toBe('');
+  });
+
+  it('omits clean advisors and only surfaces non-clean feedback', () => {
+    const md = formatRefinementFeedback(refinementReportFixture());
+    expect(md).toContain('testing-advisor');
+    expect(md).toContain('missing test A');
+    expect(md).toContain('write test A');
+    expect(md).not.toContain('stylesheet-advisor');
+  });
+
+  it('includes both concerns and recommendations under labelled sections', () => {
+    const md = formatRefinementFeedback(refinementReportFixture());
+    expect(md).toMatch(/Concerns:/);
+    expect(md).toMatch(/Recommendations:/);
+  });
+});
+
+describe('buildShapePrompt', () => {
+  it('produces a prompt with no feedback section when no report is provided', () => {
+    const prompt = buildShapePrompt('pv-test-1');
+    expect(prompt).not.toContain('Refinement feedback');
+    expect(prompt).toContain('pv-test-1');
+  });
+
+  it('splices refinement feedback into the prompt when a report is provided', () => {
+    const prompt = buildShapePrompt('pv-test-1', refinementReportFixture());
+    expect(prompt).toContain('Refinement feedback');
+    expect(prompt).toContain('missing test A');
+  });
+});
+
+describe('buildAnalyzePrompt', () => {
+  it('produces a prompt with no feedback section when no report is provided', () => {
+    const prompt = buildAnalyzePrompt('pv-epic-1', ['pv-leaf-1']);
+    expect(prompt).not.toContain('Refinement feedback');
+    expect(prompt).toContain('pv-epic-1');
+  });
+
+  it('splices refinement feedback into the prompt when a report is provided', () => {
+    const report = { ...refinementReportFixture(), phase: 'phase-5-analyze' as const };
+    const prompt = buildAnalyzePrompt('pv-epic-1', ['pv-leaf-1'], report);
+    expect(prompt).toContain('Refinement feedback');
+    expect(prompt).toContain('missing test A');
+  });
+});
+
+describe('refinement round cap', () => {
+  it('has a default cap greater than 1', () => {
+    // >= 2 — the loop must allow at least one refinement round before escalating
+    expect(REFINEMENT_ROUND_CAP_DEFAULT).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

Two compounding bugs in the shape↔advisor refinement loop produced an unbounded loop in production (run `20260417T152313-44d4` cycled 10 times in 22 minutes before being killed):

1. **Feedback was never delivered.** `buildShapePrompt(beadId)` built from the bead id alone — it never read `ctx.refinementReport`. So when an advisor returned `refinement-needed`, the shape agent was re-dispatched with the **exact same 860-byte prompt**. Same input, same output, same verdict. The agent wasn't ignoring feedback — it was receiving none. Confirmed behaviorally: every shape dispatch in the stuck run had `promptLength: 860`.
2. **No iteration cap.** `runAdvisorPass` routed refinement-needed straight back to shape with no counter and no fallback, so a persistently non-clean verdict looped forever.

Fix both together — the cap alone would just convert every refinement cycle into a human-ticket; the feedback alone still needs a cap in case the agent can't converge.

### Changes

- `formatRefinementFeedback(report)` — new helper that renders non-clean advisor verdicts (with per-advisor concerns + recommendations) as a markdown ``## Refinement feedback from prior review`` section.
- `buildShapePrompt` and `buildAnalyzePrompt` now accept an optional `RefinementReport` and splice the feedback section into the prompt.
- `shape()` and `analyze()` runners pass `ctx.refinementReport` through so re-dispatches carry the prior round's concerns.
- Per-phase `refinementRounds` counter on `PhaseCtx`. `runAdvisorPass` increments it on the refinement path and escalates to `needs-human` after `REFINEMENT_ROUND_CAP_DEFAULT = 2` rounds. Overridable via `ORCH_REFINEMENT_ROUND_CAP` env var. A new `*_cap_exceeded` log event records round count and unresolved concerns.
- Escalation reason includes the unresolved advisor summary so a human knows what the agent couldn't fix.

## Test plan

- [x] `npx vitest run .claude/orchestrators/` — 220/220 pass (10 new)
- [x] `npx eslint .claude/orchestrators/lib/phases.ts .claude/orchestrators/test/unit/phases.test.ts` — 0 errors
- [x] `formatRefinementFeedback` tested against empty/clean/non-clean reports
- [x] `buildShapePrompt` + `buildAnalyzePrompt` tested with and without a refinement report
- [x] Regression test for `shape()` captures the dispatched prompt and asserts the refinement feedback (agent name, concerns, recommendations) is spliced in when `ctx.refinementReport` is set — this directly guards against the exact bug that produced the stuck run

Closes pv-jm78.

Related: #205 (the dispatch fix that exposed this loop by letting the advisor aggregation succeed 10 times).