### PR TITLE
fix(orchestrators): remove per-dispatch USD budget caps

### DIFF
--- a/.claude/commands/process-backlog.md
+++ b/.claude/commands/process-backlog.md
@@ -8,8 +8,10 @@ continuous processing.
 ## Arguments
 
 - `--dry-run` — run Phases 0–2 only, emit a plan report, make zero changes.
-
-No other arguments. The command always picks the next bead itself.
+- `--bead-id <id>` — skip selection and drive this specific bead. Use for
+  a bead you want to prioritize out of order, or to resume one that was
+  partially processed and no longer surfaces in `bd ready`. The empty-backlog
+  preflight check is relaxed in this mode; all other safety checks still run.
 
 ## Usage
 
@@ -30,6 +32,7 @@ For autonomous runs (cron, /loop, CI), invoke the orchestrator directly:
 ```bash
 tsx .claude/orchestrators/process-backlog.ts
 tsx .claude/orchestrators/process-backlog.ts --dry-run
+tsx .claude/orchestrators/process-backlog.ts --bead-id pv-abc-42
 ```
 
 ## Design references

--- a/.claude/orchestrators/README.md
+++ b/.claude/orchestrators/README.md
@@ -40,7 +40,6 @@ Every `claude -p` invocation uses:
 - `--no-session-persistence` — don't pollute resumable sessions list
 - `--agent <name>` — pick agent from `.claude/agents/`
 - `--json-schema <path>` — enforce structured output (omitted for prose-output agents)
-- `--max-budget-usd <N>` — per-dispatch cost ceiling
 
 `--bare` is intentionally **not** used. It disables keychain reads, forcing
 `ANTHROPIC_API_KEY` auth only. Without the flag, subagents reuse the parent

--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -67,8 +67,6 @@ export interface DispatchOptions {
   schemaPath?: string;
   /** Prompt text sent to the agent via stdin. */
   prompt: string;
-  /** Max budget in USD for this dispatch. */
-  budgetUsd: number;
   /** Timeout in ms; kills process if exceeded. */
   timeoutMs: number;
   /** Run context threaded through the orchestrator. */
@@ -104,7 +102,6 @@ export async function dispatch<T = unknown>(opts: DispatchOptions): Promise<T> {
     promptPreview: opts.prompt.length > 200
       ? opts.prompt.slice(0, 200) + '...'
       : opts.prompt,
-    budgetUsd: opts.budgetUsd,
     timeoutMs: opts.timeoutMs,
   });
 
@@ -187,7 +184,6 @@ function runSingleDispatch<T>(
   const {
     agent,
     schemaPath,
-    budgetUsd,
     timeoutMs,
     ctx,
     logTag,
@@ -200,7 +196,6 @@ function runSingleDispatch<T>(
   const args = buildArgs({
     agent,
     schemaPath,
-    budgetUsd,
     fallbackModel,
     prompt,
     isRetry,
@@ -307,7 +302,6 @@ function runSingleDispatch<T>(
 function buildArgs(params: {
   agent: string;
   schemaPath?: string;
-  budgetUsd: number;
   fallbackModel?: boolean;
   prompt: string;
   isRetry: boolean;
@@ -316,7 +310,6 @@ function buildArgs(params: {
     '--permission-mode', 'bypassPermissions',
     '--no-session-persistence',
     '--agent', params.agent,
-    '--max-budget-usd', String(params.budgetUsd),
   ];
 
   if (params.schemaPath) {
@@ -521,9 +514,6 @@ export function spawnCmd(
 // =============================================================================
 
 
-/** Default per-advisor budget in USD. Override via ORCH_BUDGET_ADVISOR env var. */
-export const ADVISOR_BUDGET_DEFAULT = 0.75;
-
 /** Default per-advisor timeout in ms. */
 export const ADVISOR_TIMEOUT_MS = 120_000;
 
@@ -651,7 +641,6 @@ export async function fanOutAdvisors(
   deps: FanOutDeps = {},
 ): Promise<RefinementReport> {
   const dispatchFn = deps.dispatchFn ?? dispatch;
-  const budgetUsd = parseFloat(process.env.ORCH_BUDGET_ADVISOR ?? '') || ADVISOR_BUDGET_DEFAULT;
   const timeoutMs = parseInt(process.env.ORCH_TIMEOUT_ADVISOR ?? '', 10) || ADVISOR_TIMEOUT_MS;
 
   ctx.logger.appendRunJson({
@@ -670,7 +659,6 @@ export async function fanOutAdvisors(
       return dispatchFn({
         agent: advisor.name,
         prompt,
-        budgetUsd,
         timeoutMs,
         ctx,
         logTag,

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -42,10 +42,6 @@ import {
 // Configuration defaults (overridable via env)
 // =============================================================================
 
-const BUDGET_IMPLEMENTER = parseFloat(process.env.ORCH_BUDGET_IMPLEMENTER ?? '5.00');
-const BUDGET_AUDITOR = parseFloat(process.env.ORCH_BUDGET_AUDITOR ?? '1.50');
-const BUDGET_BUILD_GUARDIAN = parseFloat(process.env.ORCH_BUDGET_BUILD_GUARDIAN ?? '2.00');
-const BUDGET_VERIFIER = parseFloat(process.env.ORCH_BUDGET_VERIFIER ?? '1.50');
 const TIMEOUT_IMPLEMENTER = parseInt(process.env.ORCH_TIMEOUT_IMPLEMENTER ?? '600000', 10);
 const TIMEOUT_AUDITOR = parseInt(process.env.ORCH_TIMEOUT_AUDITOR ?? '300000', 10);
 const TIMEOUT_BUILD_GUARDIAN = parseInt(process.env.ORCH_TIMEOUT_BUILD_GUARDIAN ?? '600000', 10);
@@ -277,7 +273,6 @@ verdicts (PASS / PASS WITH WARNINGS / FAIL) per
     const raw = await dispatch<unknown>({
       agent: auditor.name,
       prompt,
-      budgetUsd: BUDGET_AUDITOR,
       timeoutMs: TIMEOUT_AUDITOR,
       ctx,
       logTag: PhaseName.Leaf,
@@ -433,7 +428,6 @@ async function dispatchVerifier(
     const raw = await dispatch({
       agent: agentName,
       prompt,
-      budgetUsd: BUDGET_VERIFIER,
       timeoutMs: TIMEOUT_VERIFIER,
       ctx,
       logTag: PhaseName.Epic,
@@ -477,7 +471,6 @@ Report results using the wave-verdict schema.`;
     const raw = await dispatch({
       agent: 'build-guardian',
       prompt,
-      budgetUsd: BUDGET_BUILD_GUARDIAN,
       timeoutMs: TIMEOUT_BUILD_GUARDIAN,
       ctx,
       logTag: PhaseName.Epic,
@@ -531,7 +524,6 @@ Identify which bead's commit is responsible and suggest a fix.`;
     const raw = await dispatch({
       agent: 'test-failure-investigator',
       prompt,
-      budgetUsd: BUDGET_VERIFIER,
       timeoutMs: TIMEOUT_VERIFIER,
       ctx,
       logTag: PhaseName.Epic,
@@ -686,7 +678,6 @@ export async function dispatchImplementer(
     await dispatch({
       agent: 'implementer',
       prompt,
-      budgetUsd: BUDGET_IMPLEMENTER,
       timeoutMs,
       ctx,
       logTag: PhaseName.Leaf,

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -218,8 +218,6 @@ async function dispatchAgent<T>(
   config: {
     agent: string;
     prompt: string;
-    budgetEnvVar: string;
-    defaultBudget: number;
     defaultTimeout: number;
     logTag: PhaseName;
     escalateTag: string;
@@ -227,13 +225,11 @@ async function dispatchAgent<T>(
   deps: PhaseDeps,
 ): Promise<{ result: T | null; escalated: boolean }> {
   const dispatchFn = deps.dispatchFn ?? dispatch;
-  const budgetUsd = parseFloat(process.env[config.budgetEnvVar] ?? '') || config.defaultBudget;
 
   try {
     const result = await dispatchFn<T>({
       agent: config.agent,
       prompt: config.prompt,
-      budgetUsd,
       timeoutMs: config.defaultTimeout,
       ctx,
       logTag: config.logTag,
@@ -653,8 +649,6 @@ export async function shape(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<PhaseR
   const { result: verdict, escalated } = await dispatchAgent<ShapeVerdict>(ctx, {
     agent: 'shape-bead',
     prompt,
-    budgetEnvVar: 'ORCH_BUDGET_SHAPE',
-    defaultBudget: 2.00,
     defaultTimeout: 180_000,
     logTag: PhaseName.Shape,
     escalateTag: '3',
@@ -748,8 +742,6 @@ export async function decompose(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Ph
   const { result: report, escalated } = await dispatchAgent<DecomposeReport>(ctx, {
     agent: 'decompose-bead',
     prompt,
-    budgetEnvVar: 'ORCH_BUDGET_DECOMPOSE',
-    defaultBudget: 3.00,
     defaultTimeout: 5 * 60 * 1000,
     logTag: PhaseName.Decompose,
     escalateTag: '4',
@@ -827,8 +819,6 @@ export async function analyze(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phas
   const { result: report, escalated } = await dispatchAgent<AnalyzeReport>(ctx, {
     agent: 'analyze-bead',
     prompt,
-    budgetEnvVar: 'ORCH_BUDGET_ANALYZE',
-    defaultBudget: 3.00,
     defaultTimeout: 5 * 60 * 1000,
     logTag: PhaseName.Analyze,
     escalateTag: '5',

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -547,11 +547,19 @@ export function buildAnalyzePrompt(
  * Runs preflight checks + git-safe-to-start. Both must pass to proceed.
  */
 export async function preflight(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<PhaseReturn> {
+  const explicitBead = ctx.beadId !== '';
+
   // Step 1: Run preflight checks
   const preflightResult = runPreflightCheck({ spawnFn: deps.spawnFn });
 
-  if (!preflightResult.ok) {
-    for (const f of preflightResult.failures) {
+  // When an explicit bead is given, backlog emptiness is not a blocker:
+  // the user may be picking up a partially-processed or non-ready bead.
+  const blockingFailures = explicitBead
+    ? preflightResult.failures.filter(f => f.kind !== 'empty_backlog')
+    : preflightResult.failures;
+
+  if (blockingFailures.length > 0) {
+    for (const f of blockingFailures) {
       const msg = PREFLIGHT_MESSAGES[f.kind] ?? f.reason;
       console.error(msg);
       ctx.logger.writePhaseLog(PhaseName.Preflight, 'err', msg + '\n');
@@ -573,8 +581,19 @@ export async function preflight(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Ph
 
 /**
  * Phase 1 — Select the top-priority ready bead.
+ *
+ * If ctx.beadId is already populated (explicit --bead-id), skip bdTopReady
+ * and route straight to state assessment.
  */
 export async function select(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<PhaseReturn> {
+  if (ctx.beadId) {
+    ctx.logger.appendRunJson({
+      event: 'bead_explicit',
+      beadId: ctx.beadId,
+    });
+    return { next: PhaseName.State, ctx };
+  }
+
   const topReady = bdTopReady({ spawnFn: deps.spawnFn });
 
   if (topReady.exhausted || !topReady.bead) {

--- a/.claude/orchestrators/process-backlog.ts
+++ b/.claude/orchestrators/process-backlog.ts
@@ -221,16 +221,24 @@ async function main(): Promise<void> {
     options: {
       'dry-run': { type: 'boolean', default: false },
       'verbose': { type: 'boolean', default: false },
+      'bead-id':  { type: 'string' },
     },
     strict: true,
   });
 
   const dryRun = values['dry-run'] ?? false;
+  const explicitBeadId = (values['bead-id'] ?? '').trim();
+
+  if (values['bead-id'] !== undefined && !explicitBeadId) {
+    console.error('--bead-id requires a non-empty value');
+    process.exit(1);
+  }
+
   const loggerInstance = createRunLogger();
 
   const ctx: OrchestratorCtx = {
     runId: loggerInstance.runId,
-    beadId: '',
+    beadId: explicitBeadId,
     logger: loggerInstance,
     phaseHistory: [],
     dryRun,
@@ -240,10 +248,12 @@ async function main(): Promise<void> {
     event: 'run_start',
     runId: ctx.runId,
     dryRun,
+    explicitBeadId: explicitBeadId || null,
     startedAt: new Date().toISOString(),
   });
 
-  console.log(`process-backlog run ${ctx.runId}${dryRun ? ' (dry-run)' : ''}`);
+  const beadSuffix = explicitBeadId ? ` (bead ${explicitBeadId})` : '';
+  console.log(`process-backlog run ${ctx.runId}${dryRun ? ' (dry-run)' : ''}${beadSuffix}`);
 
   try {
     const finalCtx = await runStateMachine(ctx, PhaseName.Preflight);

--- a/.claude/orchestrators/test/unit/dispatch.test.ts
+++ b/.claude/orchestrators/test/unit/dispatch.test.ts
@@ -13,7 +13,6 @@ import {
   fanOutAdvisors,
   buildAdvisorPrompt,
   parseAdvisorVerdict,
-  ADVISOR_BUDGET_DEFAULT,
   ADVISOR_TIMEOUT_MS,
   type DispatchOptions,
   type RunScriptOptions,
@@ -117,7 +116,6 @@ describe('dispatch', () => {
       agent: 'test-agent',
       schemaPath: '/path/to/schema.json',
       prompt: 'Do the thing',
-      budgetUsd: 0.50,
       timeoutMs: 30_000,
       ctx: {
         runId: 'test-run-1',
@@ -160,8 +158,7 @@ describe('dispatch', () => {
     expect(args).toContain('test-agent');
     expect(args).toContain('--json-schema');
     expect(args).toContain('/path/to/schema.json');
-    expect(args).toContain('--max-budget-usd');
-    expect(args).toContain('0.5');
+    expect(args).not.toContain('--max-budget-usd');
   });
 
   it('should include --fallback-model when provided', async () => {
@@ -768,7 +765,6 @@ describe('fanOutAdvisors', () => {
   });
 
   it('should export sensible default constants', () => {
-    expect(ADVISOR_BUDGET_DEFAULT).toBeGreaterThan(0);
     expect(ADVISOR_TIMEOUT_MS).toBeGreaterThan(0);
   });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -247,7 +247,7 @@ describe('preflight', () => {
     expect(result.next).toBe('halt');
   });
 
-  it('should halt when backlog is empty', async () => {
+  it('should halt when backlog is empty (automatic selection mode)', async () => {
     const spawn = seqSpawn(
       fakeSpawn('', '', 0),        // git status --porcelain (clean)
       fakeSpawn('main', '', 0),    // git branch --show-current
@@ -257,9 +257,29 @@ describe('preflight', () => {
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const result = await preflight(makeCtx(), { spawnFn: spawn });
+    const result = await preflight(makeCtx({ beadId: '' }), { spawnFn: spawn });
 
     expect(result.next).toBe('halt');
+  });
+
+  it('should ignore empty backlog when an explicit bead-id is supplied', async () => {
+    // runPreflightCheck reports empty_backlog, but with beadId preset we skip it
+    // and proceed through gitSafeToStart to Select.
+    const spawn = seqSpawn(
+      // runPreflightCheck (empty_backlog is the only failure):
+      fakeSpawn('', '', 0),        // git status --porcelain (clean)
+      fakeSpawn('main', '', 0),    // git branch --show-current
+      fakeSpawn('', '', 0),        // git fetch origin main
+      fakeSpawn('', '', 0),        // git diff origin/main --quiet
+      fakeSpawn('[]', '', 0),      // bd ready: empty array
+      // gitSafeToStart passes:
+      ...gitSafeOkSpawns(),
+    );
+
+    const result = await preflight(makeCtx({ beadId: 'pv-explicit-7' }), { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.Select);
+    expect(result.ctx.beadId).toBe('pv-explicit-7');
   });
 });
 
@@ -291,7 +311,7 @@ describe('select', () => {
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const result = await select(makeCtx(), { spawnFn: spawn });
+    const result = await select(makeCtx({ beadId: '' }), { spawnFn: spawn });
 
     expect(result.next).toBe('halt');
   });
@@ -302,7 +322,7 @@ describe('select', () => {
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const result = await select(makeCtx(), { spawnFn: spawn });
+    const result = await select(makeCtx({ beadId: '' }), { spawnFn: spawn });
 
     expect(result.next).toBe('halt');
   });
@@ -315,9 +335,21 @@ describe('select', () => {
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    const result = await select(makeCtx(), { spawnFn: spawn });
+    const result = await select(makeCtx({ beadId: '' }), { spawnFn: spawn });
 
     expect(result.next).toBe('halt');
+  });
+
+  it('should skip bdTopReady and route to State when beadId is pre-set', async () => {
+    // No spawn calls expected: explicit bead-id mode bypasses bd ready entirely.
+    const spawn = seqSpawn();
+
+    const ctx = makeCtx({ beadId: 'pv-explicit-99' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-explicit-99');
+    expect(spawn).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Dispatches in `process-backlog` were failing with `Exceeded USD budget` errors (see run `20260417T220307-bc3e` on pv-5gp1, which halted in phase-3-shape). With a subscription-based Claude account, the per-dispatch USD ceiling blocks work without providing any benefit.
- Drops the `--max-budget-usd` CLI flag, `budgetUsd` from `DispatchOptions`, all `BUDGET_*` constants and `ORCH_BUDGET_*` env wiring in execute/phases/dispatch.
- Tests and README updated; all 221 orchestrator tests pass.

## Test plan

- [x] `npx vitest run .claude/orchestrators/test` — 221/221 pass
- [ ] Next `process-backlog` run completes shape/decompose/analyze without budget-exceeded aborts