### PR TITLE
fix(frontend): restore visible error messages on logged-out forms (pv-404l)

### DIFF
--- a/src/client/components/logged_out/accept_invite.vue
+++ b/src/client/components/logged_out/accept_invite.vue
@@ -52,7 +52,7 @@
     <h3>{{ t('new_account_password_title') }}</h3>
     <p class="instructions">{{ t('registration_new_password') }}</p>
 
-    <ErrorAlert :error="state.passwordError ? translateError(state.passwordError) : (state.form_error ? translateError(state.form_error) : '')" />
+    <ErrorAlert id="accept-invite-error" :error="state.passwordError ? translateError(state.passwordError) : (state.form_error ? translateError(state.form_error) : '')" />
 
     <div class="form-stack">
       <label for="invite-password" class="sr-only">{{ t('password_placeholder') }}</label>

--- a/src/client/components/logged_out/accept_invite.vue
+++ b/src/client/components/logged_out/accept_invite.vue
@@ -62,6 +62,8 @@
         :placeholder="t('password_placeholder')"
         v-model="state.password"
         @blur="validatePasswordField"
+        :aria-invalid="(state.passwordError || state.form_error) ? 'true' : 'false'"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'accept-invite-error' : undefined"
         autocomplete="new-password"
         required
       />
@@ -72,12 +74,18 @@
         id="invite-password2"
         :placeholder="t('password2_placeholder')"
         v-model="state.password2"
+        :aria-invalid="(state.passwordError || state.form_error) ? 'true' : 'false'"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'accept-invite-error' : undefined"
         autocomplete="new-password"
         @keyup.enter="setPassword"
         required
       />
 
-      <button class="btn btn--primary" type="submit">
+      <button
+        class="btn btn--primary"
+        type="submit"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'accept-invite-error' : undefined"
+      >
         {{ t('set_password_button') || 'Set Password' }}
       </button>
     </div>

--- a/src/client/components/logged_out/error-alert.vue
+++ b/src/client/components/logged_out/error-alert.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="error"
+    :id="id"
     role="alert"
     aria-live="polite"
     class="error-alert"
@@ -14,6 +15,10 @@ defineProps({
   error: {
     type: String,
     default: '',
+  },
+  id: {
+    type: String,
+    required: true,
   },
 });
 </script>

--- a/src/client/components/logged_out/error-alert.vue
+++ b/src/client/components/logged_out/error-alert.vue
@@ -38,5 +38,15 @@ defineProps({
     border-color: rgb(127 29 29); /* red-900 */
     color: rgb(252 165 165); /* red-300 */
   }
+
+  /* Override global [aria-live] off-screen hiding in _accessibility.scss —
+     this alert must be visible to sighted users, not just screen readers. */
+  &[aria-live] {
+    position: static;
+    left: auto;
+    width: auto;
+    height: auto;
+    overflow: visible;
+  }
 }
 </style>

--- a/src/client/components/logged_out/login.vue
+++ b/src/client/components/logged_out/login.vue
@@ -95,7 +95,7 @@ async function doLogin() {
           novalidate>
       <h3>{{ t('title') }}</h3>
 
-      <ErrorAlert :error="state.err" />
+      <ErrorAlert id="login-error" :error="state.err" />
 
       <div class="form-stack">
         <label for="login-email" class="sr-only">{{ t('email') }}</label>

--- a/src/client/components/logged_out/password_forgot.vue
+++ b/src/client/components/logged_out/password_forgot.vue
@@ -35,11 +35,17 @@
         name="email"
         :placeholder="t('email')"
         v-model="state.email"
+        :aria-invalid="state.error ? 'true' : 'false'"
+        :aria-describedby="state.error ? 'forgot-error' : undefined"
         autocomplete="email"
         required
       />
 
-      <button class="btn btn--primary" type="submit">
+      <button
+        class="btn btn--primary"
+        type="submit"
+        :aria-describedby="state.error ? 'forgot-error' : undefined"
+      >
         {{ t('go_button') }}
       </button>
     </div>

--- a/src/client/components/logged_out/password_forgot.vue
+++ b/src/client/components/logged_out/password_forgot.vue
@@ -25,7 +25,7 @@
     <h3>{{ t('title') }}</h3>
     <p class="instructions">{{ t('instructions') }}</p>
 
-    <ErrorAlert :error="state.error" />
+    <ErrorAlert id="forgot-error" :error="state.error" />
 
     <div class="form-stack">
       <label for="reset-email" class="sr-only">{{ t('email') }}</label>

--- a/src/client/components/logged_out/password_reset.vue
+++ b/src/client/components/logged_out/password_reset.vue
@@ -9,7 +9,7 @@
     <h3>{{ t('check_email_title') }}</h3>
     <p class="instructions">{{ t('check_email') }} {{ state.email }}.</p>
 
-    <ErrorAlert :error="state.form_error ? t(state.form_error) : ''" />
+    <ErrorAlert id="reset-code-error" :error="state.form_error ? t(state.form_error) : ''" />
 
     <div class="form-stack">
       <label for="reset-code" class="sr-only">{{ t('reset_code') }}</label>
@@ -18,11 +18,17 @@
         id="reset-code"
         :placeholder="t('reset_code')"
         v-model="state.reset_code"
+        :aria-invalid="state.form_error ? 'true' : 'false'"
+        :aria-describedby="state.form_error ? 'reset-code-error' : undefined"
         autocomplete="one-time-code"
         required
       />
 
-      <button class="btn btn--primary" type="submit">
+      <button
+        class="btn btn--primary"
+        type="submit"
+        :aria-describedby="state.form_error ? 'reset-code-error' : undefined"
+      >
         {{ t('reset_button') }}
       </button>
     </div>
@@ -45,7 +51,7 @@
     <h3>{{ state.isRegistration ? t('new_account_password_title') : t('code_validated_title') }}</h3>
     <p class="instructions">{{ state.isRegistration ? t('registration_new_password') : t('set_password_prompt') }}</p>
 
-    <ErrorAlert :error="state.passwordError ? translateError(state.passwordError) : (state.form_error ? translateError(state.form_error) : '')" />
+    <ErrorAlert id="reset-password-error" :error="state.passwordError ? translateError(state.passwordError) : (state.form_error ? translateError(state.form_error) : '')" />
 
     <div class="form-stack">
       <label for="new-password" class="sr-only">{{ t('password_placeholder') }}</label>
@@ -54,6 +60,8 @@
         id="new-password"
         :placeholder="t('password_placeholder')"
         v-model="state.password"
+        :aria-invalid="(state.passwordError || state.form_error) ? 'true' : 'false'"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'reset-password-error' : undefined"
         @blur="validatePasswordField"
         autocomplete="new-password"
         required
@@ -65,12 +73,18 @@
         id="confirm-password"
         :placeholder="t('password2_placeholder')"
         v-model="state.password2"
+        :aria-invalid="(state.passwordError || state.form_error) ? 'true' : 'false'"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'reset-password-error' : undefined"
         autocomplete="new-password"
         @keyup.enter="setPassword"
         required
       />
 
-      <button class="btn btn--primary" type="submit">
+      <button
+        class="btn btn--primary"
+        type="submit"
+        :aria-describedby="(state.passwordError || state.form_error) ? 'reset-password-error' : undefined"
+      >
         {{ t("set_password_button") }}
       </button>
     </div>

--- a/src/client/components/logged_out/register.vue
+++ b/src/client/components/logged_out/register.vue
@@ -19,7 +19,7 @@
     >
       <h3>{{ t('title') }}</h3>
 
-      <ErrorAlert :error="state.err" />
+      <ErrorAlert id="register-error" :error="state.err" />
 
       <div class="form-stack">
         <label for="register-email" class="sr-only">{{ t('email') }}</label>
@@ -90,8 +90,8 @@ onBeforeMount(() => {
     router.push({ name: 'reset_password', query: { code: route.query.code }});
   }
 
-  state.err   = state.error || '';
-  state.email = state.em || '';
+  state.err   = props.error || '';
+  state.email = props.em || '';
 });
 
 async function doRegister() {

--- a/src/client/components/logged_out/register_apply.vue
+++ b/src/client/components/logged_out/register_apply.vue
@@ -98,8 +98,8 @@ onBeforeMount(() => {
     router.push({ name: 'reset_password', query: { code: route.query.code }});
   }
 
-  state.err   = state.error || '';
-  state.email = state.em || '';
+  state.err   = props.error || '';
+  state.email = props.em || '';
 });
 
 async function doApply() {

--- a/src/client/components/logged_out/register_apply.vue
+++ b/src/client/components/logged_out/register_apply.vue
@@ -19,7 +19,7 @@
     >
       <h3>{{ t('title') }}</h3>
 
-      <ErrorAlert :error="state.err" />
+      <ErrorAlert id="apply-error" :error="state.err" />
 
       <div class="form-stack">
         <label for="apply-email" class="sr-only">{{ t('email') }}</label>

--- a/src/client/components/logged_out/setup.vue
+++ b/src/client/components/logged_out/setup.vue
@@ -52,6 +52,7 @@
       <p class="instructions">{{ t('description') }}</p>
 
       <ErrorAlert
+        id="setup-error"
         :error="state.passwordError ? translateError(state.passwordError) : (state.formError ? translateError(state.formError) : '')"
       />
 

--- a/src/client/components/logged_out/setup.vue
+++ b/src/client/components/logged_out/setup.vue
@@ -63,6 +63,8 @@
           id="setup-email"
           :placeholder="t('email_placeholder')"
           v-model="state.email"
+          :aria-invalid="(state.passwordError || state.formError) ? 'true' : 'false'"
+          :aria-describedby="(state.passwordError || state.formError) ? 'setup-error' : undefined"
           autocomplete="email"
           required
         />
@@ -74,6 +76,8 @@
           :placeholder="t('password_placeholder')"
           v-model="state.password"
           @blur="validatePasswordField"
+          :aria-invalid="(state.passwordError || state.formError) ? 'true' : 'false'"
+          :aria-describedby="(state.passwordError || state.formError) ? 'setup-error' : undefined"
           autocomplete="new-password"
           required
         />
@@ -84,6 +88,8 @@
           id="setup-password-confirm"
           :placeholder="t('password_confirm_placeholder')"
           v-model="state.passwordConfirm"
+          :aria-invalid="(state.passwordError || state.formError) ? 'true' : 'false'"
+          :aria-describedby="(state.passwordError || state.formError) ? 'setup-error' : undefined"
           autocomplete="new-password"
           required
         />
@@ -95,6 +101,8 @@
             id="setup-site-title"
             :placeholder="t('site_title_placeholder')"
             v-model="state.siteTitle"
+            :aria-invalid="(state.passwordError || state.formError) ? 'true' : 'false'"
+            :aria-describedby="(state.passwordError || state.formError) ? 'setup-error' : undefined"
             required
           />
           <div class="field-description">{{ t('site_title_description') }}</div>
@@ -115,7 +123,12 @@
           <button class="btn btn--secondary" type="button" @click="goBackToLanguage">
             {{ t('back_button') }}
           </button>
-          <button class="btn btn--primary" type="submit" :disabled="state.submitting">
+          <button
+            class="btn btn--primary"
+            type="submit"
+            :disabled="state.submitting"
+            :aria-describedby="(state.passwordError || state.formError) ? 'setup-error' : undefined"
+          >
             {{ state.submitting ? t('submitting_button') : t('submit_button') }}
           </button>
         </div>

--- a/src/client/test/login.vue.test.ts
+++ b/src/client/test/login.vue.test.ts
@@ -411,6 +411,7 @@ describe('Login Behavior', () => {
     expect(wrapper.find('[role="alert"]').exists()).toBe(false);
     expect(wrapper.find('input[type="email"]').classes()).not.toContain('form-control--error');
     expect(wrapper.find('input[type="email"]').attributes('aria-describedby')).toBeUndefined();
+    expect(wrapper.find('input[type="password"]').attributes('aria-describedby')).toBeUndefined();
   });
 
   it('catch login error', async () => {

--- a/src/client/test/login.vue.test.ts
+++ b/src/client/test/login.vue.test.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 
 import { mountComponent } from '@/client/test/lib/vue';
 import Login from '@/client/components/logged_out/login.vue';
+import ErrorAlert from '@/client/components/logged_out/error-alert.vue';
 
 const routes: RouteRecordRaw[] = [
   { path: '/login',  component: {}, name: 'login', props: true },
@@ -351,6 +352,67 @@ describe('Login Behavior', () => {
     expect(loginStub.called).toBe(true);
   });
 
+  it('failed login renders translated alert text with proper ARIA wiring', async () => {
+    const { wrapper, router, authn } = mountedLogin();
+    let pushStub = sinon.createSandbox().stub(router, 'push');
+    let loginStub = sinon.createSandbox().stub(authn, 'login');
+
+    loginStub.resolves(false);
+
+    await wrapper.find('input[type="email"]').setValue('user@example.com');
+    await wrapper.find('input[type="password"]').setValue('password');
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text().length).toBeGreaterThan(0);
+    expect(alert.attributes('id')).toBe('login-error');
+    expect(alert.attributes('aria-live')).toBe('polite');
+
+    const emailInput = wrapper.find('input[type="email"]');
+    const passwordInput = wrapper.find('input[type="password"]');
+    const submitButton = wrapper.find('button[type="submit"]');
+
+    expect(emailInput.attributes('aria-describedby')).toBe('login-error');
+    expect(passwordInput.attributes('aria-describedby')).toBe('login-error');
+    expect(submitButton.attributes('aria-describedby')).toBe('login-error');
+
+    // aria-describedby should resolve to a real element in the DOM
+    expect(wrapper.find('#login-error').exists()).toBe(true);
+
+    // The red field state is applied alongside the alert
+    expect(emailInput.classes()).toContain('form-control--error');
+    expect(passwordInput.classes()).toContain('form-control--error');
+
+    expect(pushStub.called).toBe(false);
+  });
+
+  it('successful retry clears both the red field class and the alert element', async () => {
+    const { wrapper, router, authn } = mountedLogin();
+    sinon.createSandbox().stub(router, 'push');
+    let loginStub = sinon.createSandbox().stub(authn, 'login');
+
+    // First: failed login
+    loginStub.onFirstCall().resolves(false);
+    await wrapper.find('input[type="email"]').setValue('user@example.com');
+    await wrapper.find('input[type="password"]').setValue('password');
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(true);
+    expect(wrapper.find('input[type="email"]').classes()).toContain('form-control--error');
+
+    // Then: successful retry
+    loginStub.onSecondCall().resolves(true);
+    await wrapper.find('form').trigger('submit.prevent');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
+    expect(wrapper.find('input[type="email"]').classes()).not.toContain('form-control--error');
+    expect(wrapper.find('input[type="email"]').attributes('aria-describedby')).toBeUndefined();
+  });
+
   it('catch login error', async () => {
     const { wrapper, router, authn } = mountedLogin();
     let pushStub = sinon.createSandbox().stub(router, 'push');
@@ -368,6 +430,15 @@ describe('Login Behavior', () => {
     expect(wrapper.find('[role="alert"]').exists()).toBe(true);
     expect(pushStub.called).toBe(false);
     expect(loginStub.called).toBe(true);
+  });
+
+  it('empty-string error on ErrorAlert renders no alert element', () => {
+    const wrapper = mountComponent(
+      { components: { ErrorAlert }, template: '<ErrorAlert id="test-error" error="" />' },
+      createRouter({ history: createMemoryHistory(), routes }),
+      {},
+    );
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false);
   });
 
   it('login succeeds', async () => {

--- a/src/client/test/password_reset.vue.test.ts
+++ b/src/client/test/password_reset.vue.test.ts
@@ -1,8 +1,7 @@
-import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { flushPromises } from '@vue/test-utils';
 import { createMemoryHistory, createRouter, Router } from 'vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import sinon from 'sinon';
 
 import { mountComponent } from '@/client/test/lib/vue';
 import PasswordReset from '@/client/components/logged_out/password_reset.vue';
@@ -30,15 +29,6 @@ const mountPasswordReset = (authnOverrides: Record<string, any> = {}) => {
 };
 
 describe('Password Reset Error Alert', () => {
-  const sandbox = sinon.createSandbox();
-
-  beforeEach(() => {
-    // reset sandbox each test
-  });
-
-  afterEach(() => {
-    sandbox.restore();
-  });
 
   it('failed reset code submission renders alert text with linked aria-describedby', async () => {
     const { wrapper } = mountPasswordReset({

--- a/src/client/test/password_reset.vue.test.ts
+++ b/src/client/test/password_reset.vue.test.ts
@@ -1,0 +1,92 @@
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, Router } from 'vue-router';
+import { RouteRecordRaw } from 'vue-router';
+import sinon from 'sinon';
+
+import { mountComponent } from '@/client/test/lib/vue';
+import PasswordReset from '@/client/components/logged_out/password_reset.vue';
+
+const routes: RouteRecordRaw[] = [
+  { path: '/login', component: {}, name: 'login', props: true },
+  { path: '/reset', component: {}, name: 'reset_password', props: true },
+  { path: '/forgot', component: {}, name: 'forgot_password', props: true },
+];
+
+const mountPasswordReset = (authnOverrides: Record<string, any> = {}) => {
+  const router: Router = createRouter({
+    history: createMemoryHistory(),
+    routes: routes,
+  });
+  const authn = {
+    check_password_reset_token: async () => ({ valid: true, isNewAccount: false }),
+    use_password_reset_token: async () => ({}),
+    ...authnOverrides,
+  };
+  const wrapper = mountComponent(PasswordReset, router, {
+    provide: { authn },
+  });
+  return { wrapper, router, authn };
+};
+
+describe('Password Reset Error Alert', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    // reset sandbox each test
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('failed reset code submission renders alert text with linked aria-describedby', async () => {
+    const { wrapper } = mountPasswordReset({
+      check_password_reset_token: async () => ({ valid: false }),
+    });
+
+    // The form starts with code entry — submit an empty code to trigger the invalid flow
+    await wrapper.find('input#reset-code').setValue('bad-code');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text().length).toBeGreaterThan(0);
+    expect(alert.attributes('id')).toBe('reset-code-error');
+    expect(alert.attributes('aria-live')).toBe('polite');
+
+    const codeInput = wrapper.find('input#reset-code');
+    expect(codeInput.attributes('aria-describedby')).toBe('reset-code-error');
+    expect(wrapper.find('#reset-code-error').exists()).toBe(true);
+  });
+
+  it('password entry form with mismatched passwords renders alert linked to both password inputs', async () => {
+    const { wrapper } = mountPasswordReset({
+      check_password_reset_token: async () => ({ valid: true, isNewAccount: false }),
+    });
+
+    // Advance to the password-entry step by submitting a valid code
+    await wrapper.find('input#reset-code').setValue('good-code');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    // Now we should be on the password form
+    await wrapper.find('input#new-password').setValue('abc');
+    await wrapper.find('input#confirm-password').setValue('xyz');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.attributes('id')).toBe('reset-password-error');
+
+    const newPassword = wrapper.find('input#new-password');
+    const confirmPassword = wrapper.find('input#confirm-password');
+    expect(newPassword.attributes('aria-describedby')).toBe('reset-password-error');
+    expect(confirmPassword.attributes('aria-describedby')).toBe('reset-password-error');
+
+    // aria-describedby resolves to the rendered alert element
+    expect(wrapper.find('#reset-password-error').exists()).toBe(true);
+  });
+});

--- a/src/client/test/register.vue.test.ts
+++ b/src/client/test/register.vue.test.ts
@@ -92,4 +92,53 @@ describe('Register Form Validation', () => {
     expect(registerStub.calledWith('user@example.com')).toBe(true);
     expect(wrapper.find('.success-stub').isVisible()).toBe(true);
   });
+
+  it('failed registration renders translated alert text with proper ARIA wiring', async () => {
+    const { wrapper, authn } = mountedRegister();
+    currentWrapper = wrapper;
+    let registerStub = sandbox.stub(authn, 'register');
+    registerStub.rejects({ message: 'unknown_error' });
+
+    await wrapper.find('input[type="email"]').setValue('user@example.com');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text().length).toBeGreaterThan(0);
+    expect(alert.attributes('id')).toBe('register-error');
+    expect(alert.attributes('aria-live')).toBe('polite');
+
+    const emailInput = wrapper.find('input[type="email"]');
+    expect(emailInput.attributes('aria-describedby')).toBe('register-error');
+    expect(wrapper.find('#register-error').exists()).toBe(true);
+  });
+
+  it('surfaces initial error from props.error via ErrorAlert', async () => {
+    let router = createRouter({
+      history: createMemoryHistory(),
+      routes: routes,
+    });
+    let authn = { register: async () => true };
+
+    const wrapper = mountComponent(Register, router, {
+      provide: {
+        site_config: { settings: () => ({ registrationMode: 'open' }) },
+        authn,
+      },
+      props: { error: 'boom', em: 'prefilled@example.com' },
+      stubs: {
+        SuccessState: { template: '<div class="success-stub"><slot /></div>' },
+      },
+    });
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    const alert = wrapper.find('[role="alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('boom');
+
+    const emailInput = wrapper.find('input[type="email"]');
+    expect((emailInput.element as HTMLInputElement).value).toBe('prefilled@example.com');
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes pv-404l: login/register/password-reset forms showed red input borders on error but no visible error text to sighted users.
- Roots: `<ErrorAlert>` had no `id`, so `aria-describedby="login-error"` dangled; a global `[aria-live="polite"]` CSS rule hid the alert off-screen.
- Sweep covers every `logged_out/*` form that uses `<ErrorAlert>`: login, register, register_apply, password_reset, password_forgot, accept_invite, setup.

## Changes

- `error-alert.vue` — `id` is now a required prop and rendered on the root. Added `&[aria-live]` style override so the global off-screen rule doesn't hide the visible alert.
- Each logged-out form passes a unique `id` and wires matching `aria-describedby` + `aria-invalid` onto its inputs and submit button.
- `register.vue` / `register_apply.vue` — fixed `onBeforeMount` reading from non-existent `state.error`/`state.em` (now reads `props.error`/`props.em`).
- Tests: `login.vue.test.ts` / `register.vue.test.ts` extended, new `password_reset.vue.test.ts` — assert rendered alert text, `role="alert"` + `aria-live="polite"`, `id` matches `aria-describedby`, IDREF resolves, clearing removes wiring, empty-string edge case renders no alert.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] Targeted vitest on the three test files — 30 passed
- [x] Playwright MCP manual verification against live dev server:
  - Bad credentials → visible red alert + red fields, `#login-error` resolves
  - Empty credentials → "missing email or password"
  - Successful retry → alert + red class cleared, navigation proceeds
  - Forgot-password with invalid email → visible `#forgot-error`
  - Apply form empty submit → visible `#apply-error`
- [x] Computed style check confirms `.error-alert` is on-screen (`position: static`, `left: auto`) after the CSS fix

Closes pv-404l.