### PR TITLE
fix(i18n): add missing registration.apply.MissingFields translation (pv-ggn2)

### DIFF
--- a/src/client/locales/en/registration.json
+++ b/src/client/locales/en/registration.json
@@ -18,6 +18,7 @@
     "message_label": "Message",
     "go_login": "back to sign in",
     "InvalidEmail": "please enter a valid email address",
+    "MissingFields": "Please fill in all required fields.",
     "400": "bad sign in",
     "unknown_error": "An unknown error occurred",
     "application_submitted": "If this email is not already registered, your application will be reviewed.",

--- a/src/client/locales/es/registration.json
+++ b/src/client/locales/es/registration.json
@@ -16,6 +16,7 @@
     "email": "correo electrónico",
     "message_label": "Mensaje",
     "go_login": "volver a iniciar sesión",
+    "MissingFields": "Por favor completa todos los campos obligatorios.",
     "400": "error al registrar",
     "unknown_error": "Ocurrió un error desconocido",
     "application_submitted": "TODO: Si este correo no está registrado, tu solicitud será revisada.",

--- a/src/client/locales/fr/registration.json
+++ b/src/client/locales/fr/registration.json
@@ -16,6 +16,7 @@
     "email": "adresse e-mail",
     "message_label": "Message",
     "go_login": "retour à la connexion",
+    "MissingFields": "Veuillez remplir tous les champs obligatoires.",
     "400": "erreur lors de l'inscription",
     "unknown_error": "Une erreur inconnue s'est produite",
     "application_submitted": "Si cette adresse e-mail n'est pas encore enregistrée, votre demande sera examinée.",


### PR DESCRIPTION
## Summary

- Adds the missing `registration.apply.MissingFields` translation key in `en`, `es`, and `fr` locales.
- `register_apply.vue` line 107 calls `t('MissingFields')` when the apply form is submitted with empty email or message, but the key didn't exist so users saw the raw `apply.MissingFields` key rendered as the error text.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] Manual verification: submit empty apply form → error alert shows translated text instead of raw key

Surfaced during pv-404l Playwright verification. Closes pv-ggn2.