### PR TITLE
fix(activitypub): sign outbound federation deliveries from calendar domain (pv-dyyw)

### DIFF
--- a/src/common/exceptions/activitypub.ts
+++ b/src/common/exceptions/activitypub.ts
@@ -72,6 +72,25 @@ class AlreadyFollowingError extends Error {
   }
 }
 
+/**
+ * Thrown when synchronous signed federation delivery fails before a
+ * meaningful HTTP response is received from the remote server. Covers:
+ *   - signing failures (no key, missing actor)
+ *   - network/TLS/timeout errors
+ *   - SSRF block (private IP rejected by validateUrlNotPrivate)
+ *
+ * Non-2xx HTTP responses do NOT throw this error; the caller receives
+ * `{ status, data: null }` instead so it can decide how to react to a
+ * legitimate remote rejection (403, 404, etc.).
+ */
+class FederationDeliveryError extends Error {
+  constructor(message?: string) {
+    super(message || 'Federation delivery failed');
+    this.name = 'FederationDeliveryError';
+    Object.setPrototypeOf(this, FederationDeliveryError.prototype);
+  }
+}
+
 export {
   InvalidRemoteCalendarIdentifierError,
   InvalidRepostPolicyError,
@@ -84,4 +103,5 @@ export {
   RemoteProfileFetchError,
   SelfFollowError,
   AlreadyFollowingError,
+  FederationDeliveryError,
 };

--- a/src/server/activitypub/helper/outbox.ts
+++ b/src/server/activitypub/helper/outbox.ts
@@ -3,15 +3,19 @@ import { EventEmitter } from "events";
 import { Calendar } from "@/common/model/calendar";
 import { ActivityPubActivity } from "@/server/activitypub/model/base";
 import { ActivityPubOutboxMessageEntity } from "@/server/activitypub/entity/activitypub";
-import { ActivityPubActor } from "@/server/activitypub/model/base";
 
 /**
  * Shared helper for adding messages to the ActivityPub outbox.
  * This ensures that the outboxMessageAdded event is properly emitted
  * so that the outbox processor can handle delivery.
  *
+ * The activity's `actor` field is preserved on the persisted message and
+ * used by the outbox worker to resolve the signing key (calendar actor or
+ * user actor). Callers are responsible for passing a valid local calendar
+ * to anchor the message via `calendar_id` (FK).
+ *
  * @param eventBus - The event emitter to notify of new outbox messages
- * @param calendar - The calendar sending the message
+ * @param calendar - The local calendar to anchor the outbox message under
  * @param message - The ActivityPub activity to send
  */
 export async function addToOutbox(
@@ -19,19 +23,15 @@ export async function addToOutbox(
   calendar: Calendar,
   message: ActivityPubActivity,
 ): Promise<void> {
-  const calendarUrl = ActivityPubActor.actorUrl(calendar);
+  const messageEntity = ActivityPubOutboxMessageEntity.build({
+    id: message.id,
+    type: message.type,
+    calendar_id: calendar.id,
+    message_time: DateTime.utc(),
+    message: message,
+  });
+  await messageEntity.save();
 
-  if (calendarUrl === message.actor) {
-    const messageEntity = ActivityPubOutboxMessageEntity.build({
-      id: message.id,
-      type: message.type,
-      calendar_id: calendar.id,
-      message_time: DateTime.utc(),
-      message: message,
-    });
-    await messageEntity.save();
-
-    // Emit the event to trigger asynchronous processing
-    eventBus.emit('outboxMessageAdded', message);
-  }
+  // Emit the event to trigger asynchronous processing
+  eventBus.emit('outboxMessageAdded', message);
 }

--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -100,8 +100,52 @@ export default class ActivityPubInterface {
     return this.memberService.unshareEvent(account, calendar, eventUrl);
   }
 
+  /**
+   * Default federation delivery path: enqueues an activity onto the outbox so
+   * the worker signs it and fans it out to every configured recipient
+   * asynchronously. Use this for fire-and-forget. The activity is signed and
+   * delivered by the outbox worker — the caller does not see the remote
+   * response and does not need to.
+   *
+   * For the rare case where the caller MUST read the remote response body,
+   * use `deliverActivitySigned` instead.
+   *
+   * @param calendar The calendar that owns the outbox.
+   * @param message The activity to enqueue for delivery.
+   */
   async addToOutbox(calendar: Calendar, message: ActivityPubActivity): Promise<void> {
     return this.memberService.addToOutbox(calendar, message);
+  }
+
+  /**
+   * Escape hatch for synchronous signed federation delivery. ONLY use this
+   * when the caller must read the remote response body — currently only
+   * `events.ts:createRemoteEventViaActivityPub` qualifies, because it needs
+   * the created event echoed back from the remote calendar to construct the
+   * local domain model. Every other call site MUST use `addToOutbox`.
+   *
+   * The signing actor URI must equal `activity.actor` so the keyId is valid
+   * at the receiver. The activity is JSON-stringified once and the same
+   * bytes are used for both the SHA-256 Digest header and the HTTP body.
+   *
+   * Errors:
+   *   - Network / TLS / timeout / signing failure  -> throws FederationDeliveryError
+   *   - Non-2xx HTTP response                       -> resolves with `{ status, data: null }`
+   *   - 202 Accepted with empty body                -> resolves with `{ status: 202, data: null }`
+   *   - 2xx with body                               -> resolves with `{ status, data: <parsed JSON> }`
+   *
+   * Callers MUST guard `data?.id` (or whatever response field they consume).
+   *
+   * @param signingActorUri The actor URI used to sign the request. Must equal `activity.actor`.
+   * @param activity The ActivityPub activity to deliver.
+   * @param inboxUrl The remote inbox URL to POST to.
+   */
+  async deliverActivitySigned(
+    signingActorUri: string,
+    activity: Record<string, any>,
+    inboxUrl: string,
+  ): Promise<{ status: number; data: any }> {
+    return this.outboxService.deliverActivitySigned(signingActorUri, activity, inboxUrl);
   }
 
   async addToInbox(calendar: Calendar, message: ActivityPubActivity): Promise<null> {

--- a/src/server/activitypub/model/action/add.ts
+++ b/src/server/activitypub/model/action/add.ts
@@ -10,6 +10,14 @@ import { ActivityPubActivity, ActivityPubObject } from '@/server/activitypub/mod
 class AddActivity extends ActivityPubActivity {
 
   target: string | ActivityPubObject = '';
+  // Pavillion editor-invite extension fields. These are non-standard ActivityPub
+  // properties carried on the Add activity so the receiving user actor inbox can
+  // create the remote-calendar membership and remember where to deliver future
+  // edits. They survive JSON serialization through the outbox via toObject() and
+  // are restored by fromObject() when the outbox processor re-hydrates the
+  // stored message before delivery.
+  calendarId: string | null = null;
+  calendarInboxUrl: string | null = null;
 
   constructor( actorUrl: string, object: string | ActivityPubObject, target: string | ActivityPubObject = '' ) {
     super(actorUrl);
@@ -44,6 +52,12 @@ class AddActivity extends ActivityPubActivity {
     if (json.cc) {
       activity.cc = json.cc;
     }
+    if (json.calendarId) {
+      activity.calendarId = json.calendarId;
+    }
+    if (json.calendarInboxUrl) {
+      activity.calendarInboxUrl = json.calendarInboxUrl;
+    }
 
     return activity;
   }
@@ -54,6 +68,12 @@ class AddActivity extends ActivityPubActivity {
       result.target = typeof this.target === 'object' && this.target !== null
         ? ('toObject' in this.target ? (this.target as any).toObject() : this.target)
         : this.target;
+    }
+    if (this.calendarId) {
+      result.calendarId = this.calendarId;
+    }
+    if (this.calendarInboxUrl) {
+      result.calendarInboxUrl = this.calendarInboxUrl;
     }
     return result;
   }

--- a/src/server/activitypub/model/action/add.ts
+++ b/src/server/activitypub/model/action/add.ts
@@ -1,0 +1,62 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityPubActivity, ActivityPubObject } from '@/server/activitypub/model/base';
+
+/**
+ * ActivityPub Add activity. Used in Pavillion to notify a remote actor
+ * (e.g. a remote calendar editor) that they have been added to a collection
+ * such as a calendar's editor list. Add activities use explicit `to`
+ * targeting for single-recipient delivery rather than follower fan-out.
+ */
+class AddActivity extends ActivityPubActivity {
+
+  target: string | ActivityPubObject = '';
+
+  constructor( actorUrl: string, object: string | ActivityPubObject, target: string | ActivityPubObject = '' ) {
+    super(actorUrl);
+    this.type = 'Add';
+    this.object = object;
+    this.target = target;
+    const objectId = typeof object === 'string' ? object : object.id;
+    this.id = objectId + '/adds/' + uuidv4();
+  }
+
+  static fromObject( json: Record<string, any> ): AddActivity | null {
+    if (!json || typeof json !== 'object') {
+      return null;
+    }
+
+    if (!json.actor || typeof json.actor !== 'string') {
+      return null;
+    }
+
+    if (!json.object) {
+      return null;
+    }
+
+    let activity = new AddActivity(json.actor, json.object, json.target ?? '');
+
+    if (json.id) {
+      activity.id = json.id;
+    }
+    if (json.to) {
+      activity.to = json.to;
+    }
+    if (json.cc) {
+      activity.cc = json.cc;
+    }
+
+    return activity;
+  }
+
+  toObject(): Record<string, any> {
+    const result = super.toObject();
+    if (this.target) {
+      result.target = typeof this.target === 'object' && this.target !== null
+        ? ('toObject' in this.target ? (this.target as any).toObject() : this.target)
+        : this.target;
+    }
+    return result;
+  }
+}
+
+export default AddActivity;

--- a/src/server/activitypub/model/action/delete.ts
+++ b/src/server/activitypub/model/action/delete.ts
@@ -42,6 +42,12 @@ class DeleteActivity extends ActivityPubActivity {
     if ( object.id ) {
       activity.id = object.id;
     }
+    if ( object.to ) {
+      activity.to = object.to;
+    }
+    if ( object.cc ) {
+      activity.cc = object.cc;
+    }
 
     return activity;
   }

--- a/src/server/activitypub/service/http-signing.ts
+++ b/src/server/activitypub/service/http-signing.ts
@@ -1,0 +1,72 @@
+import CalendarActorService from "@/server/activitypub/service/calendar_actor";
+import UserActorService from "@/server/activitypub/service/user_actor";
+import { HttpSignature } from "@/server/activitypub/types";
+
+/**
+ * Signed headers returned by buildSignedHeaders, ready to merge into an
+ * axios request. When signing fails the helper returns null and the caller
+ * records a partial delivery error.
+ */
+export interface SignedHeaders {
+  Signature: string;
+  Date: string;
+  Digest: string;
+}
+
+/**
+ * Builds HTTP Signature headers for an outbound ActivityPub delivery.
+ * Auto-detects actor type by trying CalendarActorService first, then
+ * falling back to UserActorService.
+ *
+ * The helper itself does NOT compute the digest — the caller is responsible
+ * for JSON.stringify-ing the activity once and passing both the resulting
+ * `body` (used for actor signing context) and pre-computed `digest` so that
+ * the same string is used for the SHA-256 digest header and the HTTP body.
+ *
+ * @param actorUri - The actor URI that will sign the request
+ * @param body - The JSON-stringified request body (parsed once for signActivity)
+ * @param targetUrl - The inbox URL the request will be POSTed to
+ * @param digest - Pre-computed SHA-256 Digest header value
+ * @param calendarActorService - Service used to attempt calendar-actor signing first
+ * @param userActorService - Service used as fallback when calendar-actor signing fails
+ * @returns Signed headers object, or null if signing fails for both actor types
+ */
+export async function buildSignedHeaders(
+  actorUri: string,
+  body: string,
+  targetUrl: string,
+  digest: string,
+  calendarActorService: CalendarActorService,
+  userActorService: UserActorService,
+): Promise<SignedHeaders | null> {
+  let sig: HttpSignature | null = null;
+
+  // Parse the body once and reuse for both signing attempts to avoid redundant
+  // JSON.parse work on the fallback path.
+  const activity = JSON.parse(body);
+
+  // Try calendar actor first (most common case for outbox deliveries)
+  try {
+    sig = await calendarActorService.signActivity(actorUri, activity, targetUrl, digest);
+  }
+  catch {
+    // Calendar actor signing failed, try user actor
+    try {
+      sig = await userActorService.signActivity(actorUri, activity, targetUrl, digest);
+    }
+    catch {
+      // Both actor types failed to sign
+      return null;
+    }
+  }
+
+  if (!sig) {
+    return null;
+  }
+
+  return {
+    Signature: `keyId="${sig.keyId}",algorithm="${sig.algorithm}",headers="${sig.headers}",signature="${sig.signature}"`,
+    Date: sig.date,
+    Digest: digest,
+  };
+}

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -27,6 +27,7 @@ import ProcessInboxService from "@/server/activitypub/service/inbox";
 import { FEDERATION_HTTP_TIMEOUT_MS } from "@/server/common/constants";
 import { validateUrlNotPrivate } from "@/server/common/helper/ip-validation";
 import { buildSignedHeaders } from "@/server/activitypub/service/http-signing";
+import { FederationDeliveryError } from "@/common/exceptions/activitypub";
 
 /**
  * Service responsible for processing and distributing outgoing ActivityPub messages.
@@ -54,6 +55,129 @@ class ProcessOutboxService {
     if (!this.inboxService) {
       logger.warn('[OUTBOX] constructed without ProcessInboxService — local recipients will degrade to HTTP delivery (test-only path)');
     }
+  }
+
+  /**
+   * Synchronously signs and delivers a single ActivityPub activity to a single
+   * remote inbox, returning the parsed HTTP response. This is the "escape hatch"
+   * counterpart to addToOutbox: callers use it only when they MUST read the
+   * remote response body (currently only events.ts:createRemoteEventViaActivityPub,
+   * which needs the created event document echoed back from the remote calendar).
+   *
+   * Behavior contract:
+   *   - JSON.stringify the activity ONCE; the same string is used for digest
+   *     computation and for the axios request body. This guarantees the
+   *     receiver computes the same SHA-256 we signed.
+   *   - Generates a fresh Date header and signature on each call (no stale-
+   *     header retry).
+   *   - validateUrlNotPrivate(inboxUrl) is called immediately before
+   *     axios.post with no async work in between. The signing actor URI MUST
+   *     match the activity's `actor` field for the keyId to be valid at the
+   *     receiver.
+   *
+   * SECURITY (residual TOCTOU SSRF):
+   *   Inbox URLs are pre-vetted at follow time (resolveInboxUrl runs
+   *   validateUrlNotPrivate against the actor profile URL during follow), so
+   *   the inbox values reaching this helper are not raw user input. The
+   *   validateUrlNotPrivate call here is defense-in-depth: it re-checks the
+   *   URL right before the POST so a DNS rebind between follow time and
+   *   delivery time still fails closed.
+   *
+   * Error contract:
+   *   - Network / TLS / timeout / signing failure  -> throws FederationDeliveryError
+   *   - SSRF block (private IP rejected)            -> throws FederationDeliveryError
+   *   - Non-2xx HTTP response                       -> resolves with { status, data: null }
+   *   - 202 Accepted with empty body                -> resolves with { status: 202, data: null }
+   *   - 2xx with JSON body                          -> resolves with { status, data: <parsed JSON> }
+   *
+   * Callers MUST guard `data?.id` (or whatever response field they consume)
+   * because data is null on every non-success branch.
+   *
+   * @param signingActorUri - The actor URI used to sign the request. Must equal activity.actor.
+   * @param activity - The ActivityPub activity object to deliver.
+   * @param inboxUrl - The remote inbox URL to POST to (pre-vetted at follow time).
+   * @returns Object with the HTTP status and the parsed JSON body (or null).
+   * @throws FederationDeliveryError on signing/network/SSRF failure.
+   */
+  async deliverActivitySigned(
+    signingActorUri: string,
+    activity: Record<string, any>,
+    inboxUrl: string,
+  ): Promise<{ status: number; data: any }> {
+    // JSON.stringify the activity ONCE so the digest header and the HTTP body
+    // are guaranteed to be byte-identical. Re-stringifying could produce a
+    // different key order and break signature verification at the receiver.
+    const bodyString = JSON.stringify(activity);
+    const digest = 'SHA-256=' + createHash('sha256').update(bodyString).digest('base64');
+
+    let signedHeaders;
+    try {
+      signedHeaders = await buildSignedHeaders(
+        signingActorUri,
+        bodyString,
+        inboxUrl,
+        digest,
+        this.calendarActorService,
+        this.userActorService,
+      );
+    }
+    catch (error: any) {
+      throw new FederationDeliveryError(
+        `Signing failed for actor ${signingActorUri}: ${error?.message ?? String(error)}`,
+      );
+    }
+    if (!signedHeaders) {
+      throw new FederationDeliveryError(
+        `Signing failed for actor ${signingActorUri}: no matching key found`,
+      );
+    }
+
+    // SECURITY: re-validate the inbox URL immediately before POST. No async
+    // work between this check and axios.post — anything in the gap would
+    // re-open the TOCTOU window we are trying to close.
+    try {
+      await validateUrlNotPrivate(inboxUrl);
+    }
+    catch (error: any) {
+      throw new FederationDeliveryError(
+        `Blocked delivery to private inbox URL: ${error?.message ?? String(error)}`,
+      );
+    }
+
+    let response;
+    try {
+      response = await axios.post(inboxUrl, bodyString, {
+        timeout: FEDERATION_HTTP_TIMEOUT_MS,
+        maxRedirects: 0,
+        // Treat any HTTP status code (including non-2xx) as a resolved
+        // response so the caller can read `status` and decide. Network/TLS/
+        // timeout errors still reject and become FederationDeliveryError below.
+        validateStatus: () => true,
+        headers: {
+          'Content-Type': 'application/activity+json',
+          ...signedHeaders,
+        },
+      });
+    }
+    catch (error: any) {
+      throw new FederationDeliveryError(
+        `Network failure delivering to ${inboxUrl}: ${error?.message ?? String(error)}`,
+      );
+    }
+
+    const status = response.status;
+
+    // Non-2xx: surface status to caller, but no body.
+    if (status < 200 || status >= 300) {
+      return { status, data: null };
+    }
+
+    // 2xx with empty/no body (typical for 202 Accepted).
+    if (response.data === undefined || response.data === null || response.data === '') {
+      return { status, data: null };
+    }
+
+    return { status, data: response.data };
   }
 
   /**

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -12,6 +12,7 @@ import { ActivityPubOutboxMessageEntity, EventActivityEntity, FollowerCalendarEn
 import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
 import UpdateActivity from "@/server/activitypub/model/action/update";
 import DeleteActivity from "@/server/activitypub/model/action/delete";
+import AddActivity from "@/server/activitypub/model/action/add";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
@@ -25,18 +26,7 @@ import UserActorService from "@/server/activitypub/service/user_actor";
 import ProcessInboxService from "@/server/activitypub/service/inbox";
 import { FEDERATION_HTTP_TIMEOUT_MS } from "@/server/common/constants";
 import { validateUrlNotPrivate } from "@/server/common/helper/ip-validation";
-import { HttpSignature } from "@/server/activitypub/types";
-
-/**
- * Signed headers returned by buildSignedHeaders, ready to merge into an
- * axios request. When signing fails the method returns null and the caller
- * records a partial delivery error.
- */
-interface SignedHeaders {
-  Signature: string;
-  Date: string;
-  Digest: string;
-}
+import { buildSignedHeaders } from "@/server/activitypub/service/http-signing";
 
 /**
  * Service responsible for processing and distributing outgoing ActivityPub messages.
@@ -120,14 +110,48 @@ class ProcessOutboxService {
         if (!activity) {
           throw new Error('Failed to parse Update activity');
         }
-        recipients = await this.getRecipients(calendar, activity.object);
+        // Honor explicit `to` for targeted single-recipient delivery (e.g.,
+        // notifying the remote calendar that owns an event). Fall back to
+        // follower fan-out for the back-compat broadcast case.
+        if (activity.to && activity.to.length > 0) {
+          recipients = activity.to;
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Update activity');
+        }
+        else {
+          recipients = await this.getRecipients(calendar, activity.object);
+        }
         break;
       case 'Delete':
         activity = DeleteActivity.fromObject(message.message);
         if (!activity) {
           throw new Error('Failed to parse Delete activity');
         }
-        recipients = await this.getRecipients(calendar, activity.object);
+        // Honor explicit `to` for targeted single-recipient delivery. Fall back
+        // to follower fan-out for the back-compat broadcast case.
+        if (activity.to && activity.to.length > 0) {
+          recipients = activity.to;
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Delete activity');
+        }
+        else {
+          recipients = await this.getRecipients(calendar, activity.object);
+        }
+        break;
+      case 'Add':
+        activity = AddActivity.fromObject(message.message);
+        if (!activity) {
+          throw new Error('Failed to parse Add activity');
+        }
+        // Add activities are inherently single-recipient (e.g. editor invite
+        // to a remote actor). Honor explicit `to`. If `to` is absent, do NOT
+        // fall back to follower fan-out — that would broadcast an editor
+        // invite to every follower, which is never the intent. Log and skip.
+        if (activity.to && activity.to.length > 0) {
+          recipients = activity.to;
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Add activity');
+        }
+        else {
+          logger.warn({ activityId: activity.id }, 'Add activity has no explicit to field; skipping delivery (no follower fan-out for Add)');
+        }
         break;
       case 'Follow':
         activity = FollowActivity.fromObject(message.message);
@@ -164,7 +188,7 @@ class ProcessOutboxService {
         // Check if the activity has explicit recipients in the 'to' field
         if (activity.to && activity.to.length > 0) {
           recipients = activity.to;
-          logger.info({ recipients }, 'Using explicit recipients from to field for Undo activity');
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Undo activity');
         }
         else {
           recipients = await this.getRecipients(calendar, activity.object);
@@ -178,7 +202,7 @@ class ProcessOutboxService {
         // For Flag activities, use explicit 'to' field if present
         if (activity.to && activity.to.length > 0) {
           recipients = activity.to;
-          logger.info({ recipients }, 'Using explicit recipients from to field for Flag activity');
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Flag activity');
         }
         break;
     }
@@ -254,52 +278,6 @@ class ProcessOutboxService {
   }
 
   /**
-   * Builds HTTP Signature headers for an outbound ActivityPub delivery.
-   * Auto-detects actor type by trying CalendarActorService first, then
-   * falling back to UserActorService.
-   *
-   * @param actorUri - The actor URI that will sign the request
-   * @param body - The JSON-stringified request body (used for Digest)
-   * @param targetUrl - The inbox URL the request will be POSTed to
-   * @param digest - Pre-computed SHA-256 Digest header value
-   * @returns Signed headers object, or null if signing fails for both actor types
-   * @private
-   */
-  private async buildSignedHeaders(
-    actorUri: string,
-    body: string,
-    targetUrl: string,
-    digest: string,
-  ): Promise<SignedHeaders | null> {
-    let sig: HttpSignature | null = null;
-
-    // Try calendar actor first (most common case for outbox deliveries)
-    try {
-      sig = await this.calendarActorService.signActivity(actorUri, JSON.parse(body), targetUrl, digest);
-    }
-    catch {
-      // Calendar actor signing failed, try user actor
-      try {
-        sig = await this.userActorService.signActivity(actorUri, JSON.parse(body), targetUrl, digest);
-      }
-      catch {
-        // Both actor types failed to sign
-        return null;
-      }
-    }
-
-    if (!sig) {
-      return null;
-    }
-
-    return {
-      Signature: `keyId="${sig.keyId}",algorithm="${sig.algorithm}",headers="${sig.headers}",signature="${sig.signature}"`,
-      Date: sig.date,
-      Digest: digest,
-    };
-  }
-
-  /**
    * Delivers an activity to a recipient via HTTP POST to their inbox.
    * Resolves the recipient's inbox URL, validates it against SSRF protection,
    * signs the request with HTTP Signatures, and posts the activity payload.
@@ -343,7 +321,14 @@ class ProcessOutboxService {
       const bodyString = JSON.stringify(activityData);
       const digest = 'SHA-256=' + createHash('sha256').update(bodyString).digest('base64');
 
-      const signedHeaders = await this.buildSignedHeaders(activity.actor, bodyString, inboxUrl, digest);
+      const signedHeaders = await buildSignedHeaders(
+        activity.actor,
+        bodyString,
+        inboxUrl,
+        digest,
+        this.calendarActorService,
+        this.userActorService,
+      );
       if (!signedHeaders) {
         const errorMsg = `Signing failed for actor ${activity.actor} delivering to ${recipient}`;
         logger.error({ actorUri: activity.actor, recipient }, 'Failed to sign outbound delivery');

--- a/src/server/activitypub/test/helper/http_signature.test.ts
+++ b/src/server/activitypub/test/helper/http_signature.test.ts
@@ -752,3 +752,272 @@ describe('HTTP Signature Verification', () => {
     });
   });
 });
+
+/**
+ * End-to-end cryptographic round-trip for HTTP Signatures.
+ *
+ * Bead context: pv-dyyw.3.1 retry. The federation e2e spec
+ * (signed_delivery.spec.ts) proves the OUTBOUND delivery pipeline runs under
+ * signing, but the receive-side gate is short-circuited by SKIP_SIGNATURES on
+ * the local Docker harness, so the e2e cannot distinguish a correctly-signed
+ * POST from a forged one. These unit tests close that gap by exercising the
+ * full sign-then-verify loop with real RSA crypto:
+ *
+ *   1. Generate an in-test RSA-2048 keypair.
+ *   2. Use the real `buildSignedHeaders` helper from http-signing.ts, with the
+ *      actor services stubbed so signing resolves to the test private key.
+ *   3. Feed the signed request to the real `verifyHttpSignature` middleware
+ *      with SKIP_SIGNATURES off and the public-key cache primed with the
+ *      matching public key (no network round-trip required).
+ *   4. Assert next() is called for a clean signature.
+ *   5. Assert 401 is returned when the body is tampered after signing
+ *      (digest mismatch) — proves rejection works.
+ *
+ * The verifier is activity-type agnostic, so a single positive + single
+ * negative case is sufficient cryptographic proof for all four signed
+ * activity types (Create / Update / Delete / Add).
+ */
+describe('HTTP Signature Cryptographic Round-Trip', () => {
+  let sandbox: sinon.SinonSandbox;
+  let originalNodeEnv: string | undefined;
+  let originalSkipSignatures: string | undefined;
+
+  // RSA keypair generated once per test for cryptographic isolation
+  let privateKeyPem: string;
+  let publicKeyPem: string;
+
+  const ACTOR_URI = 'https://alpha.federation.local/o/roundtrip-cal';
+  const TARGET_URL = 'https://beta.federation.local/o/roundtrip-cal/inbox';
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    originalNodeEnv = process.env.NODE_ENV;
+    originalSkipSignatures = process.env.SKIP_SIGNATURES;
+
+    // Force the verifier into enforce mode regardless of how the test process
+    // was launched. Without this, a CI runner exporting SKIP_SIGNATURES=true
+    // would let the round-trip test pass vacuously.
+    process.env.NODE_ENV = 'test';
+    delete process.env.SKIP_SIGNATURES;
+
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    privateKeyPem = privateKey;
+    publicKeyPem = publicKey;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    else {
+      delete process.env.NODE_ENV;
+    }
+
+    if (originalSkipSignatures !== undefined) {
+      process.env.SKIP_SIGNATURES = originalSkipSignatures;
+    }
+    else {
+      delete process.env.SKIP_SIGNATURES;
+    }
+  });
+
+  /**
+   * Build a fake CalendarActorService that succeeds at signActivity using the
+   * in-test keypair. UserActorService is stubbed to throw so the
+   * buildSignedHeaders helper resolves on the calendar branch (matches the
+   * normal calendar-actor delivery path).
+   */
+  function buildActorServices(): { calendarActorService: any; userActorService: any } {
+    const calendarActorService = {
+      signActivity: async (
+        actorUri: string,
+        _activity: any,
+        targetUrl: string,
+        digest?: string,
+      ) => {
+        const url = new URL(targetUrl);
+        const host = url.host;
+        const path = url.pathname + url.search;
+        const date = new Date().toUTCString();
+
+        const signingStringParts = [
+          `(request-target): post ${path}`,
+          `host: ${host}`,
+          `date: ${date}`,
+        ];
+        if (digest) {
+          signingStringParts.push(`digest: ${digest}`);
+        }
+        const signingString = signingStringParts.join('\n');
+
+        const signer = crypto.createSign('RSA-SHA256');
+        signer.update(signingString);
+        signer.end();
+        const signature = signer.sign(privateKeyPem).toString('base64');
+
+        return {
+          keyId: `${actorUri}#main-key`,
+          signature,
+          algorithm: 'rsa-sha256',
+          headers: digest ? '(request-target) host date digest' : '(request-target) host date',
+          date,
+        };
+      },
+    };
+
+    const userActorService = {
+      signActivity: async () => {
+        throw new Error('user actor signing not used in this test');
+      },
+    };
+
+    return { calendarActorService, userActorService };
+  }
+
+  /**
+   * Construct the Express request that mirrors what an inbound POST looks like
+   * after Express has parsed headers and body. http-signature's parseRequest
+   * needs `method`, `url`, and `httpVersion` in addition to `headers`.
+   */
+  function buildIncomingRequest(
+    targetUrl: string,
+    actorUri: string,
+    body: any,
+    signedHeaders: { Signature: string; Date: string; Digest: string },
+  ): Request {
+    const url = new URL(targetUrl);
+    return {
+      method: 'POST',
+      url: url.pathname + url.search,
+      httpVersion: '1.1',
+      headers: {
+        host: url.host,
+        date: signedHeaders.Date,
+        digest: signedHeaders.Digest,
+        signature: signedHeaders.Signature,
+        'content-type': 'application/activity+json',
+      },
+      body,
+    } as unknown as Request;
+  }
+
+  it('accepts a request signed by buildSignedHeaders end-to-end', async () => {
+    const { buildSignedHeaders } = await import('@/server/activitypub/service/http-signing');
+
+    const activity = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Create',
+      actor: ACTOR_URI,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      object: {
+        type: 'Event',
+        id: 'https://alpha.federation.local/o/roundtrip-cal/events/abc',
+        name: 'Round-trip test event',
+      },
+    };
+    const body = JSON.stringify(activity);
+    const digest = 'SHA-256=' + crypto.createHash('sha256').update(body).digest('base64');
+
+    const { calendarActorService, userActorService } = buildActorServices();
+
+    const signed = await buildSignedHeaders(
+      ACTOR_URI,
+      body,
+      TARGET_URL,
+      digest,
+      calendarActorService as any,
+      userActorService as any,
+    );
+    expect(signed, 'buildSignedHeaders must produce headers for a valid actor').not.toBeNull();
+
+    // Prime the public-key cache so verifyHttpSignature does NOT try to
+    // resolve over the network. This isolates the test from axios entirely.
+    const cacheGetStub = sandbox.stub(Cache.prototype, 'get').returns(publicKeyPem);
+    sandbox.stub(Cache.prototype, 'set');
+    const axiosGetStub = sandbox.stub(axios, 'get');
+
+    // Body is parsed back to an object because Express body-parser delivers
+    // it that way to the inbox handler. The verifier re-stringifies via
+    // JSON.stringify(req.body) for digest comparison, so the structural shape
+    // (and key order) must match what we hashed above. JSON.parse/stringify
+    // round-trip preserves key order for plain objects in V8.
+    const incomingReq = buildIncomingRequest(TARGET_URL, ACTOR_URI, JSON.parse(body), signed!);
+    const res: any = {
+      status: sandbox.stub().returnsThis(),
+      json: sandbox.stub().returnsThis(),
+    };
+    const next = sandbox.spy();
+
+    await verifyHttpSignature(incomingReq, res as Response, next as any);
+
+    expect(
+      next.called,
+      'verifyHttpSignature must call next() for a request signed end-to-end with the matching keypair',
+    ).toBe(true);
+    expect(res.status.called, 'no error status should be emitted').toBe(false);
+    expect(cacheGetStub.calledWith(`${ACTOR_URI}#main-key`)).toBe(true);
+    expect(axiosGetStub.called, 'no network fetch should be needed when cache is primed').toBe(false);
+  });
+
+  it('rejects a request whose body is tampered after signing (digest mismatch)', async () => {
+    const { buildSignedHeaders } = await import('@/server/activitypub/service/http-signing');
+
+    const activity = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Create',
+      actor: ACTOR_URI,
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      object: {
+        type: 'Event',
+        id: 'https://alpha.federation.local/o/roundtrip-cal/events/abc',
+        name: 'Round-trip test event',
+      },
+    };
+    const body = JSON.stringify(activity);
+    const digest = 'SHA-256=' + crypto.createHash('sha256').update(body).digest('base64');
+
+    const { calendarActorService, userActorService } = buildActorServices();
+
+    const signed = await buildSignedHeaders(
+      ACTOR_URI,
+      body,
+      TARGET_URL,
+      digest,
+      calendarActorService as any,
+      userActorService as any,
+    );
+    expect(signed).not.toBeNull();
+
+    sandbox.stub(Cache.prototype, 'get').returns(publicKeyPem);
+    sandbox.stub(Cache.prototype, 'set');
+    sandbox.stub(axios, 'get');
+
+    // Mutate the body AFTER signing. The Signature and Digest headers still
+    // refer to the original body. The verifier hashes the tampered body and
+    // compares against the original digest -- mismatch must trigger 401.
+    const tamperedBody = { ...JSON.parse(body), object: { ...activity.object, name: 'Malicious payload' } };
+
+    const incomingReq = buildIncomingRequest(TARGET_URL, ACTOR_URI, tamperedBody, signed!);
+    const res: any = {
+      status: sandbox.stub().returnsThis(),
+      json: sandbox.stub().returnsThis(),
+    };
+    const next = sandbox.spy();
+
+    await verifyHttpSignature(incomingReq, res as Response, next as any);
+
+    expect(
+      res.status.calledWith(401),
+      'tampering with the body after signing must cause a 401 Invalid digest response',
+    ).toBe(true);
+    expect(res.json.calledWith({ error: 'Invalid digest' })).toBe(true);
+    expect(next.called, 'next() must NOT be invoked when the digest fails').toBe(false);
+  });
+});

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -1028,3 +1028,123 @@ describe('MockFederation Activity Tracking', () => {
     expect(sent[1].type).toBe('Follow');
   });
 });
+
+
+describe('deliverActivitySigned', () => {
+  let service: ProcessOutboxService;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+
+  const SIGNING_ACTOR_URI = `${LOCAL_ACTOR_URL}/users/admin`;
+
+  beforeEach(() => {
+    const eventBus = new EventEmitter();
+    service = new ProcessOutboxService(eventBus);
+    vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    vi.restoreAllMocks();
+  });
+
+  function buildActivity() {
+    return {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Create',
+      id: `${LOCAL_ACTOR_URL}/activities/abc`,
+      actor: SIGNING_ACTOR_URI,
+      object: {
+        type: 'Event',
+        id: `${LOCAL_ACTOR_URL}/events/xyz`,
+        name: 'Sync Event',
+      },
+    };
+  }
+
+  it('throws FederationDeliveryError when signing fails for both actor types', async () => {
+    sandbox.stub(service.calendarActorService, 'signActivity').rejects(new Error('no calendar actor'));
+    sandbox.stub((service as any).userActorService, 'signActivity').rejects(new Error('no user actor'));
+
+    const postStub = sandbox.stub(axios, 'post');
+
+    const { FederationDeliveryError } = await import('@/common/exceptions/activitypub');
+
+    await expect(
+      service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), REMOTE_INBOX_URL),
+    ).rejects.toBeInstanceOf(FederationDeliveryError);
+
+    expect(postStub.called).toBe(false);
+  });
+
+  it('throws FederationDeliveryError on network/timeout failure', async () => {
+    stubSigning(service, sandbox);
+    sandbox.stub(axios, 'post').rejects(new Error('ETIMEDOUT'));
+
+    const { FederationDeliveryError } = await import('@/common/exceptions/activitypub');
+
+    await expect(
+      service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), REMOTE_INBOX_URL),
+    ).rejects.toBeInstanceOf(FederationDeliveryError);
+  });
+
+  it('throws FederationDeliveryError when SSRF validation rejects the inbox URL', async () => {
+    stubSigning(service, sandbox);
+    vi.mocked(validateUrlNotPrivate).mockRejectedValueOnce(
+      new Error('Access to private IP 10.0.0.1 is not allowed'),
+    );
+    const postStub = sandbox.stub(axios, 'post');
+
+    const { FederationDeliveryError } = await import('@/common/exceptions/activitypub');
+
+    await expect(
+      service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), 'https://10.0.0.1/inbox'),
+    ).rejects.toBeInstanceOf(FederationDeliveryError);
+
+    expect(postStub.called).toBe(false);
+  });
+
+  it('returns { status, data: null } on non-2xx HTTP response', async () => {
+    stubSigning(service, sandbox);
+    sandbox.stub(axios, 'post').resolves({ status: 403, data: { error: 'forbidden' } });
+
+    const result = await service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), REMOTE_INBOX_URL);
+
+    expect(result).toEqual({ status: 403, data: null });
+  });
+
+  it('returns { status: 202, data: null } on 202 Accepted with empty body', async () => {
+    stubSigning(service, sandbox);
+    sandbox.stub(axios, 'post').resolves({ status: 202, data: '' });
+
+    const result = await service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), REMOTE_INBOX_URL);
+
+    expect(result).toEqual({ status: 202, data: null });
+  });
+
+  it('returns { status, data } on 2xx with parsed JSON body', async () => {
+    stubSigning(service, sandbox);
+    const remoteEvent = { id: `${REMOTE_PROFILE_URL}/events/created-1`, type: 'Event', name: 'Echoed' };
+    sandbox.stub(axios, 'post').resolves({ status: 201, data: remoteEvent });
+
+    const result = await service.deliverActivitySigned(SIGNING_ACTOR_URI, buildActivity(), REMOTE_INBOX_URL);
+
+    expect(result.status).toBe(201);
+    expect(result.data).toEqual(remoteEvent);
+  });
+
+  it('JSON-stringifies the activity exactly once and uses the same bytes for digest and body', async () => {
+    stubSigning(service, sandbox);
+    const postStub = sandbox.stub(axios, 'post').resolves({ status: 202, data: '' });
+
+    const activity = buildActivity();
+    await service.deliverActivitySigned(SIGNING_ACTOR_URI, activity, REMOTE_INBOX_URL);
+
+    const bodyArg = postStub.getCalls()[0].args[1];
+    expect(typeof bodyArg).toBe('string');
+
+    const { createHash } = await import('crypto');
+    const expectedDigest = 'SHA-256=' + createHash('sha256').update(bodyArg as string).digest('base64');
+    const actualDigest = postStub.getCalls()[0].args[2]?.headers['Digest'];
+    expect(actualDigest).toBe(expectedDigest);
+  });
+});

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -38,7 +38,9 @@ import {
 import {
   createMockAnnounceActivity,
   createMockCreateActivity,
+  createMockDeleteActivity,
   createMockFollowActivity,
+  createMockUpdateActivity,
   createMockFederation,
   getSentActivities,
   type MockFederationContext,
@@ -577,6 +579,223 @@ describe('processOutboxMessage', () => {
     expect(updateStub.getCalls()[0].args[0]['processed_time']).toBeDefined();
     // The delivery error should be recorded in processed_status
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toMatch(/^partial:/);
+  });
+});
+
+
+describe('processOutboxMessage — explicit `to` honoring for Update/Delete/Add', () => {
+  let service: ProcessOutboxService;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+
+  const TARGETED_ACTOR_URI = 'https://target.federation.test/calendars/owner';
+  const TARGETED_INBOX_URL = 'https://target.federation.test/calendars/owner/inbox';
+
+  beforeEach(() => {
+    const eventBus = new EventEmitter();
+    service = new ProcessOutboxService(eventBus);
+    vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    vi.restoreAllMocks();
+  });
+
+  // ---------- Update ----------
+
+  it('Update: honors explicit `to` and skips follower fan-out', async () => {
+    const updateMsg = createMockUpdateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/upd-1`,
+      name: 'Updated Event',
+    });
+    updateMsg.to = [TARGETED_ACTOR_URI];
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Update',
+      message: updateMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(TARGETED_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called when `to` is explicit').toBe(false);
+    expect(resolveStub.calledOnceWith(TARGETED_ACTOR_URI)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Update: falls back to getRecipients fan-out when `to` is absent', async () => {
+    const updateMsg = createMockUpdateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/upd-2`,
+      name: 'Broadcast Update',
+    });
+    // no `to` field set
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Update',
+      message: updateMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.calledOnce, 'getRecipients must be called for fan-out fallback').toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  // ---------- Delete ----------
+
+  it('Delete: honors explicit `to` and skips follower fan-out', async () => {
+    const deleteMsg = createMockDeleteActivity(LOCAL_ACTOR_URL, `${LOCAL_ACTOR_URL}/events/del-1`);
+    deleteMsg.to = [TARGETED_ACTOR_URI];
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Delete',
+      message: deleteMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(TARGETED_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called when `to` is explicit').toBe(false);
+    expect(resolveStub.calledOnceWith(TARGETED_ACTOR_URI)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Delete: falls back to getRecipients fan-out when `to` is absent', async () => {
+    const deleteMsg = createMockDeleteActivity(LOCAL_ACTOR_URL, `${LOCAL_ACTOR_URL}/events/del-2`);
+    // no `to` field set
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Delete',
+      message: deleteMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.calledOnce, 'getRecipients must be called for fan-out fallback').toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  // ---------- Add ----------
+
+  it('Add: honors explicit `to` and delivers only to that recipient', async () => {
+    const addMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Add',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/adds/add-1`,
+      to: [TARGETED_ACTOR_URI],
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Add',
+      message: addMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(TARGETED_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Add').toBe(false);
+    expect(resolveStub.calledOnceWith(TARGETED_ACTOR_URI)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Add: skips delivery (no fan-out) when `to` is absent', async () => {
+    const addMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Add',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/adds/add-2`,
+      // no `to` field
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Add',
+      message: addMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+
+    await service.processOutboxMessage(message);
+
+    // No follower fan-out for Add — getRecipients must NOT be called and
+    // no HTTP delivery should happen. The message is still marked processed.
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Add fan-out').toBe(false);
+    expect(resolveStub.called, 'resolveInboxUrl must NOT be called when no recipients').toBe(false);
+    expect(postStub.called, 'No HTTP POST when Add has no recipients').toBe(false);
+    expect(updateStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 });
 

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -4,7 +4,8 @@ import { EventEmitter } from 'events';
 import config from 'config';
 import axios from 'axios';
 import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
-import { PUBLIC_KEY_FETCH_TIMEOUT_MS, FEDERATION_HTTP_TIMEOUT_MS } from '@/server/common/constants';
+import { PUBLIC_KEY_FETCH_TIMEOUT_MS } from '@/server/common/constants';
+import AddActivity from '@/server/activitypub/model/action/add';
 
 import { Calendar, DefaultDateRange } from '@/common/model/calendar';
 import { Account } from '@/common/model/account';
@@ -769,51 +770,38 @@ class CalendarService {
       granted_by: grantingAccount.id,
     });
 
-    // Send ActivityPub Add activity to notify the remote user
+    // Send ActivityPub Add activity to notify the remote user via the signed
+    // outbox path. The outbox extension (pv-dyyw.1.2) honors the explicit `to`
+    // field for single-recipient delivery, so the Add activity is delivered to
+    // the remote user actor specifically rather than fanned out to followers.
+    // The calendar actor's private key signs the request because the activity's
+    // `actor` field is the calendar actor URI (per epic per-call-site signing
+    // table). Local membership is created above regardless of remote delivery
+    // outcome — best-effort semantics are preserved by the outbox worker, which
+    // logs delivery failures asynchronously.
     const localDomain = config.get<string>('domain');
     const calendarActorUri = `https://${localDomain}/calendars/${calendar.urlName}`;
     const calendarInboxUrl = `https://${localDomain}/calendars/${calendar.urlName}/inbox`;
 
-    const addActivity = {
-      '@context': 'https://www.w3.org/ns/activitystreams',
-      type: 'Add',
-      id: `${calendarActorUri}/activities/${uuidv4()}`,
-      actor: calendarActorUri,
-      object: remoteUser.actorUri,
-      target: `${calendarActorUri}/editors`,
-      calendarId: calendar.id,
-      calendarInboxUrl: calendarInboxUrl,
-    };
+    const addActivity = new AddActivity(
+      calendarActorUri,
+      remoteUser.actorUri,
+      `${calendarActorUri}/editors`,
+    );
+    addActivity.id = `${calendarActorUri}/activities/${uuidv4()}`;
+    addActivity.to = [remoteUser.actorUri];
+    addActivity.calendarId = calendar.id;
+    addActivity.calendarInboxUrl = calendarInboxUrl;
 
-    // Send to remote user's inbox
-    // SECURITY: Validate inbox URL from untrusted actor document.
-    // NOTE: DNS TOCTOU gap — validateUrlNotPrivate resolves DNS at validation time;
-    // axios re-resolves at connect time. A DNS rebinding attack could bypass this check.
     try {
-      await validateUrlNotPrivate(remoteUser.inbox);
-    }
-    catch (error) {
-      logError(error, `[Calendar] Security: Blocked inbox POST to private address ${remoteUser.inbox}`);
-      return {
-        type: 'remote_editor',
-        data: {
-          actorUri: remoteUser.actorUri,
-        },
-      };
-    }
-    try {
-      await axios.post(remoteUser.inbox, addActivity, {
-        timeout: FEDERATION_HTTP_TIMEOUT_MS,
-        maxRedirects: 0,
-        headers: {
-          'Content-Type': 'application/activity+json',
-        },
-      });
-      logger.info({ inbox: remoteUser.inbox }, 'Sent Add activity to remote user');
+      await this.activityPubInterface!.addToOutbox(calendar, addActivity);
+      logger.info({ inbox: remoteUser.inbox, calendarId: calendar.id }, 'Enqueued Add activity for remote user');
     }
     catch (error: any) {
-      // Log but don't fail - the local record is created, notification is best-effort
-      logError(error, `[Calendar] Failed to send Add activity to ${remoteUser.inbox}`);
+      // Best-effort: local membership row is already created above, so we do
+      // not fail the grant if enqueuing the outbox message hits an unexpected
+      // error (e.g. transient DB failure on the ap_outbox insert).
+      logError(error, `[Calendar] Failed to enqueue Add activity to ${remoteUser.inbox}`);
     }
 
     return {

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -20,6 +20,8 @@ import LocationService from "@/server/calendar/service/locations";
 import { EventEmitter } from 'events';
 import type MediaInterface from '@/server/media/interface';
 import type ActivityPubInterface from '@/server/activitypub/interface';
+import UpdateActivity from '@/server/activitypub/model/action/update';
+import DeleteActivity from '@/server/activitypub/model/action/delete';
 import { EventNotFoundError, InsufficientCalendarPermissionsError, CalendarNotFoundError, BulkEventsNotFoundError, MixedCalendarEventsError, CategoriesNotFoundError, LocationValidationError, InvalidExternalUrlError } from '@/common/exceptions/calendar';
 import { ValidationError } from '@/common/exceptions/base';
 import CategoryService from './categories';
@@ -476,11 +478,13 @@ class EventService {
     // Include the local event ID in eventParams so the remote can look it up
     const eventParamsWithId = { ...eventParams, id: eventId };
 
-    const updateActivity = {
+    const updateActivityObject = {
       '@context': 'https://www.w3.org/ns/activitystreams',
       type: 'Update',
       id: `https://${localDomain}/activities/${uuidv4()}`,
       actor: actorUri,
+      // Explicit single-recipient delivery: the outbox worker honors `to` and
+      // skips follower fan-out for Update activities (per pv-dyyw.1.2).
       to: [remoteCalendarActor.actorUri],
       object: {
         type: 'Event',
@@ -495,62 +499,57 @@ class EventService {
       },
     };
 
-    // Send to the remote calendar's inbox
-    const inboxUrl = remoteCalendarActor.inboxUrl;
-    if (!inboxUrl) {
+    // Verify the remote calendar inbox is configured. The outbox worker
+    // resolves and validates the inbox URL (SSRF guard) at delivery time.
+    if (!remoteCalendarActor.inboxUrl) {
       throw new CalendarNotFoundError('Remote calendar inbox URL not configured');
     }
 
-    logger.info({ inboxUrl }, 'Sending Update activity to remote calendar');
+    logger.info({ inboxUrl: remoteCalendarActor.inboxUrl }, 'Enqueuing Update activity for remote calendar');
 
-    // SECURITY: Validate that the inbox URL does not point to a private IP address
-    // to prevent SSRF attacks where a malicious remote calendar advertises an internal
-    // network address as its inbox.
-    try {
-      await validateUrlNotPrivate(inboxUrl);
-    }
-    catch (error) {
-      const errorMsg = `Security: Blocked delivery to private inbox URL: ${error instanceof Error ? error.message : String(error)}`;
-      logError(error, `[Calendar] Security: Blocked delivery to private inbox URL for update activity`);
-      throw new Error(errorMsg);
+    // Wrap as an UpdateActivity model so addToOutbox receives the expected
+    // ActivityPubActivity shape. The activity's `actor` field (user actor URI)
+    // is what the outbox worker uses to resolve the signing key via
+    // buildSignedHeaders (per pv-dyyw.1.1).
+    const updateActivity = UpdateActivity.fromObject(updateActivityObject);
+    if (!updateActivity) {
+      throw new Error('Failed to construct UpdateActivity for remote event update');
     }
 
-    try {
-      const response = await axios.post(inboxUrl, updateActivity, {
-        timeout: FEDERATION_HTTP_TIMEOUT_MS,
-        maxRedirects: 0,
-        headers: {
-          'Content-Type': 'application/activity+json',
-        },
-      });
+    // The outbox helper requires a local Calendar to anchor the message
+    // (calendar_id FK). For user-actor activities, no specific calendar is
+    // semantically the "owner" — pick the first local calendar the user can
+    // edit as the bookkeeping anchor. Delivery routing is driven by the
+    // activity's explicit `to` field, not by this calendar.
+    const userCalendars = await this.calendarService.editableCalendarsForUser(account);
+    if (userCalendars.length === 0) {
+      throw new InsufficientCalendarPermissionsError('User has no local calendar to anchor outbox delivery');
+    }
 
-      logger.info({ status: response.status }, 'Remote calendar accepted Update activity');
+    // Fire-and-forget enqueue. Errors surface asynchronously through the
+    // outbox worker's per-recipient delivery error accumulation (no synchronous
+    // 403 mapping — that pattern was tied to the inline axios.post path).
+    // TODO(pv-yowo): userCalendars[0] is bookkeeping-only — the FK on the outbox
+    // row needs an anchor but delivery is driven by activity.to. Activity
+    // construction migration into the AP domain (pv-yowo) will resolve this.
+    await this.activityPubInterface!.addToOutbox(userCalendars[0], updateActivity);
 
-      // Construct a local representation of the updated event
-      const event = new CalendarEvent(
-        eventId,
-        remoteCalendarActor.id,
-        this.generateEventUrl(eventId),
-        false,
-      );
+    // Construct a local representation of the updated event for the caller.
+    const event = new CalendarEvent(
+      eventId,
+      remoteCalendarActor.id,
+      this.generateEventUrl(eventId),
+      false,
+    );
 
-      // Add content from params
-      if (eventParams.content) {
-        for (const [language, content] of Object.entries(eventParams.content)) {
-          const contentObj = content as any;
-          event.addContent(new CalendarEventContent(language, contentObj.name || '', contentObj.description || ''));
-        }
+    if (eventParams.content) {
+      for (const [language, content] of Object.entries(eventParams.content)) {
+        const contentObj = content as any;
+        event.addContent(new CalendarEventContent(language, contentObj.name || '', contentObj.description || ''));
       }
+    }
 
-      return event;
-    }
-    catch (error: any) {
-      logError(error, '[Calendar] Failed to update event on remote calendar');
-      if (error.response?.status === 403) {
-        throw new InsufficientCalendarPermissionsError('You are not authorized to update events on this calendar');
-      }
-      throw new Error(`Failed to update event on remote calendar: ${error.message}`);
-    }
+    return event;
   }
 
   /**
@@ -576,11 +575,13 @@ class EventService {
 
     // Build the ActivityPub Delete activity
     // Include the local event ID so the remote can look it up
-    const deleteActivity = {
+    const deleteActivityObject = {
       '@context': 'https://www.w3.org/ns/activitystreams',
       type: 'Delete',
       id: `https://${localDomain}/activities/${uuidv4()}`,
       actor: actorUri,
+      // Explicit single-recipient delivery: the outbox worker honors `to` and
+      // skips follower fan-out for Delete activities (per pv-dyyw.1.2).
       to: [remoteCalendarActor.actorUri],
       object: {
         type: 'Tombstone',
@@ -591,44 +592,40 @@ class EventService {
       },
     };
 
-    // Send to the remote calendar's inbox
-    const inboxUrl = remoteCalendarActor.inboxUrl;
-    if (!inboxUrl) {
+    // Verify the remote calendar inbox is configured. The outbox worker
+    // resolves and validates the inbox URL (SSRF guard) at delivery time.
+    if (!remoteCalendarActor.inboxUrl) {
       throw new CalendarNotFoundError('Remote calendar inbox URL not configured');
     }
 
-    logger.info({ inboxUrl }, 'Sending Delete activity to remote calendar');
+    logger.info({ inboxUrl: remoteCalendarActor.inboxUrl }, 'Enqueuing Delete activity for remote calendar');
 
-    // SECURITY: Validate that the inbox URL does not point to a private IP address
-    // to prevent SSRF attacks where a malicious remote calendar advertises an internal
-    // network address as its inbox.
-    try {
-      await validateUrlNotPrivate(inboxUrl);
-    }
-    catch (error) {
-      const errorMsg = `Security: Blocked delivery to private inbox URL: ${error instanceof Error ? error.message : String(error)}`;
-      logError(error, `[Calendar] Security: Blocked delivery to private inbox URL for delete activity`);
-      throw new Error(errorMsg);
+    // Wrap as a DeleteActivity model so addToOutbox receives the expected
+    // ActivityPubActivity shape. The full Tombstone object is preserved on
+    // the activity (DeleteActivity.fromObject keeps `object` as-is) so the
+    // remote inbox can read formerType / eventId fields.
+    const deleteActivity = DeleteActivity.fromObject(deleteActivityObject);
+    if (!deleteActivity) {
+      throw new Error('Failed to construct DeleteActivity for remote event delete');
     }
 
-    try {
-      const response = await axios.post(inboxUrl, deleteActivity, {
-        timeout: FEDERATION_HTTP_TIMEOUT_MS,
-        maxRedirects: 0,
-        headers: {
-          'Content-Type': 'application/activity+json',
-        },
-      });
+    // The outbox helper requires a local Calendar to anchor the message
+    // (calendar_id FK). For user-actor activities, no specific calendar is
+    // semantically the "owner" — pick the first local calendar the user can
+    // edit as the bookkeeping anchor. Delivery routing is driven by the
+    // activity's explicit `to` field, not by this calendar.
+    const userCalendars = await this.calendarService.editableCalendarsForUser(account);
+    if (userCalendars.length === 0) {
+      throw new InsufficientCalendarPermissionsError('User has no local calendar to anchor outbox delivery');
+    }
 
-      logger.info({ status: response.status }, 'Remote calendar accepted Delete activity');
-    }
-    catch (error: any) {
-      logError(error, '[Calendar] Failed to delete event on remote calendar');
-      if (error.response?.status === 403) {
-        throw new InsufficientCalendarPermissionsError('You are not authorized to delete events on this calendar');
-      }
-      throw new Error(`Failed to delete event on remote calendar: ${error.message}`);
-    }
+    // Fire-and-forget enqueue. Errors surface asynchronously through the
+    // outbox worker's per-recipient delivery error accumulation (no synchronous
+    // 403 mapping — that pattern was tied to the inline axios.post path).
+    // TODO(pv-yowo): userCalendars[0] is bookkeeping-only — the FK on the outbox
+    // row needs an anchor but delivery is driven by activity.to. Activity
+    // construction migration into the AP domain (pv-yowo) will resolve this.
+    await this.activityPubInterface!.addToOutbox(userCalendars[0], deleteActivity);
   }
 
   /**

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 import config from 'config';
-import axios from 'axios';
 
 import { Account } from "@/common/model/account";
 import { Calendar } from "@/common/model/calendar";
@@ -31,8 +30,7 @@ import { EventCategoryContentEntity } from '@/server/calendar/entity/event_categ
 import { EventCategoryAssignmentEntity } from '@/server/calendar/entity/event_category_assignment';
 import { EventInstanceEntity } from '@/server/calendar/entity/event_instance';
 import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
-import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
-import { FEDERATION_HTTP_TIMEOUT_MS } from '@/server/common/constants';
+import { FederationDeliveryError } from '@/common/exceptions/activitypub';
 import db from '@/server/common/entity/db';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
@@ -383,61 +381,67 @@ class EventService {
 
     logger.info({ inboxUrl }, 'Sending Create activity to remote calendar');
 
-    // SECURITY: Validate that the inbox URL does not point to a private IP address
-    // to prevent SSRF attacks where a malicious remote calendar advertises an internal
-    // network address as its inbox.
+    // Delegate signed federation delivery to the AP domain. The helper handles
+    // SSRF validation, HTTP signing, and per-status response shaping internally.
+    // Network/TLS/timeout/signing failures throw FederationDeliveryError; non-2xx
+    // and empty 202 responses resolve as { status, data: null }. The signing
+    // actor URI must equal the activity's `actor` field so the receiver can
+    // resolve the keyId — both are `actorUri` here (per pv-dyyw signing table).
+    let response: { status: number; data: any };
     try {
-      await validateUrlNotPrivate(inboxUrl);
-    }
-    catch (error) {
-      const errorMsg = `Security: Blocked delivery to private inbox URL: ${error instanceof Error ? error.message : String(error)}`;
-      logError(error, `[Calendar] Security: Blocked delivery to private inbox URL for create activity`);
-      throw new Error(errorMsg);
-    }
-
-    try {
-      const response = await axios.post(inboxUrl, createActivity, {
-        timeout: FEDERATION_HTTP_TIMEOUT_MS,
-        maxRedirects: 0,
-        headers: {
-          'Content-Type': 'application/activity+json',
-        },
-      });
-
-      logger.info({ status: response.status }, 'Remote calendar accepted Create activity');
-
-      // The remote calendar should return the created event as JSON
-      if (response.data && typeof response.data === 'object' && response.data.id) {
-        // Use the event data returned by the remote calendar
-        const event = CalendarEvent.fromObject(response.data);
-        return event;
-      }
-
-      // Fallback: construct a local representation of the event if no response data
-      const event = new CalendarEvent(
-        eventId,
-        remoteCalendarActor.id,
-        this.generateEventUrl(eventId),
-        false,
-      );
-
-      // Add content from params
-      if (eventParams.content) {
-        for (const [language, content] of Object.entries(eventParams.content)) {
-          const contentObj = content as any;
-          event.addContent(new CalendarEventContent(language, contentObj.name || '', contentObj.description || ''));
-        }
-      }
-
-      return event;
+      response = await this.activityPubInterface!.deliverActivitySigned(actorUri, createActivity, inboxUrl);
     }
     catch (error: any) {
       logError(error, '[Calendar] Failed to create event on remote calendar');
-      if (error.response?.status === 403) {
-        throw new InsufficientCalendarPermissionsError('You are not authorized to create events on this calendar');
+      if (error instanceof FederationDeliveryError) {
+        throw new Error(`Failed to create event on remote calendar: ${error.message}`);
       }
-      throw new Error(`Failed to create event on remote calendar: ${error.message}`);
+      throw error;
     }
+
+    // 403 response from the remote calendar: caller is not authorized to create
+    // events there. The new contract surfaces this as a resolved { status: 403,
+    // data: null } object rather than an axios error, so check `status` directly.
+    if (response.status === 403) {
+      throw new InsufficientCalendarPermissionsError('You are not authorized to create events on this calendar');
+    }
+
+    // Other non-2xx statuses still need to surface as a meaningful error.
+    if (response.status < 200 || response.status >= 300) {
+      logError(
+        new Error(`Remote inbox returned status ${response.status}`),
+        '[Calendar] Failed to create event on remote calendar',
+      );
+      throw new Error(`Failed to create event on remote calendar: remote returned status ${response.status}`);
+    }
+
+    logger.info({ status: response.status }, 'Remote calendar accepted Create activity');
+
+    // The remote calendar should return the created event as JSON. `data` may
+    // be null (empty 202) — guard before constructing the model from it.
+    if (response.data && typeof response.data === 'object' && response.data?.id) {
+      // Use the event data returned by the remote calendar
+      const event = CalendarEvent.fromObject(response.data);
+      return event;
+    }
+
+    // Fallback: construct a local representation of the event if no response data
+    const event = new CalendarEvent(
+      eventId,
+      remoteCalendarActor.id,
+      this.generateEventUrl(eventId),
+      false,
+    );
+
+    // Add content from params
+    if (eventParams.content) {
+      for (const [language, content] of Object.entries(eventParams.content)) {
+        const contentObj = content as any;
+        event.addContent(new CalendarEventContent(language, contentObj.name || '', contentObj.description || ''));
+      }
+    }
+
+    return event;
   }
 
   /**

--- a/src/server/calendar/test/EventService/ssrf_protection.test.ts
+++ b/src/server/calendar/test/EventService/ssrf_protection.test.ts
@@ -1,11 +1,13 @@
 /**
  * Tests for SSRF protection in EventService remote ActivityPub dispatch methods.
  *
- * These tests verify that the three methods that POST to federation-supplied
- * inbox URLs (createRemoteEvent, updateRemoteEventViaActivityPub,
- * deleteRemoteEventViaActivityPub) correctly validate inbox URLs before
- * dispatching via axios, blocking delivery when the URL resolves to a private
- * IP address.
+ * The Create call site (createRemoteEvent) still posts inline via axios and
+ * its SSRF protection is verified here. The Update and Delete call sites have
+ * been migrated to the signed outbox pathway (pv-dyyw.2.2): they now enqueue
+ * activities via activityPubInterface.addToOutbox with explicit single-recipient
+ * `to` delivery. SSRF validation for those paths happens in the outbox worker
+ * (covered by AP-domain tests), so the calendar-domain tests for Update/Delete
+ * verify activity shape and outbox enqueue rather than inline axios delivery.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -14,8 +16,10 @@ import axios from 'axios';
 import { EventEmitter } from 'events';
 
 import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
 import type { CalendarActor } from '@/server/activitypub/entity/calendar_actor';
 import EventService from '@/server/calendar/service/events';
+import CalendarService from '@/server/calendar/service/calendar';
 import * as ipValidation from '@/server/common/helper/ip-validation';
 
 const REMOTE_INBOX_URL = 'https://remote.example.com/inbox';
@@ -45,11 +49,13 @@ function buildRemoteCalendarActor(inboxUrl: string): CalendarActor {
 
 /**
  * Creates a mock ActivityPubInterface with getUserActorUri stubbed to return
- * a test actor URI.
+ * a test actor URI. addToOutbox is also stubbed for migrated call sites
+ * (Update / Delete via signed outbox pathway).
  */
 function buildMockApInterface() {
   return {
     getUserActorUri: sinon.stub().resolves('https://local.example.com/users/test'),
+    addToOutbox: sinon.stub().resolves(),
   } as any;
 }
 
@@ -114,50 +120,30 @@ describe('EventService', () => {
     });
   });
 
-  describe('updateRemoteEventViaActivityPub', () => {
+  describe('updateRemoteEventViaActivityPub (migrated to addToOutbox)', () => {
     let service: EventService;
     let sandbox: sinon.SinonSandbox;
     let account: Account;
-    let postStub: sinon.SinonStub;
-    let validateUrlStub: sinon.SinonStub;
+    let mockApInterface: any;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       service = new EventService(new EventEmitter());
-      service.setActivityPubInterface(buildMockApInterface());
+      mockApInterface = buildMockApInterface();
+      service.setActivityPubInterface(mockApInterface);
       account = new Account('account-123', 'test@example.com', 'test@example.com');
 
-      postStub = sandbox.stub(axios, 'post');
-
-      // Default: SSRF validation passes
-      validateUrlStub = sandbox.stub(ipValidation, 'validateUrlNotPrivate').resolves(true);
+      // The migrated path looks up the user's editable local calendars to
+      // anchor the outbox message (calendar_id FK). Provide one.
+      const userCalendar = new Calendar('local-cal-id', 'local_cal');
+      sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser').resolves([userCalendar]);
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    it('should throw and NOT call axios.post when inbox URL is a private IP (SSRF)', async () => {
-      const remoteCalendarActor = buildRemoteCalendarActor(PRIVATE_INBOX_URL);
-      const eventId = '11111111-1111-4111-8111-111111111111';
-      const eventParams = {
-        content: { en: { name: 'Updated Event', description: 'Updated description' } },
-        start_date: '2026-03-02',
-        start_time: '11:00',
-      };
-
-      validateUrlStub.rejects(
-        new Error('Access to private IP address 192.168.1.1 is not allowed'),
-      );
-
-      await expect(
-        (service as any).updateRemoteEventViaActivityPub(account, remoteCalendarActor, eventId, eventParams),
-      ).rejects.toThrow('Security: Blocked delivery to private inbox URL');
-
-      expect(postStub.called).toBe(false);
-    });
-
-    it('should call axios.post when inbox URL passes SSRF validation', async () => {
+    it('should enqueue an Update activity via addToOutbox with explicit `to`', async () => {
       const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
       const eventId = '11111111-1111-4111-8111-111111111111';
       const eventParams = {
@@ -165,64 +151,82 @@ describe('EventService', () => {
         start_date: '2026-03-02',
         start_time: '11:00',
       };
-
-      postStub.resolves({ status: 200, data: {} });
 
       await (service as any).updateRemoteEventViaActivityPub(account, remoteCalendarActor, eventId, eventParams);
 
-      expect(postStub.called).toBe(true);
-      expect(postStub.firstCall.args[0]).toBe(REMOTE_INBOX_URL);
+      expect(mockApInterface.addToOutbox.calledOnce).toBe(true);
+      const [calendarArg, activityArg] = mockApInterface.addToOutbox.firstCall.args;
+      expect(calendarArg.id).toBe('local-cal-id');
+      expect(activityArg.type).toBe('Update');
+      expect(activityArg.actor).toBe('https://local.example.com/users/test');
+      // Explicit single-recipient delivery — outbox worker honors `to` and
+      // skips follower fan-out for Update activities (per pv-dyyw.1.2).
+      expect(activityArg.to).toEqual([remoteCalendarActor.actorUri]);
+    });
+
+    it('should throw when remote calendar inbox URL is missing', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor('') as any;
+      remoteCalendarActor.inboxUrl = null;
+      const eventId = '11111111-1111-4111-8111-111111111111';
+      const eventParams = {
+        content: { en: { name: 'Updated Event', description: 'Updated description' } },
+      };
+
+      await expect(
+        (service as any).updateRemoteEventViaActivityPub(account, remoteCalendarActor, eventId, eventParams),
+      ).rejects.toThrow();
+
+      expect(mockApInterface.addToOutbox.called).toBe(false);
     });
   });
 
-  describe('deleteRemoteEventViaActivityPub', () => {
+  describe('deleteRemoteEventViaActivityPub (migrated to addToOutbox)', () => {
     let service: EventService;
     let sandbox: sinon.SinonSandbox;
     let account: Account;
-    let postStub: sinon.SinonStub;
-    let validateUrlStub: sinon.SinonStub;
+    let mockApInterface: any;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       service = new EventService(new EventEmitter());
-      service.setActivityPubInterface(buildMockApInterface());
+      mockApInterface = buildMockApInterface();
+      service.setActivityPubInterface(mockApInterface);
       account = new Account('account-123', 'test@example.com', 'test@example.com');
 
-      postStub = sandbox.stub(axios, 'post');
-
-      // Default: SSRF validation passes
-      validateUrlStub = sandbox.stub(ipValidation, 'validateUrlNotPrivate').resolves(true);
+      const userCalendar = new Calendar('local-cal-id', 'local_cal');
+      sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser').resolves([userCalendar]);
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    it('should throw and NOT call axios.post when inbox URL is a private IP (SSRF)', async () => {
-      const remoteCalendarActor = buildRemoteCalendarActor(PRIVATE_INBOX_URL);
-      const eventId = '22222222-2222-4222-8222-222222222222';
-
-      validateUrlStub.rejects(
-        new Error('Access to private IP address 192.168.1.1 is not allowed'),
-      );
-
-      await expect(
-        (service as any).deleteRemoteEventViaActivityPub(account, remoteCalendarActor, eventId),
-      ).rejects.toThrow('Security: Blocked delivery to private inbox URL');
-
-      expect(postStub.called).toBe(false);
-    });
-
-    it('should call axios.post when inbox URL passes SSRF validation', async () => {
+    it('should enqueue a Delete activity via addToOutbox with explicit `to`', async () => {
       const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
       const eventId = '22222222-2222-4222-8222-222222222222';
 
-      postStub.resolves({ status: 200, data: {} });
-
       await (service as any).deleteRemoteEventViaActivityPub(account, remoteCalendarActor, eventId);
 
-      expect(postStub.called).toBe(true);
-      expect(postStub.firstCall.args[0]).toBe(REMOTE_INBOX_URL);
+      expect(mockApInterface.addToOutbox.calledOnce).toBe(true);
+      const [calendarArg, activityArg] = mockApInterface.addToOutbox.firstCall.args;
+      expect(calendarArg.id).toBe('local-cal-id');
+      expect(activityArg.type).toBe('Delete');
+      expect(activityArg.actor).toBe('https://local.example.com/users/test');
+      // Explicit single-recipient delivery — outbox worker honors `to` and
+      // skips follower fan-out for Delete activities (per pv-dyyw.1.2).
+      expect(activityArg.to).toEqual([remoteCalendarActor.actorUri]);
+    });
+
+    it('should throw when remote calendar inbox URL is missing', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor('') as any;
+      remoteCalendarActor.inboxUrl = null;
+      const eventId = '22222222-2222-4222-8222-222222222222';
+
+      await expect(
+        (service as any).deleteRemoteEventViaActivityPub(account, remoteCalendarActor, eventId),
+      ).rejects.toThrow();
+
+      expect(mockApInterface.addToOutbox.called).toBe(false);
     });
   });
 });

--- a/src/server/calendar/test/EventService/ssrf_protection.test.ts
+++ b/src/server/calendar/test/EventService/ssrf_protection.test.ts
@@ -1,18 +1,24 @@
 /**
- * Tests for SSRF protection in EventService remote ActivityPub dispatch methods.
+ * Tests for federated ActivityPub dispatch in EventService.
  *
- * The Create call site (createRemoteEvent) still posts inline via axios and
- * its SSRF protection is verified here. The Update and Delete call sites have
- * been migrated to the signed outbox pathway (pv-dyyw.2.2): they now enqueue
- * activities via activityPubInterface.addToOutbox with explicit single-recipient
- * `to` delivery. SSRF validation for those paths happens in the outbox worker
- * (covered by AP-domain tests), so the calendar-domain tests for Update/Delete
- * verify activity shape and outbox enqueue rather than inline axios delivery.
+ * All three call sites (Create, Update, Delete) are now migrated off the inline
+ * axios.post pathway:
+ *   - Create  -> activityPubInterface.deliverActivitySigned (signed sync delivery
+ *                because the caller reads back the remote response body to
+ *                construct the local CalendarEvent model). SSRF validation,
+ *                signing, and timeout enforcement happen inside the helper.
+ *   - Update  -> activityPubInterface.addToOutbox (signed async delivery via
+ *                the outbox worker, single-recipient via explicit `to`).
+ *   - Delete  -> activityPubInterface.addToOutbox (same as Update).
+ *
+ * SSRF protection for the migrated paths is exercised in the AP-domain tests
+ * for the outbox helper / worker. The calendar-domain tests here verify the
+ * service-layer contract: which AP method is called, with what activity shape,
+ * and how the helper's response/exceptions are mapped to caller-visible errors.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
-import axios from 'axios';
 import { EventEmitter } from 'events';
 
 import { Account } from '@/common/model/account';
@@ -20,10 +26,10 @@ import { Calendar } from '@/common/model/calendar';
 import type { CalendarActor } from '@/server/activitypub/entity/calendar_actor';
 import EventService from '@/server/calendar/service/events';
 import CalendarService from '@/server/calendar/service/calendar';
-import * as ipValidation from '@/server/common/helper/ip-validation';
+import { InsufficientCalendarPermissionsError } from '@/common/exceptions/calendar';
+import { FederationDeliveryError } from '@/common/exceptions/activitypub';
 
 const REMOTE_INBOX_URL = 'https://remote.example.com/inbox';
-const PRIVATE_INBOX_URL = 'https://192.168.1.1/inbox';
 
 /**
  * Builds a minimal CalendarActor model for testing.
@@ -48,62 +54,37 @@ function buildRemoteCalendarActor(inboxUrl: string): CalendarActor {
 }
 
 /**
- * Creates a mock ActivityPubInterface with getUserActorUri stubbed to return
- * a test actor URI. addToOutbox is also stubbed for migrated call sites
- * (Update / Delete via signed outbox pathway).
+ * Creates a mock ActivityPubInterface with the methods used by EventService
+ * stubbed: getUserActorUri, addToOutbox, and deliverActivitySigned.
  */
 function buildMockApInterface() {
   return {
     getUserActorUri: sinon.stub().resolves('https://local.example.com/users/test'),
     addToOutbox: sinon.stub().resolves(),
+    deliverActivitySigned: sinon.stub().resolves({ status: 202, data: null }),
   } as any;
 }
 
 describe('EventService', () => {
-  describe('createRemoteEvent', () => {
+  describe('createRemoteEvent (migrated to deliverActivitySigned)', () => {
     let service: EventService;
     let sandbox: sinon.SinonSandbox;
     let account: Account;
-    let postStub: sinon.SinonStub;
-    let validateUrlStub: sinon.SinonStub;
+    let mockApInterface: any;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       service = new EventService(new EventEmitter());
-      service.setActivityPubInterface(buildMockApInterface());
+      mockApInterface = buildMockApInterface();
+      service.setActivityPubInterface(mockApInterface);
       account = new Account('account-123', 'test@example.com', 'test@example.com');
-
-      postStub = sandbox.stub(axios, 'post');
-
-      // Default: SSRF validation passes
-      validateUrlStub = sandbox.stub(ipValidation, 'validateUrlNotPrivate').resolves(true);
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
-    it('should throw and NOT call axios.post when inbox URL is a private IP (SSRF)', async () => {
-      const remoteCalendarActor = buildRemoteCalendarActor(PRIVATE_INBOX_URL);
-      const eventParams = {
-        content: { en: { name: 'Test Event', description: 'Test description' } },
-        start_date: '2026-03-01',
-        start_time: '10:00',
-      };
-
-      // Override: simulate validateUrlNotPrivate blocking a private IP
-      validateUrlStub.rejects(
-        new Error('Access to private IP address 192.168.1.1 is not allowed'),
-      );
-
-      await expect(
-        (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams),
-      ).rejects.toThrow('Security: Blocked delivery to private inbox URL');
-
-      expect(postStub.called).toBe(false);
-    });
-
-    it('should call axios.post when inbox URL passes SSRF validation', async () => {
+    it('signs Create delivery with the user actor URI matching activity.actor', async () => {
       const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
       const eventParams = {
         content: { en: { name: 'Test Event', description: 'Test description' } },
@@ -111,12 +92,123 @@ describe('EventService', () => {
         start_time: '10:00',
       };
 
-      postStub.resolves({ status: 200, data: {} });
+      mockApInterface.deliverActivitySigned.resolves({ status: 202, data: null });
 
       await (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams);
 
-      expect(postStub.called).toBe(true);
-      expect(postStub.firstCall.args[0]).toBe(REMOTE_INBOX_URL);
+      expect(mockApInterface.deliverActivitySigned.calledOnce).toBe(true);
+      const [signingActorUri, activityArg, inboxUrlArg] = mockApInterface.deliverActivitySigned.firstCall.args;
+      // Per epic per-call-site signing actor table: Create signs with the user
+      // actor URI, which must equal the activity's `actor` field so the keyId
+      // is valid at the receiver.
+      expect(signingActorUri).toBe('https://local.example.com/users/test');
+      expect(activityArg.actor).toBe(signingActorUri);
+      expect(activityArg.type).toBe('Create');
+      expect(activityArg.to).toEqual([remoteCalendarActor.actorUri]);
+      expect(inboxUrlArg).toBe(REMOTE_INBOX_URL);
+    });
+
+    it('uses returned event data when remote response has data with an id', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      const remoteEventId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+      mockApInterface.deliverActivitySigned.resolves({
+        status: 200,
+        data: {
+          id: remoteEventId,
+          calendarId: remoteCalendarActor.id,
+        },
+      });
+
+      const result = await (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams);
+      expect(result.id).toBe(remoteEventId);
+    });
+
+    it('falls back to a locally-constructed event when response.data is null (e.g. empty 202)', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      mockApInterface.deliverActivitySigned.resolves({ status: 202, data: null });
+
+      const result = await (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams);
+      // Falls back to a locally-constructed CalendarEvent with the calendar ID
+      // matching the remote calendar actor.
+      expect(result).toBeDefined();
+      expect(result.calendarId).toBe(remoteCalendarActor.id);
+    });
+
+    it('falls back when response.data is non-null but has no id', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      // Some receivers return an empty object on success.
+      mockApInterface.deliverActivitySigned.resolves({ status: 200, data: {} });
+
+      const result = await (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams);
+      expect(result).toBeDefined();
+      expect(result.calendarId).toBe(remoteCalendarActor.id);
+    });
+
+    it('throws InsufficientCalendarPermissionsError when remote returns 403', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      // Per the new contract, non-2xx is a *resolved* { status, data: null }
+      // — the service must inspect status, not catch an axios-style error.
+      mockApInterface.deliverActivitySigned.resolves({ status: 403, data: null });
+
+      await expect(
+        (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams),
+      ).rejects.toThrow(InsufficientCalendarPermissionsError);
+    });
+
+    it('throws a generic error for other non-2xx statuses', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      mockApInterface.deliverActivitySigned.resolves({ status: 500, data: null });
+
+      await expect(
+        (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams),
+      ).rejects.toThrow('Failed to create event on remote calendar');
+    });
+
+    it('wraps FederationDeliveryError thrown by the helper as a generic error', async () => {
+      const remoteCalendarActor = buildRemoteCalendarActor(REMOTE_INBOX_URL);
+      const eventParams = {
+        content: { en: { name: 'Test Event', description: 'Test description' } },
+        start_date: '2026-03-01',
+        start_time: '10:00',
+      };
+
+      mockApInterface.deliverActivitySigned.rejects(
+        new FederationDeliveryError('Network failure delivering to remote inbox'),
+      );
+
+      await expect(
+        (service as any).createRemoteEvent(account, remoteCalendarActor, eventParams),
+      ).rejects.toThrow('Failed to create event on remote calendar');
     });
   });
 

--- a/src/server/calendar/test/service/remote_editor_grant.test.ts
+++ b/src/server/calendar/test/service/remote_editor_grant.test.ts
@@ -9,6 +9,7 @@ import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
 import { v4 as uuidv4 } from 'uuid';
 import sinon from 'sinon';
 import axios from 'axios';
+import config from 'config';
 
 import db from '@/server/common/entity/db';
 import CalendarService from '@/server/calendar/service/calendar';
@@ -19,14 +20,19 @@ import { UserActorEntity } from '@/server/activitypub/entity/user_actor';
 import { Account } from '@/common/model/account';
 import AccountsInterface from '@/server/accounts/interface';
 import type ActivityPubInterface from '@/server/activitypub/interface';
+import AddActivity from '@/server/activitypub/model/action/add';
 import { EventEmitter } from 'events';
 
 /**
  * Creates a mock ActivityPubInterface that delegates user actor lookups
  * to the real UserActorEntity database. This allows integration-style tests
  * to create DB rows directly while the service uses interface-based calls.
+ *
+ * `addToOutbox` is a sinon stub so editor-invite tests can assert the activity
+ * shape (actor, to, object, target, calendarId, calendarInboxUrl) that the
+ * service enqueues for delivery via the signed outbox path (pv-dyyw).
  */
-function createMockActivityPubInterface(): Partial<ActivityPubInterface> {
+function createMockActivityPubInterface(addToOutboxStub: sinon.SinonStub): Partial<ActivityPubInterface> {
   return {
     async findUserActorByUri(actorUri: string) {
       const entity = await UserActorEntity.findOne({ where: { actor_uri: actorUri } });
@@ -49,6 +55,7 @@ function createMockActivityPubInterface(): Partial<ActivityPubInterface> {
       });
       return { id: entity.id };
     },
+    addToOutbox: addToOutboxStub as unknown as ActivityPubInterface['addToOutbox'],
   };
 }
 
@@ -63,12 +70,14 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
   let sandbox: sinon.SinonSandbox;
   let service: CalendarService;
   let mockAccountsInterface: Partial<AccountsInterface>;
+  let addToOutboxStub: sinon.SinonStub;
   let testAccountId: string;
   let testCalendarId: string;
   let testAccount: Account;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
+    addToOutboxStub = sandbox.stub().resolves();
     await db.sync({ force: true });
 
     // Create test account
@@ -110,7 +119,7 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
     );
 
     // Wire up mock ActivityPub interface for user actor lookups
-    service.setActivityPubInterface(createMockActivityPubInterface() as ActivityPubInterface);
+    service.setActivityPubInterface(createMockActivityPubInterface(addToOutboxStub) as ActivityPubInterface);
   });
 
   afterEach(async () => {
@@ -151,9 +160,6 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
           },
         },
       });
-
-      // Mock the Add activity notification POST (best-effort, won't fail if it errors)
-      sandbox.stub(axios, 'post').resolves({ status: 200 });
 
       // Federated email (beta.federation.local is different from pavillion.dev)
       const result = await service.grantEditAccessByEmail(
@@ -221,9 +227,6 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
         },
       });
 
-      // Mock the Add activity notification POST (best-effort, won't fail if it errors)
-      sandbox.stub(axios, 'post').resolves({ status: 200 });
-
       const result = await service.grantEditAccessByEmail(
         testAccount,
         testCalendarId,
@@ -250,6 +253,24 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
         },
       });
       expect(membership).not.toBeNull();
+
+      // Verify the Add activity was enqueued via the signed outbox path with
+      // the calendar actor as the signing actor and the remote user as the
+      // single explicit recipient (so the outbox honors targeted delivery
+      // rather than fanning out to followers).
+      const localDomain = config.get<string>('domain');
+      const expectedCalendarActorUri = `https://${localDomain}/calendars/test_calendar`;
+      expect(addToOutboxStub.calledOnce).toBe(true);
+      const [calendarArg, activityArg] = addToOutboxStub.firstCall.args;
+      expect(calendarArg.id).toBe(testCalendarId);
+      expect(activityArg).toBeInstanceOf(AddActivity);
+      expect(activityArg.type).toBe('Add');
+      expect(activityArg.actor).toBe(expectedCalendarActorUri);
+      expect(activityArg.object).toBe('https://beta.federation.local/users/Admin');
+      expect(activityArg.target).toBe(`${expectedCalendarActorUri}/editors`);
+      expect(activityArg.to).toEqual(['https://beta.federation.local/users/Admin']);
+      expect(activityArg.calendarId).toBe(testCalendarId);
+      expect(activityArg.calendarInboxUrl).toBe(`${expectedCalendarActorUri}/inbox`);
     });
 
     it('should throw error if remote editor already exists', async () => {
@@ -353,12 +374,11 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
       expect(axiosStub.callCount).toBe(1);
     });
 
-    it('should return remote_editor without posting to inbox if inbox URL resolves to private IP', async () => {
-      // WebFinger and actor URL validations pass; inbox POST validation is blocked
+    it('should not fail the grant if the outbox enqueue throws (best-effort delivery)', async () => {
+      // WebFinger and actor URL validations pass
       vi.mocked(validateUrlNotPrivate)
         .mockResolvedValueOnce(true)  // WebFinger
-        .mockResolvedValueOnce(true)  // actor URI
-        .mockRejectedValueOnce(new Error('IP address is private'));  // inbox
+        .mockResolvedValueOnce(true);  // actor URI
 
       const axiosStub = sandbox.stub(axios, 'get');
       axiosStub.onFirstCall().resolves({
@@ -381,7 +401,14 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
           publicKey: { publicKeyPem: '-----BEGIN PUBLIC KEY-----...' },
         },
       });
-      const axiosPostStub = sandbox.stub(axios, 'post');
+
+      // Simulate a failure enqueuing the Add activity (e.g. transient DB error
+      // on the ap_outbox insert). The local membership row should still be
+      // created — local state is not contingent on remote delivery success.
+      // SSRF protection for the remote inbox URL is enforced by the outbox
+      // worker (deliverViaHttp -> validateUrlNotPrivate), so the calendar
+      // service no longer needs to gate on it itself.
+      addToOutboxStub.rejects(new Error('outbox insert failed'));
 
       const result = await service.grantEditAccessByEmail(
         testAccount,
@@ -389,10 +416,18 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
         'Admin@beta.federation.local',
       );
 
-      // The grant itself succeeds (DB record created), but the inbox notification is skipped
       expect(result.type).toBe('remote_editor');
       expect((result.data as any).actorUri).toBe('https://beta.federation.local/users/Admin');
-      expect(axiosPostStub.called).toBe(false);
+
+      // Local membership should still exist despite the enqueue failure
+      const userActor = await UserActorEntity.findOne({
+        where: { actor_uri: 'https://beta.federation.local/users/Admin' },
+      });
+      expect(userActor).not.toBeNull();
+      const membership = await CalendarMemberEntity.findOne({
+        where: { calendar_id: testCalendarId, user_actor_id: userActor!.id },
+      });
+      expect(membership).not.toBeNull();
     });
 
     it('should throw error if Person actor type is wrong', async () => {

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -105,7 +105,12 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
   });
 
   test('should allow editor from Instance Beta to create event on Instance Alpha calendar', async () => {
-    // Editor from Instance Beta creates an event on Instance Alpha calendar
+    // Editor from Instance Beta creates an event on Instance Alpha calendar.
+    // The editor-invite `Add` activity is delivered asynchronously through the
+    // outbox worker (pv-dyyw), so Beta may not yet know about the remote
+    // calendar when the previous test's grant call returns. Poll the create
+    // request until Beta has established the remote calendar membership and
+    // accepts the event (201), or until the timeout elapses.
     const eventData = {
       calendarId: alphaCalendarId,
       content: {
@@ -120,20 +125,25 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
       end_time: '16:00',
     };
 
-    const response = await fetch(`${INSTANCE_BETA.baseUrl}/api/v1/events`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${betaAdminToken}`,
+    let response: Response | undefined;
+    await expect.poll(
+      async () => {
+        response = await fetch(`${INSTANCE_BETA.baseUrl}/api/v1/events`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${betaAdminToken}`,
+          },
+          body: JSON.stringify(eventData),
+          // @ts-ignore - agent is not in the TypeScript types but works at runtime
+          agent: httpsAgent,
+        });
+        return response.status;
       },
-      body: JSON.stringify(eventData),
-      // @ts-ignore - agent is not in the TypeScript types but works at runtime
-      agent: httpsAgent,
-    });
+      { timeout: 15000, intervals: [500, 1000, 2000] },
+    ).toBe(201);
 
-    expect(response.status).toBe(201);
-
-    const event = await response.json();
+    const event = await response!.json();
     expect(event.content.en.name).toBe('Cross-Instance Event');
     expect(event.calendarId).toBe(alphaCalendarId);
   });
@@ -217,19 +227,22 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
 
     expect(updateResponse.status).toBe(200);
 
-    // Verify update is reflected on Instance Alpha
-    const verifyResponse = await getCalendarEvents(
-      INSTANCE_ALPHA,
-      alphaAdminToken,
-      alphaCalendarUrlName,
-    );
-    const updatedEvents = await verifyResponse.json();
-    const updatedEvent = updatedEvents.find((e: any) => e.id === event.id);
-
-    expect(updatedEvent.content.en.name).toBe('Updated Cross-Instance Event');
-    expect(updatedEvent.content.en.description).toBe(
-      'Event updated by editor from Instance Beta',
-    );
+    // Verify update is reflected on Instance Alpha. The Update activity is
+    // delivered asynchronously through the outbox worker (pv-dyyw), so poll
+    // until the remote instance reflects the new title.
+    await expect.poll(
+      async () => {
+        const verifyResponse = await getCalendarEvents(
+          INSTANCE_ALPHA,
+          alphaAdminToken,
+          alphaCalendarUrlName,
+        );
+        const updatedEvents = await verifyResponse.json();
+        const updated = updatedEvents.find((e: any) => e.id === event.id);
+        return updated?.content?.en?.name;
+      },
+      { timeout: 15000, intervals: [500, 1000, 2000] },
+    ).toBe('Updated Cross-Instance Event');
   });
 
   test('should allow editor to delete event on remote calendar', async () => {
@@ -262,16 +275,21 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
 
     expect(deleteResponse.status).toBe(204); // No content on successful delete
 
-    // Verify deletion on Instance Alpha
-    const verifyResponse = await getCalendarEvents(
-      INSTANCE_ALPHA,
-      alphaAdminToken,
-      alphaCalendarUrlName,
-    );
-    const remainingEvents = await verifyResponse.json();
-    const deletedEvent = remainingEvents.find((e: any) => e.id === event.id);
-
-    expect(deletedEvent).toBeUndefined();
+    // Verify deletion on Instance Alpha. The Delete activity is delivered
+    // asynchronously through the outbox worker (pv-dyyw), so poll until the
+    // remote instance no longer returns the event.
+    await expect.poll(
+      async () => {
+        const verifyResponse = await getCalendarEvents(
+          INSTANCE_ALPHA,
+          alphaAdminToken,
+          alphaCalendarUrlName,
+        );
+        const remainingEvents = await verifyResponse.json();
+        return remainingEvents.find((e: any) => e.id === event.id);
+      },
+      { timeout: 15000, intervals: [500, 1000, 2000] },
+    ).toBeUndefined();
   });
 
   test('should allow owner to revoke cross-instance editor access', async () => {

--- a/tests/e2e/federation/helpers/api.ts
+++ b/tests/e2e/federation/helpers/api.ts
@@ -452,6 +452,44 @@ export async function updateEvent(
 }
 
 /**
+ * Delete an event by id
+ *
+ * Deletes an event using the Pavillion API. When the calendar
+ * has followers, this will trigger a Delete (Tombstone) activity
+ * to those followers.
+ *
+ * @param instance - The instance where the event exists
+ * @param token - Authentication token from getToken()
+ * @param eventId - ID of the event to delete
+ * @param calendarId - ID of the calendar (required for cross-instance deletes; optional otherwise)
+ * @throws Error if delete fails (response is not 204)
+ */
+export async function deleteEvent(
+  instance: InstanceConfig,
+  token: string,
+  eventId: string,
+  calendarId?: string,
+): Promise<void> {
+  const url = calendarId
+    ? `${instance.baseUrl}/api/v1/events/${encodeURIComponent(eventId)}?calendarId=${encodeURIComponent(calendarId)}`
+    : `${instance.baseUrl}/api/v1/events/${encodeURIComponent(eventId)}`;
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+    },
+    // @ts-ignore - agent is not in the TypeScript types but works at runtime
+    agent: httpsAgent,
+  });
+
+  if (response.status !== 204) {
+    const errorText = await response.text();
+    throw new Error(`Failed to delete event: ${response.status} ${errorText}`);
+  }
+}
+
+/**
  * Get list of calendars for the authenticated user
  *
  * @param instance - The instance to query

--- a/tests/e2e/federation/signed_delivery.spec.ts
+++ b/tests/e2e/federation/signed_delivery.spec.ts
@@ -1,0 +1,386 @@
+/**
+ * Signed Outbound Delivery for All Four Signed Activity Types
+ *
+ * Bead context: pv-dyyw.3.1 -- empirical proof that all four signed
+ * deliveries (Create, Update, Delete, Add) from this instance flow through
+ * the outbox under HTTP signatures and reach the remote inbox handler.
+ *
+ * Coverage (one assertion per signed activity type):
+ *   - Create(Event)              -> remote calendar inbox
+ *   - Update(Event)              -> remote calendar inbox
+ *   - Delete(Event) (Tombstone)  -> remote calendar inbox
+ *   - Add (editor invite)        -> remote user inbox
+ *
+ * What this proves (and what it does NOT prove):
+ *   Each test triggers a local action that, after Wave 2 of the pv-dyyw epic,
+ *   routes through addToOutbox / deliverActivitySigned. The outbox worker
+ *   signs the activity (Date, Digest, Signature headers) and POSTs it to the
+ *   remote inbox. We assert the side effect of each delivery on the remote
+ *   (event in feed, inbox log entry, editor relationship recorded), proving
+ *   the OUTBOUND signing + delivery pipeline works end to end.
+ *
+ *   This spec does NOT, on its own, prove that the receive-side cryptographic
+ *   gate would reject a forged or unsigned request: the Docker federation
+ *   harness sets SKIP_SIGNATURES=true on both instances, so
+ *   verifyHttpSignature short-circuits on the receiver. The cryptographic
+ *   round-trip (sign with a real RSA key, then verify with the matching
+ *   public key, both with SKIP_SIGNATURES=false) is proven separately by the
+ *   unit tests in
+ *   `src/server/activitypub/test/helper/http_signature.test.ts`
+ *   under describe block "HTTP Signature Cryptographic Round-Trip".
+ *
+ *   Together, this e2e (outbound pipeline) plus those unit tests
+ *   (cryptographic verification) cover the bead's acceptance criteria.
+ *
+ * Prerequisites:
+ *   - Federation environment running: npm run federation:start
+ *   - /etc/hosts entries for alpha.federation.local and beta.federation.local
+ */
+
+import { test, expect } from '@playwright/test';
+import https from 'https';
+import { execSync } from 'child_process';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  formatRemoteCalendarId,
+  generateCalendarName,
+} from './helpers/instances';
+import {
+  getToken,
+  createCalendar,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+  followCalendar,
+  getFeed,
+  grantEditorAccessByEmail,
+} from './helpers/api';
+
+// Self-signed cert tolerance for local Docker federation environment
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+/**
+ * Poll Beta's feed for an event matching the predicate.
+ *
+ * Returns the matching event if found within the timeout, otherwise undefined.
+ * Polling avoids brittle fixed sleeps when federation latency varies.
+ */
+async function waitForFeedEvent(
+  token: string,
+  calendarId: string,
+  predicate: (e: { content: Record<string, { title: string }> }) => boolean,
+  timeoutMs = 15000,
+  intervalMs = 1000,
+): Promise<{ id: string; content: Record<string, { title: string }> } | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const feed = await getFeed(INSTANCE_BETA, token, calendarId);
+    const match = feed.events.find(predicate);
+    if (match) return match;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return undefined;
+}
+
+/**
+ * Capture the current Beta container log line count so we can later inspect
+ * only log entries emitted AFTER an action under test. Without this anchor,
+ * a stale entry from a prior run (or a prior test in the same run) could
+ * satisfy a substring assertion and produce a false positive.
+ */
+function getBetaLogLineCount(): number {
+  try {
+    const out = execSync(
+      'docker logs pavillion-federation-beta 2>&1 | wc -l',
+      { encoding: 'utf8' },
+    );
+    return parseInt(out.trim(), 10) || 0;
+  }
+  catch {
+    return 0;
+  }
+}
+
+/**
+ * Poll Beta's container logs (only entries emitted AFTER `sinceLine`) for
+ * evidence that an inbox activity of the given type, mentioning the given
+ * needle, was processed.
+ *
+ * The inbox processing pipeline runs only AFTER verifyHttpSignature accepts
+ * the request. So any log entry from inbox.ts that mentions the activity
+ * type and the needle is positive evidence that signed delivery reached the
+ * inbox handler. Downstream business-logic outcomes (accept, reject,
+ * ownership failure) are out of scope here -- we are proving that the
+ * activity arrived, not that it was semantically valid.
+ *
+ * Used for Delete(Tombstone) where the side-effect ("event gone from feed")
+ * is masked by ownership-verification rules that fetch the now-deleted
+ * source object and fail with 404/500, rejecting the activity at a layer
+ * far below the inbox handler.
+ *
+ * @param activityType - ActivityPub activity type to look for (e.g. 'Delete')
+ * @param needle - Substring that must appear in the post-anchor log slice
+ *                 (typically the event id under test)
+ * @param sinceLine - Log line count captured BEFORE the action; only lines
+ *                    after this offset are considered
+ */
+function waitForBetaInboxActivity(
+  activityType: string,
+  needle: string,
+  sinceLine: number,
+  timeoutMs = 20000,
+  intervalMs = 1000,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      try {
+        // Slice the log to only entries emitted AFTER the action under test.
+        // tail -n +N starts at line N (1-indexed), so sinceLine + 1 yields
+        // strictly the new entries.
+        const logs = execSync(
+          `docker logs pavillion-federation-beta 2>&1 | tail -n +${sinceLine + 1}`,
+          { encoding: 'utf8' },
+        );
+        // The activityType is logged as a structured field; tolerate ANSI
+        // color codes around the JSON-ish key by checking substrings.
+        if (
+          logs.includes(needle)
+          && logs.includes('activityType')
+          && logs.includes(`"${activityType}"`)
+        ) {
+          resolve(true);
+          return;
+        }
+      }
+      catch { /* container may briefly be unavailable */ }
+      if (Date.now() >= deadline) {
+        resolve(false);
+        return;
+      }
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+/**
+ * Poll an async action that returns truthy on success. Useful when we need
+ * to wait for cross-instance state to settle (e.g. an editor relationship
+ * recorded on Beta after a signed Add delivery from Alpha) without resorting
+ * to fixed sleeps that flake in CI.
+ *
+ * Resolves with the truthy result on success or undefined on timeout.
+ */
+async function pollUntil<T>(
+  attempt: () => Promise<T | undefined>,
+  timeoutMs = 20000,
+  intervalMs = 1000,
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const result = await attempt();
+      if (result) return result;
+    }
+    catch { /* keep polling on transient errors */ }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return undefined;
+}
+
+test.describe.serial('Signed Delivery for All Four Activity Types', () => {
+  let alphaToken: string;
+  let betaToken: string;
+
+  let alphaCalendar: { id: string; urlName: string };
+  let betaCalendar: { id: string; urlName: string };
+  let createdEventId: string;
+  const createTitle = `SigDelivery Create ${Date.now()}`;
+  const updateTitle = `SigDelivery Update ${Date.now()}`;
+
+  test.beforeAll(async () => {
+    alphaToken = await getToken(
+      INSTANCE_ALPHA,
+      INSTANCE_ALPHA.adminEmail,
+      INSTANCE_ALPHA.adminPassword,
+    );
+    betaToken = await getToken(
+      INSTANCE_BETA,
+      INSTANCE_BETA.adminEmail,
+      INSTANCE_BETA.adminPassword,
+    );
+
+    // Fresh calendars on both instances so we don't collide with sibling specs.
+    alphaCalendar = await createCalendar(INSTANCE_ALPHA, alphaToken, {
+      urlName: generateCalendarName('asd'),
+      content: { en: { name: 'Alpha SigDelivery Calendar' } },
+    });
+    betaCalendar = await createCalendar(INSTANCE_BETA, betaToken, {
+      urlName: generateCalendarName('bsd'),
+      content: { en: { name: 'Beta SigDelivery Calendar' } },
+    });
+
+    // Beta follows Alpha. The Follow itself is a signed activity; the
+    // resulting Accept proves the round-trip works. Subsequent Create /
+    // Update / Delete event activities from Alpha then flow to Beta's
+    // calendar inbox under HTTP signatures.
+    const alphaRemoteId = formatRemoteCalendarId(alphaCalendar.urlName, INSTANCE_ALPHA);
+    await followCalendar(INSTANCE_BETA, betaToken, betaCalendar.id, alphaRemoteId);
+
+    // Allow Follow/Accept handshake to settle.
+    await new Promise(resolve => setTimeout(resolve, 3000));
+  });
+
+  test('Create(Event) signed delivery is accepted by remote calendar inbox', async () => {
+    // Create an event on Alpha. Outbox worker signs and POSTs Create(Event)
+    // to Beta's inbox. If signing or verification failed, the event would
+    // never reach Beta's feed.
+    const event = await createEvent(INSTANCE_ALPHA, alphaToken, {
+      calendarId: alphaCalendar.id,
+      content: {
+        en: {
+          title: createTitle,
+          description: 'Signed Create delivery test',
+        },
+      },
+      startTime: '2026-07-01T18:00:00Z',
+      endTime: '2026-07-01T20:00:00Z',
+    });
+    createdEventId = event.id;
+
+    const propagated = await waitForFeedEvent(
+      betaToken,
+      betaCalendar.id,
+      (e) => e.content?.en?.title === createTitle,
+    );
+
+    expect(
+      propagated,
+      'Create(Event) must be visible in remote feed after signed delivery',
+    ).toBeDefined();
+  });
+
+  test('Update(Event) signed delivery is accepted by remote calendar inbox', async () => {
+    // Mutate the previously-created event on Alpha. Outbox emits a signed
+    // Update(Event); Beta processes the update and refreshes the title in
+    // its feed.
+    expect(createdEventId).toBeDefined();
+    await updateEvent(INSTANCE_ALPHA, alphaToken, createdEventId, {
+      calendarId: alphaCalendar.id,
+      content: {
+        en: {
+          title: updateTitle,
+          description: 'Signed Update delivery test',
+        },
+      },
+      startTime: '2026-07-01T18:00:00Z',
+      endTime: '2026-07-01T20:00:00Z',
+    });
+
+    const updated = await waitForFeedEvent(
+      betaToken,
+      betaCalendar.id,
+      (e) => e.content?.en?.title === updateTitle,
+    );
+
+    expect(
+      updated,
+      'Update(Event) must be reflected in remote feed after signed delivery',
+    ).toBeDefined();
+  });
+
+  test('Delete(Event) Tombstone signed delivery is accepted by remote calendar inbox', async () => {
+    // Delete the event on Alpha. Outbox emits a signed Delete (Tombstone) and
+    // POSTs it to Beta's calendar inbox. The signature gate runs first; only
+    // if it passes does the inbox handler log "Received inbox activity".
+    //
+    // We assert delivery acceptance via Beta's container logs rather than via
+    // feed observation because Beta's actorOwnsObject check fetches the
+    // (now-deleted) event from Alpha and rejects on 404, which would mask a
+    // signature success. The presence of "Received inbox activity" with
+    // activityType: Delete and the deleted event id proves signed delivery
+    // succeeded; the downstream ownership rejection is a separate concern
+    // outside this bead's scope.
+    expect(createdEventId).toBeDefined();
+    const deletedId = createdEventId;
+
+    // Anchor BEFORE the delete so the log assertion cannot match entries
+    // from prior runs or earlier tests in this run.
+    const logAnchor = getBetaLogLineCount();
+
+    await deleteEvent(INSTANCE_ALPHA, alphaToken, deletedId);
+
+    const delivered = await waitForBetaInboxActivity('Delete', deletedId, logAnchor);
+
+    expect(
+      delivered,
+      'Delete(Event) Tombstone must reach Beta\'s inbox handler (proves signed delivery reached the inbox)',
+    ).toBe(true);
+  });
+
+  test('Add editor-invite signed delivery is accepted by remote user inbox', async () => {
+    // Trigger an editor invite from Alpha for a Beta user. This produces an
+    // Add activity addressed to the Beta user's inbox via addToOutbox with
+    // explicit `to`. The outbox worker signs and delivers it. Successful
+    // delivery is proven by Beta recording the editor relationship -- which
+    // Beta exposes by allowing the invited user to operate on Alpha's
+    // calendar.
+    const editorEmail = `Admin@${INSTANCE_BETA.domain}`;
+    const inviteCalendar = await createCalendar(INSTANCE_ALPHA, alphaToken, {
+      urlName: generateCalendarName('asa'),
+      content: { en: { name: 'Alpha SigDelivery Add Calendar' } },
+    });
+
+    const grantResponse = await grantEditorAccessByEmail(
+      INSTANCE_ALPHA,
+      alphaToken,
+      inviteCalendar.id,
+      editorEmail,
+    );
+    expect(grantResponse.status).toBe(201);
+
+    // Beta-side proof: the invited remote user can now create an event on
+    // Alpha's inviteCalendar. This requires that Beta processed the Add
+    // activity and recorded the editor relationship -- which only happens
+    // if the Add was successfully delivered to and accepted by Beta's user
+    // inbox.
+    //
+    // Federation latency varies, so retry the proof action until it succeeds
+    // or we hit the deadline. A fixed sleep (the previous implementation)
+    // either over-waits or flakes on slow CI.
+    const eventData = {
+      calendarId: inviteCalendar.id,
+      content: {
+        en: {
+          name: `SigDelivery Add Event ${Date.now()}`,
+          description: 'Created by remote editor after signed Add delivery',
+        },
+      },
+      start_date: '2026-07-15',
+      start_time: '14:00',
+      end_date: '2026-07-15',
+      end_time: '16:00',
+    };
+
+    const successfulResponse = await pollUntil(async () => {
+      const response = await fetch(`${INSTANCE_BETA.baseUrl}/api/v1/events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${betaToken}`,
+        },
+        body: JSON.stringify(eventData),
+        // @ts-ignore - agent is not in the TypeScript types but works at runtime
+        agent: httpsAgent,
+      });
+      return response.status === 201 ? response : undefined;
+    }, 20000, 1000);
+
+    expect(
+      successfulResponse,
+      'Add editor-invite must be accepted by Beta so the remote editor can act on the invited calendar',
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes epic [pv-dyyw](https://github.com/stephenhoward/pavillion/issues?q=pv-dyyw): four outbound ActivityPub deliveries in the calendar domain were posting unsigned, causing strict AP consumers (Mastodon, Mobilizon, Gancio) to reject inbound `Create`/`Update`/`Delete` event operations and `Add` editor invites. This PR routes all four through the existing signed pathway and proves the signing chain end-to-end.

**Phase 1 launch-readiness federation interop blocker.**

### Approach: hybrid signed delivery

- **Outbox path (default, async)** — `addToOutbox` for fire-and-forget activities. The outbox worker signs and delivers via `buildSignedHeaders` + `deliverViaHttp`.
- **Sync escape hatch** — new `deliverActivitySigned` on `ActivityPubInterface` for the one call site (Create) that needs the remote response body to capture the remote event URI.

The hybrid rule is documented in JSDoc on both interface methods so future contributors know which to use.

### Which actor signs, and why

Every outbound activity is signed. The signing actor is dictated by which private key the local instance actually holds in each scenario — not a style choice. Calendar actors are the primary signers across the system; the user-actor path is narrowly scoped to cross-instance remote-editor flows where the user is the only signable principal available locally.

| Flow | Call site | Signer | Why |
|---|---|---|---|
| Local event Create → followers (Announce) | outbox handler (outside this PR) | **Calendar actor** | Local instance owns the calendar's key |
| Local event Update → followers | outbox handler (outside this PR) | **Calendar actor** | Local instance owns the calendar's key |
| Local event Delete → followers | outbox handler (outside this PR) | **Calendar actor** | Local instance owns the calendar's key |
| `Add` editor invite → remote user | `calendar.ts:811` | **Calendar actor** | Invite originates from the local calendar |
| Remote-calendar editor: Create event on remote | `events.ts:397` | **User actor** | Target calendar lives on another instance; its key isn't locally held. The user is the authenticated editor. |
| Remote-calendar editor: Update event on remote | `events.ts:519` | **User actor** | Same — remote calendar's key not available; user authenticates as editor |
| Remote-calendar editor: Delete event on remote | `events.ts:615` | **User actor** | Same — remote calendar's key not available; user authenticates as editor |

The first three rows (local → follower fan-out) go through the calendar domain's event bus handlers → `addToOutbox(calendar, …)` → the outbox worker, which signs via `buildSignedHeaders` using the calendar actor's key. That path already existed; this PR does not touch it.

The last four rows are the call sites this PR migrates from bare `axios.post` to signed delivery.

### Per-call-site migration (this PR's changes)

| Call site | Old | New | Signing actor |
|---|---|---|---|
| `events.ts:397` Create | bare `axios.post` | `deliverActivitySigned` | user actor (remote-editor flow) |
| `events.ts:519` Update | bare `axios.post` | `addToOutbox` | user actor (remote-editor flow) |
| `events.ts:615` Delete | bare `axios.post` | `addToOutbox` | user actor (remote-editor flow) |
| `calendar.ts:811` Add invite | bare `axios.post` | `addToOutbox` | calendar actor |

### Other infrastructure changes

- Extracted `buildSignedHeaders` from `outbox.ts` into a sibling AP-domain module `http-signing.ts` (kept inside the AP domain per DEC-003; not in `server/common`).
- Extended `processOutboxMessage` to honor explicit `to` for `Update`/`Delete`/`Add` (single-recipient targeted delivery; mirrors existing Undo/Flag pattern).
- Added `AddActivity` model with Pavillion extension fields (`calendarId`, `calendarInboxUrl`).
- Added `FederationDeliveryError` exception with proper name + prototype setup.
- Removed silent-drop actor-equality guard in `helper/outbox.ts` so user-actor activities can be enqueued under a calendar anchor.
- Logging hygiene: switched explicit-`to` log payloads from `{ recipients }` (full actor URIs) to `{ recipientCount }` to prevent leaking editor-invite recipient identity into structured logs.

### Verification

- **Unit round-trip** (`http_signature.test.ts`): real RSA-2048 keypair, real `buildSignedHeaders`, real `verifyHttpSignature` with `SKIP_SIGNATURES` cleared. Positive case asserts `next()`; negative tampers body and asserts 401.
- **E2E outbound delivery** (`signed_delivery.spec.ts`): one signed scenario per activity type (Create/Update/Delete/Add) verified via feed propagation, post-anchored container log inspection (Delete), and polling-based proof action (Add).
- All 4 build-guardian runs green; pre-existing AP webfinger / e2e email failures unchanged from main.

### Known follow-ups (filed, not in this PR)

- **pv-yowo** — move ActivityPub activity construction from the calendar domain into the AP domain (architecture-advisor's deferred Option A; closes the wire-format leak)
- **pv-3xit** — enable receive-side HTTP signature verification in the federation e2e harness (currently `SKIP_SIGNATURES=true` on alpha and beta, so the e2e proves outbound delivery only; the unit round-trip carries the cryptographic-correctness load)

### Recorded warnings (not blocking, surfaced for awareness)

- Privacy: outbox `processed_status` column accumulates actor URIs in delivery error strings (pre-existing, broader than this PR)
- Security: no type-guard on `activity.to` array elements at enqueue time (defense-in-depth gap, not exploitable today)
- Architecture: `userCalendars[0]` bookkeeping anchor for user-actor outbox messages — TODO(pv-yowo) markers added inline

## Test plan

- [x] `npm run lint` — 0 errors
- [x] Unit tests (targeted): http_signature.test.ts 34/34, outbox.test.ts 38/38, ssrf_protection.test.ts 11/11, remote_editor_grant.test.ts 15/15
- [x] Full unit + integration suite — no new regressions vs. main
- [x] `npm run build` — frontend + widget SDK both clean
- [x] Federation e2e (`signed_delivery.spec.ts`) — 4/4 passing under Docker harness
- [ ] Manual: federate against a real Mastodon or Mobilizon instance and confirm `Create`/`Update`/`Delete`/`Add` arrive and are accepted (deferred to staging)
