### PR TITLE
feat(site): link "Powered by Pavillion" footer to pavillion.social

### DIFF
--- a/src/client/components/logged_out/root.vue
+++ b/src/client/components/logged_out/root.vue
@@ -14,7 +14,9 @@ const siteTitle = ref(site_config.settings().siteTitle);
       <RouterView />
     </section>
     <footer class="logo">
-      <div class="pavillion-logo"/> Powered by Pavillion
+      <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
+        <div class="pavillion-logo"/> Powered by Pavillion
+      </a>
     </footer>
   </main>
 </template>

--- a/src/client/components/logged_out/root.vue
+++ b/src/client/components/logged_out/root.vue
@@ -1,8 +1,11 @@
 <script setup>
 import { inject, ref } from 'vue';
+import { useTranslation } from 'i18next-vue';
+
 const site_config = inject('site_config');
 
 const siteTitle = ref(site_config.settings().siteTitle);
+const { t } = useTranslation('system');
 </script>
 
 <template>
@@ -15,7 +18,7 @@ const siteTitle = ref(site_config.settings().siteTitle);
     </section>
     <footer class="logo">
       <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
-        <div class="pavillion-logo"/> Powered by Pavillion
+        <div class="pavillion-logo"/> {{ t('powered_by') }}
       </a>
     </footer>
   </main>

--- a/src/client/locales/en/system.json
+++ b/src/client/locales/en/system.json
@@ -7,6 +7,7 @@
     "feed_button": "Feed",
     "inbox_badge_label": "{{count}} unread notification"
   },
+  "powered_by": "Powered by Pavillion",
   "language_picker": {
     "search_language": "Search for a language",
     "select_language": "Select a Language",

--- a/src/client/locales/es/system.json
+++ b/src/client/locales/es/system.json
@@ -7,6 +7,7 @@
     "feed_button": "Noticias",
     "inbox_badge_label": ""
   },
+  "powered_by": "Desarrollado por Pavillion",
   "language_picker": {
     "search_language": "Buscar un idioma",
     "select_language": "Seleccionar un Idioma",

--- a/src/client/locales/fr/system.json
+++ b/src/client/locales/fr/system.json
@@ -7,6 +7,7 @@
     "feed_button": "Fil d'actualité",
     "inbox_badge_label": ""
   },
+  "powered_by": "Propulsé par Pavillion",
   "language_picker": {
     "search_language": "Rechercher une langue",
     "select_language": "Sélectionner une langue",

--- a/src/site/components/app.vue
+++ b/src/site/components/app.vue
@@ -6,7 +6,9 @@ import LanguageSwitcher from './language-switcher.vue';
   <RouterView />
   <footer>
     <div class="logo">
-      <div class="pavillion-logo"/> Powered by Pavillion
+      <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
+        <div class="pavillion-logo"/> Powered by Pavillion
+      </a>
     </div>
     <LanguageSwitcher />
   </footer>

--- a/src/site/components/app.vue
+++ b/src/site/components/app.vue
@@ -1,5 +1,8 @@
 <script setup>
+import { useTranslation } from 'i18next-vue';
 import LanguageSwitcher from './language-switcher.vue';
+
+const { t } = useTranslation('system');
 </script>
 
 <template>
@@ -7,7 +10,7 @@ import LanguageSwitcher from './language-switcher.vue';
   <footer>
     <div class="logo">
       <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
-        <div class="pavillion-logo"/> Powered by Pavillion
+        <div class="pavillion-logo"/> {{ t('powered_by') }}
       </a>
     </div>
     <LanguageSwitcher />

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -5,6 +5,7 @@
         "beta_languages": "Beta",
         "beta_label": "Beta"
     },
+    "powered_by": "Powered by Pavillion",
     "not_found_error_message": "Not Found",
     "not_found_suggestion": "The calendar or event you are looking for does not exist or may have been removed.",
     "not_found_go_home": "Go to Homepage",

--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -5,6 +5,7 @@
         "beta_languages": "Beta",
         "beta_label": "Beta"
     },
+    "powered_by": "Desarrollado por Pavillion",
     "not_found_error_message": "No encontrado",
     "not_found_suggestion": "El calendario o evento que buscas no existe o puede haber sido eliminado.",
     "not_found_go_home": "Ir a la página principal",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -5,6 +5,7 @@
         "beta_languages": "Beta",
         "beta_label": "Beta"
     },
+    "powered_by": "Propulsé par Pavillion",
     "not_found_error_message": "Page non trouvée",
     "not_found_suggestion": "Le calendrier ou l'événement que vous recherchez n'existe pas ou a peut-être été supprimé.",
     "not_found_go_home": "Retour à l'accueil",


### PR DESCRIPTION
## Summary
- Wrap the "Powered by Pavillion" tag line in `src/site/components/app.vue` (public site footer) and `src/client/components/logged_out/root.vue` (logged-out client footer) in an anchor pointing to https://pavillion.social.
- Uses `target="_blank" rel="noopener noreferrer"`, matching the external-link convention already used in `src/widget/components/event-detail-overlay.vue` and `src/site/components/event-instance.vue`.

## Test plan
- [ ] Visit a public calendar view and confirm the footer tag line is clickable and opens pavillion.social in a new tab.
- [ ] Visit the logged-out client shell (e.g., the login page) and confirm the same for its footer tag line.
- [ ] Verify no visual regression on the footer logo + text layout.