### PR TITLE
fix(client): stop useDialog stealing focus from autofocus descendants

### DIFF
--- a/src/client/composables/useDialog.ts
+++ b/src/client/composables/useDialog.ts
@@ -53,10 +53,15 @@ export function useDialog(
   const titleId = computed(() => `${idPrefix}-title-${dialogId.value}`);
 
   const trapFocus = () => {
-    // First-focusable focus trap: defer to the next tick so the dialog is in
-    // the top layer before focusing.
+    // Fallback only: <dialog>.showModal() already focuses the first [autofocus]
+    // or focusable descendant per spec. Only focus the dialog element itself
+    // when the native behavior did not land focus inside the dialog.
     setTimeout(() => {
-      dialogRef.value?.focus();
+      const el = dialogRef.value;
+      if (!el) return;
+      const active = document.activeElement;
+      if (active && active !== el && el.contains(active)) return;
+      el.focus();
     }, 0);
   };
 

--- a/src/client/test/composables/useDialog.test.ts
+++ b/src/client/test/composables/useDialog.test.ts
@@ -76,7 +76,7 @@ describe('useDialog', () => {
       expect(document.body.classList.contains('modal-open')).toBe(true);
     });
 
-    it('traps focus via setTimeout', () => {
+    it('focuses the dialog element when no descendant holds focus (fallback)', () => {
       const { el, focusSpy } = makeDialogStub();
       dialogRef.value = el;
       const { open } = useDialog(dialogRef, emit);
@@ -85,6 +85,25 @@ describe('useDialog', () => {
       expect(focusSpy).not.toHaveBeenCalled();
       vi.runAllTimers();
       expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not steal focus from a descendant that already holds it (autofocus)', () => {
+      const { el, focusSpy } = makeDialogStub();
+      const input = document.createElement('input');
+      el.appendChild(input);
+      // Simulate the native <dialog>.showModal() having focused an autofocus
+      // descendant before our setTimeout callback runs.
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => input,
+      });
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+
+      open();
+      vi.runAllTimers();
+
+      expect(focusSpy).not.toHaveBeenCalled();
     });
 
     it('is a no-op when already open (concurrent open)', () => {


### PR DESCRIPTION
## Summary

- `useDialog.trapFocus` unconditionally re-focused the `<dialog>` element after `showModal()`, overriding the native spec behavior that focuses the first `[autofocus]` descendant.
- Symptom: the language picker modal's search input briefly showed focus and then lost it, forcing a click before typing. Same pattern would affect any other `Modal`/`Sheet` consumer relying on `autofocus`.
- Fix: `trapFocus` now only focuses the dialog element as a fallback — when no descendant already holds focus.

## Changes

- `src/client/composables/useDialog.ts` — guard `trapFocus` with an `activeElement`-inside-dialog check.
- `src/client/test/composables/useDialog.test.ts` — existing test renamed to describe the fallback; new test asserts the dialog's `focus()` is not called when a descendant (simulating autofocus) already holds focus.

## Test plan

- [x] `npx vitest run src/client/test/composables/useDialog.test.ts` — 14 pass
- [x] `npx vitest run src/client` — 1586 / 1586 pass
- [x] `npx eslint` on changed files — clean
- [x] Manual: open Calendar → Manage → Settings → Add language. Search input holds focus on modal open; typing filters the list without clicking.
- [x] Fallback path still covered by test (dialogs without autofocus descendants still get focus on the dialog itself).

Closes pv-vw7l