### PR TITLE
fix(styles): restore footer colors on Powered by Pavillion links

### DIFF
--- a/src/client/assets/style/layout/_logged-out.scss
+++ b/src/client/assets/style/layout/_logged-out.scss
@@ -47,6 +47,17 @@
     font-size: 0.875rem; /* 14px */
     color: var(--pav-color-stone-500);
 
+    a {
+      color: inherit;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--pav-space-2);
+
+      &:hover {
+        color: var(--pav-color-brand-primary);
+      }
+    }
+
     @media (prefers-color-scheme: dark) {
       color: var(--pav-color-stone-400);
     }

--- a/src/site/assets/style.scss
+++ b/src/site/assets/style.scss
@@ -99,8 +99,20 @@ button.primary {
       text-align: center;
       color: $public-text-secondary-light;
 
+      a {
+        color: inherit;
+
+        &:hover {
+          color: $public-accent-hover-light;
+        }
+      }
+
       @media (prefers-color-scheme: dark) {
         color: $public-text-secondary-dark;
+
+        a:hover {
+          color: $public-accent-hover-dark;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Wrapping the footer tag line in a link (#214) caused the anchors to pick up the global link colors, losing the original gray (client) and near-black (site) footer palettes.
- Scope the footer anchor to `color: inherit` so the logo + text keep their original colors, and shift to the accent / brand-primary color on `:hover`.
- On the client, the anchor also takes the `inline-flex` + `gap` from its former parent so the space between the logomark and the text is preserved.

## Test plan

- [ ] Load a logged-out client route (e.g. `/login`) in light and dark mode — footer text/logo should be stone-500/400; hovering turns brand-primary.
- [ ] Load the public site (`/view/...`) in light and dark mode — footer text is secondary (near-black / off-white) with a black logomark; hovering shifts the text to the accent color.