### PR TITLE
fix(common): preserve recurrenceSummary across CalendarEvent serialization

### DIFF
--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -114,6 +114,22 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
   sourceCalendar: { urlName: string; host: string; url: string } | null = null;
 
   /**
+   * True when the event has any recurring (non-exclusion) schedule.
+   * Populated by the public API's `toPublicEventObject` projection; not set
+   * on authenticated payloads. Carried on the model so presentation code
+   * can conditionally render recurrence affordances.
+   */
+  isRecurring: boolean = false;
+
+  /**
+   * Structured recurrence intent emitted by the public API:
+   * `{ key: string, params: Record<string, any> }` where `key` resolves
+   * against the presentation layer's `recurrence.*` translations.
+   * Null for non-recurring events or authenticated payloads.
+   */
+  recurrenceSummary: { key: string; params: Record<string, any> } | null = null;
+
+  /**
    * Constructor for CalendarEvent.
    *
    * @param {string} [id] - Unique identifier for the event
@@ -210,6 +226,8 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
     event.sourceCalendar = obj.sourceCalendar ?? null;
     event.externalUrl = obj.externalUrl ?? null;
     event.urlPrompt = URL_PROMPT_VALUES.includes(obj.urlPrompt) ? obj.urlPrompt : null;
+    event.isRecurring = obj.isRecurring === true;
+    event.recurrenceSummary = obj.recurrenceSummary ?? null;
 
     if ( obj.content ) {
       for( let [language,strings] of Object.entries(obj.content) ) {
@@ -263,6 +281,8 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
       eventSourceUrl: this.eventSourceUrl,
       externalUrl: this.externalUrl,
       urlPrompt: this.urlPrompt,
+      isRecurring: this.isRecurring,
+      recurrenceSummary: this.recurrenceSummary,
       content: Object.fromEntries(
         Object.entries(this._content)
           .map(([language, strings]: [string, CalendarEventContent]) => [language, strings.toObject()]),


### PR DESCRIPTION
## Summary

Follow-up to #222. The public API at `/api/public/v1/instances/:id` projects `isRecurring` and `recurrenceSummary: { key, params }` onto each event via `toPublicEventObject`, but `CalendarEvent.fromObject` in `src/common/model/events.ts` dropped both fields on the way in because neither was declared on the class or copied out of the payload.

The public site event instance page reads `state.instance.event.recurrenceSummary`, so the recurrence badge and the "Recurring Event" sidebar card never rendered — even though the JSON payload contained the correct intent.

## Changes

- Declare `isRecurring: boolean` and `recurrenceSummary: { key, params } | null` on `CalendarEvent`.
- Hydrate both in `fromObject()` so API payloads survive model conversion.
- Re-emit both in `toObject()` so `clone()` and store round-trips preserve them.

## Test plan

- [x] Live check via Playwright on a weekly recurring seed event ("Outdoor Yoga Class") — both the top recurrence badge and the "Recurring Event" sidebar card now render "Every week" with zero console errors.
- [x] `src/site/test/components/event-instance.test.ts` — 56/56 tests pass.
- [x] ESLint clean on the changed file.