### PR TITLE
feat(client): add i18n to location-picker-modal.vue (pv-k8wp)

### DIFF
--- a/src/client/components/common/location-picker-modal.vue
+++ b/src/client/components/common/location-picker-modal.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+import { useTranslation } from 'i18next-vue';
 import { Search, MapPin, Check } from 'lucide-vue-next';
 import PillButton from '@/client/components/common/pill-button.vue';
 import Sheet from '@/client/components/common/Sheet.vue';
 import type { EventLocation } from '@/common/model/location';
+
+const { t } = useTranslation('event_editor', { keyPrefix: 'location_picker' });
 
 /**
  * LocationPickerModal Component
@@ -108,7 +111,7 @@ defineExpose({ close, sheetRef });
 <template>
   <Sheet
     ref="sheetRef"
-    title="Select Location"
+    :title="t('title')"
     @close="close"
   >
     <div class="location-picker-body">
@@ -120,8 +123,8 @@ defineExpose({ close, sheetRef });
             v-model="searchQuery"
             type="text"
             class="search-input"
-            placeholder="Search locations..."
-            aria-label="Search locations"
+            :placeholder="t('search_placeholder')"
+            :aria-label="t('aria_search_label')"
           />
         </div>
       </div>
@@ -153,12 +156,12 @@ defineExpose({ close, sheetRef });
 
         <div v-else-if="!hasLocations" class="empty-state">
           <MapPin :size="48" class="empty-icon" />
-          <p>No locations yet</p>
-          <p class="empty-hint">Create your first location to get started</p>
+          <p>{{ t('empty_title') }}</p>
+          <p class="empty-hint">{{ t('empty_help') }}</p>
         </div>
 
         <div v-else class="empty-state">
-          <p>No locations match your search</p>
+          <p>{{ t('no_results') }}</p>
         </div>
       </div>
 
@@ -169,14 +172,14 @@ defineExpose({ close, sheetRef });
           size="sm"
           @click="handleRemoveLocation"
         >
-          Remove location
+          {{ t('remove_button') }}
         </PillButton>
         <PillButton
           variant="primary"
           size="sm"
           @click="handleCreateNew"
         >
-          Create New
+          {{ t('create_new_button') }}
         </PillButton>
       </footer>
     </div>

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -59,6 +59,16 @@
     "no_series_available": "No series available",
     "no_series_help": "Create series in calendar management to group related events"
   },
+  "location_picker": {
+    "title": "Select Location",
+    "search_placeholder": "Search locations...",
+    "aria_search_label": "Search locations",
+    "empty_title": "No locations yet",
+    "empty_help": "Create your first location to get started",
+    "no_results": "No locations match your search",
+    "remove_button": "Remove location",
+    "create_new_button": "Create New"
+  },
   "external_link": {
     "section_title": "External Link",
     "url_label": "URL",

--- a/src/client/test/components/location-picker-modal.test.ts
+++ b/src/client/test/components/location-picker-modal.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { mount } from '@vue/test-utils';
+import i18next from 'i18next';
+import I18NextVue from 'i18next-vue';
 import LocationPickerModal from '@/client/components/common/location-picker-modal.vue';
 import PillButton from '@/client/components/common/pill-button.vue';
 import { EventLocation } from '@/common/model/location';
+import enEventEditor from '@/client/locales/en/event_editor.json';
 
 /**
  * Sheet stub: renders a native <dialog> with the given title + slot so
@@ -21,7 +24,23 @@ const SheetStub = {
   emits: ['close'],
 };
 
-const SHEET_GLOBAL = { global: { stubs: { Sheet: SheetStub } } };
+beforeAll(async () => {
+  await i18next.init({
+    lng: 'en',
+    resources: {
+      en: {
+        event_editor: enEventEditor,
+      },
+    },
+  });
+});
+
+const SHEET_GLOBAL = {
+  global: {
+    plugins: [[I18NextVue, { i18next }] as const],
+    stubs: { Sheet: SheetStub },
+  },
+};
 
 describe('LocationPickerModal', () => {
   const mockLocations = [
@@ -99,6 +118,7 @@ describe('LocationPickerModal', () => {
           selectedLocationId: null,
         },
         global: {
+          plugins: [[I18NextVue, { i18next }] as const],
           components: { PillButton },
           stubs: { Sheet: SheetStub },
         },
@@ -227,6 +247,7 @@ describe('LocationPickerModal', () => {
           selectedLocationId: null,
         },
         global: {
+          plugins: [[I18NextVue, { i18next }] as const],
           components: { PillButton },
           stubs: { Sheet: SheetStub },
         },
@@ -247,6 +268,7 @@ describe('LocationPickerModal', () => {
           selectedLocationId: 'loc-1',
         },
         global: {
+          plugins: [[I18NextVue, { i18next }] as const],
           components: { PillButton },
           stubs: { Sheet: SheetStub },
         },


### PR DESCRIPTION
## Summary

Closes the i18n gap flagged by the `pv-32pq.2` audit: `location-picker-modal.vue` had 8 hardcoded English strings and no `useTranslation` import. This epic wires the component to i18next using the existing `event_editor` namespace with `keyPrefix: 'location_picker'`, matching the pattern already used by the parent `edit_event.vue`.

- Replaced 8 hardcoded strings with short-form `t()` calls (`title`, `search_placeholder`, `aria_search_label`, `empty_title`, `empty_help`, `no_results`, `remove_button`, `create_new_button`)
- Added a `location_picker` block to `src/client/locales/en/event_editor.json` with the 8 keys
- Registered `I18NextVue` + `i18next.init` in the component's test harness so `useTranslation` resolves during `setup()`

Key naming follows `i18n-keys.md` conventions: `aria_` prefix for ARIA labels, `_help` suffix for hint text, `_button` suffix for button labels, `_placeholder` suffix for input placeholders. Only the `en` baseline is added — other locales fall back via the standard i18next chain.

Beads: pv-k8wp (epic), pv-k8wp.1, pv-k8wp.2, pv-k8wp.3 — all closed.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] Targeted unit tests: `location-picker-modal.test.ts` — 16/16 pass
- [x] Full unit suite — 6698 pass
- [x] Integration suite — 464 pass (1 pre-existing unrelated failure in `feed-workflow.test.ts`)
- [x] Build — frontend + widget SDK both succeed
- [x] E2E — 130 pass, including Event Location Management and Modal/Sheet Consolidation Smoke Tests
- [x] i18n-auditor: PASS WITH WARNINGS (warnings are out-of-scope: missing `aria-label` on list items; tests assert raw strings)