### PR TITLE
chore(activitypub): reorder unshareEvent side effects to fire after transaction commit (pv-psum.1)

### DIFF
--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -492,9 +492,9 @@ class ActivityPubService {
     });
     let actorUrl = await this.actorUrl(calendar);
     for (let share of shares) {
-      this.addToOutbox(calendar, new UndoActivity(actorUrl, share.id));
-      // Emit eventUnreposted before destroy so share.event_id is still accessible
-      this.eventBus.emit('eventUnreposted', { eventId: share.event_id, calendarId: calendar.id });
+      // Capture event_id before destroy so it survives for the post-commit emit.
+      const eventId = share.event_id;
+      const shareActivityId = share.id;
 
       // Destroy the SharedEventEntity and upsert a RepostDismissalEntity row
       // for (event_id, calendar_id) in the same transaction so partial failure
@@ -506,12 +506,16 @@ class ActivityPubService {
         await share.destroy({ transaction: t });
         await RepostDismissalEntity.findOrCreate({
           where: {
-            event_id: share.event_id,
+            event_id: eventId,
             calendar_id: calendar.id,
           },
           transaction: t,
         });
       });
+
+      // Side effects fire only after the transaction commits — mirrors shareEvent.
+      this.addToOutbox(calendar, new UndoActivity(actorUrl, shareActivityId));
+      this.eventBus.emit('eventUnreposted', { eventId, calendarId: calendar.id });
     }
   }
 

--- a/src/server/activitypub/test/service/members-dismissal.test.ts
+++ b/src/server/activitypub/test/service/members-dismissal.test.ts
@@ -34,6 +34,7 @@ import {
 describe('unshareEvent - RepostDismissalEntity upsert', () => {
   let service: ActivityPubService;
   let sandbox: sinon.SinonSandbox;
+  let eventBus: EventEmitter;
 
   const calendarId = 'c00a0000-0000-4000-8000-000000000001';
   const otherCalendarId = 'c00a0000-0000-4000-8000-000000000002';
@@ -48,7 +49,7 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
     // the full EventEntity FK graph (LocationEntity, EventSeriesEntity, etc.).
     await db.query('PRAGMA foreign_keys = OFF');
 
-    const eventBus = new EventEmitter();
+    eventBus = new EventEmitter();
     service = new ActivityPubService(eventBus, new CalendarInterface(eventBus));
 
     // Allow permission checks
@@ -85,6 +86,9 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
     const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
     const account = Account.fromObject({ id: 'test-account-id' });
 
+    // Spy on eventBus.emit to verify exact post-commit payload
+    const emitSpy = sandbox.spy(eventBus, 'emit');
+
     await service.unshareEvent(account, calendar, eventApUrl);
 
     // SharedEventEntity row should be gone
@@ -100,6 +104,18 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
     expect(dismissals).toHaveLength(1);
     expect(dismissals[0].event_id).toBe(localEventId);
     expect(dismissals[0].calendar_id).toBe(calendarId);
+
+    // addToOutbox must fire exactly once per destroyed share, post-commit
+    const addToOutboxStub = service.addToOutbox as sinon.SinonStub;
+    expect(addToOutboxStub.callCount).toBe(1);
+
+    // eventBus.emit must fire exactly once for eventUnreposted with the exact
+    // payload — captured share.event_id must survive entity destroy.
+    const unrepostEmits = emitSpy.getCalls().filter((c) => c.args[0] === 'eventUnreposted');
+    expect(unrepostEmits).toHaveLength(1);
+    expect(
+      emitSpy.calledWith('eventUnreposted', { eventId: localEventId, calendarId }),
+    ).toBe(true);
   });
 
   it('is idempotent: calling unshareEvent twice does not create duplicate dismissal rows', async () => {

--- a/src/server/activitypub/test/service/members.test.ts
+++ b/src/server/activitypub/test/service/members.test.ts
@@ -1149,7 +1149,7 @@ describe("unshareEvent - eventUnreposted emission", () => {
     expect(emittedPayloads[0].calendarId).toBe(calendar.id);
   });
 
-  it('should emit eventUnreposted before calling share.destroy()', async () => {
+  it('should emit eventUnreposted after the transaction commits (after share.destroy)', async () => {
     const account = Account.fromObject({ id: 'test-account-id' });
     const calendar = Calendar.fromObject({ id: 'test-calendar-id', urlName: 'test-calendar' });
     const eventApUrl = 'https://remote.example.com/events/event-789';
@@ -1185,8 +1185,8 @@ describe("unshareEvent - eventUnreposted emission", () => {
 
     await service.unshareEvent(account, calendar, eventApUrl);
 
-    // Verify emit happens before destroy
-    expect(operationOrder).toEqual(['emit', 'destroy']);
+    // Verify emit happens after destroy (transaction commits before side effects).
+    expect(operationOrder).toEqual(['destroy', 'emit']);
   });
 
   it('should emit eventUnreposted for each share when multiple shares exist', async () => {


### PR DESCRIPTION
## Summary

Reorder side effects in `ActivityPubService.unshareEvent` so the `db.transaction` (which performs `share.destroy` + `RepostDismissalEntity.findOrCreate`) runs first, and `addToOutbox(...)` + `eventBus.emit('eventUnreposted', ...)` fire only after the transaction commits. This mirrors the ordering already used in `shareEvent` and prevents downstream consumers from reacting to an unshare that hasn't actually been persisted yet.

Concretely:

- Capture `share.event_id` (and `share.id`) into locals before the transaction so those values survive the `share.destroy`.
- Keep the `share.destroy` + `RepostDismissalEntity.findOrCreate` inside a single transaction (unchanged semantics — still atomic).
- Emit `UndoActivity` to the outbox and `eventUnreposted` on the event bus only after the transaction resolves.

The test `members-dismissal.test.ts` is strengthened with an exact-payload `sinon.calledWith` assertion on `eventBus.emit('eventUnreposted', { eventId, calendarId })` and a `callCount` check on `addToOutbox`, locking in that the captured `event_id` survives destroy and that each side effect fires exactly once per share.

## Bead references

- Closes: `pv-psum.1`
- Parent epic: `pv-psum`
- Sibling bead `pv-psum.2` (rollback regression test) is still open and depends on this merging first.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx vitest run src/server/activitypub/test/service/members-dismissal.test.ts` — 7/7 pass