### PR TITLE
fix(orchestrator): disable shell in spawnCmd to prevent argv metacharacter errors (pv-2kup)

### DIFF
--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -495,9 +495,15 @@ export function spawnCmd(
   spawnFn: typeof spawnSync = spawnSync,
   env?: Record<string, string>,
 ): CmdResult {
+  // NOTE: shell must be false. With shell: true, Node flattens cmd+args into a
+  // single string and hands it to /bin/sh -c without quoting, so argv values
+  // containing shell metacharacters (parens, $, backticks, ;, |, &, *, ?, [, ],
+  // <, >) cause shell parse errors. PR titles/bodies and bead titles routinely
+  // contain these. With shell: false, argv is passed straight to execve and
+  // metacharacters pass through literally. See bead pv-2kup.
   const result: SpawnSyncReturns<Buffer> = spawnFn(cmd, args, {
     encoding: 'buffer' as never,
-    shell: true,
+    shell: false,
     timeout: 120_000,
     env: env ? { ...process.env, ...env } : undefined,
   });

--- a/.claude/orchestrators/test/unit/dispatch.test.ts
+++ b/.claude/orchestrators/test/unit/dispatch.test.ts
@@ -536,6 +536,39 @@ describe('spawnCmd', () => {
     const spawnOpts = mockSpawnFn.mock.calls[0][2] as Record<string, unknown>;
     expect(spawnOpts.env).toBeUndefined();
   });
+
+  // Regression: bead pv-2kup. With shell: true, Node flattens argv into a
+  // single shell command and bash parse-errors on metacharacters like '(' ')'
+  // in argv values (PR titles, commit messages, bead titles). spawnCmd must
+  // pass shell: false so argv goes directly to execve.
+  it('should pass shell: false to spawnSync (regression: pv-2kup)', () => {
+    mockSpawnFn.mockReturnValue(fakeSpawnResult('', '', 0));
+
+    spawnCmd('gh', ['pr', 'create', '--title', 'fix: thing (pv-2kup)'],
+      logStub.logger, PhaseName.PR, mockSpawnFn);
+
+    const spawnOpts = mockSpawnFn.mock.calls[0][2] as Record<string, unknown>;
+    expect(spawnOpts.shell).toBe(false);
+  });
+
+  it('should handle argv values containing shell metacharacters without shell errors (regression: pv-2kup)', () => {
+    // Use the real spawnSync (default) with a harmless command whose argv
+    // contains the exact metacharacters that broke `gh pr create` in run
+    // 20260422T003112-3159: parentheses, dollar, backticks, semicolons, pipes.
+    // With shell: true this bash-parse-errored. With shell: false the argv is
+    // delivered verbatim to the process.
+    const trickyArg = 'fix: thing (pv-2kup) $USER `whoami`; |& > <';
+    const result = spawnCmd(
+      'node',
+      ['-e', `process.stdout.write(process.argv[1])`, trickyArg],
+      logStub.logger,
+      PhaseName.PR,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(trickyArg);
+    expect(result.stderr).toBe('');
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`spawnCmd` in `.claude/orchestrators/lib/dispatch.ts` passed `{ shell: true }` to `spawnSync`. With `shell: true`, Node flattens `cmd + args` into a single string and hands it to `/bin/sh -c` without quoting, so any argv containing shell metacharacters ( `(` `)` `$` `` ` `` `;` `|` `&` `*` `?` `[` `]` `<` `>` ) triggers a bash parse error. PR titles, commit messages, and bead titles routinely contain these characters.

Closes bead `pv-2kup`.

## Root cause

With `shell: true`, Node passes `cmd + ' ' + args.join(' ')` to `/bin/sh -c` unquoted. The shell then re-parses the combined string, and any metacharacter in an argv value is interpreted as shell syntax rather than a literal.

## Fix

One-line change: `shell: true` → `shell: false` (plus an explanatory comment). With `shell: false`, Node passes argv directly to the OS `execve`, so metacharacters pass through literally.

## Evidence

From run `20260422T003112-3159`, `phase-8-pr.err`:

```
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `gh pr create --title chore: Reorder unshareEvent side effects to fire after transaction commit (pv-psum.1) --body ## Summary'
gh pr create failed (exit 2)
```

A PR title ending in `(pv-psum.1)` was enough to bash-parse-error the whole `gh pr create` invocation. The child-bead PR that motivated this fix was ultimately submitted manually as #226 — this fix prevents that class of failure for future runs.

## Caller audit

Grepped every `spawnCmd(` caller under `.claude/orchestrators/`. All callers pass argv-style with no reliance on shell features (no pipes, redirects, globs, `&&`, `;`, env-var expansion inside argv strings). Safe to disable the shell.

Callsites audited:

- `.claude/orchestrators/lib/phases.ts:1275` — `bd show --json <beadId>`
- `.claude/orchestrators/lib/phases.ts:1300` — `git branch --show-current`
- `.claude/orchestrators/lib/phases.ts:1311` — `git checkout -b <branchName>`
- `.claude/orchestrators/lib/execute.ts:1217` — `git branch --show-current`
- `.claude/orchestrators/lib/execute.ts:1231` — `bd show --json <beadId>`
- `.claude/orchestrators/lib/execute.ts:1268` — `bd show --json <childId>` (epic children)
- `.claude/orchestrators/lib/execute.ts:1307` — `git push -u origin <branchName>`
- `.claude/orchestrators/lib/execute.ts:1319` — `gh pr create --title ... --body ...` (the failing callsite)

Every call is a single command with literal argv flags and dynamic string values — exactly the shape that `shell: false` is designed for.

## Tests

Added two regression tests in `.claude/orchestrators/test/unit/dispatch.test.ts`:

1. Asserts `spawnSync` is invoked with `shell: false` when `spawnCmd` is called (guards against regression).
2. Exercises the real `spawnSync` with an argv containing the exact metacharacters that broke the original run (`fix: thing (pv-2kup) $USER \`whoami\`; |& > <`) and asserts it executes cleanly and returns the argv verbatim — the test would have failed under the old `shell: true` behavior.

## Verification

- `npm run lint` — passes (0 errors; 276 pre-existing warnings unrelated to this change)
- `npx vitest run .claude/orchestrators/test` — 224/224 tests pass, including the 2 new regression tests
