### PR TITLE
test(activitypub): rollback assertion for unshareEvent side effects (pv-psum.2)

### DIFF
--- a/src/server/activitypub/test/service/members-dismissal.test.ts
+++ b/src/server/activitypub/test/service/members-dismissal.test.ts
@@ -238,6 +238,62 @@ describe('unshareEvent - RepostDismissalEntity upsert', () => {
       findOrCreateStub.restore();
     }
   });
+
+  it('does not fire addToOutbox or eventUnreposted emit when the transaction rolls back', async () => {
+    // Seed the AP URL → local event UUID lookup
+    await EventObjectEntity.create({
+      event_id: localEventId,
+      ap_id: eventApUrl,
+      attributed_to: 'https://remote.example.com/calendars/some-calendar',
+    });
+
+    // Seed a SharedEventEntity that unshareEvent would try to destroy
+    await SharedEventEntity.create({
+      id: 'share-activity-uuid-rollback-side-effects',
+      event_id: localEventId,
+      calendar_id: calendarId,
+      auto_posted: false,
+    });
+
+    // Capture the sandbox-stubbed addToOutbox and spy eventBus.emit so we can
+    // assert neither side effect escapes the aborted transaction.
+    const addToOutboxStub = service.addToOutbox as sinon.SinonStub;
+    const emitSpy = sandbox.spy(eventBus, 'emit');
+
+    // Force the dismissal write to throw, rolling back the entire transaction.
+    // Use sinon.stub directly (not sandbox) so we can restore it in finally
+    // even if the assertions blow up.
+    const findOrCreateStub = sinon.stub(RepostDismissalEntity, 'findOrCreate')
+      .rejects(new Error('forced rollback'));
+
+    const calendar = Calendar.fromObject({ id: calendarId, urlName: 'test-calendar' });
+    const account = Account.fromObject({ id: 'test-account-id' });
+
+    try {
+      await expect(
+        service.unshareEvent(account, calendar, eventApUrl),
+      ).rejects.toThrow('forced rollback');
+
+      // addToOutbox must NOT have fired — the post-commit side effect should
+      // never run when the transaction rolls back.
+      expect(addToOutboxStub.called).toBe(false);
+
+      // eventBus.emit must NOT have fired for 'eventUnreposted'. Filter by
+      // channel name so unrelated emits on the shared bus cannot flake this.
+      const unrepostEmits = emitSpy.getCalls().filter((c) => c.args[0] === 'eventUnreposted');
+      expect(unrepostEmits).toHaveLength(0);
+
+      // Sanity-check: the SharedEventEntity row still exists, confirming the
+      // rollback actually engaged (mirrors the Wave 2 rollback test).
+      const remainingShares = await SharedEventEntity.findAll({
+        where: { event_id: localEventId, calendar_id: calendarId },
+      });
+      expect(remainingShares).toHaveLength(1);
+    }
+    finally {
+      findOrCreateStub.restore();
+    }
+  });
 });
 
 describe('shareEvent - RepostDismissalEntity deletion', () => {


### PR DESCRIPTION
## Summary

Adds a regression test that proves `addToOutbox` and `eventBus.emit('eventUnreposted')` never fire when the `unshareEvent` transaction rolls back. Mirrors the Wave 2 rollback pattern already established in `members-dismissal.test.ts`:

- Stubs `RepostDismissalEntity.findOrCreate` to reject, forcing the transaction to abort.
- Captures the sandbox-stubbed `addToOutbox` and spies `eventBus.emit`.
- Filters emit calls by the `'eventUnreposted'` channel so unrelated emits on the shared bus cannot flake the assertion.
- Sanity-checks that the `SharedEventEntity` row survived, confirming the rollback actually engaged.

This guards the side-effect reordering shipped in pv-psum.1 against a future refactor silently reintroducing the transaction-escape bug.

## Context

This PR completes `pv-psum.2`. The work was originally produced by a `/process-backlog` run (`20260422T024223-af5f`) that failed to commit before pushing and attempting PR creation, leaving the branch empty on origin and the bead falsely marked closed. This commit lands the implementer's work and restores correct bead state.

## Test plan

- [x] `npx vitest run src/server/activitypub/test/service/members-dismissal.test.ts` — 8/8 passing
- [x] `npm run lint` — 0 errors (warnings only, within known-issues range)
- [x] No source changes to `unshareEvent` or `shareEvent`; test-only addition