### PR TITLE
feat(orchestrator): add post-implementer verification gate

### DIFF
--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -1464,6 +1464,27 @@ export async function runPR(
 
   const branchName = branchCmd.stdout;
 
+  // Step 0.5: Backstop — refuse to PR an empty branch. The leaf/epic
+  // verification gates should have caught this, but if any code path
+  // slips past them we still won't push empty branches or call gh.
+  const baseBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  const revCountCmd = spawnCmd(
+    'git', ['rev-list', '--count', `${baseBranch}..HEAD`],
+    logger, PhaseName.PR, spawnFn,
+  );
+
+  if (revCountCmd.exitCode !== 0 || revCountCmd.stdout.trim() === '0') {
+    logger.appendRunJson({
+      event: 'pr_finalize_aborted',
+      reason: 'no commits on branch',
+    });
+    logger.writePhaseLog(
+      PhaseName.PR, 'err',
+      `Branch ${branchName} has no commits ahead of ${baseBranch} — refusing to create empty PR\n`,
+    );
+    return { next: 'halt', ctx };
+  }
+
   // Step 1: Verify bead(s) are CLOSED
   const bdResult = spawnCmd(
     'bd', ['show', '--json', ctx.beadId], logger, PhaseName.PR, spawnFn,

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -793,6 +793,97 @@ export async function dispatchImplementer(
 }
 
 // =============================================================================
+// Exported: verifyImplementerCompletion
+// =============================================================================
+
+/**
+ * Verification result returned by `verifyImplementerCompletion`.
+ *
+ * On success, `changedFiles` is the authoritative list derived from
+ * `git diff --name-only <base>...HEAD` — callers must use this in place
+ * of any stale `deps.changedFiles`.
+ */
+export type VerificationResult =
+  | { passed: true; changedFiles: string[] }
+  | { passed: false; reason: string };
+
+/**
+ * Verify that the implementer subagent actually committed its work.
+ *
+ * Runs after a successful `dispatchImplementer`, before `runAudit`. Catches
+ * the failure mode where an implementer declares success (and may even have
+ * called `bd close`) but never committed — producing an empty branch that
+ * silently passes through audit and fails at `gh pr create`.
+ *
+ * Checks, in order:
+ *   1. Working tree is clean (`git status --porcelain` returns empty).
+ *   2. Branch has commits ahead of base (`git rev-list --count base..HEAD > 0`).
+ *   3. Computes authoritative `changedFiles` via `git diff --name-only base...HEAD`.
+ *
+ * Base branch defaults to `main`; override via `GIT_SAFE_MAIN_BRANCH` env var
+ * (consistent with preflight checks in `helpers.ts`).
+ */
+export function verifyImplementerCompletion(
+  ctx: PhaseCtx,
+  deps: ExecuteDeps,
+): VerificationResult {
+  const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const baseBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+
+  const statusResult = spawnFn('git', ['status', '--porcelain'], {
+    encoding: 'buffer' as never,
+    shell: false,
+    timeout: 10_000,
+  });
+  const statusOutput = (statusResult.stdout?.toString('utf-8') ?? '').trim();
+  if (statusOutput !== '') {
+    const firstLine = statusOutput.split('\n')[0].trim();
+    const reason = `uncommitted or untracked changes present: ${firstLine}`;
+    ctx.logger.appendRunJson({
+      event: 'implementer-verification-failed',
+      phase: PhaseName.Leaf,
+      beadId: ctx.beadId,
+      reason,
+    });
+    return { passed: false, reason };
+  }
+
+  const revResult = spawnFn('git', ['rev-list', '--count', `${baseBranch}..HEAD`], {
+    encoding: 'buffer' as never,
+    shell: false,
+    timeout: 10_000,
+  });
+  const revCount = (revResult.stdout?.toString('utf-8') ?? '').trim();
+  if (revCount === '0') {
+    const reason = `no commits on branch ahead of ${baseBranch}`;
+    ctx.logger.appendRunJson({
+      event: 'implementer-verification-failed',
+      phase: PhaseName.Leaf,
+      beadId: ctx.beadId,
+      reason,
+    });
+    return { passed: false, reason };
+  }
+
+  const diffResult = spawnFn('git', ['diff', '--name-only', `${baseBranch}...HEAD`], {
+    encoding: 'buffer' as never,
+    shell: false,
+    timeout: 10_000,
+  });
+  const diffOutput = (diffResult.stdout?.toString('utf-8') ?? '').trim();
+  const changedFiles = diffOutput === '' ? [] : diffOutput.split('\n');
+
+  ctx.logger.appendRunJson({
+    event: 'implementer-verification-passed',
+    phase: PhaseName.Leaf,
+    beadId: ctx.beadId,
+    changedFilesCount: changedFiles.length,
+  });
+
+  return { passed: true, changedFiles };
+}
+
+// =============================================================================
 // Exported: runAudit
 // =============================================================================
 

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -1051,6 +1051,12 @@ export async function runLeafExecution(
   deps: ExecuteDeps = {},
 ): Promise<LeafExecutionResult> {
   const warnings: string[] = [];
+  // The verification-gate helpers expect PhaseCtx; runLeafExecution is always
+  // called from leafPhase with a PhaseCtx at runtime, or from tests with a
+  // RunContext whose extra PhaseCtx fields the helpers do not touch. Cast is
+  // safe because verifyImplementerCompletion / reopenBead use only beadId and
+  // logger, both of which live on RunContext.
+  const phaseCtx = ctx as PhaseCtx;
 
   // --- Attempt 1: Implementer ---
   const implResult = await dispatchImplementer(beadId, ctx, deps);
@@ -1062,8 +1068,19 @@ export async function runLeafExecution(
     return escalateLeaf(beadId, ctx, deps, `implementer failure: ${implResult.reason}`, 1);
   }
 
-  // --- Attempt 1: Auditors ---
-  const auditResult = await runAudit(beadId, ctx, deps);
+  // --- Attempt 1: Verification gate ---
+  const gate1 = verifyImplementerCompletion(phaseCtx, deps);
+  if (!gate1.passed) {
+    reopenBead(beadId, phaseCtx, deps, 'verification-gate-retry');
+    const retryResult = await retryAfterVerificationFailure(beadId, ctx, deps, gate1.reason);
+    if (retryResult) return retryResult;
+    reopenBead(beadId, phaseCtx, deps, 'verification-gate-escalate');
+    return escalateLeaf(beadId, ctx, deps, `verification gate exhausted: ${gate1.reason}`, 1);
+  }
+
+  // --- Attempt 1: Auditors (with gate-authoritative changedFiles) ---
+  const auditDeps: ExecuteDeps = { ...deps, changedFiles: gate1.changedFiles };
+  const auditResult = await runAudit(beadId, ctx, auditDeps);
   warnings.push(...auditResult.warnings);
 
   if (auditResult.passed) {
@@ -1080,8 +1097,16 @@ export async function runLeafExecution(
     return escalateLeaf(beadId, ctx, deps, `retry implementer failure: ${retryImplResult.reason}`, 1);
   }
 
-  // --- Retry: re-run auditors ---
-  const retryAuditResult = await runAudit(beadId, ctx, deps);
+  // --- Retry: Verification gate (second pass) ---
+  const gate2 = verifyImplementerCompletion(phaseCtx, deps);
+  if (!gate2.passed) {
+    reopenBead(beadId, phaseCtx, deps, 'verification-gate-escalate');
+    return escalateLeaf(beadId, ctx, deps, `verification gate exhausted after retry: ${gate2.reason}`, 1);
+  }
+
+  // --- Retry: re-run auditors (with fresh changedFiles) ---
+  const retryAuditDeps: ExecuteDeps = { ...deps, changedFiles: gate2.changedFiles };
+  const retryAuditResult = await runAudit(beadId, ctx, retryAuditDeps);
   warnings.push(...retryAuditResult.warnings);
 
   if (retryAuditResult.passed) {
@@ -1114,6 +1139,44 @@ async function retryAfterFailure(
   }
 
   const auditResult = await runAudit(beadId, ctx, deps);
+  if (auditResult.passed) {
+    return { outcome: 'complete', retryCount: 1, warnings: auditResult.warnings };
+  }
+
+  return null;
+}
+
+/**
+ * Attempt a retry after a verification-gate failure.
+ *
+ * Mirrors `retryAfterFailure` but scoped to the gate-trip case:
+ * the implementer declared success but git state refuted it.
+ * Feeds a specific correction into `retryContext.concerns`.
+ */
+async function retryAfterVerificationFailure(
+  beadId: string,
+  ctx: RunContext,
+  deps: ExecuteDeps,
+  reason: string,
+): Promise<LeafExecutionResult | null> {
+  const concern = `Verification failed: ${reason}. You must commit ALL changes (including new/untracked files) to the current branch before declaring completion. Do not call 'bd close' until the commit exists on the branch.`;
+
+  const retryImplResult = await dispatchImplementer(beadId, ctx, {
+    ...deps,
+    retryContext: { concerns: [concern], attempt: 2 },
+  });
+
+  if (!retryImplResult.ok) {
+    return null;
+  }
+
+  const gateRetry = verifyImplementerCompletion(ctx as PhaseCtx, deps);
+  if (!gateRetry.passed) {
+    return null;
+  }
+
+  const auditDeps: ExecuteDeps = { ...deps, changedFiles: gateRetry.changedFiles };
+  const auditResult = await runAudit(beadId, ctx, auditDeps);
   if (auditResult.passed) {
     return { outcome: 'complete', retryCount: 1, warnings: auditResult.warnings };
   }

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -835,6 +835,19 @@ export function verifyImplementerCompletion(
     shell: false,
     timeout: 10_000,
   });
+  if (statusResult.status !== 0 || statusResult.error) {
+    const stderrSnippet = (statusResult.stderr?.toString('utf-8') ?? '').trim()
+      || statusResult.error?.message
+      || `exit ${statusResult.status}`;
+    const reason = `git status --porcelain failed: ${stderrSnippet}`;
+    ctx.logger.appendRunJson({
+      event: 'implementer-verification-failed',
+      phase: PhaseName.Leaf,
+      beadId: ctx.beadId,
+      reason,
+    });
+    return { passed: false, reason };
+  }
   const statusOutput = (statusResult.stdout?.toString('utf-8') ?? '').trim();
   if (statusOutput !== '') {
     const firstLine = statusOutput.split('\n')[0].trim();
@@ -853,8 +866,22 @@ export function verifyImplementerCompletion(
     shell: false,
     timeout: 10_000,
   });
+  if (revResult.status !== 0 || revResult.error) {
+    const stderrSnippet = (revResult.stderr?.toString('utf-8') ?? '').trim()
+      || revResult.error?.message
+      || `exit ${revResult.status}`;
+    const reason = `git rev-list --count failed: ${stderrSnippet}`;
+    ctx.logger.appendRunJson({
+      event: 'implementer-verification-failed',
+      phase: PhaseName.Leaf,
+      beadId: ctx.beadId,
+      reason,
+    });
+    return { passed: false, reason };
+  }
   const revCount = (revResult.stdout?.toString('utf-8') ?? '').trim();
-  if (revCount === '0') {
+  const revCountNum = Number(revCount);
+  if (!Number.isFinite(revCountNum) || revCountNum <= 0) {
     const reason = `no commits on branch ahead of ${baseBranch}`;
     ctx.logger.appendRunJson({
       event: 'implementer-verification-failed',
@@ -870,6 +897,19 @@ export function verifyImplementerCompletion(
     shell: false,
     timeout: 10_000,
   });
+  if (diffResult.status !== 0 || diffResult.error) {
+    const stderrSnippet = (diffResult.stderr?.toString('utf-8') ?? '').trim()
+      || diffResult.error?.message
+      || `exit ${diffResult.status}`;
+    const reason = `git diff --name-only failed: ${stderrSnippet}`;
+    ctx.logger.appendRunJson({
+      event: 'implementer-verification-failed',
+      phase: PhaseName.Leaf,
+      beadId: ctx.beadId,
+      reason,
+    });
+    return { passed: false, reason };
+  }
   const diffOutput = (diffResult.stdout?.toString('utf-8') ?? '').trim();
   const changedFiles = diffOutput === '' ? [] : diffOutput.split('\n');
 

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -1289,8 +1289,22 @@ export async function runEpicExecution(
         continue;
       }
 
-      const changedFiles = deps.changedFilesForBead?.(beadId) ?? [];
-      const auditResult = await runAudit(beadId, ctx, { ...deps, changedFiles });
+      // Verification gate — mirror leaf-path enforcement. Scope ctx.beadId to
+      // the child bead so gate/reopen log events identify the bead, not the epic.
+      // Epic wave loop handles retries at the wave level via MAX_WAVE_RETRIES;
+      // here we just mark this bead as failed for this wave and move on.
+      const beadCtx: RunContext = { ...ctx, beadId };
+      const gate = verifyImplementerCompletion(beadCtx, deps);
+      if (!gate.passed) {
+        reopenBead(beadId, beadCtx, deps, 'verification-gate-epic-escalate');
+        waveState.beadsFailed.push(beadId);
+        continue;
+      }
+
+      const auditResult = await runAudit(beadId, ctx, {
+        ...deps,
+        changedFiles: gate.changedFiles,
+      });
       allWarnings.push(...auditResult.warnings);
 
       if (auditResult.passed) {
@@ -1303,7 +1317,10 @@ export async function runEpicExecution(
         });
 
         if (retryResult.ok) {
-          const retryAudit = await runAudit(beadId, ctx, { ...deps, changedFiles });
+          const retryAudit = await runAudit(beadId, ctx, {
+            ...deps,
+            changedFiles: gate.changedFiles,
+          });
           allWarnings.push(...retryAudit.warnings);
 
           if (retryAudit.passed) {

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -824,7 +824,7 @@ export type VerificationResult =
  * (consistent with preflight checks in `helpers.ts`).
  */
 export function verifyImplementerCompletion(
-  ctx: PhaseCtx,
+  ctx: RunContext,
   deps: ExecuteDeps,
 ): VerificationResult {
   const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
@@ -936,7 +936,7 @@ export function verifyImplementerCompletion(
  */
 export function reopenBead(
   beadId: string,
-  ctx: PhaseCtx,
+  ctx: RunContext,
   deps: ExecuteDeps,
   reasonTag: string,
 ): void {
@@ -1051,12 +1051,6 @@ export async function runLeafExecution(
   deps: ExecuteDeps = {},
 ): Promise<LeafExecutionResult> {
   const warnings: string[] = [];
-  // The verification-gate helpers expect PhaseCtx; runLeafExecution is always
-  // called from leafPhase with a PhaseCtx at runtime, or from tests with a
-  // RunContext whose extra PhaseCtx fields the helpers do not touch. Cast is
-  // safe because verifyImplementerCompletion / reopenBead use only beadId and
-  // logger, both of which live on RunContext.
-  const phaseCtx = ctx as PhaseCtx;
 
   // --- Attempt 1: Implementer ---
   const implResult = await dispatchImplementer(beadId, ctx, deps);
@@ -1069,12 +1063,12 @@ export async function runLeafExecution(
   }
 
   // --- Attempt 1: Verification gate ---
-  const gate1 = verifyImplementerCompletion(phaseCtx, deps);
+  const gate1 = verifyImplementerCompletion(ctx, deps);
   if (!gate1.passed) {
-    reopenBead(beadId, phaseCtx, deps, 'verification-gate-retry');
+    reopenBead(beadId, ctx, deps, 'verification-gate-retry');
     const retryResult = await retryAfterVerificationFailure(beadId, ctx, deps, gate1.reason);
     if (retryResult) return retryResult;
-    reopenBead(beadId, phaseCtx, deps, 'verification-gate-escalate');
+    reopenBead(beadId, ctx, deps, 'verification-gate-escalate');
     return escalateLeaf(beadId, ctx, deps, `verification gate exhausted: ${gate1.reason}`, 1);
   }
 
@@ -1098,9 +1092,9 @@ export async function runLeafExecution(
   }
 
   // --- Retry: Verification gate (second pass) ---
-  const gate2 = verifyImplementerCompletion(phaseCtx, deps);
+  const gate2 = verifyImplementerCompletion(ctx, deps);
   if (!gate2.passed) {
-    reopenBead(beadId, phaseCtx, deps, 'verification-gate-escalate');
+    reopenBead(beadId, ctx, deps, 'verification-gate-escalate');
     return escalateLeaf(beadId, ctx, deps, `verification gate exhausted after retry: ${gate2.reason}`, 1);
   }
 
@@ -1170,7 +1164,7 @@ async function retryAfterVerificationFailure(
     return null;
   }
 
-  const gateRetry = verifyImplementerCompletion(ctx as PhaseCtx, deps);
+  const gateRetry = verifyImplementerCompletion(ctx, deps);
   if (!gateRetry.passed) {
     return null;
   }

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -923,6 +923,38 @@ export function verifyImplementerCompletion(
   return { passed: true, changedFiles };
 }
 
+/**
+ * Reset a bead's status to `in_progress`.
+ *
+ * Used when the implementer subagent closed its own bead prematurely
+ * (e.g., before committing), so that retry or escalation finds an
+ * accurate bead state rather than a falsely-closed one.
+ *
+ * Idempotent — safe to call regardless of current bead status. Failures
+ * of the `bd` command itself are logged but never throw: we don't want
+ * to block an escalation path because a beads CLI call hiccupped.
+ */
+export function reopenBead(
+  beadId: string,
+  ctx: PhaseCtx,
+  deps: ExecuteDeps,
+  reasonTag: string,
+): void {
+  const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const result = spawnFn('bd', ['update', beadId, '--status=in_progress'], {
+    encoding: 'buffer' as never,
+    shell: false,
+    timeout: 10_000,
+  });
+  const success = result.status === 0;
+  ctx.logger.appendRunJson({
+    event: 'bead-reopened',
+    beadId,
+    reason: reasonTag,
+    success,
+  });
+}
+
 // =============================================================================
 // Exported: runAudit
 // =============================================================================

--- a/.claude/orchestrators/test/integration/verification-gate.test.ts
+++ b/.claude/orchestrators/test/integration/verification-gate.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import type { SpawnSyncOptions, SpawnSyncReturns } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { verifyImplementerCompletion } from '../../lib/execute.js';
+import { type RunLogger } from '../../lib/types.js';
+import type { PhaseCtx } from '../../lib/execute.js';
+
+/**
+ * Runs the verification gate against a real ephemeral git repo.
+ * Catches wrong-flag-to-git bugs that unit stubs miss:
+ * `main..HEAD` vs `main...HEAD` semantics, porcelain format drift, etc.
+ */
+describe('verifyImplementerCompletion — integration', () => {
+  let repoDir: string;
+
+  function git(...args: string[]): string {
+    const result = spawnSync('git', args, {
+      cwd: repoDir,
+      encoding: 'utf-8',
+    });
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+    }
+    return result.stdout.trim();
+  }
+
+  /**
+   * spawnFn that injects `cwd: repoDir` into every invocation so the
+   * verification gate runs against our ephemeral repo without relying on
+   * `process.chdir()` (unsupported in Vitest workers).
+   */
+  function repoScopedSpawn(
+    command: string,
+    args: readonly string[],
+    options: SpawnSyncOptions,
+  ): SpawnSyncReturns<Buffer> {
+    return spawnSync(command, args as string[], {
+      ...options,
+      cwd: repoDir,
+    }) as SpawnSyncReturns<Buffer>;
+  }
+
+  function makeCtx(): PhaseCtx {
+    const runJsonEntries: Record<string, unknown>[] = [];
+    const logger: RunLogger = {
+      writePhaseLog: () => {},
+      appendRunJson: (e) => runJsonEntries.push(e),
+      runDir: () => '/tmp/fake',
+    };
+    return {
+      runId: 'integration-run',
+      beadId: 'pv-int.1',
+      logger,
+      phaseHistory: [],
+      dryRun: false,
+    };
+  }
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), 'verify-gate-'));
+
+    // git 2.28+ supports --initial-branch; fall back to rename if unavailable.
+    const initResult = spawnSync('git', ['init', '--initial-branch=main'], {
+      cwd: repoDir,
+      encoding: 'utf-8',
+    });
+    if (initResult.status !== 0) {
+      git('init');
+      git('branch', '-m', 'main');
+    }
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    writeFileSync(join(repoDir, 'README.md'), '# test\n');
+    git('add', 'README.md');
+    git('commit', '-m', 'initial');
+
+    git('checkout', '-b', 'feat/test');
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('returns passed=false when working tree has a modified file', () => {
+    writeFileSync(join(repoDir, 'README.md'), '# test changed\n');
+
+    const result = verifyImplementerCompletion(makeCtx(), { scriptSpawnFn: repoScopedSpawn as never });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toMatch(/uncommitted or untracked/);
+    }
+  });
+
+  it('returns passed=false when working tree has an untracked file', () => {
+    writeFileSync(join(repoDir, 'new.ts'), 'export {};\n');
+
+    const result = verifyImplementerCompletion(makeCtx(), { scriptSpawnFn: repoScopedSpawn as never });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toMatch(/\?\? new\.ts/);
+    }
+  });
+
+  it('returns passed=false when branch has no commits ahead of main', () => {
+    const result = verifyImplementerCompletion(makeCtx(), { scriptSpawnFn: repoScopedSpawn as never });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toBe('no commits on branch ahead of main');
+    }
+  });
+
+  it('returns passed=true with accurate changedFiles when a commit exists and tree is clean', () => {
+    writeFileSync(join(repoDir, 'a.ts'), 'export const a = 1;\n');
+    writeFileSync(join(repoDir, 'b.ts'), 'export const b = 2;\n');
+    git('add', 'a.ts', 'b.ts');
+    git('commit', '-m', 'add a and b');
+
+    const result = verifyImplementerCompletion(makeCtx(), { scriptSpawnFn: repoScopedSpawn as never });
+
+    expect(result.passed).toBe(true);
+    if (result.passed) {
+      expect(result.changedFiles.sort()).toEqual(['a.ts', 'b.ts']);
+    }
+  });
+});

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -666,6 +666,86 @@ describe('runLeafExecution', () => {
 });
 
 // =============================================================================
+// runEpicExecution
+// =============================================================================
+
+describe('runEpicExecution', () => {
+  let logStub: ReturnType<typeof stubLogger>;
+
+  beforeEach(async () => {
+    logStub = stubLogger();
+    vi.clearAllMocks();
+    const helpers = await import('../../lib/helpers.js');
+    vi.mocked(helpers.discoverAgents).mockReturnValue([]);
+    vi.mocked(helpers.bdEscalate).mockReturnValue(undefined);
+    // Treat beads in this suite as enriched so they enter the implementer wave.
+    vi.mocked(helpers.bdEnrichmentCheck).mockReturnValue(true);
+  });
+
+  it('runs verification gate per bead in an epic wave and escalates on gate failure', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx: RunContext = {
+      runId: 'test-run',
+      beadId: 'epic-parent',
+      logger: logStub.logger,
+      phaseHistory: [],
+    };
+
+    const initialBeads = ['pv-child.1'];
+
+    // Implementer + downstream verifier agents all return success.
+    // Build-guardian needs valid JSON for a pass verdict; return that uniformly
+    // so the wave-end chain passes cleanly and the per-bead gate-failure path
+    // is what drives the outcome.
+    const spawnFn = vi.fn().mockImplementation(() =>
+      createMockChild(JSON.stringify({ verdict: 'pass' }), '', 0),
+    );
+
+    // Gate fails with zero commits; bd/git calls otherwise cooperate.
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'status')   return fakeSpawnResult('', '', 0);
+      if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('0\n', '', 0);
+      if (cmd === 'git' && args[0] === 'diff')     return fakeSpawnResult('', '', 0);
+      // bd ready (cascade) returns no new beads so the while-loop exits.
+      if (cmd === 'bd' && args[0] === 'ready')     return fakeSpawnResult('[]', '', 0);
+      if (cmd === 'bd')                            return fakeSpawnResult('', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const result = await runEpicExecution('epic-parent', initialBeads, ctx, {
+      spawnFn,
+      scriptSpawnFn,
+    });
+
+    // Gate fired and reported the zero-commit failure for the child bead.
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'implementer-verification-failed',
+        beadId: 'pv-child.1',
+        reason: 'no commits on branch ahead of main',
+      }),
+    );
+
+    // Bead was reopened with the epic-specific escalate tag.
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'bead-reopened',
+        beadId: 'pv-child.1',
+        reason: 'verification-gate-epic-escalate',
+      }),
+    );
+
+    // The bead ended up flagged as failed/escalated in the epic result.
+    const failedLike = [
+      ...(result.beadsFailed ?? []),
+      ...(result.escalatedBeads ?? []),
+    ];
+    expect(failedLike).toContain('pv-child.1');
+  });
+});
+
+// =============================================================================
 // runWithConcurrencyCap
 // =============================================================================
 

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -866,7 +866,12 @@ describe('runPR', () => {
 
   function makeDeps(results: SpawnSyncReturns<Buffer>[]): ExecuteDeps {
     let callIndex = 0;
-    const spawnFn = vi.fn().mockImplementation(() => {
+    const spawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      // Intercept the rev-list backstop probe so the existing sequential
+      // fixtures don't have to know about it. Default: branch has commits.
+      if (cmd === 'git' && args[0] === 'rev-list') {
+        return fakeSpawnResult('1\n', '', 0);
+      }
       const result = results[callIndex] ?? results[results.length - 1];
       callIndex++;
       return result;
@@ -961,6 +966,53 @@ describe('runPR', () => {
 
     const result = await runPR(ctx, deps);
     expect(result.next).toBe('halt');
+  });
+});
+
+describe('runPR backstop', () => {
+  it('halts before push if branch has zero commits ahead of main', async () => {
+    const logStub = stubLogger();
+    const ctx: PhaseCtx = {
+      runId: 'test-run',
+      beadId: 'pv-empty.1',
+      logger: logStub.logger,
+      phaseHistory: [],
+      dryRun: false,
+    };
+
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'branch' && args[1] === '--show-current') {
+        return fakeSpawnResult('chore/pv-empty-1\n', '', 0);
+      }
+      if (cmd === 'git' && args[0] === 'rev-list') {
+        return fakeSpawnResult('0\n', '', 0);
+      }
+      // Anything else (bd show, git push, gh pr create) must NOT be called.
+      // If it is, return failure so assertions catch the leak.
+      return fakeSpawnResult('', 'unexpected spawn', 1);
+    });
+
+    const { runPR } = await import('../../lib/execute.js');
+    const result = await runPR(ctx, { scriptSpawnFn });
+
+    expect(result.next).toBe('halt');
+    expect(ctx.prUrl).toBeUndefined();
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'pr_finalize_aborted',
+        reason: 'no commits on branch',
+      }),
+    );
+
+    // Assert the sequence: only branch detect + rev-list were called.
+    const cmds = scriptSpawnFn.mock.calls.map((c: [string, string[]]) =>
+      `${c[0]} ${c[1]?.[0] ?? ''}`);
+    expect(cmds).toContain('git branch');
+    expect(cmds).toContain('git rev-list');
+    expect(cmds).not.toContain('git push');
+    expect(cmds).not.toContain('gh pr');
+    expect(cmds).not.toContain('bd show');
   });
 });
 

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -374,8 +374,15 @@ describe('runLeafExecution', () => {
       return createMockChild(JSON.stringify(auditVerdict), '', 0);
     });
 
+    // Gate probes: clean tree, 1 commit ahead of base, 1 changed file
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('src/server/calendar/service/calendar.ts\n', '', 0));
+
     const result = await runLeafExecution('pv-test-1', ctx, {
       spawnFn: mockSpawnFn,
+      scriptSpawnFn,
       changedFiles: ['src/server/calendar/service/calendar.ts'],
       selectAuditorsFn: async () => matchResult,
     });
@@ -423,8 +430,20 @@ describe('runLeafExecution', () => {
       }
     });
 
+    // Gate probes fire once per implementer success: 3 probes per call, 2 calls total
+    const scriptSpawnFn = vi.fn()
+      // Attempt 1 gate
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('src/server/calendar/service/calendar.ts\n', '', 0))
+      // Retry gate
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('src/server/calendar/service/calendar.ts\n', '', 0));
+
     const result = await runLeafExecution('pv-test-1', ctx, {
       spawnFn: mockSpawnFn,
+      scriptSpawnFn,
       changedFiles: ['src/server/calendar/service/calendar.ts'],
       selectAuditorsFn: async () => matchResult,
     });
@@ -462,14 +481,73 @@ describe('runLeafExecution', () => {
       return createMockChild(JSON.stringify(failVerdict), '', 0);
     });
 
+    // Gate probes fire once per implementer success: 3 probes per call, 2 calls total
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('src/server/calendar/service/calendar.ts\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('src/server/calendar/service/calendar.ts\n', '', 0));
+
     const result = await runLeafExecution('pv-test-1', ctx, {
       spawnFn: mockSpawnFn,
+      scriptSpawnFn,
       changedFiles: ['src/server/calendar/service/calendar.ts'],
       selectAuditorsFn: async () => matchResult,
     });
 
     expect(result.outcome).toBe('halt');
     expect(result.reason).toContain('retry exhausted');
+  });
+
+  it('calls verification gate after implementer success and uses its changedFiles for audit', async () => {
+    const { runLeafExecution } = await import('../../lib/execute.js');
+
+    // Implementer succeeds once
+    const spawnFn = vi.fn().mockImplementation(() => createMockChild('done', '', 0));
+
+    // Gate probes: clean tree, 1 commit, 1 changed file.
+    // Probes may fire more than once if a retry occurs; keep returning passing
+    // results so the test never exhausts the mock sequence — we only assert
+    // that the FIRST gate pass drove the authoritative changedFiles.
+    const scriptSpawnFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes('--porcelain')) return fakeSpawnResult('', '', 0);
+      if (args.includes('--count')) return fakeSpawnResult('1\n', '', 0);
+      if (args.includes('--name-only')) return fakeSpawnResult('src/gate.ts\n', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const passingSelector = vi.fn().mockResolvedValue([]); // empty selection -> audit fails
+    // We don't actually care about audit outcome for this test; we only assert the gate fired and
+    // changedFiles was overridden.
+
+    await runLeafExecution('pv-gate.1', ctx, {
+      spawnFn,
+      scriptSpawnFn,
+      selectAuditorsFn: passingSelector,
+      changedFiles: ['STALE.ts'], // intentionally stale; gate must override
+    });
+
+    // Gate fired and passed
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'implementer-verification-passed',
+        changedFilesCount: 1,
+      }),
+    );
+
+    // audit-skip did NOT fire (gate produced a non-empty changedFiles)
+    expect(logStub.runJsonEntries).not.toContainEqual(
+      expect.objectContaining({ event: 'audit-skip' }),
+    );
+
+    // Auditor selector was called with the gate's changedFiles, not the stale dep
+    expect(passingSelector).toHaveBeenCalledWith(
+      ['src/gate.ts'],
+      expect.any(Object),
+      expect.any(Object),
+    );
   });
 });
 
@@ -718,10 +796,17 @@ describe('leafPhase', () => {
       createMockChild(JSON.stringify(implementerResult), '', 0),
     );
 
+    // Gate probes: clean tree, 1 commit, 0 changed files -> audit-skip passes
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('1\n', '', 0))
+      .mockReturnValueOnce(fakeSpawnResult('', '', 0));
+
     const ctx = makePhaseCtx(logStub);
 
     const result = await leafPhase(ctx, {
       spawnFn: mockSpawnFn,
+      scriptSpawnFn,
       changedFiles: [],
     });
 

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -549,6 +549,120 @@ describe('runLeafExecution', () => {
       expect.any(Object),
     );
   });
+
+  it('retries implementer when gate fails on first attempt, succeeds on retry', async () => {
+    const { runLeafExecution } = await import('../../lib/execute.js');
+
+    const gateCtx: RunContext = { ...makeCtx(logStub), beadId: 'pv-gate.2' };
+
+    // Implementer succeeds both attempts
+    const spawnFn = vi.fn().mockImplementation(() => createMockChild('done', '', 0));
+
+    // scriptSpawnFn: route by argv. First status call is dirty; subsequent clean.
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'status') {
+        const call = scriptSpawnFn.mock.calls
+          .filter(c => c[0] === 'git' && (c[1] as string[])[0] === 'status').length;
+        return call === 1
+          ? fakeSpawnResult(' M a.ts\n', '', 0)
+          : fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('1\n', '', 0);
+      // Empty diff -> audit-skip pass-through (we're exercising the gate, not audit).
+      if (cmd === 'git' && args[0] === 'diff') return fakeSpawnResult('', '', 0);
+      if (cmd === 'bd') return fakeSpawnResult('', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const selectAuditorsFn = vi.fn().mockResolvedValue([]);
+
+    const result = await runLeafExecution('pv-gate.2', gateCtx, {
+      spawnFn,
+      scriptSpawnFn,
+      selectAuditorsFn,
+    });
+
+    expect(result.outcome).toBe('complete');
+    expect(result.retryCount).toBe(1);
+
+    const verificationEvents = logStub.runJsonEntries
+      .filter(e => typeof e.event === 'string' && (e.event as string).startsWith('implementer-verification'))
+      .map(e => e.event);
+    expect(verificationEvents).toEqual([
+      'implementer-verification-failed',
+      'implementer-verification-passed',
+    ]);
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'bead-reopened',
+        beadId: 'pv-gate.2',
+        reason: 'verification-gate-retry',
+      }),
+    );
+  });
+
+  it('escalates when gate fails on both attempts', async () => {
+    const { runLeafExecution } = await import('../../lib/execute.js');
+
+    const gateCtx: RunContext = { ...makeCtx(logStub), beadId: 'pv-gate.3' };
+
+    const spawnFn = vi.fn().mockImplementation(() => createMockChild('done', '', 0));
+
+    // Status always dirty, everything else cooperates
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'status') return fakeSpawnResult(' M a.ts\n', '', 0);
+      if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('1\n', '', 0);
+      if (cmd === 'git' && args[0] === 'diff') return fakeSpawnResult('a.ts\n', '', 0);
+      if (cmd === 'bd') return fakeSpawnResult('', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const result = await runLeafExecution('pv-gate.3', gateCtx, {
+      spawnFn,
+      scriptSpawnFn,
+    });
+
+    expect(result.outcome).toBe('halt');
+
+    const reopenEvents = logStub.runJsonEntries.filter(e => e.event === 'bead-reopened');
+    expect(reopenEvents).toHaveLength(2);
+    expect(reopenEvents.map(e => e.reason)).toEqual([
+      'verification-gate-retry',
+      'verification-gate-escalate',
+    ]);
+  });
+
+  it('escalates when tree is clean but branch has zero commits (the observed failure)', async () => {
+    const { runLeafExecution } = await import('../../lib/execute.js');
+
+    const gateCtx: RunContext = { ...makeCtx(logStub), beadId: 'pv-psum.2' };
+
+    const spawnFn = vi.fn().mockImplementation(() => createMockChild('done', '', 0));
+
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'git' && args[0] === 'status') return fakeSpawnResult('', '', 0);
+      if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('0\n', '', 0);
+      if (cmd === 'git' && args[0] === 'diff') return fakeSpawnResult('', '', 0);
+      if (cmd === 'bd') return fakeSpawnResult('', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const result = await runLeafExecution('pv-psum.2', gateCtx, {
+      spawnFn,
+      scriptSpawnFn,
+    });
+
+    expect(result.outcome).toBe('halt');
+
+    const failReasons = logStub.runJsonEntries
+      .filter(e => e.event === 'implementer-verification-failed')
+      .map(e => e.reason);
+    expect(failReasons).toEqual([
+      'no commits on branch ahead of main',
+      'no commits on branch ahead of main',
+    ]);
+  });
 });
 
 // =============================================================================

--- a/.claude/orchestrators/test/unit/verification-gate.test.ts
+++ b/.claude/orchestrators/test/unit/verification-gate.test.ts
@@ -141,4 +141,44 @@ describe('verifyImplementerCompletion', () => {
       expect(result.reason).toBe('no commits on branch ahead of main');
     }
   });
+
+  it('returns passed=false with porcelain reason when tree is dirty', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(' M src/a.ts\n'));
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result).toEqual({
+      passed: false,
+      reason: 'uncommitted or untracked changes present: M src/a.ts',
+    });
+
+    expect(scriptSpawnFn).toHaveBeenCalledTimes(1);
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'implementer-verification-failed',
+        beadId: 'pv-test.1',
+        reason: 'uncommitted or untracked changes present: M src/a.ts',
+      }),
+    );
+  });
+
+  it('returns passed=false for untracked files only', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('?? src/newfile.ts\n'));
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toContain('?? src/newfile.ts');
+    }
+  });
 });

--- a/.claude/orchestrators/test/unit/verification-gate.test.ts
+++ b/.claude/orchestrators/test/unit/verification-gate.test.ts
@@ -181,4 +181,60 @@ describe('verifyImplementerCompletion', () => {
       expect(result.reason).toContain('?? src/newfile.ts');
     }
   });
+
+  it('returns passed=false when branch has zero commits ahead of main', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(''))
+      .mockReturnValueOnce(fakeSpawnResult('0\n'));
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result).toEqual({
+      passed: false,
+      reason: 'no commits on branch ahead of main',
+    });
+
+    expect(scriptSpawnFn).toHaveBeenCalledTimes(2);
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'implementer-verification-failed',
+        reason: 'no commits on branch ahead of main',
+      }),
+    );
+  });
+
+  it('honors GIT_SAFE_MAIN_BRANCH override in the reason string', () => {
+    const prev = process.env.GIT_SAFE_MAIN_BRANCH;
+    process.env.GIT_SAFE_MAIN_BRANCH = 'develop';
+    try {
+      const logStub = stubLogger();
+      const ctx = makeCtx(logStub);
+
+      const scriptSpawnFn = vi.fn()
+        .mockReturnValueOnce(fakeSpawnResult(''))
+        .mockReturnValueOnce(fakeSpawnResult('0\n'));
+
+      const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+      expect(result).toEqual({
+        passed: false,
+        reason: 'no commits on branch ahead of develop',
+      });
+
+      expect(scriptSpawnFn).toHaveBeenNthCalledWith(
+        2,
+        'git',
+        ['rev-list', '--count', 'develop..HEAD'],
+        expect.any(Object),
+      );
+    }
+    finally {
+      if (prev === undefined) delete process.env.GIT_SAFE_MAIN_BRANCH;
+      else process.env.GIT_SAFE_MAIN_BRANCH = prev;
+    }
+  });
 });

--- a/.claude/orchestrators/test/unit/verification-gate.test.ts
+++ b/.claude/orchestrators/test/unit/verification-gate.test.ts
@@ -63,4 +63,82 @@ describe('verifyImplementerCompletion', () => {
       }),
     );
   });
+
+  it('fails closed when git status exits non-zero', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce({
+        ...fakeSpawnResult(''),
+        status: 128,
+        stderr: Buffer.from('fatal: not a git repository\n', 'utf-8'),
+      });
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toMatch(/^git status --porcelain failed:/);
+      expect(result.reason).toContain('fatal: not a git repository');
+    }
+    expect(scriptSpawnFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when git rev-list exits non-zero', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(''))
+      .mockReturnValueOnce({
+        ...fakeSpawnResult(''),
+        status: 128,
+        stderr: Buffer.from('fatal: bad revision \'main..HEAD\'\n', 'utf-8'),
+      });
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toMatch(/^git rev-list --count failed:/);
+    }
+  });
+
+  it('fails closed when git diff exits non-zero', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(''))
+      .mockReturnValueOnce(fakeSpawnResult('2\n'))
+      .mockReturnValueOnce({
+        ...fakeSpawnResult(''),
+        status: 1,
+        stderr: Buffer.from('something broke\n', 'utf-8'),
+      });
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toMatch(/^git diff --name-only failed:/);
+    }
+  });
+
+  it('fails closed when rev-list returns non-numeric garbage', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(''))
+      .mockReturnValueOnce(fakeSpawnResult('abc\n'));
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result.passed).toBe(false);
+    if (!result.passed) {
+      expect(result.reason).toBe('no commits on branch ahead of main');
+    }
+  });
 });

--- a/.claude/orchestrators/test/unit/verification-gate.test.ts
+++ b/.claude/orchestrators/test/unit/verification-gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SpawnSyncReturns } from 'node:child_process';
+import { PhaseName, type RunLogger } from '../../lib/types.js';
+import type { PhaseCtx } from '../../lib/execute.js';
+import { verifyImplementerCompletion } from '../../lib/execute.js';
+
+function stubLogger(): {
+  logger: RunLogger;
+  runJsonEntries: Record<string, unknown>[];
+} {
+  const runJsonEntries: Record<string, unknown>[] = [];
+  const logger: RunLogger = {
+    writePhaseLog: vi.fn(),
+    appendRunJson(entry) { runJsonEntries.push(entry); },
+    runDir: () => '/tmp/fake-run-dir',
+  };
+  return { logger, runJsonEntries };
+}
+
+function fakeSpawnResult(stdout: string, status = 0): SpawnSyncReturns<Buffer> {
+  return {
+    stdout: Buffer.from(stdout, 'utf-8'),
+    stderr: Buffer.from('', 'utf-8'),
+    status,
+    signal: null,
+    pid: 1234,
+    output: [null, Buffer.from(stdout), Buffer.from('')],
+  };
+}
+
+function makeCtx(logStub: ReturnType<typeof stubLogger>, beadId = 'pv-test.1'): PhaseCtx {
+  return {
+    runId: 'test-run',
+    beadId,
+    logger: logStub.logger,
+    phaseHistory: [],
+    dryRun: false,
+  };
+}
+
+describe('verifyImplementerCompletion', () => {
+  it('returns passed with changedFiles when tree is clean and commits exist', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub);
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult(''))
+      .mockReturnValueOnce(fakeSpawnResult('2\n'))
+      .mockReturnValueOnce(fakeSpawnResult('src/a.ts\nsrc/b.ts\n'));
+
+    const result = verifyImplementerCompletion(ctx, { scriptSpawnFn });
+
+    expect(result).toEqual({
+      passed: true,
+      changedFiles: ['src/a.ts', 'src/b.ts'],
+    });
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'implementer-verification-passed',
+        beadId: 'pv-test.1',
+        changedFilesCount: 2,
+      }),
+    );
+  });
+});

--- a/.claude/orchestrators/test/unit/verification-gate.test.ts
+++ b/.claude/orchestrators/test/unit/verification-gate.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { SpawnSyncReturns } from 'node:child_process';
 import { PhaseName, type RunLogger } from '../../lib/types.js';
 import type { PhaseCtx } from '../../lib/execute.js';
-import { verifyImplementerCompletion } from '../../lib/execute.js';
+import { verifyImplementerCompletion, reopenBead } from '../../lib/execute.js';
 
 function stubLogger(): {
   logger: RunLogger;
@@ -236,5 +236,52 @@ describe('verifyImplementerCompletion', () => {
       if (prev === undefined) delete process.env.GIT_SAFE_MAIN_BRANCH;
       else process.env.GIT_SAFE_MAIN_BRANCH = prev;
     }
+  });
+});
+
+describe('reopenBead', () => {
+  it('runs bd update --status=in_progress and logs a bead-reopened event', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub, 'pv-psum.2');
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('', 0));
+
+    reopenBead('pv-psum.2', ctx, { scriptSpawnFn }, 'verification-gate-retry');
+
+    expect(scriptSpawnFn).toHaveBeenCalledWith(
+      'bd',
+      ['update', 'pv-psum.2', '--status=in_progress'],
+      expect.any(Object),
+    );
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'bead-reopened',
+        beadId: 'pv-psum.2',
+        reason: 'verification-gate-retry',
+        success: true,
+      }),
+    );
+  });
+
+  it('logs success=false when bd update exits non-zero but does not throw', () => {
+    const logStub = stubLogger();
+    const ctx = makeCtx(logStub, 'pv-psum.2');
+
+    const scriptSpawnFn = vi.fn()
+      .mockReturnValueOnce(fakeSpawnResult('', 1));
+
+    expect(() =>
+      reopenBead('pv-psum.2', ctx, { scriptSpawnFn }, 'verification-gate-escalate'),
+    ).not.toThrow();
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'bead-reopened',
+        beadId: 'pv-psum.2',
+        success: false,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Adds an orchestrator-side verification gate that runs after a successful `dispatchImplementer` and before `runAudit`. The gate refuses to let a leaf bead advance unless:

1. Working tree is clean (including untracked files), AND
2. Branch has commits ahead of base (default `main`, overridable via `GIT_SAFE_MAIN_BRANCH`).

Gate failures reopen the bead (the implementer may have prematurely called `bd close`) and feed into the existing retry-once path; exhausted retries escalate cleanly. The same gate is applied to the per-bead path inside `runEpicExecution`. `runPR` gains a cheap backstop that refuses to push an empty branch.

Motivated by process-backlog run `20260422T024223-af5f`, which silently produced an empty branch and a failed `gh pr create` because the implementer subagent never committed. This was the second observed occurrence of that failure mode; the gate closes the structural hole.

## New JSONL events

- `implementer-verification-passed` — gate cleared
- `implementer-verification-failed` — includes reason citing the specific git command
- `bead-reopened` — premature close recovery, tagged with reason
- `pr_finalize_aborted` — backstop trip in `runPR`

## Test plan

- [x] 11 unit tests in \`.claude/orchestrators/test/unit/verification-gate.test.ts\` cover the two helpers in isolation: happy path, dirty tree, untracked files, zero commits, env override, git exit-code failures, non-numeric rev counts, and bd-update failures.
- [x] 4 new integration tests in \`.claude/orchestrators/test/unit/execute.test.ts\` cover the wired flow through \`runLeafExecution\` (gate-passes-and-overrides-changedFiles, retry-success, escalate-on-both-fail, the exact observed zero-commits failure) plus \`runEpicExecution\` and the \`runPR\` backstop.
- [x] 4 integration tests in \`.claude/orchestrators/test/integration/verification-gate.test.ts\` run the gate against a real ephemeral git repo to catch wrong-flag and porcelain-format bugs unit stubs miss.
- [x] Full orchestrator suite: 245/245 pass.
- [x] \`npm run lint\`: 0 errors, 276 pre-existing warnings unchanged.