### PR TITLE
chore(calendars): translate calendars list load-error message (pv-nodr)

### DIFF
--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -74,7 +74,7 @@ async function loadCalendars() {
   }
   catch (error) {
     console.error('Error loading calendars:', error);
-    state.err = 'Failed to load calendars';
+    state.err = t('error_loading_calendars');
   }
   finally {
     state.isLoading = false;

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -28,7 +28,8 @@
         "role_owner": "Owner",
         "role_editor": "Editor",
         "aria_navigate_calendar": "Navigate to calendar: {{calendarName}}, role: {{role}}",
-        "aria_view_public_calendar": "View public calendar: {{name}} (opens in new tab)"
+        "aria_view_public_calendar": "View public calendar: {{name}} (opens in new tab)",
+        "error_loading_calendars": "Failed to load calendars"
     },
     "selector": {
         "select_calendar_title": "Select Calendar",


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `'Failed to load calendars'` string in the authenticated calendars list with a translated `list.error_loading_calendars` key.
- `state.err` is still not rendered in the template; displaying the error to the user is a separate concern and can be picked up in a follow-up bead if desired.

## Beads closed

- pv-nodr — Add i18n key for calendars list error state

## Test plan

- [x] `npm run lint` (0 errors)
- [x] `npm run build`
- [ ] Manual verification that the key resolves in the UI (error path requires simulated API failure)