### PR TITLE
feat(orchestrator): resilience + epic promotion (pv-4p63)

### DIFF
--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -521,7 +521,7 @@ export function spawnCmd(
 
 
 /** Default per-advisor timeout in ms. */
-export const ADVISOR_TIMEOUT_MS = 120_000;
+export const ADVISOR_TIMEOUT_MS = 240_000;
 
 export interface AdvisorVerdict {
   agent: string;

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -48,6 +48,13 @@ export interface PreflightFailure {
 export interface PreflightResult {
   ok: boolean;
   failures: PreflightFailure[];
+  /**
+   * Set when preflight detected an orphaned orchestrator branch (see
+   * tryRecoverOrphanBranch) and successfully returned the working tree to
+   * main. The Phase 0 runner uses this to emit a `preflight_recovered`
+   * event so the condition is visible in run logs.
+   */
+  recovered?: { orphanedBranch: string };
 }
 
 export interface BeadJson {
@@ -55,7 +62,25 @@ export interface BeadJson {
   issue_type?: string;
   priority?: number;
   created_at?: string;
+  status?: string;
+  parent?: string;
+  dependencies?: BeadDependency[];
+  dependents?: BeadDependency[];
   [key: string]: unknown;
+}
+
+export interface BeadDependency {
+  id: string;
+  status?: string;
+  issue_type?: string;
+  dependency_type?: string;
+  [key: string]: unknown;
+}
+
+export interface EpicPromotionResult {
+  epicId: string;
+  epicTitle?: string;
+  readyChildCount: number;
 }
 
 export interface TopReadyResult {
@@ -166,17 +191,77 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
 // =============================================================================
 
 /**
+ * Orchestrator-generated branch pattern. Matches the format produced by
+ * `branchName()`: `<type>/<kebab-title>-<beadId-with-dashes>`.
+ *
+ * Loose by design — a branch that matches this pattern still has to pass
+ * every other recovery guard (clean tree, no commits ahead of main, no open
+ * PR) before preflight will touch it.
+ */
+const ORCHESTRATOR_BRANCH_PATTERN = /^(chore|feat|fix)\/[a-z0-9][a-z0-9-]*-pv-[a-z0-9-]+$/;
+
+/**
+ * Decide whether the current non-main branch is a stale, abandoned
+ * orchestrator branch that's safe to check out of automatically.
+ *
+ * Safe-to-recover requires ALL of:
+ *   - branch name matches the orchestrator-generated pattern
+ *   - working tree is clean (no uncommitted changes)
+ *   - branch has no commits ahead of main
+ *   - no open PR exists for the branch
+ *
+ * Any gh/git failure returns false — safer to halt than to guess.
+ */
+function canRecoverOrphanBranch(
+  branch: string,
+  mainBranch: string,
+  spawn: SpawnFn,
+): boolean {
+  if (!ORCHESTRATOR_BRANCH_PATTERN.test(branch)) return false;
+
+  const status = run('git', ['status', '--porcelain'], spawn);
+  if (status.exitCode !== 0 || status.stdout.length > 0) return false;
+
+  const revList = run('git', ['rev-list', '--count', `${mainBranch}..${branch}`], spawn);
+  if (revList.exitCode !== 0) return false;
+  const ahead = parseInt(revList.stdout || '0', 10);
+  if (Number.isNaN(ahead) || ahead > 0) return false;
+
+  const prList = run(
+    'gh',
+    ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number'],
+    spawn,
+  );
+  if (prList.exitCode !== 0) return false;
+
+  try {
+    const prs = JSON.parse(prList.stdout || '[]');
+    if (Array.isArray(prs) && prs.length > 0) return false;
+  }
+  catch {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * Full preflight gate. Checks:
  *   - dirty_tree:     working tree has uncommitted changes
  *   - wrong_branch:   not on main (or GIT_SAFE_MAIN_BRANCH)
  *   - stale_main:     local main differs from origin/main
  *   - empty_backlog:  no ready beads excluding needs-human beads
+ *
+ * Before reporting `wrong_branch`, preflight attempts to recover from an
+ * orphaned orchestrator branch (see canRecoverOrphanBranch). Successful
+ * recovery sets `result.recovered` and silences the `wrong_branch` failure.
  */
 export function preflight(deps: SpawnDeps = {}): PreflightResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
   const mainBranch = process.env.PREFLIGHT_MAIN_BRANCH ?? 'main';
   const readyLimit = parseInt(process.env.PREFLIGHT_READY_LIMIT ?? '50', 10);
   const failures: PreflightFailure[] = [];
+  let recovered: { orphanedBranch: string } | undefined;
 
   // 1. Clean working tree
   const statusResult = run('git', ['status', '--porcelain'], spawn);
@@ -187,12 +272,23 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
     });
   }
 
-  // 2. On main branch
+  // 2. On main branch — attempt orphan recovery first
   const branchResult = run('git', ['branch', '--show-current'], spawn);
-  if (branchResult.stdout !== mainBranch) {
+  let currentBranch = branchResult.stdout;
+  if (currentBranch && currentBranch !== mainBranch) {
+    if (canRecoverOrphanBranch(currentBranch, mainBranch, spawn)) {
+      const checkout = run('git', ['checkout', mainBranch], spawn);
+      if (checkout.exitCode === 0) {
+        recovered = { orphanedBranch: currentBranch };
+        currentBranch = mainBranch;
+      }
+    }
+  }
+
+  if (currentBranch !== mainBranch) {
     failures.push({
       kind: 'wrong_branch',
-      reason: `expected to be on '${mainBranch}' but currently on '${branchResult.stdout}'`,
+      reason: `expected to be on '${mainBranch}' but currently on '${currentBranch}'`,
     });
   }
 
@@ -246,6 +342,7 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
   return {
     ok: failures.length === 0,
     failures,
+    ...(recovered ? { recovered } : {}),
   };
 }
 
@@ -708,6 +805,110 @@ export function bdListChildren(beadId: string, deps: SpawnDeps = {}): string[] {
     }
   }
   return childIds;
+}
+
+// =============================================================================
+// bdShowJson
+// =============================================================================
+
+/**
+ * Load the full JSON record for a bead via `bd show <id> --json`. Returns null
+ * when the call fails or the output is unparseable. `bd show --json` wraps its
+ * output in a single-element array; this helper unwraps it.
+ */
+export function bdShowJson(beadId: string, deps: SpawnDeps = {}): BeadJson | null {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+  const result = run('bd', ['show', beadId, '--json'], spawn);
+  if (result.exitCode !== 0 || !result.stdout) return null;
+
+  try {
+    const parsed = JSON.parse(result.stdout);
+    const record = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (!record || typeof record !== 'object') return null;
+    return record as BeadJson;
+  }
+  catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// checkEpicPromotion
+// =============================================================================
+
+/**
+ * Decide whether a selected leaf bead should be promoted to its parent epic.
+ *
+ * Promotion condition: the selected bead's parent is an analyzed epic with
+ * at least 2 ready children (including the selected bead itself). This lets
+ * the orchestrator run the epic as a wave — one branch, one PR closing all
+ * children — instead of fragmenting the epic across multiple single-leaf runs.
+ *
+ * Note: an analyzed epic is always "blocked" by its own unclosed children in
+ * bd's dependency DAG. That is NOT disqualifying — it's exactly the condition
+ * under which wave orchestration applies.
+ *
+ * Returns null when any of these hold:
+ *   - the selected bead has no parent
+ *   - the parent is not an epic
+ *   - the parent has not reached the 'analyzed' state
+ *   - fewer than 2 children are currently ready (no unmet blockers,
+ *     not labelled needs-human)
+ */
+export function checkEpicPromotion(
+  selectedBeadId: string,
+  deps: SpawnDeps = {},
+): EpicPromotionResult | null {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+
+  // 1. Load selected bead, check for a parent
+  const selected = bdShowJson(selectedBeadId, deps);
+  if (!selected || !selected.parent) return null;
+
+  // 2. Load parent, require epic
+  const parent = bdShowJson(selected.parent, deps);
+  if (!parent || parent.issue_type !== 'epic') return null;
+
+  // 3. Require analyzed state — we don't promote to an epic that hasn't had
+  //    its children enriched yet, since the wave executor needs enrichment.
+  const parentState = bdState(parent.id, deps);
+  if (parentState.missing_phases.includes('analyzed')) return null;
+
+  // 4. Count ready children. Build a set of currently-ready bead ids from
+  //    `bd ready --json` to match bd's own readiness semantics, then count
+  //    how many of the epic's children appear in that set.
+  const readyResult = run('bd', ['ready', '--limit=200', '--json'], spawn);
+  if (readyResult.exitCode !== 0) return null;
+
+  let readyBeads: BeadJson[];
+  try {
+    readyBeads = JSON.parse(readyResult.stdout) as BeadJson[];
+  }
+  catch {
+    return null;
+  }
+
+  const readyIds = new Set(readyBeads.map(b => b.id));
+  const childIds = bdListChildren(parent.id, deps);
+
+  let readyChildCount = 0;
+  for (const childId of childIds) {
+    if (!readyIds.has(childId)) continue;
+    // Exclude children that are labelled needs-human
+    const labelResult = run('bd', ['label', 'list', childId], spawn);
+    const hasNeedsHuman = labelResult.stdout
+      .split('\n')
+      .some(line => line.trim() === '- needs-human');
+    if (!hasNeedsHuman) readyChildCount++;
+  }
+
+  if (readyChildCount < 2) return null;
+
+  return {
+    epicId: parent.id,
+    epicTitle: typeof parent.title === 'string' ? parent.title : undefined,
+    readyChildCount,
+  };
 }
 
 // =============================================================================

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -32,6 +32,7 @@ import {
   bdEscalate,
   bdCreateFollowup,
   branchName,
+  checkEpicPromotion,
   discoverAgents,
   type StateVerdict,
   type SizingVerdict,
@@ -304,7 +305,7 @@ async function selectAdvisors(
     const raw = await dispatchFn<unknown>({
       agent: 'agent-selector',
       prompt,
-      timeoutMs: 120_000,
+      timeoutMs: 180_000,
       ctx,
       logTag,
     });
@@ -377,20 +378,34 @@ async function dispatchAgent<T>(
     return { result, escalated: false };
   }
   catch (err) {
-    if (err instanceof DispatchMalformedError || err instanceof DispatchTimeoutError) {
-      const reason = err instanceof DispatchTimeoutError
-        ? `${config.agent} subagent timed out: ${err.message}`
-        : `${config.agent} subagent returned malformed output: ${err.message}`;
+    if (err instanceof DispatchTimeoutError) {
+      // Timeout is classified as a transient_halt — the bead itself is fine,
+      // automation just didn't finish. We halt the current run but do NOT add
+      // the needs-human label, so the bead stays eligible for bd ready on the
+      // next /process-backlog invocation. The run verdict (classifyVerdict)
+      // will pick up the "timed out" error text and classify transient_halt.
+      const reason = `${config.agent} subagent timed out: ${err.message}`;
+      ctx.logger.appendRunJson({
+        event: `${config.agent.replace(/-/g, '_')}_timed_out`,
+        beadId: ctx.beadId,
+        reason,
+        phase: config.escalateTag,
+      });
+      ctx.logger.writePhaseLog(config.logTag, 'err', reason + '\n');
+      return { result: null, escalated: true };
+    }
 
+    if (err instanceof DispatchMalformedError) {
+      const reason = `${config.agent} subagent returned malformed output: ${err.message}`;
       ctx.logger.appendRunJson({
         event: `${config.agent.replace(/-/g, '_')}_escalated`,
         beadId: ctx.beadId,
         reason,
       });
-
       escalate(ctx.beadId, reason, config.escalateTag, config.logTag, deps, ctx);
       return { result: null, escalated: true };
     }
+
     throw err;
   }
 }
@@ -535,7 +550,7 @@ async function defaultAdvisorTriage(
     const raw = await dispatchFn<unknown>({
       agent: 'advisor-triage',
       prompt,
-      timeoutMs: 90_000,
+      timeoutMs: 180_000,
       ctx,
       logTag,
     });
@@ -898,6 +913,13 @@ export async function preflight(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Ph
   // Step 1: Run preflight checks
   const preflightResult = runPreflightCheck({ spawnFn: deps.spawnFn });
 
+  if (preflightResult.recovered) {
+    ctx.logger.appendRunJson({
+      event: 'preflight_recovered',
+      orphanedBranch: preflightResult.recovered.orphanedBranch,
+    });
+  }
+
   // When an explicit bead is given, backlog emptiness is not a blocker:
   // the user may be picking up a partially-processed or non-ready bead.
   const blockingFailures = explicitBead
@@ -960,6 +982,28 @@ export async function select(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
     createdAt: bead.created_at,
   });
 
+  // Epic promotion: if the selected leaf's parent is an analyzed epic with
+  // >= 2 ready children, pivot ctx.beadId to the epic id so the epic phase
+  // runs as a wave (one branch, parallel implementers, one PR closing all
+  // children) rather than running one leaf at a time.
+  //
+  // Skipped for leaves without a parent, non-epic parents, unanalyzed epics,
+  // or single-child cases — in those cases the orchestrator keeps current
+  // single-leaf behavior.
+  if (bead.issue_type !== 'epic') {
+    const promotion = checkEpicPromotion(bead.id, deps);
+    if (promotion) {
+      ctx.beadId = promotion.epicId;
+      ctx.logger.appendRunJson({
+        event: 'promoted_to_epic',
+        from: bead.id,
+        to: promotion.epicId,
+        epicTitle: promotion.epicTitle,
+        readyChildCount: promotion.readyChildCount,
+      });
+    }
+  }
+
   return { next: PhaseName.State, ctx };
 }
 
@@ -1014,7 +1058,7 @@ export async function shape(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<PhaseR
   const { result: verdict, escalated } = await dispatchAgent<ShapeVerdict>(ctx, {
     agent: 'shape-bead',
     prompt,
-    defaultTimeout: 180_000,
+    defaultTimeout: 300_000,
     logTag: PhaseName.Shape,
     escalateTag: '3',
   }, deps);

--- a/.claude/orchestrators/process-backlog.ts
+++ b/.claude/orchestrators/process-backlog.ts
@@ -150,6 +150,45 @@ export async function runStateMachine(
 // ---------------------------------------------------------------------------
 
 /**
+ * Classify how a run ended so /loop consumers and humans can tell recoverable
+ * halts from blockers.
+ *
+ *   `completed`       — a PR was opened; next /process-backlog run should
+ *                       pick a different bead.
+ *   `transient_halt`  — the run halted on a condition that typically clears
+ *                       between invocations (subagent timeout, wrong_branch
+ *                       preflight before orphan recovery lands). The same
+ *                       bead is still eligible; retry after a delay.
+ *   `needs_human`     — the run halted on a condition requiring human input
+ *                       (advisor REQUEST CHANGES, verification exhausted,
+ *                       dirty tree, stale main, empty backlog).
+ *
+ * Exported for testing.
+ */
+export type RunVerdict = 'completed' | 'transient_halt' | 'needs_human';
+
+const TRANSIENT_ERROR_PATTERNS = [
+  /timed out/i,
+  /timeout/i,
+  /wrong_branch/i,
+  /stale_main/i,
+];
+
+export function classifyVerdict(ctx: OrchestratorCtx): RunVerdict {
+  if (ctx.prUrl) return 'completed';
+
+  const failed = ctx.phaseHistory.filter((p) => !p.ok);
+  for (const p of failed) {
+    const text = p.error ?? '';
+    if (TRANSIENT_ERROR_PATTERNS.some((rx) => rx.test(text))) {
+      return 'transient_halt';
+    }
+  }
+
+  return 'needs_human';
+}
+
+/**
  * Build the structured markdown summary from the run context.
  *
  * Exported for testing.
@@ -160,6 +199,7 @@ export function buildSummary(ctx: OrchestratorCtx): string {
   const prUrl = ctx.prUrl ?? '(none)';
   const beadsClosed = ctx.beadsClosed ?? [ctx.beadId].filter(Boolean);
   const failed = ctx.phaseHistory.filter((p) => !p.ok);
+  const verdict = classifyVerdict(ctx);
 
   const lines: string[] = [
     '',
@@ -170,6 +210,7 @@ export function buildSummary(ctx: OrchestratorCtx): string {
     `Beads Touched: ${beadsClosed.join(', ') || '(none)'}`,
     `PR: ${prUrl}`,
     `Total Duration: ${totalMs}ms`,
+    `Verdict: ${verdict}`,
     `Status: ${failed.length > 0 ? 'completed with errors' : 'completed'}`,
   ];
 
@@ -206,6 +247,7 @@ function printSummary(ctx: OrchestratorCtx): void {
     beadsClosed: ctx.beadsClosed ?? [ctx.beadId].filter(Boolean),
     phasesExecuted: ctx.phaseHistory.map((p) => p.phase),
     totalDurationMs: ctx.phaseHistory.reduce((sum, p) => sum + p.durationMs, 0),
+    verdict: classifyVerdict(ctx),
     errors: ctx.phaseHistory
       .filter((p) => !p.ok)
       .map((p) => ({ phase: p.phase, error: p.error })),

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -153,6 +153,82 @@ describe('preflight', () => {
     const result = preflight({ spawnFn: spawn as never });
     expect(result.failures.map(f => f.kind)).toContain('empty_backlog');
   });
+
+  // ---------------------------------------------------------------------------
+  // Orphan branch recovery
+  // ---------------------------------------------------------------------------
+
+  it('recovers from an orphaned orchestrator branch and continues preflight', () => {
+    // Branch matches pattern, tree clean, no commits ahead, no open PR →
+    // checkout main and proceed without reporting wrong_branch.
+    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
+    const spawn = seqSpawn(
+      fakeSpawn(''),                           // git status (clean)
+      fakeSpawn('chore/some-title-pv-abc'),    // git branch --show-current
+      // canRecoverOrphanBranch:
+      fakeSpawn(''),                           // git status (clean)
+      fakeSpawn('0'),                          // git rev-list --count main..branch
+      fakeSpawn('[]'),                         // gh pr list (no open PR)
+      fakeSpawn('', '', 0),                    // git checkout main (success)
+      // Resume preflight:
+      fakeSpawn('', '', 0),                    // git fetch origin main
+      fakeSpawn('', '', 0),                    // git diff (no diff)
+      fakeSpawn(beadsJson),                    // bd ready
+      fakeSpawn('  - other'),                  // bd label list pv-x1
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+    expect(result.recovered).toEqual({ orphanedBranch: 'chore/some-title-pv-abc' });
+    expect(result.failures.map(f => f.kind)).not.toContain('wrong_branch');
+  });
+
+  it('does not recover when branch has commits ahead of main', () => {
+    const spawn = seqSpawn(
+      fakeSpawn(''),                              // git status (clean)
+      fakeSpawn('feat/wip-pv-xyz'),               // git branch
+      // canRecoverOrphanBranch:
+      fakeSpawn(''),                              // git status (clean)
+      fakeSpawn('3'),                             // git rev-list: 3 commits ahead → refuse
+      // No checkout; proceed with wrong_branch failure:
+      fakeSpawn('', '', 0),                       // git fetch
+      fakeSpawn('', '', 0),                       // git diff
+      fakeSpawn('[]'),                            // bd ready (empty)
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.recovered).toBeUndefined();
+    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
+  });
+
+  it('does not recover when branch has an open PR', () => {
+    const spawn = seqSpawn(
+      fakeSpawn(''),                              // git status
+      fakeSpawn('fix/bug-pv-pqr'),                // git branch
+      fakeSpawn(''),                              // git status (recovery check)
+      fakeSpawn('0'),                             // no commits ahead
+      fakeSpawn('[{"number":101}]'),              // gh pr list: open PR exists → refuse
+      fakeSpawn('', '', 0),                       // git fetch
+      fakeSpawn('', '', 0),                       // git diff
+      fakeSpawn('[]'),                            // bd ready
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.recovered).toBeUndefined();
+    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
+  });
+
+  it('does not recover non-orchestrator-looking branch names', () => {
+    // Branch doesn't match pattern → skip recovery entirely, report wrong_branch.
+    const spawn = seqSpawn(
+      fakeSpawn(''),                              // git status
+      fakeSpawn('my-local-experiment'),           // git branch — no type prefix
+      // canRecoverOrphanBranch returns false on pattern mismatch — no extra calls
+      fakeSpawn('', '', 0),                       // git fetch
+      fakeSpawn('', '', 0),                       // git diff
+      fakeSpawn('[]'),                            // bd ready
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.recovered).toBeUndefined();
+    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
+  });
 });
 
 // =============================================================================

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -355,6 +355,240 @@ describe('select', () => {
     expect(result.ctx.beadId).toBe('pv-explicit-99');
     expect(spawn).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // Epic promotion
+  // -------------------------------------------------------------------------
+  //
+  // When /process-backlog auto-selects a leaf whose parent is an analyzed
+  // epic with >= 2 ready children, we want it to pivot to the epic id so
+  // the epic phase can run as a wave. These tests cover the decision matrix.
+
+  /** Text for bdState() that looks like an enriched (analyzed) epic. */
+  function beadTextAnalyzedEpic(): string {
+    return [
+      'OPEN pv-epic',
+      'DESCRIPTION',
+      'A nontrivial epic that spans multiple beads.',
+      'DESIGN',
+      'Break the work into independent leaves.',
+      'ACCEPTANCE CRITERIA',
+      '- All child beads close',
+      'CHILDREN',
+      '  ↳ pv-child-1',
+      '  ↳ pv-child-2',
+      'NOTES',
+      'Implementation Context: children enriched with scope and test plan.',
+    ].join('\n');
+  }
+
+  /** Text for bdState() that looks like an epic before analyze. */
+  function beadTextShapedOnlyEpic(): string {
+    return [
+      'OPEN pv-epic',
+      'DESCRIPTION',
+      'Shaped epic without children yet.',
+      'DESIGN',
+      'TBD',
+      'ACCEPTANCE CRITERIA',
+      '- Define child beads',
+      'NOTES',
+      'not yet analyzed',
+    ].join('\n');
+  }
+
+  it('should promote leaf to its analyzed epic parent with 2+ ready children', async () => {
+    const leaf = { id: 'pv-child-1', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-child-1', issue_type: 'task', parent: 'pv-epic' };
+    const epicFull = {
+      id: 'pv-epic',
+      issue_type: 'epic',
+      title: 'Orchestrator resilience',
+      dependents: [
+        { id: 'pv-child-1', dependency_type: 'parent-child' },
+        { id: 'pv-child-2', dependency_type: 'parent-child' },
+      ],
+    };
+
+    const spawn = seqSpawn(
+      // bdTopReady
+      fakeSpawn(JSON.stringify([leaf]), '', 0),  // bd ready --limit=5 --json
+      fakeSpawn('- other', '', 0),                // bd label list pv-child-1
+
+      // checkEpicPromotion
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),     // bd show pv-child-1 --json
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),     // bd show pv-epic --json
+      fakeSpawn(beadTextAnalyzedEpic(), '', 0),         // bd show pv-epic (bdState)
+      fakeSpawn(JSON.stringify([                        // bd ready --limit=200 --json
+        { id: 'pv-child-1' }, { id: 'pv-child-2' },
+      ]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),     // bd show pv-epic --json (bdListChildren)
+      fakeSpawn('- other', '', 0),                      // bd label list pv-child-1
+      fakeSpawn('- other', '', 0),                      // bd label list pv-child-2
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-epic');
+  });
+
+  it('should not promote when leaf has no parent', async () => {
+    const leaf = { id: 'pv-solo', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-solo', issue_type: 'task' };  // no parent
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),  // no parent -> early return
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-solo');
+  });
+
+  it('should not promote when parent is not an epic', async () => {
+    const leaf = { id: 'pv-sub', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-sub', issue_type: 'task', parent: 'pv-task-parent' };
+    const parentFull = { id: 'pv-task-parent', issue_type: 'task' };  // not an epic
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),
+      fakeSpawn(JSON.stringify([parentFull]), '', 0),  // issue_type != epic -> return null
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-sub');
+  });
+
+  it('should not promote when epic parent is not yet analyzed', async () => {
+    const leaf = { id: 'pv-child-1', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-child-1', issue_type: 'task', parent: 'pv-epic' };
+    const epicFull = { id: 'pv-epic', issue_type: 'epic' };
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn(beadTextShapedOnlyEpic(), '', 0),  // bdState: missing_phases includes 'analyzed'
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-child-1');
+  });
+
+  it('should not promote when epic has only 1 ready child', async () => {
+    const leaf = { id: 'pv-child-1', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-child-1', issue_type: 'task', parent: 'pv-epic' };
+    const epicFull = {
+      id: 'pv-epic',
+      issue_type: 'epic',
+      dependents: [
+        { id: 'pv-child-1', dependency_type: 'parent-child' },
+        { id: 'pv-child-2', dependency_type: 'parent-child' },  // exists but not ready
+      ],
+    };
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn(beadTextAnalyzedEpic(), '', 0),
+      fakeSpawn(JSON.stringify([{ id: 'pv-child-1' }]), '', 0),  // only child-1 in bd ready
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn('- other', '', 0),
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.next).toBe(PhaseName.State);
+    expect(result.ctx.beadId).toBe('pv-child-1');
+  });
+
+  it('should promote even when bd reports the epic parent as blocked-by-children', async () => {
+    // Guard: an analyzed epic's bd status may be "blocked" because bd views
+    // its unclosed children as blockers. That's normal for epics and must NOT
+    // prevent promotion — the wave executor iterates exactly those children.
+    const leaf = { id: 'pv-child-1', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-child-1', issue_type: 'task', parent: 'pv-epic' };
+    const epicFull = {
+      id: 'pv-epic',
+      issue_type: 'epic',
+      status: 'blocked',   // bd reports blocked — must not disqualify promotion
+      dependents: [
+        { id: 'pv-child-1', dependency_type: 'parent-child' },
+        { id: 'pv-child-2', dependency_type: 'parent-child' },
+        { id: 'pv-child-3', dependency_type: 'parent-child' },
+      ],
+    };
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn(beadTextAnalyzedEpic(), '', 0),
+      fakeSpawn(JSON.stringify([
+        { id: 'pv-child-1' }, { id: 'pv-child-2' }, { id: 'pv-child-3' },
+      ]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn('- other', '', 0),
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.ctx.beadId).toBe('pv-epic');
+  });
+
+  it('should not promote when 2 children exist but one is needs-human labelled', async () => {
+    const leaf = { id: 'pv-child-1', issue_type: 'task', priority: 1 };
+    const leafFull = { id: 'pv-child-1', issue_type: 'task', parent: 'pv-epic' };
+    const epicFull = {
+      id: 'pv-epic',
+      issue_type: 'epic',
+      dependents: [
+        { id: 'pv-child-1', dependency_type: 'parent-child' },
+        { id: 'pv-child-2', dependency_type: 'parent-child' },
+      ],
+    };
+
+    const spawn = seqSpawn(
+      fakeSpawn(JSON.stringify([leaf]), '', 0),
+      fakeSpawn('- other', '', 0),
+      fakeSpawn(JSON.stringify([leafFull]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn(beadTextAnalyzedEpic(), '', 0),
+      fakeSpawn(JSON.stringify([
+        { id: 'pv-child-1' }, { id: 'pv-child-2' },
+      ]), '', 0),
+      fakeSpawn(JSON.stringify([epicFull]), '', 0),
+      fakeSpawn('- other', '', 0),         // child-1 label list
+      fakeSpawn('- needs-human', '', 0),    // child-2 labelled -> excluded
+    );
+
+    const ctx = makeCtx({ beadId: '' });
+    const result = await select(ctx, { spawnFn: spawn });
+
+    expect(result.ctx.beadId).toBe('pv-child-1');
+  });
 });
 
 // =============================================================================
@@ -444,20 +678,43 @@ describe('shape', () => {
     expect(result.next).toBe('halt');
   });
 
-  it('should escalate and halt on dispatch timeout', async () => {
-    // escalate() calls bdEscalate: bd label add, bd show --json, bd update
+  it('should halt without escalating to needs-human on dispatch timeout', async () => {
+    // Timeout is classified as transient_halt: the run halts but the bead
+    // stays open and eligible for the next /process-backlog invocation.
+    // bdEscalate is NOT called, so no bd spawn calls should happen here.
+    const spawn = seqSpawn();
+
+    const log = stubLogger();
+    const ctx = makeCtx({ logger: log.logger });
+    const result = await shape(ctx, {
+      dispatchFn: async () => { throw new DispatchTimeoutError('shape-bead', 300000); },
+      spawnFn: spawn,
+    });
+
+    expect(result.next).toBe('halt');
+    expect(spawn).not.toHaveBeenCalled();
+    // Verify the timeout event was logged (distinct from *_escalated)
+    expect(log.jsonEntries.some(e => e.event === 'shape_bead_timed_out')).toBe(true);
+    expect(log.jsonEntries.some(e => e.event === 'shape_bead_escalated')).toBe(false);
+  });
+
+  it('should escalate to needs-human on malformed dispatch output', async () => {
+    // Malformed output IS an escalation: bdEscalate runs its bd commands.
     const spawn = seqSpawn(
       fakeSpawn('', '', 0),                                 // bd label add
       fakeSpawn(JSON.stringify([{ notes: '' }]), '', 0),    // bd show --json
       fakeSpawn('', '', 0),                                 // bd update --append-notes
     );
 
-    const result = await shape(makeCtx(), {
-      dispatchFn: async () => { throw new DispatchTimeoutError('shape-bead', 180000); },
+    const log = stubLogger();
+    const { DispatchMalformedError } = await import('../../lib/dispatch.js');
+    const result = await shape(makeCtx({ logger: log.logger }), {
+      dispatchFn: async () => { throw new DispatchMalformedError('shape-bead', 'not json'); },
       spawnFn: spawn,
     });
 
     expect(result.next).toBe('halt');
+    expect(log.jsonEntries.some(e => e.event === 'shape_bead_escalated')).toBe(true);
   });
 
   // Regression: shape() used to build its prompt from beadId only,

--- a/.claude/orchestrators/test/unit/pipeline.test.ts
+++ b/.claude/orchestrators/test/unit/pipeline.test.ts
@@ -9,6 +9,7 @@ import { PhaseName, type RunLogger, type PhaseResult } from '../../lib/types.js'
 import {
   runStateMachine,
   buildSummary,
+  classifyVerdict,
   type OrchestratorCtx,
 } from '../../process-backlog.js';
 import type { PhaseRunner } from '../../lib/execute.js';
@@ -299,5 +300,67 @@ describe('buildSummary', () => {
 
     expect(summary).toContain('=== Process Backlog Run Summary ===');
     expect(summary).toContain('===================================');
+  });
+
+  it('includes the verdict line', () => {
+    const ctx = makeCtx({
+      beadId: 'pv-1',
+      prUrl: 'https://github.com/pull/1',
+      phaseHistory: [],
+    });
+    expect(buildSummary(ctx)).toContain('Verdict: completed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyVerdict
+// ---------------------------------------------------------------------------
+
+describe('classifyVerdict', () => {
+  it('returns completed when PR was opened', () => {
+    const ctx = makeCtx({
+      prUrl: 'https://github.com/pull/42',
+      phaseHistory: [],
+    });
+    expect(classifyVerdict(ctx)).toBe('completed');
+  });
+
+  it('returns transient_halt when a phase failed with a timeout', () => {
+    const ctx = makeCtx({
+      phaseHistory: [
+        { phase: PhaseName.Shape, ok: false, durationMs: 180000,
+          error: 'shape-bead subagent timed out after 180000ms' },
+      ] as PhaseResult[],
+    });
+    expect(classifyVerdict(ctx)).toBe('transient_halt');
+  });
+
+  it('returns transient_halt when preflight halts on wrong_branch', () => {
+    const ctx = makeCtx({
+      phaseHistory: [
+        { phase: PhaseName.Preflight, ok: false, durationMs: 300,
+          error: 'wrong_branch: expected main but on feat/x' },
+      ] as PhaseResult[],
+    });
+    expect(classifyVerdict(ctx)).toBe('transient_halt');
+  });
+
+  it('returns needs_human for non-transient failures without a PR', () => {
+    const ctx = makeCtx({
+      phaseHistory: [
+        { phase: PhaseName.ShapeAdvisors, ok: false, durationMs: 10000,
+          error: 'advisor REQUEST CHANGES after refinement' },
+      ] as PhaseResult[],
+    });
+    expect(classifyVerdict(ctx)).toBe('needs_human');
+  });
+
+  it('returns needs_human when there are no failures and no PR', () => {
+    const ctx = makeCtx({
+      phaseHistory: [
+        { phase: PhaseName.Preflight, ok: true, durationMs: 100 },
+      ] as PhaseResult[],
+    });
+    expect(classifyVerdict(ctx)).toBe('needs_human');
   });
 });


### PR DESCRIPTION
## Summary

Four changes to make `/process-backlog` more independent and reduce the number of runs that halt without opening a PR. See `~/.claude/plans/please-look-through-the-clever-donut.md` for the analysis of past run logs that motivated this work.

- **Epic promotion** — Phase 1 pivots to the parent epic when a selected leaf belongs to an analyzed epic with ≥2 ready children, so the epic runs as a wave instead of one leaf at a time
- **Preflight orphan recovery** — auto-checkout `main` when the repo is on an orchestrator-generated branch with a clean tree, no commits ahead, and no open PR
- **Timeout classification** — timeouts halt without adding `needs-human`; the bead stays eligible for the next run. Timeout budgets raised across the board
- **Run verdict** — `run_summary` now carries `completed | transient_halt | needs_human` so `/loop` consumers can distinguish recoverable halts from blockers

## Beads closed

- pv-4p63 — Orchestrator resilience + epic promotion (epic)
- pv-gzs7 — Epic promotion in Phase 1 bead selection
- pv-bjlb — Preflight orphan-branch recovery
- pv-zocp — Timeout classification: retry-next-run vs needs-human
- pv-xyhq — Add verdict field to run_summary

## Behavior changes worth noting

- Analyzed epics are **always** blocked-by-children in bd's view. `checkEpicPromotion` explicitly does not gate on that — a guard test pins the invariant so future refactors don't reintroduce the bug
- Orphan-branch recovery is scoped to the `^(chore|feat|fix)/.+-pv-[a-z0-9-]+$` pattern AND clean tree AND zero commits ahead AND no open PR. Any guard failing means preflight still halts with `wrong_branch`
- Timeouts emit a new `*_timed_out` event (distinct from `*_escalated`). Malformed-output escalations keep their old `*_escalated` event and still add `needs-human`
- `classifyVerdict()` is pattern-based over phase errors; no phase runner needed to be modified to write a verdict hint

## Test plan

- [x] `npx vitest run .claude/orchestrators/test/unit` — 253 passing (20 new)
- [x] `npx eslint .claude/orchestrators/` — no new errors or warnings introduced (3 pre-existing errors on main, unrelated)
- [ ] End-to-end: next `/process-backlog` run from clean main should hit one of the new paths (promotion on a ready-leaf-with-epic-parent, or just run normally with a verdict line in the summary)

## Out of scope

- Extracting `epicPhase` into a shared `lib/waves.ts` so `/spawn-bead-workers` and `/process-backlog` share one wave executor — deferrable cleanup from the plan, not done here
- A retry counter on timeouts (e.g. escalate after 2 consecutive timeouts on the same bead) — logs now carry enough signal to add this later if needed
- Advisor-fanOut timeout handling (those still become synthetic `escalate` verdicts and flow through advisor-triage)