### PR TITLE
feat(deploy): parametrize docker image tag via PAVILLION_IMAGE_TAG

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@
 services:
   # Pavillion application server (web mode)
   app:
-    image: ghcr.io/stephenhoward/pavillion:latest
+    image: ghcr.io/stephenhoward/pavillion:${PAVILLION_IMAGE_TAG:-latest}
     container_name: pavillion-app
     depends_on:
       db:
@@ -98,7 +98,7 @@ services:
   # Pavillion worker container (worker mode)
   # Processes background jobs including database backups and monitoring
   worker:
-    image: ghcr.io/stephenhoward/pavillion:latest
+    image: ghcr.io/stephenhoward/pavillion:${PAVILLION_IMAGE_TAG:-latest}
     container_name: pavillion-worker
     # Pass --worker flag to unified entrypoint
     command: ["--worker"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -272,6 +272,7 @@ chmod 600 secrets/*.txt
 | `S3_ENDPOINT` | No | - | Custom S3 endpoint (for DigitalOcean Spaces, MinIO) |
 | `DOMAIN` | No | `localhost` | Public domain name (required for standalone mode) |
 | `COMPOSE_PROFILES` | No | - | Set to `standalone` to enable built-in Caddy proxy |
+| `PAVILLION_IMAGE_TAG` | No | `latest` | Tag of the `ghcr.io/stephenhoward/pavillion` image to deploy. Set to `main` on staging to track unreleased builds, or pin to a specific version (e.g., `v1.2.3`) for reproducible production deploys. |
 | `SMTP_HOST` | No | - | SMTP server hostname |
 | `SMTP_PORT` | No | `587` | SMTP server port |
 | `SMTP_USER` | No | - | SMTP authentication username |


### PR DESCRIPTION
## Summary

- Replace hardcoded `:latest` in `docker-compose.yml` (app + worker) with `${PAVILLION_IMAGE_TAG:-latest}`. Default behavior is unchanged.
- Operators can now set `PAVILLION_IMAGE_TAG` in `.env` (already gitignored, already managed by `bin/deploy.sh`) to track a non-stable tag — e.g., `:main` on staging — or pin a specific version on production.
- Document the variable in `docs/deployment.md`.

## Why

`bin/deploy.sh` aborts on a dirty working tree (`check_working_tree_clean`), which is the right safety guard. But it conflicted with the only mechanism operators had to override the image tag: dirty-editing the tracked compose file. The two collided on staging where I want to track `:main` instead of `:latest`. Parametrizing through `.env` resolves the conflict without weakening the deploy guard or introducing a `--autostash` foot-gun.

Closes pv-eszv.

## Test plan

- [x] `docker compose config` with no env var → both services resolve to `ghcr.io/stephenhoward/pavillion:latest` (unchanged from before)
- [x] `PAVILLION_IMAGE_TAG=main docker compose config` → both services resolve to `ghcr.io/stephenhoward/pavillion:main`
- [ ] On staging: set `PAVILLION_IMAGE_TAG=main` in `.env`, run `bin/deploy.sh`, confirm clean tree + main image pulled