### PR TITLE
feat(deploy): caddy-extras.d extension point for per-instance Caddy snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ AGENTS.md
 # Per-instance deploy state managed by bin/deploy.sh
 # Lists secrets ever provisioned on this instance. Not for version control.
 .deploy-state
+
+# Per-instance Caddy snippets dropped into the extras.d extension point.
+# README.md is tracked; *.caddyfile snippets are operator-supplied per-instance.
+caddy-extras.d/*.caddyfile

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,15 @@
 {$DOMAIN} {
-    encode gzip zstd
-    reverse_proxy app:3000
+	encode gzip zstd
+
+	# Operator extension point. Drop *.caddyfile snippets into ./caddy-extras.d/
+	# to add per-instance handlers (e.g., a webhook listener on a staging
+	# server). The directory is gitignored, so production deploys ship with no
+	# snippets and the import resolves to nothing. Snippets are imported
+	# before the catch-all handle below, so any matchers they declare take
+	# precedence over the default app proxy.
+	import /etc/caddy/extras.d/*.caddyfile
+
+	handle {
+		reverse_proxy app:3000
+	}
 }

--- a/caddy-extras.d/README.md
+++ b/caddy-extras.d/README.md
@@ -1,0 +1,59 @@
+# Caddy extras.d — per-instance snippets
+
+This directory is an extension point for the standalone-mode Caddyfile. Drop
+files named `*.caddyfile` here to add handlers that should only exist on
+this specific instance (e.g., a staging server's auto-deploy webhook
+listener). Snippet files in this directory are gitignored; only this README
+is tracked.
+
+## How it works
+
+The tracked `Caddyfile` ends with:
+
+```caddy
+{$DOMAIN} {
+    encode gzip zstd
+
+    import /etc/caddy/extras.d/*.caddyfile
+
+    handle {
+        reverse_proxy app:3000
+    }
+}
+```
+
+The `import` line expands inline at config-load time. Each snippet's
+`handle` blocks are evaluated before the catch-all `handle { reverse_proxy
+app:3000 }`, so matchers in your snippets take precedence over the default
+app proxy. With no snippets present, Caddy logs one info-level "no files
+matching import glob pattern" line and serves the default config.
+
+## Example: staging auto-deploy webhook
+
+`caddy-extras.d/hooks.caddyfile`:
+
+```caddy
+handle /hooks/* {
+    reverse_proxy host.docker.internal:9000
+}
+```
+
+The `caddy` service in `docker-compose.yml` already declares the
+`host.docker.internal:host-gateway` extra host, so the upstream resolves to
+the container host on Linux without further configuration. Any process
+listening on port 9000 on the host (webhookd, a custom listener, etc.)
+will receive forwarded `/hooks/*` requests.
+
+## Conventions
+
+- One concern per snippet file. Multiple snippets are concatenated in glob
+  order, so prefix filenames with a number if order matters
+  (`10-hooks.caddyfile`, `20-something-else.caddyfile`).
+- Snippets contain only directives that are valid inside a site block —
+  typically `handle`, `route`, `redir`, `respond`, etc. They cannot open a
+  new site block of their own (that would need a top-level import, which
+  this extension point does not provide).
+- Validate after editing:
+  ```bash
+  docker compose --profile standalone exec caddy caddy validate --config /etc/caddy/Caddyfile
+  ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,6 +186,8 @@ services:
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Operator-supplied per-instance snippets (gitignored). See caddy-extras.d/README.md.
+      - ./caddy-extras.d:/etc/caddy/extras.d:ro
       - caddy-data:/data
       - caddy-config:/config
     environment:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -187,6 +187,23 @@ docker compose ps
 
 You should see four containers: `pavillion-app`, `pavillion-worker`, `pavillion-db`, and `pavillion-caddy`.
 
+#### Per-Instance Caddy Snippets (`caddy-extras.d/`)
+
+The standalone Caddyfile imports `*.caddyfile` snippets from `caddy-extras.d/` before the default app proxy. The directory is gitignored (only `caddy-extras.d/README.md` is tracked), so production deploys ship with no snippets and the import is a no-op. Use this extension point when a single instance needs a Caddy handler that does not belong in the upstream config — for example, a staging server that exposes an auto-deploy webhook listener on the host:
+
+```caddy
+# caddy-extras.d/hooks.caddyfile (gitignored, per-instance only)
+handle /hooks/* {
+    reverse_proxy host.docker.internal:9000
+}
+```
+
+Snippets must contain only directives valid inside a site block (`handle`, `route`, `redir`, `respond`, etc.). After editing, validate with:
+
+```bash
+docker compose --profile standalone exec caddy caddy validate --config /etc/caddy/Caddyfile
+```
+
 ## Secrets Management
 
 ### How Secrets Work


### PR DESCRIPTION
## Summary

Add an extension point in the standalone Caddyfile so per-instance handlers (e.g., a webhook listener on a staging server) live outside the tracked tree. The tracked Caddyfile imports `*.caddyfile` snippets from a new `caddy-extras.d/` directory; the directory is gitignored except for a `README.md` that documents the pattern.

- **Production**: `caddy-extras.d/` is empty, the import is a no-op, and Caddy serves only the app proxy. No `/hooks/*` (or any other staging-only path) appears as attack surface on instances that don't use it.
- **Staging / per-instance**: drop `caddy-extras.d/hooks.caddyfile` (or any `*.caddyfile`) locally with a `handle` block. Caddy picks it up on next start. Tracked tree stays clean, so `bin/deploy.sh`'s working-tree-clean guard keeps working without a flag.

Closes pv-i02e.

## Why

Staging needs a `/hooks/*` route in Caddy that proxies to a host-side webhook listener. Two paths I rejected:

1. **Track the `/hooks/*` block in the production Caddyfile and noop it** — adds a publicly-exposed path to every instance for a feature only the maintainer's staging server uses, for no benefit.
2. **Add `--autostash` to `bin/deploy.sh`** — keeps the dirty tree working but introduces stash-pop conflicts in the middle of deploys when upstream touches the same file.

The extras.d shape is the same idea as the docker-compose `.env` override pattern we already use: tracked code defines an extension point with safe defaults; per-instance config lives in gitignored files.

## Verification

Validated with `caddy:2-alpine` against the tracked Caddyfile:

- **Empty `caddy-extras.d/`**: `caddy validate` returns `Valid configuration`. One info-level warning logged: `No files matching import glob pattern`. (Expected; not an error.)
- **With a sample `hooks.caddyfile` snippet**: adapted-JSON inspection (`caddy adapt`) shows the `/hooks/*` route lands in the same group as the catch-all `handle`, with the matched `/hooks/*` route ordered first. Caddy evaluates routes in the same group top-down with first-match, so `/hooks/*` requests go to the snippet's upstream and everything else falls through to `reverse_proxy app:3000`.

## Files changed

- `Caddyfile` — wrap `reverse_proxy app:3000` in a catch-all `handle`, add `import /etc/caddy/extras.d/*.caddyfile` before it. Indentation switches to tabs per `caddy fmt`'s required style.
- `docker-compose.yml` — mount `./caddy-extras.d:/etc/caddy/extras.d:ro` on the caddy service.
- `caddy-extras.d/README.md` — new file documenting the pattern with a staging-hooks example.
- `.gitignore` — ignore `caddy-extras.d/*.caddyfile` (only the README is tracked).
- `docs/deployment.md` — new sub-section under Standalone Mode describing the extension point.

## Test plan

- [x] Empty extras.d: `caddy validate` passes (warns on zero-match glob, which is documented behavior).
- [x] With a sample hooks snippet: `caddy adapt` JSON shows correct route ordering.
- [x] `docker compose --profile standalone config` resolves the new bind mount cleanly.
- [ ] On staging: drop the actual `hooks.caddyfile` into `caddy-extras.d/`, run `bin/deploy.sh`, confirm `/hooks/...` reaches the host listener and other paths reach the app.