### PR TITLE
style: restore auth card lift, mid-align site footer logo, scope hyphens to <p>

### DIFF
--- a/src/client/assets/style/base/_reset.scss
+++ b/src/client/assets/style/base/_reset.scss
@@ -66,8 +66,10 @@ input, button, textarea, select {
 /* Typography overflow handling */
 p, h1, h2, h3, h4, h5, h6 {
   overflow-wrap: break-word;
+}
 
-  /* Prevent long words from breaking layout */
+/* Hyphenation for paragraph copy only; headings should not auto-hyphenate. */
+p {
   hyphens: auto;
 }
 

--- a/src/client/assets/style/layout/_logged-out.scss
+++ b/src/client/assets/style/layout/_logged-out.scss
@@ -6,7 +6,7 @@
   justify-content: center;
   min-height: 100vh;
   padding: var(--pav-space-4) var(--pav-space-4);
-  background-color: var(--pav-surface-secondary);
+  background-color: var(--pav-surface-primary);
 
   /* Header with site title */
   header {
@@ -71,9 +71,7 @@
     background-color: var(--pav-surface-card);
     border-radius: 1rem; /* 16px - rounded-2xl */
     padding: var(--pav-space-10);
-    /* No semantic "shadow-ring" token exists; use color-mix on the stone-200 token
-       so the ring tracks the token layer even though it does not flip for dark mode. */
-    box-shadow: var(--pav-shadow-lg), 0 0 0 1px color-mix(in srgb, var(--pav-color-stone-200) 50%, transparent);
+    box-shadow: var(--pav-shadow-lg), var(--pav-shadow-ring);
 
     /* Two-column layout for login card with info panel */
     &:has(.welcome-card-info) {

--- a/src/client/assets/style/themes/_light.scss
+++ b/src/client/assets/style/themes/_light.scss
@@ -33,4 +33,8 @@
   --pav-nav-active-icon: var(--pav-color-interactive-active);
   --pav-nav-inactive-text: var(--pav-color-stone-500);
   --pav-nav-inactive-icon: var(--pav-color-stone-400);
+
+  /* Hairline ring layered into box-shadow for cards/surfaces. Resolves through
+     --pav-border-subtle so it adapts automatically to the active theme. */
+  --pav-shadow-ring: 0 0 0 1px color-mix(in srgb, var(--pav-border-subtle) 50%, transparent);
 }

--- a/src/site/assets/style.scss
+++ b/src/site/assets/style.scss
@@ -101,6 +101,9 @@ button.primary {
 
       a {
         color: inherit;
+        display: inline-flex;
+        align-items: center;
+        gap: $public-space-sm;
 
         &:hover {
           color: $public-accent-hover-light;


### PR DESCRIPTION
## Summary

Four small visual fixes to the logged-out / public-site surfaces, all pure SCSS.

- **Welcome card ring:** introduces a new `--pav-shadow-ring` semantic token (a 1px ring built via `color-mix` over `--pav-border-subtle`) and points `.welcome-card` at it. The dark-mode ring previously resolved to stone-200 @ 50% — a bright cream halo around the card. It now resolves through the theme layer to stone-700 @ 50%, a subtle warm-grey hairline.
- **Welcome card lift:** the logged-out `main` background swaps from `--pav-surface-secondary` to `--pav-surface-primary`. This restores the v0.2.8 dark-mode pairing (page `stone-900` / card `stone-800`) so the card visibly lifts above the page again, and aligns with the convention used by `_shell.scss`, `_reset.scss`, and the `.card` mixin elsewhere in the app.
- **Heading hyphenation:** splits the `p, h1-h6` reset so `hyphens: auto` is scoped to `<p>` only. Headings keep `overflow-wrap: break-word` but no longer auto-hyphenate.
- **Public site footer logo:** the inner `<a>` inside `footer .logo` becomes `inline-flex` with `align-items: center` and a small gap, so the Pavillion glyph and the "Powered by Pavillion" text mid-align — matching the auth pages, where the inner anchor was already flex-centered. Previously the logo glyph sat on the text baseline, looking misaligned.

## Test plan

- [ ] `/auth/login` in dark mode: card visibly lifted above a deeper page background; ring is a subtle warm-grey hairline (not bright cream).
- [ ] `/auth/login` in light mode: card visible via shadow + ring; no regression vs. main.
- [ ] `/view/<calendar>` footer: hexagonal Pavillion glyph and "Powered by Pavillion" wordmark are vertically mid-aligned.
- [ ] Long single-word headings no longer break with a soft hyphen mid-word; long paragraph text still hyphenates.
- [ ] `npm run build` passes; `npm run lint` reports 0 errors.