### PR TITLE
fix(widget): include startTime slug in list-view event navigation (pv-9x2c)

### DIFF
--- a/src/widget/components/list-view.vue
+++ b/src/widget/components/list-view.vue
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import { usePublicCalendarStore } from '@/site/stores/publicCalendarStore';
 import { useWidgetStore } from '../stores/widgetStore';
 import EventImage from '@/site/components/event-image.vue';
+import { formatInstanceSlug } from '@/common/utils/instance-slug';
 
 const { t } = useTranslation('system');
 const router = useRouter();
@@ -36,6 +37,7 @@ const openEvent = (instance: any) => {
     params: {
       urlName: widgetStore.calendarUrlName!,
       eventId: instance.event.id,
+      startTime: formatInstanceSlug(instance.start),
     },
   });
 };

--- a/src/widget/components/test/viewComponents.test.ts
+++ b/src/widget/components/test/viewComponents.test.ts
@@ -293,6 +293,35 @@ describe('Widget View Components', () => {
         },
       });
     });
+
+    it('ListView openEvent pushes route params including startTime slug', async () => {
+      const publicStore = usePublicCalendarStore();
+      const widgetStore = useWidgetStore();
+      widgetStore.setCalendarUrlName('mycal');
+
+      publicStore.allEvents = [buildInstance(fixedStart)] as any;
+
+      const pushSpy = vi.spyOn(router, 'push');
+
+      const wrapper = mount(ListView, {
+        global: {
+          plugins: [[I18NextVue, { i18next }], router],
+        },
+      });
+
+      const eventEl = wrapper.find('.event');
+      expect(eventEl.exists()).toBe(true);
+      await eventEl.trigger('click');
+
+      expect(pushSpy).toHaveBeenCalledWith({
+        name: 'widget-event-detail',
+        params: {
+          urlName: 'mycal',
+          eventId: 'evt-1',
+          startTime: fixedSlug,
+        },
+      });
+    });
   });
 
   describe('Navigation and Gestures', () => {


### PR DESCRIPTION
## Summary

- `src/widget/components/list-view.vue` `openEvent()` was pushing only `{ urlName, eventId }` to the router, dropping the `startTime` slug that `week-view.vue` and `month-view.vue` already include. The overlay still rendered (the route makes `:startTime` optional), but URL identity for the specific occurrence was lost — undermining the durability goal pv-3hsk delivered elsewhere.
- Mirror the week/month-view pattern by importing `formatInstanceSlug` and adding `startTime: formatInstanceSlug(instance.start)` to the route params.
- Add a regression test in `viewComponents.test.ts` next to the existing WeekView/MonthView slug-nav assertions, asserting list-view clicks push the slug-bearing route.

Closes pv-9x2c.

## Test plan

- [x] `npx vitest run src/widget/components/test/viewComponents.test.ts` — 13/13 passing including new ListView assertion
- [x] `eslint` clean on changed files