### PR TITLE
fix(deploy): wire CALENDAR_IMPORT_HMAC_SECRET into deploy manifest (pv-uqew)

### DIFF
--- a/bin/deploy-manifest.tsv
+++ b/bin/deploy-manifest.tsv
@@ -30,3 +30,4 @@ SESSION_SECRET	openssl_rand_base64_32	stable	Signs browser session cookies. Rota
 DB_PASSWORD	openssl_rand_base64_32	stable	PostgreSQL password. Must match the existing database volume.
 EMAIL_HASH_SECRET	openssl_rand_base64_32	stable	Hashes reporter emails for moderation. Rotation de-anonymizes prior reports.
 ENCRYPTION_KEY	openssl_rand_hex_32	stable	Encrypts funding provider API keys at rest. Rotation breaks decryption of stored keys.
+CALENDAR_IMPORT_HMAC_SECRET	openssl_rand_base64_32	regenerable	HMAC for ICS import DNS/rel-me verification snippets. Rotation only invalidates pending verification challenges.

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -27,6 +27,7 @@
 #   - ENCRYPTION_KEY_FILE     -> ENCRYPTION_KEY
 #   - S3_SECRET_KEY_FILE      -> S3_SECRET_KEY
 #   - SMTP_PASSWORD_FILE      -> SMTP_PASSWORD
+#   - CALENDAR_IMPORT_HMAC_SECRET_FILE -> CALENDAR_IMPORT_HMAC_SECRET
 #
 # Worker Mode:
 #   When the --worker flag is present in the command, the container runs in
@@ -284,6 +285,7 @@ main() {
     file_env 'SESSION_SECRET'
     file_env 'EMAIL_HASH_SECRET'
     file_env 'ENCRYPTION_KEY'
+    file_env 'CALENDAR_IMPORT_HMAC_SECRET'
     file_env 'S3_SECRET_KEY'
     file_env 'SMTP_PASSWORD'
   fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - EMAIL_HASH_SECRET=${EMAIL_HASH_SECRET:-}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
+      - CALENDAR_IMPORT_HMAC_SECRET=${CALENDAR_IMPORT_HMAC_SECRET:-}
       # Docker secrets via _FILE pattern (recommended for production)
       # When set, the entrypoint reads secret from file and unsets _FILE variable
       - DB_PASSWORD_FILE=${DB_PASSWORD_FILE:-}
@@ -66,6 +67,7 @@ services:
       - SMTP_PASSWORD_FILE=${SMTP_PASSWORD_FILE:-}
       - EMAIL_HASH_SECRET_FILE=${EMAIL_HASH_SECRET_FILE:-}
       - ENCRYPTION_KEY_FILE=${ENCRYPTION_KEY_FILE:-}
+      - CALENDAR_IMPORT_HMAC_SECRET_FILE=${CALENDAR_IMPORT_HMAC_SECRET_FILE:-}
       # Optional S3 storage configuration
       - S3_BUCKET=${S3_BUCKET:-}
       - S3_REGION=${S3_REGION:-}
@@ -121,6 +123,7 @@ services:
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - EMAIL_HASH_SECRET=${EMAIL_HASH_SECRET:-}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
+      - CALENDAR_IMPORT_HMAC_SECRET=${CALENDAR_IMPORT_HMAC_SECRET:-}
       # Docker secrets via _FILE pattern (recommended for production)
       - DB_PASSWORD_FILE=${DB_PASSWORD_FILE:-}
       - JWT_SECRET_FILE=${JWT_SECRET_FILE:-}
@@ -128,6 +131,7 @@ services:
       - SMTP_PASSWORD_FILE=${SMTP_PASSWORD_FILE:-}
       - EMAIL_HASH_SECRET_FILE=${EMAIL_HASH_SECRET_FILE:-}
       - ENCRYPTION_KEY_FILE=${ENCRYPTION_KEY_FILE:-}
+      - CALENDAR_IMPORT_HMAC_SECRET_FILE=${CALENDAR_IMPORT_HMAC_SECRET_FILE:-}
       # Optional SMTP configuration for email alerts
       - SMTP_HOST=${SMTP_HOST:-}
       - SMTP_PORT=${SMTP_PORT:-}


### PR DESCRIPTION
## Summary

PR #236 (commit 562b6a1, *ICS import foundation*) added a hard production-startup check in `src/server/common/helper/production-validation.ts` that throws if `calendar.import.hmacSecret` is unset or contains the `development-only` sentinel — but did **not** declare `CALENDAR_IMPORT_HMAC_SECRET` in `bin/deploy-manifest.tsv`. On the next `bin/deploy.sh` upgrade, `missing_secrets()` doesn't list it, `resolve_missing()` doesn't generate it, `.env` stays empty for that key, and the new container boots into a crash loop on pavillion.events / demo / staging.

This PR wires the secret into the four plumbing files the manifest header rule requires:

- **`bin/deploy-manifest.tsv`** — adds `CALENDAR_IMPORT_HMAC_SECRET` as `openssl_rand_base64_32`, stability `regenerable`
- **`docker-compose.yml`** — adds `CALENDAR_IMPORT_HMAC_SECRET` (plain + `_FILE` variant) to both `app` and `worker` env blocks
- **`bin/entrypoint.sh`** — adds `file_env 'CALENDAR_IMPORT_HMAC_SECRET'` and the corresponding header-comment line
- **`src/server/common/helper/production-validation.ts`** — already references it (added in #236); no change needed

### Stability rationale

`regenerable`. The secret signs the short-lived DNS/`rel-me` verification snippets shown to users while they prove ownership of an ICS import source. Rotating it only invalidates pending verification challenges — nothing at rest is decrypted with it, no past data is recovered through it.

### Upgrade behavior on existing instances

Walking the `resolve_missing()` decision tree:

1. `CALENDAR_IMPORT_HMAC_SECRET` is missing from `.env` → enters the loop
2. The name is not yet recorded in `.deploy-state` on any existing instance (it has never been provisioned before this manifest entry exists)
3. → Case 1: *"newly-introduced this version"* — auto-generated regardless of stability tier, silently

Net result: pavillion.events, demo, and staging self-heal on the next `deploy.sh` run. No operator paste required.

### Why this slipped through

`PR #236` did not run / did not need to update the manifest checklist when adding the validator. The `bin/deploy-manifest.tsv` header comment is explicit:

> New secrets are added in the same PR that introduces the production validation requiring them.

Filing follow-up to add this pairing (production validator ↔ manifest entry) to the `/shape-bead` checklist so the next secret addition can't slip through the same gap.

## Test plan

- [x] `bash bin/check-manifest.sh` — *all 6 manifest entries are fully wired.*
- [x] `bash bin/test/run.sh` — 50 deploy + 11 manifest test cases pass
- [x] `npx vitest run src/server/common/test/config` — 22/22 production-validation / secrets / JWT externalization tests pass
- [ ] On merge: confirm staging redeploys cleanly (auto-deploy should generate the secret, container should not crash-loop)

Closes pv-uqew.