### PR TITLE
fix(site/widget): hide empty hero image placeholder when event has no media (pv-50ne)

### DIFF
--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -236,7 +236,7 @@ onBeforeMount(async () => {
       <div v-if="state.err" role="alert" class="error">{{ state.err }}</div>
 
       <!-- Hero image -->
-      <div class="hero-image-wrapper">
+      <div v-if="state.instance.event.media" class="hero-image-wrapper">
         <EventImage
           :media="state.instance.event.media"
           context="feature"

--- a/src/site/components/event.vue
+++ b/src/site/components/event.vue
@@ -188,7 +188,7 @@ function closeReportModal() {
       <div v-if="state.err" role="alert" class="error">{{ state.err }}</div>
 
       <!-- Hero image -->
-      <div class="hero-image-wrapper">
+      <div v-if="state.event.media" class="hero-image-wrapper">
         <EventImage
           :media="state.event.media"
           context="feature"

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -209,7 +209,7 @@ onBeforeMount(async () => {
 
       <main class="instance-main">
         <!-- Hero image -->
-        <div class="hero-image-wrapper">
+        <div v-if="state.instance.event.media" class="hero-image-wrapper">
           <EventImage
             :media="state.instance.event.media"
             context="feature"


### PR DESCRIPTION
## Summary

- Gates the `.hero-image-wrapper` div on `event.media` in `event.vue`, `event-instance.vue`, and the widget `event-detail-overlay.vue` so the empty 2:1 gradient placeholder no longer renders for events without an image.
- The `EventImage` component already renders nothing when media is absent, but the parent wrapper kept its `public-hero-image` mixin styling — taking up significant vertical space and pushing content down with no payoff.
- Event cards are untouched: they intentionally use a `no-image-fallback` pattern.

Closes pv-50ne.

## Test plan

- [x] `npx vitest run` for `event.test.ts`, `event-instance.test.ts`, `event-detail-overlay.test.ts` — 122 tests pass
- [x] Browser verified on `/view/test_calendar/events/.../20260429-0830` (Book Club Meeting, no media): page now opens directly with recurrence badge and title — empty placeholder gone
- [x] ESLint clean on changed files