### PR TITLE
feat(widget): add Powered by Pavillion footer

### DIFF
--- a/src/widget/components/app.vue
+++ b/src/widget/components/app.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
+import { useTranslation } from 'i18next-vue';
 import { useWidgetStore } from '../stores/widgetStore';
 
+const { t } = useTranslation('system');
 const widgetStore = useWidgetStore();
 const route = useRoute();
 const rootRef = ref<HTMLElement | null>(null);
@@ -75,15 +77,72 @@ onMounted(() => {
     ref="rootRef"
     class="widget-root">
     <RouterView />
+    <footer class="widget-footer">
+      <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
+        <span class="pavillion-logo" aria-hidden="true"/> {{ t('powered_by') }}
+      </a>
+    </footer>
   </div>
 </template>
 
 <style scoped lang="scss">
+@use '@/site/assets/mixins' as *;
+
 .widget-root {
   width: 100%;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+}
+
+.widget-footer {
+  flex: 0 0 auto;
+  padding: $public-space-sm $public-space-md;
+  border-top: 1px solid $public-border-subtle-light;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: $public-font-size-xs;
+  text-align: center;
+  color: $public-text-secondary-light;
+
+  @include public-dark-mode {
+    border-top-color: $public-border-subtle-dark;
+    color: $public-text-secondary-dark;
+  }
+
+  a {
+    color: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: $public-space-sm;
+    text-decoration: none;
+
+    &:hover {
+      color: $public-accent-hover-light;
+
+      @include public-dark-mode {
+        color: $public-accent-hover-dark;
+      }
+    }
+  }
+
+  .pavillion-logo {
+    display: inline-block;
+    background-color: $public-text-primary-light;
+    mask-size: contain;
+    mask-repeat: no-repeat;
+    mask-image: url('@/client/assets/pavillion-logo.svg');
+    -webkit-mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-image: url('@/client/assets/pavillion-logo.svg');
+    width: 16px;
+    height: 16px;
+
+    @include public-dark-mode {
+      background-color: $public-text-primary-dark;
+    }
+  }
 }
 
 // Auto color mode (uses system preference)

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -345,14 +345,9 @@ onBeforeMount(async () => {
 @use '@/site/assets/mixins' as *;
 
 .event-detail-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
   background: $public-bg-primary-light;
-  z-index: 100;
-  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 

--- a/src/widget/components/widget-container.vue
+++ b/src/widget/components/widget-container.vue
@@ -174,7 +174,8 @@ onUnmounted(() => {
 .widget-container {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
   background: $public-bg-primary-light;
 


### PR DESCRIPTION
## Summary

- Adds an attribution footer to widget screens (list/month/week and event-detail), matching the pattern already used on the public site and the client logged-out shell: a link to https://pavillion.social with the Pavillion logo mark and the `system:powered_by` translation.
- Switches `widget-container` and `event-detail-overlay` from viewport-locked layouts (`height: 100vh` / `position: fixed`) to `flex: 1` within `widget-root`. Necessary because the existing layouts each filled the iframe; the new footer would have either pushed past the bottom or been hidden under the fixed overlay. The flex layout keeps the iframe ResizeObserver auto-height behavior working.

Closes pv-43m0.

## Test plan

- [x] `npx vitest run src/widget src/site` — 595 tests pass
- [x] `npm run build` — clean
- [x] Manual verification in browser at `/widget/test_calendar`:
  - List, month, week views all render the footer below the calendar
  - Event detail view renders the footer below the event content
  - Dark mode (`?colorMode=dark`) inverts the logo and border correctly
- [x] Footer is a real `<footer>` landmark with an external link (`target="_blank" rel="noopener noreferrer"`)