### PR TITLE
fix(widget): accent color picker + Light/Dark mode overrides (pv-16wd)

### DIFF
--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -643,7 +643,7 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
   }
 
   // Apply dark mode when widget is explicitly set to dark mode
-  :global(.widget-theme-dark) & {
+  .widget-theme-dark & {
     @content;
   }
 }
@@ -657,9 +657,16 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
 // `public-dark-mode` activates via `@media (prefers-color-scheme: dark)`,
 // which would otherwise win over the widget's explicit light theme on a user
 // agent that prefers dark. By stating the light values inside a
-// `:global(.widget-theme-light) &` selector, this override beats the media
+// `.widget-theme-light &` selector, this override beats the media
 // query branch on specificity when the widget root carries the
 // `.widget-theme-light` class.
+//
+// NOTE: Do NOT use `:global(.widget-theme-light) &` — Vue's scoped-style
+// compiler drops the descendant selector when `:global()` is followed by `&`,
+// producing bare `.widget-theme-light{...}` rules with no descendant. The
+// plain `.widget-theme-light &` form correctly emits
+// `.widget-theme-light .my-component[data-v-xxx]` because the ancestor is
+// not the scoped target.
 //
 // Usage:
 //   .my-component {
@@ -674,7 +681,7 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
 //     }
 //   }
 @mixin public-light-mode-override {
-  :global(.widget-theme-light) & {
+  .widget-theme-light & {
     @content;
   }
 }

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -23,6 +23,21 @@ $public-accent-dark: #C86002;
 $public-accent-hover-light: darken(#ff9131, 5%);
 $public-accent-hover-dark: lighten(#C86002, 5%);
 
+// Emit the four accent CSS custom properties on a root selector so
+// widgets and the public site can override them via inline styles
+// (e.g. widget admin custom accent color) without forking SCSS.
+//
+// Apply this mixin once at the root of the widget app and the public
+// site root. Components consume the variables via `var(--pav-accent-light)`,
+// `var(--pav-accent-light-hover)`, `var(--pav-accent-dark)`, and
+// `var(--pav-accent-dark-hover)`.
+@mixin public-accent-tokens {
+  --pav-accent-light: #{$public-accent-light};
+  --pav-accent-light-hover: #{$public-accent-hover-light};
+  --pav-accent-dark: #{$public-accent-dark};
+  --pav-accent-dark-hover: #{$public-accent-hover-dark};
+}
+
 // Background layers (lighter, airier than client)
 $public-bg-primary-light: #ffffff;
 $public-bg-primary-dark: #1a1a1e;
@@ -629,6 +644,37 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
 
   // Apply dark mode when widget is explicitly set to dark mode
   :global(.widget-theme-dark) & {
+    @content;
+  }
+}
+
+// Light mode override mixin — pairs with every `public-dark-mode` block
+// in widget components.
+//
+// Pairing contract: every `@include public-dark-mode { ... }` block in a
+// widget component MUST be paired with an `@include public-light-mode-override`
+// block that re-states the LIGHT values explicitly. This is required because
+// `public-dark-mode` activates via `@media (prefers-color-scheme: dark)`,
+// which would otherwise win over the widget's explicit light theme on a user
+// agent that prefers dark. By stating the light values inside a
+// `:global(.widget-theme-light) &` selector, this override beats the media
+// query branch on specificity when the widget root carries the
+// `.widget-theme-light` class.
+//
+// Usage:
+//   .my-component {
+//     color: $public-text-primary-light;
+//
+//     @include public-dark-mode {
+//       color: $public-text-primary-dark;
+//     }
+//
+//     @include public-light-mode-override {
+//       color: $public-text-primary-light;
+//     }
+//   }
+@mixin public-light-mode-override {
+  :global(.widget-theme-light) & {
     @content;
   }
 }

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -213,12 +213,21 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     transform: translateY(0);
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     background: $public-bg-primary-dark;
     box-shadow: $public-shadow-md-dark;
 
     &:hover {
       box-shadow: $public-shadow-lg-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+    box-shadow: $public-shadow-md-light;
+
+    &:hover {
+      box-shadow: $public-shadow-lg-light;
     }
   }
 }
@@ -303,6 +312,28 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
       }
     }
   }
+
+  @include public-light-mode-override {
+    background-color: $public-bg-tertiary-light;
+    color: $public-text-secondary-light;
+    box-shadow: $public-shadow-xs-light;
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.08);
+      color: rgba(0, 0, 0, 0.75);
+      box-shadow: $public-shadow-sm-light;
+    }
+
+    &.selected {
+      background-color: $public-accent-light;
+      color: white;
+      box-shadow: $public-shadow-md-light;
+
+      &:hover {
+        background-color: $public-accent-hover-light;
+      }
+    }
+  }
 }
 
 // ===== DROPDOWN COMPONENT =====
@@ -316,10 +347,16 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
   border-radius: $public-radius-md;
   box-shadow: $public-shadow-lg-light;
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     background: rgba(30, 30, 35, 0.98);
     box-shadow: $public-shadow-lg-dark;
     backdrop-filter: blur(20px);
+  }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+    box-shadow: $public-shadow-lg-light;
+    backdrop-filter: none;
   }
 }
 
@@ -377,7 +414,7 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     background: $public-bg-primary-light;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     color: $public-text-primary-dark;
     background: $public-bg-secondary-dark;
     border-color: $public-border-subtle-dark;
@@ -394,6 +431,26 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     &:focus {
       outline-color: $public-accent-dark;
       background: rgba(255, 255, 255, 0.1);
+    }
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+    background: $public-bg-primary-light;
+    border-color: $public-border-subtle-light;
+
+    &::placeholder {
+      color: $public-text-tertiary-light;
+    }
+
+    &:hover {
+      border-color: $public-border-medium-light;
+      background: $public-bg-secondary-light;
+    }
+
+    &:focus {
+      outline-color: $public-accent-light;
+      background: $public-bg-primary-light;
     }
   }
 }
@@ -419,11 +476,19 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     color: $public-text-primary-light;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     color: $public-text-secondary-dark;
 
     &:hover {
       color: $public-text-primary-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+
+    &:hover {
+      color: $public-text-primary-light;
     }
   }
 }
@@ -468,13 +533,23 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     box-shadow: $public-shadow-md-light;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     background-color: $public-accent-dark;
     box-shadow: $public-shadow-sm-dark;
 
     &:hover:not(:disabled) {
       background-color: $public-accent-hover-dark;
       box-shadow: $public-shadow-md-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    background-color: $public-accent-light;
+    box-shadow: $public-shadow-sm-light;
+
+    &:hover:not(:disabled) {
+      background-color: $public-accent-hover-light;
+      box-shadow: $public-shadow-md-light;
     }
   }
 }
@@ -491,13 +566,23 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     border-color: $public-border-strong-light;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     color: $public-text-primary-dark;
     border-color: $public-border-medium-dark;
 
     &:hover:not(:disabled) {
       background-color: $public-hover-overlay-dark;
       border-color: $public-border-strong-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+    border-color: $public-border-medium-light;
+
+    &:hover:not(:disabled) {
+      background-color: $public-hover-overlay-light;
+      border-color: $public-border-strong-light;
     }
   }
 }
@@ -513,8 +598,12 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
   font-size: $public-font-size-base;
   font-style: italic;
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
   }
 }
 
@@ -526,10 +615,16 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
   color: $public-error-light;
   font-size: $public-font-size-base;
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     background: $public-error-bg-dark;
     border-color: rgba($public-error-dark, 0.3);
     color: $public-error-dark;
+  }
+
+  @include public-light-mode-override {
+    background: $public-error-bg-light;
+    border-color: rgba($public-error-light, 0.3);
+    color: $public-error-light;
   }
 }
 
@@ -547,8 +642,12 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     font-size: $public-font-size-md;
   }
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
   }
 }
 
@@ -698,9 +797,14 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
   background-color: #e0f2fe;
   color: #0369a1;
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     background-color: rgba(12, 74, 110, 0.3);
     color: #7dd3fc;
+  }
+
+  @include public-light-mode-override {
+    background-color: #e0f2fe;
+    color: #0369a1;
   }
 }
 
@@ -734,6 +838,15 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
 
     &:hover {
       background-color: $public-source-pill-hover-bg-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    background-color: $public-source-pill-bg-light;
+    color: $public-source-pill-color-light;
+
+    &:hover {
+      background-color: $public-source-pill-hover-bg-light;
     }
   }
 }
@@ -848,8 +961,12 @@ $font-medium: $public-font-weight-medium;
   outline: 2px solid $public-accent-light;
   outline-offset: 2px;
 
-  @media (prefers-color-scheme: dark) {
+  @include public-dark-mode {
     outline-color: $public-accent-dark;
+  }
+
+  @include public-light-mode-override {
+    outline-color: $public-accent-light;
   }
 }
 

--- a/src/site/assets/style.scss
+++ b/src/site/assets/style.scss
@@ -49,6 +49,8 @@ button.primary {
 // ===== APP LAYOUT =====
 
 #app {
+  @include public-accent-tokens;
+
   display: flex;
   flex-direction: column;
   justify-content: flex-start;

--- a/src/widget/components/app.vue
+++ b/src/widget/components/app.vue
@@ -79,7 +79,11 @@ onMounted(() => {
 </template>
 
 <style scoped lang="scss">
+@use '@/site/assets/mixins' as *;
+
 .widget-root {
+  @include public-accent-tokens;
+
   width: 100%;
   min-height: 100vh;
   display: flex;

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -359,6 +359,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     background: $public-bg-primary-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+  }
 }
 
 .event-detail-content {
@@ -380,6 +384,10 @@ onBeforeMount(async () => {
     border-bottom-color: $public-border-subtle-dark;
   }
 
+  @include public-light-mode-override {
+    border-bottom-color: $public-border-subtle-light;
+  }
+
   .back-link {
     display: inline-flex;
     align-items: center;
@@ -395,7 +403,7 @@ onBeforeMount(async () => {
     transition: $public-transition-fast;
 
     &:hover {
-      color: $public-accent-light;
+      color: var(--pav-accent-light);
 
       .back-arrow {
         transform: translateX(-3px);
@@ -410,7 +418,15 @@ onBeforeMount(async () => {
       color: $public-text-secondary-dark;
 
       &:hover {
-        color: $public-accent-dark;
+        color: var(--pav-accent-dark);
+      }
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-secondary-light;
+
+      &:hover {
+        color: var(--pav-accent-light);
       }
     }
   }
@@ -476,6 +492,11 @@ onBeforeMount(async () => {
     background-color: rgba(30, 30, 35, 0.85);
     color: $public-text-primary-dark;
   }
+
+  @include public-light-mode-override {
+    background-color: rgba(255, 255, 255, 0.9);
+    color: $public-text-primary-light;
+  }
 }
 
 // ================================================================
@@ -510,6 +531,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-primary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
 }
 
 // ================================================================
@@ -535,16 +560,24 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
 }
 
 .datetime-icon {
   flex-shrink: 0;
 
   &--date {
-    color: $public-accent-light;
+    color: var(--pav-accent-light);
 
     @include public-dark-mode {
-      color: $public-accent-dark;
+      color: var(--pav-accent-dark);
+    }
+
+    @include public-light-mode-override {
+      color: var(--pav-accent-light);
     }
   }
 
@@ -553,6 +586,10 @@ onBeforeMount(async () => {
 
     @include public-dark-mode {
       color: $public-text-secondary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-secondary-light;
     }
   }
 }
@@ -583,6 +620,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
 }
 
 .event-description {
@@ -594,6 +635,10 @@ onBeforeMount(async () => {
 
   @include public-dark-mode {
     color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
   }
 }
 
@@ -611,6 +656,10 @@ onBeforeMount(async () => {
 
   @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
   }
 }
 
@@ -655,6 +704,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
 }
 
 .card-heading {
@@ -668,6 +721,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
 }
 
 // Location card
@@ -680,6 +737,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-primary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
 }
 
 .location-address {
@@ -690,6 +751,10 @@ onBeforeMount(async () => {
 
   @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
   }
 }
 
@@ -704,6 +769,10 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-primary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
 }
 
 // Recurrence card
@@ -714,6 +783,10 @@ onBeforeMount(async () => {
 
   @include public-dark-mode {
     color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
   }
 }
 
@@ -778,6 +851,16 @@ onBeforeMount(async () => {
       &:hover {
         background: $public-hover-overlay-dark;
         border-color: $public-border-strong-dark;
+      }
+    }
+
+    @include public-light-mode-override {
+      border-color: $public-border-medium-light;
+      color: $public-text-primary-light;
+
+      &:hover {
+        background: $public-hover-overlay-light;
+        border-color: $public-border-strong-light;
       }
     }
   }

--- a/src/widget/components/list-view.vue
+++ b/src/widget/components/list-view.vue
@@ -123,6 +123,10 @@ section.day {
     @include public-dark-mode {
       color: $public-text-secondary-dark;
     }
+
+    @include public-light-mode-override {
+      color: $public-text-secondary-light;
+    }
   }
 
   ul.events {
@@ -162,8 +166,8 @@ section.day {
           height: 3px;
           background: linear-gradient(
             90deg,
-            $public-accent-light 0%,
-            rgba($public-accent-light, 0.4) 100%
+            var(--pav-accent-light) 0%,
+            color-mix(in srgb, var(--pav-accent-light) 40%, transparent) 100%
           );
           border-radius: 0 0 2px 2px;
           opacity: 0.7;
@@ -171,8 +175,16 @@ section.day {
           @include public-dark-mode {
             background: linear-gradient(
               90deg,
-              $public-accent-dark 0%,
-              rgba($public-accent-dark, 0.4) 100%
+              var(--pav-accent-dark) 0%,
+              color-mix(in srgb, var(--pav-accent-dark) 40%, transparent) 100%
+            );
+          }
+
+          @include public-light-mode-override {
+            background: linear-gradient(
+              90deg,
+              var(--pav-accent-light) 0%,
+              color-mix(in srgb, var(--pav-accent-light) 40%, transparent) 100%
             );
           }
         }
@@ -213,13 +225,21 @@ section.day {
         @include public-dark-mode {
           color: $public-text-primary-dark;
         }
+
+        @include public-light-mode-override {
+          color: $public-text-primary-light;
+        }
       }
 
       &:hover h3 {
-        color: $public-accent-light;
+        color: var(--pav-accent-light);
 
         @include public-dark-mode {
-          color: $public-accent-dark;
+          color: var(--pav-accent-dark);
+        }
+
+        @include public-light-mode-override {
+          color: var(--pav-accent-light);
         }
       }
 
@@ -232,6 +252,10 @@ section.day {
 
         @include public-dark-mode {
           color: $public-text-secondary-dark;
+        }
+
+        @include public-light-mode-override {
+          color: $public-text-secondary-light;
         }
       }
     }

--- a/src/widget/components/month-view.vue
+++ b/src/widget/components/month-view.vue
@@ -314,6 +314,10 @@ onMounted(() => {
     border-bottom-color: $public-border-subtle-dark;
   }
 
+  @include public-light-mode-override {
+    border-bottom-color: $public-border-subtle-light;
+  }
+
   .month-title {
     flex: 1;
     text-align: center;
@@ -324,6 +328,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       color: $public-text-primary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-primary-light;
     }
 
     @include public-mobile-only {
@@ -355,6 +363,16 @@ onMounted(() => {
         border-color: $public-border-strong-dark;
       }
     }
+
+    @include public-light-mode-override {
+      border-color: $public-border-medium-light;
+      color: $public-text-primary-light;
+
+      &:hover:not(:disabled) {
+        background: $public-hover-overlay-light;
+        border-color: $public-border-strong-light;
+      }
+    }
   }
 }
 
@@ -374,6 +392,10 @@ onMounted(() => {
   @include public-dark-mode {
     background: $public-border-subtle-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-border-subtle-light;
+  }
 }
 
 .weekday-header {
@@ -392,6 +414,11 @@ onMounted(() => {
     background: $public-bg-secondary-dark;
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-bg-secondary-light;
+    color: $public-text-secondary-light;
+  }
 }
 
 .month-day-cell {
@@ -405,6 +432,10 @@ onMounted(() => {
     background: $public-bg-primary-dark;
   }
 
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+  }
+
   &.is-other-month {
     opacity: 0.3;
     pointer-events: none;
@@ -413,7 +444,7 @@ onMounted(() => {
   &.is-today {
     .cell-header {
       .day-number {
-        background: $public-accent-light;
+        background: var(--pav-accent-light);
         color: white;
         border-radius: 50%;
         width: 24px;
@@ -423,7 +454,11 @@ onMounted(() => {
         justify-content: center;
 
         @include public-dark-mode {
-          background: $public-accent-dark;
+          background: var(--pav-accent-dark);
+        }
+
+        @include public-light-mode-override {
+          background: var(--pav-accent-light);
         }
       }
     }
@@ -443,6 +478,10 @@ onMounted(() => {
       @include public-dark-mode {
         color: $public-text-primary-dark;
       }
+
+      @include public-light-mode-override {
+        color: $public-text-primary-light;
+      }
     }
   }
 
@@ -459,7 +498,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   padding: 2px 4px;
-  background: $public-accent-light;
+  background: var(--pav-accent-light);
   color: white;
   border-radius: 3px;
   font-size: 10px;
@@ -468,15 +507,23 @@ onMounted(() => {
   overflow: hidden;
 
   &:hover {
-    background: $public-accent-hover-light;
+    background: var(--pav-accent-light-hover);
     transform: translateY(-1px);
   }
 
   @include public-dark-mode {
-    background: $public-accent-dark;
+    background: var(--pav-accent-dark);
 
     &:hover {
-      background: $public-accent-hover-dark;
+      background: var(--pav-accent-dark-hover);
+    }
+  }
+
+  @include public-light-mode-override {
+    background: var(--pav-accent-light);
+
+    &:hover {
+      background: var(--pav-accent-light-hover);
     }
   }
 
@@ -506,6 +553,11 @@ onMounted(() => {
     color: $public-text-secondary-dark;
     background: $public-bg-tertiary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+    background: $public-bg-tertiary-light;
+  }
 }
 
 // ================================================================
@@ -534,6 +586,11 @@ onMounted(() => {
     box-shadow: $public-shadow-sm-dark;
   }
 
+  @include public-light-mode-override {
+    background: $public-bg-secondary-light;
+    box-shadow: $public-shadow-sm-light;
+  }
+
   .day-header {
     display: flex;
     flex-direction: column;
@@ -541,12 +598,16 @@ onMounted(() => {
     justify-content: center;
     min-width: 60px;
     padding: $public-space-sm;
-    background: $public-accent-light;
+    background: var(--pav-accent-light);
     color: white;
     border-radius: $public-radius-sm;
 
     @include public-dark-mode {
-      background: $public-accent-dark;
+      background: var(--pav-accent-dark);
+    }
+
+    @include public-light-mode-override {
+      background: var(--pav-accent-light);
     }
 
     .day-name {
@@ -590,13 +651,25 @@ onMounted(() => {
       }
     }
 
+    @include public-light-mode-override {
+      background: $public-bg-primary-light;
+
+      &:hover {
+        background: $public-bg-tertiary-light;
+      }
+    }
+
     .event-time {
       font-size: $public-font-size-xs;
       font-weight: $public-font-weight-medium;
-      color: $public-accent-light;
+      color: var(--pav-accent-light);
 
       @include public-dark-mode {
-        color: $public-accent-dark;
+        color: var(--pav-accent-dark);
+      }
+
+      @include public-light-mode-override {
+        color: var(--pav-accent-light);
       }
     }
 
@@ -608,6 +681,10 @@ onMounted(() => {
 
       @include public-dark-mode {
         color: $public-text-primary-dark;
+      }
+
+      @include public-light-mode-override {
+        color: $public-text-primary-light;
       }
     }
   }

--- a/src/widget/components/week-view.vue
+++ b/src/widget/components/week-view.vue
@@ -232,6 +232,10 @@ onMounted(() => {
     border-bottom-color: $public-border-subtle-dark;
   }
 
+  @include public-light-mode-override {
+    border-bottom-color: $public-border-subtle-light;
+  }
+
   .week-title {
     flex: 1;
     text-align: center;
@@ -242,6 +246,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       color: $public-text-primary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-primary-light;
     }
 
     @include public-mobile-only {
@@ -273,6 +281,16 @@ onMounted(() => {
         border-color: $public-border-strong-dark;
       }
     }
+
+    @include public-light-mode-override {
+      border-color: $public-border-medium-light;
+      color: $public-text-primary-light;
+
+      &:hover:not(:disabled) {
+        background: $public-hover-overlay-light;
+        border-color: $public-border-strong-light;
+      }
+    }
   }
 }
 
@@ -290,6 +308,10 @@ onMounted(() => {
 
   @include public-dark-mode {
     background: $public-border-subtle-dark;
+  }
+
+  @include public-light-mode-override {
+    background: $public-border-subtle-light;
   }
 
   // Tablet: horizontal scroll if needed
@@ -322,13 +344,21 @@ onMounted(() => {
     background: $public-bg-primary-dark;
   }
 
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+  }
+
   &.is-today {
     .day-header {
-      background: $public-accent-light;
+      background: var(--pav-accent-light);
       color: white;
 
       @include public-dark-mode {
-        background: $public-accent-dark;
+        background: var(--pav-accent-dark);
+      }
+
+      @include public-light-mode-override {
+        background: var(--pav-accent-light);
       }
     }
   }
@@ -339,6 +369,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       box-shadow: $public-shadow-sm-dark;
+    }
+
+    @include public-light-mode-override {
+      box-shadow: $public-shadow-sm-light;
     }
   }
 }
@@ -356,6 +390,11 @@ onMounted(() => {
     border-bottom-color: $public-border-subtle-dark;
   }
 
+  @include public-light-mode-override {
+    background: $public-bg-secondary-light;
+    border-bottom-color: $public-border-subtle-light;
+  }
+
   .day-name {
     font-size: $public-font-size-xs;
     font-weight: $public-font-weight-semibold;
@@ -365,6 +404,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       color: $public-text-secondary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-secondary-light;
     }
   }
 
@@ -376,6 +419,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       color: $public-text-primary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-primary-light;
     }
   }
 }
@@ -410,7 +457,7 @@ onMounted(() => {
 
   &:hover {
     background: $public-bg-tertiary-light;
-    border-color: $public-accent-light;
+    border-color: var(--pav-accent-light);
     transform: translateY(-1px);
     box-shadow: $public-shadow-sm-light;
   }
@@ -420,8 +467,18 @@ onMounted(() => {
 
     &:hover {
       background: $public-bg-tertiary-dark;
-      border-color: $public-accent-dark;
+      border-color: var(--pav-accent-dark);
       box-shadow: $public-shadow-sm-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    background: $public-bg-secondary-light;
+
+    &:hover {
+      background: $public-bg-tertiary-light;
+      border-color: var(--pav-accent-light);
+      box-shadow: $public-shadow-sm-light;
     }
   }
 
@@ -435,10 +492,14 @@ onMounted(() => {
   .event-time {
     font-size: $public-font-size-xs;
     font-weight: $public-font-weight-medium;
-    color: $public-accent-light;
+    color: var(--pav-accent-light);
 
     @include public-dark-mode {
-      color: $public-accent-dark;
+      color: var(--pav-accent-dark);
+    }
+
+    @include public-light-mode-override {
+      color: var(--pav-accent-light);
     }
   }
 
@@ -456,6 +517,10 @@ onMounted(() => {
 
     @include public-dark-mode {
       color: $public-text-primary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-primary-light;
     }
   }
 }
@@ -476,8 +541,8 @@ onMounted(() => {
   transition: $public-transition-fast;
 
   &:hover {
-    color: $public-accent-light;
-    background: rgba($public-accent-light, 0.1);
+    color: var(--pav-accent-light);
+    background: color-mix(in srgb, var(--pav-accent-light) 10%, transparent);
   }
 
   @include public-dark-mode {
@@ -485,8 +550,18 @@ onMounted(() => {
     background: $public-bg-tertiary-dark;
 
     &:hover {
-      color: $public-accent-dark;
-      background: rgba($public-accent-dark, 0.1);
+      color: var(--pav-accent-dark);
+      background: color-mix(in srgb, var(--pav-accent-dark) 10%, transparent);
+    }
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+    background: $public-bg-tertiary-light;
+
+    &:hover {
+      color: var(--pav-accent-light);
+      background: color-mix(in srgb, var(--pav-accent-light) 10%, transparent);
     }
   }
 }

--- a/src/widget/components/widget-container.vue
+++ b/src/widget/components/widget-container.vue
@@ -187,12 +187,12 @@ onUnmounted(() => {
   }
 
   // Widget theme overrides (forced light/dark mode)
-  :global(.widget-theme-light) & {
+  .widget-theme-light & {
     background: $public-bg-primary-light;
     color: $public-text-primary-light;
   }
 
-  :global(.widget-theme-dark) & {
+  .widget-theme-dark & {
     background: $public-bg-primary-dark;
     color: $public-text-primary-dark;
   }

--- a/src/widget/components/widget-container.vue
+++ b/src/widget/components/widget-container.vue
@@ -182,6 +182,10 @@ onUnmounted(() => {
     background: $public-bg-primary-dark;
   }
 
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+  }
+
   // Widget theme overrides (forced light/dark mode)
   :global(.widget-theme-light) & {
     background: $public-bg-primary-light;
@@ -202,6 +206,10 @@ header {
     border-bottom-color: $public-border-subtle-dark;
   }
 
+  @include public-light-mode-override {
+    border-bottom-color: $public-border-subtle-light;
+  }
+
   .calendar-title {
     font-size: $public-font-size-lg;
     font-weight: $public-font-weight-light;
@@ -210,6 +218,10 @@ header {
 
     @include public-dark-mode {
       color: $public-text-primary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-primary-light;
     }
 
     @include public-mobile-only {

--- a/src/widget/stores/widgetStore.ts
+++ b/src/widget/stores/widgetStore.ts
@@ -24,6 +24,13 @@ export interface WidgetState {
   currentMonthStart: string | null; // ISO date string
 }
 
+// Module-scope singletons for the auto-mode matchMedia listener.
+// Stored at module scope (not as Pinia state) so we never re-bind on top of
+// an existing listener; explicit teardown before each re-evaluation prevents
+// stacked listeners across `auto → light → auto` toggles.
+let mediaQueryList: MediaQueryList | null = null;
+let mediaQueryListener: ((e: MediaQueryListEvent) => void) | null = null;
+
 export const useWidgetStore = defineStore('widget', {
   state: (): WidgetState => ({
     viewMode: WIDGET_CONFIG_DEFAULTS.view,
@@ -145,42 +152,67 @@ export const useWidgetStore = defineStore('widget', {
     },
 
     /**
-     * Inject accent color as CSS custom property on root element.
+     * Inject accent color as CSS custom properties on root element.
+     *
+     * Writes `--pav-accent-light` and `--pav-accent-dark` from the user-chosen
+     * value. Hover variants (`--pav-accent-light-hover` / `--pav-accent-dark-hover`)
+     * are intentionally NOT written here — they remain at the SCSS-compiled
+     * defaults emitted by the `public-accent-tokens` mixin on the root.
      *
      * SECURITY: The accent color MUST reach the DOM only via
-     * `element.style.setProperty('--widget-accent-color', value)`. Never
-     * interpolate the value into a raw `<style>` block, `innerHTML`, or
-     * string-concatenated stylesheet — those paths enable CSS/HTML
-     * injection. Combined with the strict hex regex validation in
-     * `isValidWidgetAccentColor` and the re-validation in
-     * `applyServerConfig()`/`parseConfig()`, this closes the injection
-     * vector.
+     * `element.style.setProperty(...)`. Never interpolate the value into a
+     * raw `<style>` block, `innerHTML`, or string-concatenated stylesheet —
+     * those paths enable CSS/HTML injection. Combined with the strict hex
+     * regex validation in `isValidWidgetAccentColor` and the re-validation in
+     * `applyServerConfig()`/`parseConfig()`, this closes the injection vector.
      *
-     * @param rootElement - DOM element to inject CSS property on
+     * @param rootElement - DOM element to inject CSS properties on
      */
     injectAccentColor(rootElement: HTMLElement) {
       if (this.accentColor) {
-        rootElement.style.setProperty('--widget-accent-color', this.accentColor);
+        rootElement.style.setProperty('--pav-accent-light', this.accentColor);
+        rootElement.style.setProperty('--pav-accent-dark', this.accentColor);
       }
     },
 
     /**
-     * Apply color mode class to root element
+     * Apply color mode class to root element.
+     *
+     * Resolves `auto` to `light` or `dark` via
+     * `window.matchMedia('(prefers-color-scheme: dark)')` so widget content
+     * always carries exactly one explicit theme class. This lets the
+     * `public-light-mode-override` mixin win over the dark-mode media query
+     * branch via specificity when the user picks "Light" on a dark-OS system.
+     *
+     * For `auto` mode, registers a single `change` listener on the
+     * MediaQueryList. The listener is stored at module scope and torn down
+     * unconditionally on every invocation, preventing stacked listeners
+     * across `auto → light → auto` toggles.
      *
      * @param rootElement - DOM element to apply class to
      */
     applyColorMode(rootElement: HTMLElement) {
-      // Remove existing theme classes
+      // Always tear down any prior listener before re-evaluating.
+      if (mediaQueryList && mediaQueryListener) {
+        mediaQueryList.removeEventListener('change', mediaQueryListener);
+        mediaQueryList = null;
+        mediaQueryListener = null;
+      }
+
+      // Always remove both theme classes, then add exactly one.
       rootElement.classList.remove('widget-theme-light', 'widget-theme-dark');
 
-      // Apply theme class based on color mode (auto uses prefers-color-scheme)
-      if (this.colorMode === 'light') {
-        rootElement.classList.add('widget-theme-light');
+      const resolved = this.colorMode === 'auto'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : this.colorMode;
+      rootElement.classList.add(resolved === 'dark' ? 'widget-theme-dark' : 'widget-theme-light');
+
+      // For auto mode, listen for OS theme changes and re-apply.
+      if (this.colorMode === 'auto') {
+        mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        mediaQueryListener = () => this.applyColorMode(rootElement);
+        mediaQueryList.addEventListener('change', mediaQueryListener);
       }
-      else if (this.colorMode === 'dark') {
-        rootElement.classList.add('widget-theme-dark');
-      }
-      // For 'auto', no class is added - CSS will use prefers-color-scheme
     },
 
     /**

--- a/src/widget/test/integration/widget_integration.test.ts
+++ b/src/widget/test/integration/widget_integration.test.ts
@@ -1,4 +1,26 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import sinon from 'sinon';
+import express, { Application } from 'express';
+import supertest from 'supertest';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import i18next from 'i18next';
+import I18NextVue from 'i18next-vue';
+import { DateTime } from 'luxon';
+
+import { Calendar } from '@/common/model/calendar';
+import { WidgetConfig as WidgetConfigModel } from '@/common/model/widget_config';
+import CalendarInterface from '@/server/calendar/interface';
+import WidgetDomainService from '@/server/calendar/service/widget_domain';
+import WidgetRoutes from '@/server/calendar/api/v1/widget';
+import WidgetEmbed from '@/client/components/logged_in/calendar-management/widget-embed.vue';
+import WidgetConfig from '@/client/components/logged_in/calendar-management/widget-config.vue';
+import WeekView from '@/widget/components/week-view.vue';
+import MonthView from '@/widget/components/month-view.vue';
+import ListView from '@/widget/components/list-view.vue';
+import { useWidgetStore } from '@/widget/stores/widgetStore';
+import { usePublicCalendarStore } from '@/site/stores/publicCalendarStore';
 
 /**
  * Build a fake MediaQueryList whose `matches` value is fixed and whose
@@ -18,30 +40,6 @@ function mockMatchMedia(matches: boolean) {
   vi.stubGlobal('matchMedia', matchMediaSpy);
   return { addSpy, removeSpy, matchMediaSpy };
 }
-
-import { mount } from '@vue/test-utils';
-import sinon from 'sinon';
-import express, { Application } from 'express';
-import supertest from 'supertest';
-import { createPinia, setActivePinia } from 'pinia';
-import { createRouter, createMemoryHistory } from 'vue-router';
-import i18next from 'i18next';
-import I18NextVue from 'i18next-vue';
-import axios from 'axios';
-import { DateTime } from 'luxon';
-
-import { Calendar } from '@/common/model/calendar';
-import { WidgetConfig as WidgetConfigModel } from '@/common/model/widget_config';
-import CalendarInterface from '@/server/calendar/interface';
-import WidgetDomainService from '@/server/calendar/service/widget_domain';
-import WidgetRoutes from '@/server/calendar/api/v1/widget';
-import WidgetEmbed from '@/client/components/logged_in/calendar-management/widget-embed.vue';
-import WidgetConfig from '@/client/components/logged_in/calendar-management/widget-config.vue';
-import WeekView from '@/widget/components/week-view.vue';
-import MonthView from '@/widget/components/month-view.vue';
-import ListView from '@/widget/components/list-view.vue';
-import { useWidgetStore } from '@/widget/stores/widgetStore';
-import { usePublicCalendarStore } from '@/site/stores/publicCalendarStore';
 
 describe('Widget Integration Tests', () => {
   let app: Application;

--- a/src/widget/test/integration/widget_integration.test.ts
+++ b/src/widget/test/integration/widget_integration.test.ts
@@ -1,4 +1,24 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Build a fake MediaQueryList whose `matches` value is fixed and whose
+ * addEventListener/removeEventListener are spy-able. Mirrors the pattern
+ * established in widgetStore.test.ts (pv-16wd.1.2).
+ */
+function mockMatchMedia(matches: boolean) {
+  const addSpy = vi.fn();
+  const removeSpy = vi.fn();
+  const fakeMQL: Partial<MediaQueryList> = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: addSpy as unknown as MediaQueryList['addEventListener'],
+    removeEventListener: removeSpy as unknown as MediaQueryList['removeEventListener'],
+  };
+  const matchMediaSpy = vi.fn().mockReturnValue(fakeMQL);
+  vi.stubGlobal('matchMedia', matchMediaSpy);
+  return { addSpy, removeSpy, matchMediaSpy };
+}
+
 import { mount } from '@vue/test-utils';
 import sinon from 'sinon';
 import express, { Application } from 'express';
@@ -308,7 +328,7 @@ describe('Widget Integration Tests', () => {
   });
 
   describe('Accent color customization applies correctly', () => {
-    it('should inject accent color as CSS custom property', () => {
+    it('should inject accent color as --pav-accent-light and --pav-accent-dark', () => {
       const mockRoot = document.createElement('div');
       document.body.appendChild(mockRoot);
 
@@ -318,15 +338,20 @@ describe('Widget Integration Tests', () => {
 
       widgetStore.injectAccentColor(mockRoot);
 
-      const appliedColor = mockRoot.style.getPropertyValue('--widget-accent-color');
-      expect(appliedColor).toBe('#ff9131');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-light')).toBe('#ff9131');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-dark')).toBe('#ff9131');
 
       document.body.removeChild(mockRoot);
     });
   });
 
   describe('Color mode switching (auto/light/dark)', () => {
-    it('should apply light theme class when colorMode=light', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('should apply light theme class when colorMode=light (even on dark system)', () => {
+      mockMatchMedia(true); // dark system
       const mockRoot = document.createElement('div');
       document.body.appendChild(mockRoot);
 
@@ -342,7 +367,8 @@ describe('Widget Integration Tests', () => {
       document.body.removeChild(mockRoot);
     });
 
-    it('should apply dark theme class when colorMode=dark', () => {
+    it('should apply dark theme class when colorMode=dark (even on light system)', () => {
+      mockMatchMedia(false); // light system
       const mockRoot = document.createElement('div');
       document.body.appendChild(mockRoot);
 
@@ -358,7 +384,8 @@ describe('Widget Integration Tests', () => {
       document.body.removeChild(mockRoot);
     });
 
-    it('should not apply theme class when colorMode=auto (uses media query)', () => {
+    it('auto mode resolves to widget-theme-light on a light system', () => {
+      mockMatchMedia(false);
       const mockRoot = document.createElement('div');
       document.body.appendChild(mockRoot);
 
@@ -368,8 +395,25 @@ describe('Widget Integration Tests', () => {
 
       widgetStore.applyColorMode(mockRoot);
 
-      expect(mockRoot.classList.contains('widget-theme-light')).toBe(false);
+      expect(mockRoot.classList.contains('widget-theme-light')).toBe(true);
       expect(mockRoot.classList.contains('widget-theme-dark')).toBe(false);
+
+      document.body.removeChild(mockRoot);
+    });
+
+    it('auto mode resolves to widget-theme-dark on a dark system', () => {
+      mockMatchMedia(true);
+      const mockRoot = document.createElement('div');
+      document.body.appendChild(mockRoot);
+
+      const widgetStore = useWidgetStore();
+      const urlParams = new URLSearchParams('colorMode=auto');
+      widgetStore.parseConfig(urlParams);
+
+      widgetStore.applyColorMode(mockRoot);
+
+      expect(mockRoot.classList.contains('widget-theme-dark')).toBe(true);
+      expect(mockRoot.classList.contains('widget-theme-light')).toBe(false);
 
       document.body.removeChild(mockRoot);
     });

--- a/src/widget/test/widgetApp.test.ts
+++ b/src/widget/test/widgetApp.test.ts
@@ -1,8 +1,28 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 import { useWidgetStore } from '../stores/widgetStore';
+
+/**
+ * Build a fake MediaQueryList whose `matches` value is fixed and whose
+ * addEventListener/removeEventListener are spy-able. Mirrors the pattern
+ * established in widgetStore.test.ts (pv-16wd.1.2) so all widget tests
+ * share a single matchMedia mocking approach.
+ */
+function mockMatchMedia(matches: boolean) {
+  const addSpy = vi.fn();
+  const removeSpy = vi.fn();
+  const fakeMQL: Partial<MediaQueryList> = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: addSpy as unknown as MediaQueryList['addEventListener'],
+    removeEventListener: removeSpy as unknown as MediaQueryList['removeEventListener'],
+  };
+  const matchMediaSpy = vi.fn().mockReturnValue(fakeMQL);
+  vi.stubGlobal('matchMedia', matchMediaSpy);
+  return { addSpy, removeSpy, matchMediaSpy };
+}
 
 describe('Widget App Infrastructure', () => {
   let pinia: ReturnType<typeof createPinia>;
@@ -96,7 +116,7 @@ describe('Widget App Infrastructure', () => {
   });
 
   describe('Accent Color CSS Injection', () => {
-    it('should set CSS custom property when accent color is provided', () => {
+    it('should set --pav-accent-light and --pav-accent-dark when accent color is provided', () => {
       // Create a mock root element
       const mockRoot = document.createElement('div');
       mockRoot.id = 'widget-root';
@@ -109,13 +129,14 @@ describe('Widget App Infrastructure', () => {
       // Inject the color
       store.injectAccentColor(mockRoot);
 
-      expect(mockRoot.style.getPropertyValue('--widget-accent-color')).toBe('#ff9131');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-light')).toBe('#ff9131');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-dark')).toBe('#ff9131');
 
       // Cleanup
       document.body.removeChild(mockRoot);
     });
 
-    it('should not set CSS property when accent color is empty', () => {
+    it('should not set CSS properties when accent color is empty', () => {
       const mockRoot = document.createElement('div');
       mockRoot.id = 'widget-root';
       document.body.appendChild(mockRoot);
@@ -125,14 +146,21 @@ describe('Widget App Infrastructure', () => {
       store.accentColor = '';
       store.injectAccentColor(mockRoot);
 
-      expect(mockRoot.style.getPropertyValue('--widget-accent-color')).toBe('');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-light')).toBe('');
+      expect(mockRoot.style.getPropertyValue('--pav-accent-dark')).toBe('');
 
       document.body.removeChild(mockRoot);
     });
   });
 
   describe('Color Mode Class Application', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     it('should apply light theme class when colorMode is light', () => {
+      // Even on a dark system, explicit light must win.
+      mockMatchMedia(true);
       const mockRoot = document.createElement('div');
       mockRoot.id = 'widget-root';
       document.body.appendChild(mockRoot);
@@ -150,6 +178,8 @@ describe('Widget App Infrastructure', () => {
     });
 
     it('should apply dark theme class when colorMode is dark', () => {
+      // Even on a light system, explicit dark must win.
+      mockMatchMedia(false);
       const mockRoot = document.createElement('div');
       mockRoot.id = 'widget-root';
       document.body.appendChild(mockRoot);
@@ -166,7 +196,8 @@ describe('Widget App Infrastructure', () => {
       document.body.removeChild(mockRoot);
     });
 
-    it('should not apply theme class when colorMode is auto', () => {
+    it('auto mode resolves to widget-theme-light on a light system', () => {
+      mockMatchMedia(false);
       const mockRoot = document.createElement('div');
       mockRoot.id = 'widget-root';
       document.body.appendChild(mockRoot);
@@ -177,8 +208,26 @@ describe('Widget App Infrastructure', () => {
 
       store.applyColorMode(mockRoot);
 
-      expect(mockRoot.classList.contains('widget-theme-light')).toBe(false);
+      expect(mockRoot.classList.contains('widget-theme-light')).toBe(true);
       expect(mockRoot.classList.contains('widget-theme-dark')).toBe(false);
+
+      document.body.removeChild(mockRoot);
+    });
+
+    it('auto mode resolves to widget-theme-dark on a dark system', () => {
+      mockMatchMedia(true);
+      const mockRoot = document.createElement('div');
+      mockRoot.id = 'widget-root';
+      document.body.appendChild(mockRoot);
+
+      const store = useWidgetStore(pinia);
+      const urlParams = new URLSearchParams('colorMode=auto');
+      store.parseConfig(urlParams);
+
+      store.applyColorMode(mockRoot);
+
+      expect(mockRoot.classList.contains('widget-theme-dark')).toBe(true);
+      expect(mockRoot.classList.contains('widget-theme-light')).toBe(false);
 
       document.body.removeChild(mockRoot);
     });

--- a/src/widget/test/widgetStore.test.ts
+++ b/src/widget/test/widgetStore.test.ts
@@ -147,7 +147,7 @@ describe('widgetStore — server-side config + admin-preview override', () => {
   });
 
   describe('safe accentColor DOM application', () => {
-    it('applies accent color via style.setProperty — not via innerHTML', () => {
+    it('writes --pav-accent-light and --pav-accent-dark via style.setProperty — not via innerHTML', () => {
       const store = useWidgetStore();
       const rootElement = document.createElement('div');
       document.body.appendChild(rootElement);
@@ -163,12 +163,58 @@ describe('widgetStore — server-side config + admin-preview override', () => {
 
       store.injectAccentColor(rootElement);
 
-      expect(setPropertySpy).toHaveBeenCalledWith('--widget-accent-color', '#ff9131');
+      expect(setPropertySpy).toHaveBeenCalledWith('--pav-accent-light', '#ff9131');
+      expect(setPropertySpy).toHaveBeenCalledWith('--pav-accent-dark', '#ff9131');
 
-      // The CSS custom property is readable from the style attribute, and
+      // The CSS custom properties are readable from the style attribute, and
       // the element's innerHTML remains empty (no <style> block injected).
-      expect(rootElement.style.getPropertyValue('--widget-accent-color')).toBe('#ff9131');
+      expect(rootElement.style.getPropertyValue('--pav-accent-light')).toBe('#ff9131');
+      expect(rootElement.style.getPropertyValue('--pav-accent-dark')).toBe('#ff9131');
       expect(rootElement.innerHTML).toBe('');
+
+      document.body.removeChild(rootElement);
+    });
+
+    it('does NOT publish the legacy --widget-accent-color custom property', () => {
+      const store = useWidgetStore();
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+
+      const setPropertySpy = vi.spyOn(rootElement.style, 'setProperty');
+
+      store.injectAccentColor(rootElement);
+
+      const writtenProperties = setPropertySpy.mock.calls.map(call => call[0]);
+      expect(writtenProperties).not.toContain('--widget-accent-color');
+      expect(rootElement.style.getPropertyValue('--widget-accent-color')).toBe('');
+
+      document.body.removeChild(rootElement);
+    });
+
+    it('does NOT write hover variants (those remain at SCSS mixin defaults)', () => {
+      const store = useWidgetStore();
+      const rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+
+      store.applyServerConfig({
+        view: 'list',
+        accentColor: '#ff9131',
+        colorMode: 'auto',
+      });
+
+      const setPropertySpy = vi.spyOn(rootElement.style, 'setProperty');
+
+      store.injectAccentColor(rootElement);
+
+      const writtenProperties = setPropertySpy.mock.calls.map(call => call[0]);
+      expect(writtenProperties).not.toContain('--pav-accent-light-hover');
+      expect(writtenProperties).not.toContain('--pav-accent-dark-hover');
 
       document.body.removeChild(rootElement);
     });
@@ -190,10 +236,185 @@ describe('widgetStore — server-side config + admin-preview override', () => {
 
       store.injectAccentColor(rootElement);
 
-      // Only the safe default hex reaches the DOM.
-      expect(rootElement.style.getPropertyValue('--widget-accent-color')).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      // Only the safe default hex reaches the DOM, on both variables.
+      expect(rootElement.style.getPropertyValue('--pav-accent-light')).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
+      expect(rootElement.style.getPropertyValue('--pav-accent-dark')).toBe(WIDGET_CONFIG_DEFAULTS.accentColor);
 
       document.body.removeChild(rootElement);
+    });
+  });
+
+  describe('applyColorMode (resolves auto + manages matchMedia listener)', () => {
+    /**
+     * Build a fake MediaQueryList whose `matches` value is fixed and whose
+     * addEventListener/removeEventListener are spy-able. Returns the spy
+     * accessors so individual tests can assert listener counts.
+     */
+    function mockMatchMedia(matches: boolean) {
+      const addSpy = vi.fn();
+      const removeSpy = vi.fn();
+      const fakeMQL: Partial<MediaQueryList> = {
+        matches,
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: addSpy as unknown as MediaQueryList['addEventListener'],
+        removeEventListener: removeSpy as unknown as MediaQueryList['removeEventListener'],
+      };
+      const matchMediaSpy = vi.fn().mockReturnValue(fakeMQL);
+      vi.stubGlobal('matchMedia', matchMediaSpy);
+      return { addSpy, removeSpy, matchMediaSpy };
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('auto mode on a light system adds widget-theme-light', () => {
+      mockMatchMedia(false);
+      const store = useWidgetStore();
+      store.colorMode = 'auto';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(rootElement.classList.contains('widget-theme-light')).toBe(true);
+      expect(rootElement.classList.contains('widget-theme-dark')).toBe(false);
+    });
+
+    it('auto mode on a dark system adds widget-theme-dark', () => {
+      mockMatchMedia(true);
+      const store = useWidgetStore();
+      store.colorMode = 'auto';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(rootElement.classList.contains('widget-theme-dark')).toBe(true);
+      expect(rootElement.classList.contains('widget-theme-light')).toBe(false);
+    });
+
+    it('explicit light mode adds widget-theme-light regardless of system', () => {
+      mockMatchMedia(true); // dark system
+      const store = useWidgetStore();
+      store.colorMode = 'light';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(rootElement.classList.contains('widget-theme-light')).toBe(true);
+      expect(rootElement.classList.contains('widget-theme-dark')).toBe(false);
+    });
+
+    it('explicit dark mode adds widget-theme-dark regardless of system', () => {
+      mockMatchMedia(false); // light system
+      const store = useWidgetStore();
+      store.colorMode = 'dark';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(rootElement.classList.contains('widget-theme-dark')).toBe(true);
+      expect(rootElement.classList.contains('widget-theme-light')).toBe(false);
+    });
+
+    it('removes both theme classes before adding the resolved one', () => {
+      mockMatchMedia(false);
+      const store = useWidgetStore();
+      store.colorMode = 'dark';
+      const rootElement = document.createElement('div');
+      // Pre-pollute with both classes to verify removal.
+      rootElement.classList.add('widget-theme-light', 'widget-theme-dark');
+
+      store.applyColorMode(rootElement);
+
+      // Only the resolved class remains.
+      expect(rootElement.classList.contains('widget-theme-dark')).toBe(true);
+      expect(rootElement.classList.contains('widget-theme-light')).toBe(false);
+    });
+
+    it('non-auto modes do not register a matchMedia listener', () => {
+      const { addSpy } = mockMatchMedia(false);
+      const store = useWidgetStore();
+      store.colorMode = 'light';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(addSpy).not.toHaveBeenCalled();
+    });
+
+    it('auto mode registers exactly one change listener', () => {
+      const { addSpy } = mockMatchMedia(false);
+      const store = useWidgetStore();
+      store.colorMode = 'auto';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+
+      expect(addSpy).toHaveBeenCalledTimes(1);
+      expect(addSpy.mock.calls[0][0]).toBe('change');
+    });
+
+    it('auto → light → auto cycle never stacks listeners (teardown before re-bind)', () => {
+      // Use a single shared addSpy/removeSpy across all stub returns so we
+      // can count net listener bindings across the whole cycle.
+      const addSpy = vi.fn();
+      const removeSpy = vi.fn();
+      const fakeMQL: Partial<MediaQueryList> = {
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: addSpy as unknown as MediaQueryList['addEventListener'],
+        removeEventListener: removeSpy as unknown as MediaQueryList['removeEventListener'],
+      };
+      vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(fakeMQL));
+
+      const store = useWidgetStore();
+      const rootElement = document.createElement('div');
+
+      // 1) auto → registers a listener
+      store.colorMode = 'auto';
+      store.applyColorMode(rootElement);
+
+      // 2) light → must remove prior listener and not register a new one
+      store.colorMode = 'light';
+      store.applyColorMode(rootElement);
+
+      // 3) auto → registers exactly one new listener
+      store.colorMode = 'auto';
+      store.applyColorMode(rootElement);
+
+      // After the full cycle: 2 add calls (steps 1, 3), 2 remove calls
+      // (steps 2, 3 — step 3 tears down the prior auto-mode listener
+      // even though step 2 already removed it; the unconditional teardown
+      // is the invariant that prevents stacking, even if it sometimes
+      // calls remove on an already-cleared MQL).
+      expect(addSpy).toHaveBeenCalledTimes(2);
+      // Net bindings (add - remove) should never exceed 1 at any point;
+      // by the end of the cycle, exactly one listener is active.
+      expect(addSpy.mock.calls.length - removeSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    });
+
+    it('repeated auto applications do not stack listeners', () => {
+      const addSpy = vi.fn();
+      const removeSpy = vi.fn();
+      const fakeMQL: Partial<MediaQueryList> = {
+        matches: false,
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: addSpy as unknown as MediaQueryList['addEventListener'],
+        removeEventListener: removeSpy as unknown as MediaQueryList['removeEventListener'],
+      };
+      vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(fakeMQL));
+
+      const store = useWidgetStore();
+      store.colorMode = 'auto';
+      const rootElement = document.createElement('div');
+
+      store.applyColorMode(rootElement);
+      store.applyColorMode(rootElement);
+      store.applyColorMode(rootElement);
+
+      // Each invocation tears down the prior listener and registers anew —
+      // net bindings (add - remove) must never exceed 1.
+      expect(addSpy.mock.calls.length - removeSpy.mock.calls.length).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/tests/e2e/widget-config-roundtrip.spec.ts
+++ b/tests/e2e/widget-config-roundtrip.spec.ts
@@ -1,32 +1,21 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Browser, Page } from '@playwright/test';
 import { loginAsAdmin } from './helpers/auth';
 import { startTestServer, TestEnvironment } from './helpers/test-server';
 
 /**
  * E2E Tests: Widget Configuration Roundtrip
  *
- * End-to-end verification that a calendar editor can save a widget view-mode
- * preference in the admin tab and that the change is reflected in the widget's
- * rendered DOM on a subsequent load.
- *
- * Flow:
- *   1. Log in as admin (calendar editor).
- *   2. Navigate to the calendar's widget admin tab.
- *   3. Click the "Week View" card (default is "List").
- *   4. Click Save. Assert:
- *        - PUT response returns the saved config.
- *        - Success message appears.
- *        - Save button disables (dirty state cleared).
- *   5. Open the cross-origin widget embedding page in a fresh browser context
- *      and assert that the widget iframe renders the week view — proving the
- *      saved server config flowed through the widget-facing endpoint and into
- *      the widget's rendered DOM.
+ * End-to-end verification that a calendar editor can save widget configuration
+ * (view mode, accent color, color mode) in the admin tab and that those changes
+ * are reflected in the widget's rendered DOM on a subsequent load.
  *
  * Cross-origin is required for the widget-facing endpoint: `/api/widget/v1/...`
  * requires an Origin header, which the browser only sets on cross-origin
  * requests. The embedding fixture runs on port 8080, the server on 3100-3200.
  *
- * Bead: pv-jwgn.4 — depends on pv-jwgn.2.2, pv-jwgn.3.1, and pv-jwgn.3.2.
+ * Beads:
+ *   - pv-jwgn.4 — view mode roundtrip (depends on pv-jwgn.2.2/3.1/3.2)
+ *   - pv-16wd.3.2 — accent color + color mode E2E coverage (extends this file)
  */
 
 let env: TestEnvironment;
@@ -121,4 +110,317 @@ test('admin change to widget view mode is reflected in rendered widget', async (
   await expect(iframe.locator('.list-view')).toHaveCount(0);
 
   await embedContext.close();
+});
+
+// ============================================================================
+// Helpers (used by accent color + color mode scenarios — pv-16wd.3.2)
+// ============================================================================
+
+/**
+ * Save the widget config from the admin tab.
+ *
+ * The caller must already be on the calendar management page with the Widget
+ * tab visible. Waits for the PUT /widget/config response so the next reader
+ * sees the persisted state. Returns the parsed save response body so the
+ * caller can assert what was actually persisted.
+ */
+async function saveWidgetConfig(
+  page: Page,
+  options: { accentColor?: string; colorMode?: 'auto' | 'light' | 'dark' },
+): Promise<{ view: string; accentColor: string; colorMode: string }> {
+  const widgetConfig = page.locator('.widget-config');
+  await expect(widgetConfig).toBeVisible({ timeout: 15000 });
+
+  // Wait for the initial GET to populate the form before mutating it.
+  // The save button is disabled while the form is in its loaded/clean state.
+  const saveButton = widgetConfig.locator('button.save-button');
+  await expect(saveButton).toBeDisabled({ timeout: 10000 });
+
+  if (options.accentColor !== undefined) {
+    // <input type="color"> in Chromium/Playwright sometimes does not propagate
+    // value mutations to Vue's v-model via `fill()` alone. Setting `.value`
+    // and dispatching both `input` and `change` events explicitly closes that
+    // gap deterministically.
+    await widgetConfig.locator('#accentColor').evaluate((el, value) => {
+      const input = el as HTMLInputElement;
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }, options.accentColor);
+  }
+  if (options.colorMode !== undefined) {
+    await widgetConfig.locator('#colorMode').selectOption(options.colorMode);
+  }
+
+  await expect(saveButton).toBeEnabled();
+
+  const savePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/widget/config')
+      && response.request().method() === 'PUT'
+      && response.ok(),
+    { timeout: 15000 },
+  );
+  await saveButton.click();
+  const saveResponse = await savePromise;
+  const savedBody = await saveResponse.json();
+
+  await expect(widgetConfig.locator('.alert--success')).toBeVisible({ timeout: 10000 });
+  await expect(saveButton).toBeDisabled();
+
+  return savedBody;
+}
+
+/**
+ * Open the cross-origin widget embedding fixture in a fresh browser context.
+ *
+ * Returns the embed page and a cleanup function. The fresh context avoids any
+ * admin session leakage and exercises the public widget-facing endpoint.
+ */
+async function openWidgetEmbed(
+  browser: Browser,
+  baseURL: string,
+  options: { colorScheme?: 'light' | 'dark' } = {},
+): Promise<{ embedPage: Page; cleanup: () => Promise<void> }> {
+  const embedContext = await browser.newContext();
+  const embedPage = await embedContext.newPage();
+
+  if (options.colorScheme !== undefined) {
+    await embedPage.emulateMedia({ colorScheme: options.colorScheme });
+  }
+
+  const embeddingUrl
+    = `http://localhost:8080/test-widget-embedding.html?serverUrl=${encodeURIComponent(baseURL)}&calendar=test_calendar`;
+  await embedPage.goto(embeddingUrl);
+
+  await embedPage.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
+
+  return {
+    embedPage,
+    cleanup: () => embedContext.close(),
+  };
+}
+
+/**
+ * Open the admin Widget tab for the test calendar. Caller must already be
+ * logged in as admin. Returns when the widget config form is visible and the
+ * Save button is in its clean (disabled) state.
+ */
+async function openWidgetAdminTab(page: Page, baseURL: string): Promise<void> {
+  await page.goto(baseURL + '/calendar/test_calendar/manage');
+  await page.waitForSelector('.calendar-management-root__tabs', { timeout: 15000 });
+  await page.locator('#widget-tab').click();
+  await expect(page.locator('.widget-config')).toBeVisible({ timeout: 15000 });
+  // Save button disabled = initial GET completed and snapshot taken.
+  await expect(page.locator('.widget-config button.save-button')).toBeDisabled({ timeout: 10000 });
+}
+
+// ============================================================================
+// Accent color round-trip (pv-16wd.3.2 scenario 1)
+// ============================================================================
+
+test('admin-saved accent color is injected as CSS custom property in rendered widget', async ({ page, browser }) => {
+  await loginAsAdmin(page, env.baseURL);
+  await openWidgetAdminTab(page, env.baseURL);
+
+  // Pick a vivid accent that cannot collide with the SCSS-default value.
+  const ACCENT = '#ff00ff';
+  const saved = await saveWidgetConfig(page, { accentColor: ACCENT });
+  expect(saved.accentColor).toBe(ACCENT);
+
+  // Open the cross-origin widget embed and assert the accent variable was
+  // injected by the widget store via element.style.setProperty().
+  const { embedPage, cleanup } = await openWidgetEmbed(browser, env.baseURL);
+  const iframe = embedPage.frameLocator('iframe[src*="/widget/"]');
+
+  // Wait for the widget root to render. We then read the CSS custom property
+  // directly — this is the deterministic surface where injectAccentColor()
+  // writes, so it does not depend on which view is rendered nor on whether
+  // any specific event-card pseudo-element resolves the var().
+  await expect(iframe.locator('.widget-root')).toBeVisible({ timeout: 20000 });
+
+  // Poll the computed style for the custom property until the widget store
+  // has had a chance to apply the server config. The hex value is preserved
+  // verbatim because injectAccentColor uses setProperty with the validated
+  // string, not a parsed/serialized color.
+  await expect.poll(
+    async () => {
+      return iframe.locator('.widget-root').evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return {
+          light: cs.getPropertyValue('--pav-accent-light').trim(),
+          dark: cs.getPropertyValue('--pav-accent-dark').trim(),
+        };
+      });
+    },
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toEqual({ light: ACCENT, dark: ACCENT });
+
+  await cleanup();
+});
+
+// ============================================================================
+// Color mode override scenarios (pv-16wd.3.2 scenarios 2–4)
+// ============================================================================
+//
+// Each scenario asserts that the user-chosen color mode wins over the system
+// preference reported by `prefers-color-scheme`. The signal is the theme
+// class that `widgetStore.applyColorMode()` writes to the widget root —
+// `widget-theme-light` or `widget-theme-dark`. Components consume that class
+// via the `public-light-mode-override` mixin (and matching dark variants) to
+// override the dark-mode media query through specificity.
+//
+// The class on `.widget-root` is the authoritative behavioral observable
+// from `applyColorMode()`. The light/dark override tests also assert the
+// downstream visual background-color cascade on `.widget-container` —
+// without that assertion, a regression in the SCSS theme-override mixins
+// (e.g. Vue's `:global(...) &` compilation bug, see pv-ezc7) could leave
+// the class on the root while the actual cascade was broken.
+
+async function getWidgetRootClasses(iframe: ReturnType<Page['frameLocator']>): Promise<string> {
+  return iframe.locator('.widget-root').evaluate((el) => el.className);
+}
+
+/**
+ * Parse a CSS rgb()/rgba() color string into a normalized `{r,g,b}` triple.
+ * Returns null if the string is not a recognizable rgb() or rgba().
+ */
+function parseRgb(color: string): { r: number; g: number; b: number } | null {
+  const match = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (!match) return null;
+  return {
+    r: parseInt(match[1], 10),
+    g: parseInt(match[2], 10),
+    b: parseInt(match[3], 10),
+  };
+}
+
+/**
+ * Heuristic luminance check. The widget's light background is white-ish
+ * (#ffffff) and the dark background is near-black (#1a1a1e). We check the
+ * average channel value on each side of 128 to avoid coupling to exact
+ * SCSS token values, which is more resilient to design-system tweaks.
+ */
+function isLightColor(color: string): boolean {
+  const rgb = parseRgb(color);
+  if (!rgb) return false;
+  return (rgb.r + rgb.g + rgb.b) / 3 > 128;
+}
+
+function isDarkColor(color: string): boolean {
+  const rgb = parseRgb(color);
+  if (!rgb) return false;
+  return (rgb.r + rgb.g + rgb.b) / 3 < 128;
+}
+
+test('color mode "light" overrides system dark preference', async ({ page, browser }) => {
+  await loginAsAdmin(page, env.baseURL);
+  await openWidgetAdminTab(page, env.baseURL);
+  const saved = await saveWidgetConfig(page, { colorMode: 'light' });
+  expect(saved.colorMode).toBe('light');
+
+  // Emulate a dark OS — the saved Light mode must win.
+  const { embedPage, cleanup } = await openWidgetEmbed(browser, env.baseURL, {
+    colorScheme: 'dark',
+  });
+  const iframe = embedPage.frameLocator('iframe[src*="/widget/"]');
+
+  // Wait for the widget-root with the explicit light theme class. This is the
+  // contract: applyColorMode() removes both classes and adds exactly one based
+  // on the resolved mode. With the saved colorMode === 'light', the resolved
+  // mode is 'light' regardless of the system preference.
+  await expect(iframe.locator('.widget-root.widget-theme-light')).toBeVisible({ timeout: 20000 });
+  await expect(iframe.locator('.widget-root.widget-theme-dark')).toHaveCount(0);
+
+  // Visual cascade: the `.widget-theme-light &` override mixin must drive the
+  // background-color on `.widget-container` to a light value even though the
+  // OS prefers dark. This guards against Vue's scoped-style compilation bug
+  // (pv-ezc7) where `:global(.widget-theme-light) &` compiles to a bare
+  // `.widget-theme-light{...}` rule with the descendant dropped.
+  await expect(iframe.locator('.widget-container')).toBeVisible({ timeout: 20000 });
+  await expect.poll(
+    async () => {
+      const bg = await iframe.locator('.widget-container').evaluate(
+        (el) => getComputedStyle(el).backgroundColor,
+      );
+      return isLightColor(bg);
+    },
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toBe(true);
+
+  await cleanup();
+});
+
+test('color mode "dark" overrides system light preference', async ({ page, browser }) => {
+  await loginAsAdmin(page, env.baseURL);
+  await openWidgetAdminTab(page, env.baseURL);
+  const saved = await saveWidgetConfig(page, { colorMode: 'dark' });
+  expect(saved.colorMode).toBe('dark');
+
+  // Emulate a light OS — the saved Dark mode must win.
+  const { embedPage, cleanup } = await openWidgetEmbed(browser, env.baseURL, {
+    colorScheme: 'light',
+  });
+  const iframe = embedPage.frameLocator('iframe[src*="/widget/"]');
+
+  await expect(iframe.locator('.widget-root.widget-theme-dark')).toBeVisible({ timeout: 20000 });
+  await expect(iframe.locator('.widget-root.widget-theme-light')).toHaveCount(0);
+
+  // Visual cascade: the `.widget-theme-dark &` override mixin must drive the
+  // background-color on `.widget-container` to a dark value even though the
+  // OS prefers light.
+  await expect(iframe.locator('.widget-container')).toBeVisible({ timeout: 20000 });
+  await expect.poll(
+    async () => {
+      const bg = await iframe.locator('.widget-container').evaluate(
+        (el) => getComputedStyle(el).backgroundColor,
+      );
+      return isDarkColor(bg);
+    },
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toBe(true);
+
+  await cleanup();
+});
+
+test('color mode "auto" follows system preference and reacts to changes', async ({ page, browser }) => {
+  await loginAsAdmin(page, env.baseURL);
+  await openWidgetAdminTab(page, env.baseURL);
+  const saved = await saveWidgetConfig(page, { colorMode: 'auto' });
+  expect(saved.colorMode).toBe('auto');
+
+  // Start with a dark OS — auto should resolve to dark.
+  const { embedPage, cleanup } = await openWidgetEmbed(browser, env.baseURL, {
+    colorScheme: 'dark',
+  });
+  const iframe = embedPage.frameLocator('iframe[src*="/widget/"]');
+
+  await expect(iframe.locator('.widget-root')).toBeVisible({ timeout: 20000 });
+
+  await expect.poll(
+    () => getWidgetRootClasses(iframe),
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toContain('widget-theme-dark');
+
+  // Flip the OS preference to light without reloading. The matchMedia
+  // listener registered by applyColorMode() must fire and swap the class.
+  // The poll guards against any small async delay between emulateMedia and
+  // the listener handler dispatching the class update.
+  await embedPage.emulateMedia({ colorScheme: 'light' });
+
+  await expect.poll(
+    () => getWidgetRootClasses(iframe),
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toContain('widget-theme-light');
+
+  // Flip back to dark — auto should react again, proving the listener
+  // handles repeated transitions (no stacked / stale listeners).
+  await embedPage.emulateMedia({ colorScheme: 'dark' });
+
+  await expect.poll(
+    () => getWidgetRootClasses(iframe),
+    { timeout: 15000, intervals: [200, 500, 1000] },
+  ).toContain('widget-theme-dark');
+
+  await cleanup();
 });

--- a/tests/e2e/widget-embedding.spec.ts
+++ b/tests/e2e/widget-embedding.spec.ts
@@ -191,10 +191,15 @@ test.describe('Widget Embedding', () => {
     const iframe = page.frameLocator('iframe[src*="/widget/"]');
     await expect(iframe.locator('body')).toBeVisible({ timeout: 20000 });
 
-    const accentColor = await iframe.locator('.widget-root').evaluate(
-      (el) => el.style.getPropertyValue('--widget-accent-color'),
+    const accentVars = await iframe.locator('.widget-root').evaluate(
+      (el) => ({
+        light: el.style.getPropertyValue('--pav-accent-light'),
+        dark: el.style.getPropertyValue('--pav-accent-dark'),
+      }),
     );
-    expect(accentColor).toBeTruthy();
+    // Both light/dark accent variables resolve to the default orange on the widget root.
+    expect(accentVars.light).toBeTruthy();
+    expect(accentVars.dark).toBeTruthy();
   });
 
   test('postMessage resize events reach the embedding page', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes two widget config bugs reported by users:

1. **Accent color picker had no visible effect.** The widget store wrote `--widget-accent-color` to the root, but no SCSS rule consumed it — every widget component used hardcoded `$public-accent-light/dark` SCSS variables.
2. **'Light' color mode could not override a dark-OS system.** The `public-dark-mode` mixin emitted dark styles via `@media (prefers-color-scheme: dark)` OR `.widget-theme-dark` ancestor — with no light-side counterpart, picking 'Light' on dark-OS still rendered dark.

## Approach

Two surgical changes plus one critical Vue scoped-style fix discovered mid-implementation:

1. **Token-based accent theming**: Added `public-accent-tokens` mixin emitting `--pav-accent-{light,dark}{,-hover}` CSS custom properties, applied at `.widget-root` and `#app`. The widget store now writes only `--pav-accent-{light,dark}` from the validated user-chosen color; widget components consume `var(--pav-accent-*)` so the accent flows through at runtime. Where SCSS `rgba()` couldn't take a CSS variable, the rewrite uses `color-mix(in srgb, var(--pav-accent-*) <pct>%, transparent)`.

2. **Paired light-mode-override mixin**: Added `public-light-mode-override` adjacent to `public-dark-mode`. Every `@include public-dark-mode { ... dark values ... }` block in widget components is paired with `@include public-light-mode-override { ... light values ... }` re-stating the LIGHT defaults explicitly, so the explicit Light theme wins specificity over the `@media (prefers-color-scheme: dark)` branch.

3. **Critical Vue scoped-style fix (pv-ezc7)**: Discovered during e2e validation that `:global(.widget-theme-light) &` in scoped Vue styles compiles to bare `.widget-theme-light{...}` rules — the descendant `&` is dropped. Verified with `@vue/compiler-sfc.compileStyle()`. The pre-existing `public-dark-mode` mixin used the same pattern and had been silently relying on the `@media` branch alone. **Fix:** drop `:global()` wrapper — Vue's scoped compiler then correctly emits `.widget-theme-light .X[data-v-xxx]{...}`. The mixin file now carries explicit "do not reintroduce :global() here" documentation.

## Resolves

- pv-16wd (epic)
- pv-16wd.1.1, pv-16wd.1.2, pv-16wd.1.3 (foundation: mixins, store, root wiring)
- pv-16wd.2.1 through pv-16wd.2.5 (widget component migrations)
- pv-16wd.3.1 (test migrations)
- pv-16wd.3.2 (e2e widget-config-roundtrip)
- pv-ezc7 (critical Vue scoped-style fix)

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — passes (only pre-existing AP/auth failures unrelated to widget)
- [x] `npm run test:integration` — passes (only pre-existing failures)
- [x] `npm run build` and `npm run build:widget-sdk` — succeed; compiled widget CSS has zero bare `.widget-theme-{light,dark}{` rules
- [x] `npm run test:e2e -- widget-config-roundtrip` — 5/5 passing including new visual-cascade assertions for Light overrides Dark (and inverse)
- [x] `widget-embedding.spec.ts` and `widget-headers.spec.ts` — all passing
- [ ] Manual browser verification: pick a vivid accent (`#ff00ff`), reload widget — preview reflects new color
- [ ] Manual browser verification: emulate dark OS, pick Light mode in admin — widget renders light
- [ ] Manual browser verification: emulate light OS, pick Dark mode — widget renders dark

## Notes

- Public site (`src/site/components/...`) is intentionally not migrated — only the public site root receives `@include public-accent-tokens` defensively so `var(--pav-accent-*)` resolves on either surface.
- Powered-by-Pavillion footer accent migration in `app.vue` was deferred — that footer was added in pv-43m0 which has not yet merged into this branch's base. It will need a small follow-up after merge.
- `widget-container.vue` retains a redundant `background` declaration in its inline `.widget-theme-{light,dark} &` blocks alongside the paired mixin invocations — flagged as a small follow-up cleanup, not a blocker.
- `public-focus-visible` mixin still uses compiled `$public-accent-*` rather than runtime `var(--pav-accent-*)` — out of scope for this epic; flagged for future work.