### PR TITLE
feat(site): show default date range in public date-filter button (pv-2p6y)

### DIFF
--- a/src/site/components/search-filter-public.vue
+++ b/src/site/components/search-filter-public.vue
@@ -231,7 +231,7 @@ import i18next from 'i18next';
 import { useRoute, useRouter } from 'vue-router';
 import { usePublicCalendarStore } from '../stores/publicCalendarStore';
 import CategoryPillSelector from './category-pill-selector.vue';
-import { getThisWeek, getNextWeek } from '@/common/utils/datePresets';
+import { getThisWeek, getNextWeek, getDefaultDateRange } from '@/common/utils/datePresets';
 import type { ViewMode } from '@/widget/stores/widgetStore';
 import { Search, CalendarDays } from 'lucide-vue-next';
 
@@ -271,6 +271,14 @@ const state = reactive({
   dateFilterMode: null as 'thisWeek' | 'nextWeek' | 'custom' | null,
 });
 
+// Default date range mirrors what publicCalendarStore.loadEvents() sends to the
+// API when no explicit filter is set, so the displayed range matches the
+// fetched range. Reactive on calendarDefaultDateRange so it refreshes once
+// loadCalendar() resolves the per-calendar override.
+const defaultRange = computed(() =>
+  getDefaultDateRange(publicStore.calendarDefaultDateRange),
+);
+
 // Computed property for button text
 const dateFilterButtonText = computed(() => {
   if (state.dateFilterMode === 'thisWeek') {
@@ -287,7 +295,9 @@ const dateFilterButtonText = computed(() => {
     if (state.startDate) return `From ${formatDate(state.startDate)}`;
     if (state.endDate) return `Until ${formatDate(state.endDate)}`;
   }
-  return t('custom'); // "Select Dates"
+  // No filter active: surface the implicit default window so the visitor
+  // can see what date range the events list represents.
+  return formatDateRange(defaultRange.value.startDate, defaultRange.value.endDate);
 });
 
 // Computed label for the clear button — adapts based on active filter types

--- a/src/site/test/components/search-filter-public.test.ts
+++ b/src/site/test/components/search-filter-public.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { createRouter, createMemoryHistory } from 'vue-router';
@@ -632,6 +632,56 @@ describe('SearchFilterPublic Component', () => {
       const buttonText = wrapper.find('.button-text').text();
       expect(buttonText).toBe('Feb 24');
       expect(buttonText).not.toContain('24-24');
+    });
+  });
+
+  describe('Default Date Range Display', () => {
+    // Fix "now" so getDefaultDateRange() resolves to a known string.
+    // 2026-04-29T12:00:00Z renders to Apr 29 in every reasonable test-runner zone.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-29T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should show the default date range in the button label when no filter is active', async () => {
+      const wrapper = mount(SearchFilterPublic, {
+        global: {
+          plugins: [pinia, router, [I18NextVue, { i18next }]],
+        },
+      });
+
+      await flushPromises();
+
+      // Store default is '2weeks' → today (Apr 29) + 14 days = May 13.
+      // formatDateRange picks the cross-month form "Apr 29 - May 13".
+      const buttonText = wrapper.find('.button-text').text();
+      expect(buttonText).toBe('Apr 29 - May 13');
+    });
+
+    it('should re-render the button label when calendarDefaultDateRange changes', async () => {
+      const store = usePublicCalendarStore();
+
+      const wrapper = mount(SearchFilterPublic, {
+        global: {
+          plugins: [pinia, router, [I18NextVue, { i18next }]],
+        },
+      });
+
+      await flushPromises();
+
+      // Initial: '2weeks' default → 14 days
+      expect(wrapper.find('.button-text').text()).toBe('Apr 29 - May 13');
+
+      // Simulate loadCalendar() resolving with a per-calendar override
+      store.calendarDefaultDateRange = '1week';
+      await flushPromises();
+
+      // After change: '1week' → 7 days → May 6
+      expect(wrapper.find('.button-text').text()).toBe('Apr 29 - May 6');
     });
   });
 


### PR DESCRIPTION
## Summary

When no date filter is active, the public site (`/view/:calendarName`) and the widget list view date-filter button now show the implicit default date range (e.g. **"Apr 29 - May 13"**) instead of the static **"Select Dates"** label, so visitors can see what date window the events list represents without opening the filter dropdown.

- Single touchpoint: `dateFilterButtonText` computed in `src/site/components/search-filter-public.vue` — fall-through branch now returns `formatDateRange(defaultRange.value.startDate, defaultRange.value.endDate)`.
- The displayed range is derived from `publicCalendarStore.calendarDefaultDateRange` via `getDefaultDateRange()`, mirroring `publicCalendarStore.loadEvents()` so the visible label and the API query stay in lockstep.
- Reuses the existing locale-aware `formatDateRange()` helper — no new i18n keys.
- The button's `aria-label` is unchanged ("Filter by Date Range") to preserve the action affordance for screen readers; a future accessibility-focused bead can add `aria-describedby` to announce the visible range alongside.
- Widget list view inherits automatically (it already uses the same `SearchFilterPublic` component); week/month widget views correctly do not render the filter, so there's no leak of the new label there.

Closes pv-2p6y.

## Test plan

- [x] Vitest: `npm run test:unit -- search-filter-public` — 50/50 pass (incl. 2 new "Default Date Range Display" cases: rendered-DOM assertion with fixed `vi.setSystemTime`, plus reactivity test mutating `store.calendarDefaultDateRange`).
- [x] Vitest full unit suite: 7363/7363 pass.
- [x] Lint: 0 errors.
- [x] Manual site (`/view/test_calendar`): default label shows "Apr 29 - May 13"; activating "This Week" swaps to "This Week"; clearing reverts.
- [x] Manual widget list view (`/widget/test_calendar?view=list`): same default label.
- [x] Manual widget week view (`?view=week`): no `.date-filter-button` rendered (confirmed via DOM query) — no leak.
- [x] aria-label still reads "Filter by Date Range" on the button.