### PR TITLE
docs: add git-workflow skill

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: git-workflow
+description: Pavillion git and GitHub conventions for branches, commits, pull requests, and releases. Use when naming a branch, drafting a commit message, opening a pull request, or cutting a release.
+---
+
+# Git Workflow
+
+Pavillion's git and GitHub conventions. This skill is the canonical source for branch naming, commit format, pull-request shape, and release-notes format and procedure.
+
+## Foundational principle
+
+GitHub artifacts must be self-contained for GitHub readers. Local-only references (bead IDs, personal tracker IDs) do not appear in branch names, commits, PR titles or bodies, or release notes. Only GitHub-referenceable identifiers — PR numbers, issue numbers, commit SHAs, release tags — appear in GitHub-visible artifacts.
+
+## Reference files
+
+| Operation | File |
+|---|---|
+| Naming a branch | [branches.md](branches.md) |
+| Writing a commit | [commits.md](commits.md) |
+| Opening a pull request | [pull-requests.md](pull-requests.md) |
+| Cutting a release | [releases.md](releases.md) |
+
+Read the relevant reference file for the operation you are doing. Each is self-contained — you do not need to read the others.
+
+## Related
+
+The `bead-branch-and-pr` skill provides orchestrator-internal helper scripts (`branch-name.sh`, `commit-msg.sh`, `pr-body.sh`), the `gitSafeToStart` working-tree check, and the build-guardian-before-push gate. It consumes the conventions defined here; it is not a parallel source of truth.

--- a/.claude/skills/git-workflow/branches.md
+++ b/.claude/skills/git-workflow/branches.md
@@ -1,0 +1,49 @@
+# Branch Naming
+
+## Pattern
+
+```
+<type>/<kebab-title>
+```
+
+Examples:
+
+- `feat/widget-powered-by-footer`
+- `fix/widget-config-accent-light-mode`
+- `refactor/client-shadow-focus-brand`
+
+## Allowed types
+
+The full conventional-commit set:
+
+- `feat` — new functionality
+- `fix` — bug fix
+- `chore` — housekeeping, tooling
+- `refactor` — code restructure with no behavior change
+- `docs` — documentation only
+- `test` — test changes only
+- `perf` — performance improvement
+- `ci` — CI configuration
+- `build` — build system or external dependencies
+- `style` — formatting, whitespace
+
+## Casing and characters
+
+- Lowercase only.
+- Alphanumerics and hyphens. The only slash is the one separating the type prefix from the title.
+- Words separated by single hyphens. No underscores or dots.
+
+## Length
+
+Total branch name ≤ 60 characters. If the kebab-title alone would push the branch over 60 chars, truncate the title segment at a word boundary; the type prefix is always preserved.
+
+## Branch base
+
+Branch from `main` by default. If there is a reason to branch from somewhere else, prompt the user before branching.
+
+## Disallowed
+
+- Bead IDs or other local tracker IDs.
+- Suffix-style ID encoding (no `<title>-<id>`, no trailing identifiers).
+- Mixed case.
+- Underscores.

--- a/.claude/skills/git-workflow/commits.md
+++ b/.claude/skills/git-workflow/commits.md
@@ -1,0 +1,103 @@
+# Commit Messages
+
+## Header format
+
+```
+<type>(<scope>): <summary>
+```
+
+When no scope fits, omit the parenthetical entirely:
+
+```
+<type>: <summary>
+```
+
+## Allowed types
+
+The full conventional-commit set: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`, `ci`, `build`, `style`. Same set as branch prefixes.
+
+## Scope (optional)
+
+Pick the scope that best reflects what the change touches.
+
+**Backend domains** (under `src/server/`):
+
+- `accounts`
+- `calendar`
+- `federation` (or a specific subsystem like `ap-inbox`)
+- `media`
+- `configuration`
+- `public`
+- and any other domain present in the codebase
+
+**Frontend surfaces:**
+
+- `client` — authenticated user app
+- `site` — public calendar viewer
+- `widget` — embeddable widget
+- `admin` — instance admin pages
+
+If nothing fits, omit the scope. Do not invent scopes to satisfy the format.
+
+## Summary rules
+
+- Imperative mood: "add" not "added", "fix" not "fixes".
+- Lowercase first letter.
+- No trailing period.
+- Header total ≤ 72 characters.
+
+## Body
+
+Generally include a body unless the change is genuinely trivial (typo, single-line tweak). The body should describe broadly *where* the changes happened and *why*. Wrap lines around 72 characters.
+
+## Footers
+
+When applicable:
+
+- `Closes #N` or `Fixes #N` — for GitHub issue auto-link. Also goes in the PR body (see [pull-requests.md](pull-requests.md)).
+- `BREAKING CHANGE: <description>` — call out backward-incompatible changes.
+
+## Never include
+
+- Assistant trailers: `Co-authored-by: Claude`, `Generated-by: ...`, or any other AI-attribution line.
+- Local tracker IDs: bead IDs, personal task IDs.
+- Manually written `(#PR)` suffix — GitHub squash merge appends this automatically.
+
+## Merge strategy
+
+Squash merge is the default. Each PR collapses to one commit on `main`. The last commit message before merge becomes the historical record on `main`, with `(#PR)` auto-appended by GitHub.
+
+## Examples
+
+A feature commit with body and issue footer:
+
+```
+feat(calendar): add cancel-occurrence flow for recurring events
+
+Calendar owners can now cancel a single occurrence of a recurring event
+without affecting the rest of the series. Cancellation writes a one-off
+override row that is consulted when expanding the series, and the public
+site and widget rendering paths skip the cancelled instance.
+
+Closes #198
+```
+
+A trivial fix with no body:
+
+```
+fix(widget): preserve focus on overlay close
+```
+
+A breaking-change commit:
+
+```
+refactor(federation): rename Actor.preferredUsername to Actor.handle
+
+Aligns the field name with the rest of the codebase and the spec
+glossary. Affects all federation entity serializers and the inbound
+activity parsers.
+
+BREAKING CHANGE: federation actors now expose `handle` instead of
+`preferredUsername`. Downstream consumers reading from the actor JSON
+must update their key reference.
+```

--- a/.claude/skills/git-workflow/pull-requests.md
+++ b/.claude/skills/git-workflow/pull-requests.md
@@ -1,0 +1,52 @@
+# Pull Requests
+
+## Title
+
+Mirrors the commit format:
+
+```
+<type>(<scope>): <summary>
+```
+
+For multi-commit branches, write a title that summarizes the branch as a whole rather than copying any single commit.
+
+## Body template
+
+Three sections, all required:
+
+```markdown
+## Motivation
+
+[why this work was needed; what problem it solves]
+
+## Approach
+
+[what was done; the strategy or design taken; non-obvious decisions]
+
+## Validation
+
+[how this was tested; what was verified; relevant test runs]
+```
+
+No conditional sections (Screenshots, Migration notes, Deployment notes). Anything contextual goes inline in Approach or Validation.
+
+## Issue references
+
+`Closes #N` or `Fixes #N` appears in **both**:
+
+1. The PR body — so GitHub auto-closes the issue on merge.
+2. The commit footer — so the audit trail survives the squash merge.
+
+In the PR body, place the reference wherever it reads naturally — top of Motivation as opening context, or as a final footer line.
+
+## Workflow
+
+- **No draft PRs.** Open a PR only when ready for merge.
+- **No auto-merge.** The user reviews and merges manually.
+- **Push to origin** only after build-guardian PASS (lint, unit, integration, build, e2e via build-guardian).
+- **Squash merge** on landing.
+
+## Disallowed
+
+- Bead IDs or other local tracker references in title or body.
+- "Beads closed" sections, "Linked tickets" sections, or any other local-only reference list.

--- a/.claude/skills/git-workflow/releases.md
+++ b/.claude/skills/git-workflow/releases.md
@@ -1,0 +1,79 @@
+# Releases
+
+## Format
+
+```markdown
+## Features
+
+- **<area or feature name>** — <description>
+
+## Fixes & Updates
+
+- **<area or feature name>** — <description>
+```
+
+Release notes describe what shipped from the perspective of users, calendar owners, and instance operators. They do not cite PR numbers, commit SHAs, or any other implementation detail — those can be derived later with tooling if needed and should not clutter the user-facing summary.
+
+## Section semantics
+
+**Features**
+
+Only end-user-visible new capabilities. Audience: calendar owners, instance operators, public site viewers, event attendees. Things they can see and use that they could not before.
+
+**Fixes & Updates**
+
+Everything else user-relevant: bug fixes, behind-the-scenes correctness changes (federation signing, serialization), refactors with user-visible impact (modal consolidation), i18n cleanup, infrastructure and deployment changes that operators feel.
+
+**Drop entirely**
+
+Orchestrator and agent infrastructure, advisor and auditor wiring, internal-only tooling and test additions — anything that does not affect what an end user, calendar owner, or instance operator sees or operates.
+
+## Bullet shape
+
+- Group by feature or area. When a single feature shipped across multiple PRs, it remains one bullet describing the feature — implementation slicing is invisible in release notes.
+- One-liner for small focused changes; multi-sentence (~3 sentences with *what* + *why* + *what is affected*) for bigger chunks of work.
+- No PR numbers, commit SHAs, bead IDs, or other implementation references.
+
+## Tagging
+
+- Tag format: `vX.Y.Z` (semver).
+- Tag `main` at the merge commit; no release branches.
+- Every release is final unless the user explicitly says otherwise (no RC, beta, or pre-release pattern by default).
+- The user decides version bumps and 1.0 timing — this skill does not prescribe semver rules. The agent may suggest a bump, but the call is the user's.
+
+## Cut-a-release procedure
+
+The agent drafts; the user approves.
+
+1. **Identify the last released tag.**
+
+   ```bash
+   gh release list --limit 1
+   # or
+   git describe --tags --abbrev=0
+   ```
+
+2. **Survey merged PRs since that tag.** Combine sources for best context:
+
+   ```bash
+   gh pr list --state merged --base main --search "merged:>=<last-tag-date>"
+   git log <last-tag>..main --oneline
+   ```
+
+   Open PRs visually when a title alone does not carry intent — read the PR body for the *why*.
+
+3. **Classify each PR** into Features, Fixes & Updates, or Drop using the section semantics above.
+
+4. **Group multi-PR work** into single bullets by feature or area. The same feature spread across two or three PRs becomes one bullet describing the feature — the PR slicing is not surfaced in the notes.
+
+5. **Draft the release notes** in the markdown structure above.
+
+6. **Present the draft to the user** with a proposed (or "your call") semver bump.
+
+7. **On approval, publish:**
+
+   ```bash
+   gh release create vX.Y.Z --notes-file <draft.md>
+   ```
+
+   This tags `main` at HEAD.


### PR DESCRIPTION
## Motivation

Pavillion has had no canonical source for git and GitHub conventions. Commit format, branch naming, PR shape, and release-notes structure lived in muscle memory and partially in `bead-branch-and-pr`, which is bead-scoped and embeds local bead IDs into branches, commits, and PR bodies — references that GitHub readers cannot resolve.

## Approach

Add a project-level skill at `.claude/skills/git-workflow/` consisting of an index `SKILL.md` plus four reference files (`branches.md`, `commits.md`, `pull-requests.md`, `releases.md`). The index states a foundational principle — GitHub artifacts must be self-contained for GitHub readers; no local-tracker references — and routes to the relevant reference file by operation.

The skill is the canonical source for these conventions. `bead-branch-and-pr` becomes downstream tooling that consumes them; cleaning up its helper scripts to stop embedding bead IDs is tracked separately and out of scope here.

## Validation

- The Claude Code resolver picked up the new skill mid-session (appeared in the available-skills list immediately after `SKILL.md` was committed).
- End-to-end sweep: all five files present, every cross-reference in `SKILL.md` resolves, frontmatter parses, no placeholder strings (`TODO`, `TBD`, `FIXME`, etc.), no stray bead IDs in any skill content.
- The illustrative commit examples in `commits.md` were checked against the rules they embody (imperative mood, ≤72 chars, lowercase first letter, no trailing period).
- All commits on this branch were authored using the new conventions — no bead-ID suffixes, no assistant trailers, conventional-commit headers with bodies that describe broadly where and why.