### PR TITLE
feat(site,widget): sync widget layouts with site via shared components (pv-rtu1)

### DIFF
--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -1039,6 +1039,12 @@ $public-link-color: $public-accent-light;
       box-shadow: $public-shadow-xl-dark;
     }
   }
+
+  @include public-light-mode-override {
+    &:hover {
+      box-shadow: $public-shadow-xl-light;
+    }
+  }
 }
 
 // ===== SIDEBAR CARD (white bg, bordered, rounded) =====
@@ -1085,6 +1091,14 @@ $public-link-color: $public-accent-light;
 
     &::before {
       background: $public-accent-dark;
+    }
+  }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+
+    &::before {
+      background: $public-link-color;
     }
   }
 }

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -1059,6 +1059,11 @@ $public-link-color: $public-accent-light;
     background: $public-bg-primary-dark;
     border-color: $public-border-subtle-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+    border-color: $public-border-subtle-light;
+  }
 }
 
 // ===== STICKY DATE HEADING =====
@@ -1155,6 +1160,14 @@ $public-link-color: $public-accent-light;
       135deg,
       $public-bg-secondary-dark 0%,
       $public-bg-tertiary-dark 100%
+    );
+  }
+
+  @include public-light-mode-override {
+    background: linear-gradient(
+      135deg,
+      $public-bg-secondary-light 0%,
+      $public-bg-tertiary-light 100%
     );
   }
 }

--- a/src/site/components/EventDetailBody.vue
+++ b/src/site/components/EventDetailBody.vue
@@ -1,0 +1,730 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useTranslation } from 'i18next-vue';
+import { DateTime } from 'luxon';
+import i18next from 'i18next';
+import { Calendar, CalendarX, Clock, Repeat, MapPin, Accessibility } from 'lucide-vue-next';
+
+import { useLocalizedContent } from '@/site/composables/useLocalizedContent';
+import { useRecurrenceText } from '@/site/composables/useRecurrenceText';
+import EventImage from '@/site/components/event-image.vue';
+import AddToCalendar from '@/site/components/add-to-calendar.vue';
+import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
+import type CalendarEventInstance from '@/common/model/event_instance';
+import type { Calendar as CalendarModel } from '@/common/model/calendar';
+import type { EventCategory } from '@/common/model/event_category';
+
+const props = defineProps<{
+  instance: CalendarEventInstance;
+  calendar: CalendarModel;
+  categoryHrefBuilder?: (category: EventCategory) => string;
+}>();
+
+const { t } = useTranslation('system');
+const { localizedContent } = useLocalizedContent();
+
+/**
+ * Returns true when start and end fall on the same calendar day.
+ */
+function isSameDay(start: DateTime, end: DateTime): boolean {
+  return start.hasSame(end, 'day');
+}
+
+/**
+ * Computed human-readable recurrence text derived from the public API's
+ * `recurrenceSummary: { key, params }` intent shape.
+ */
+const recurrenceText = useRecurrenceText(
+  () => props.instance?.event?.recurrenceSummary ?? null,
+);
+
+/**
+ * Computed event-level accessibility info from event content.
+ */
+const eventAccessibilityInfo = computed(() => {
+  if (!props.instance?.event) return '';
+  const content = localizedContent(props.instance.event);
+  return content?.accessibilityInfo ?? '';
+});
+
+/**
+ * Computed localized accessibility info for the location.
+ * Handles both EventLocation models (TranslatedModel) and plain objects.
+ */
+const locationAccessibilityInfo = computed(() => {
+  const location = props.instance?.event?.location;
+  if (!location || typeof location.hasContent !== 'function') {
+    return '';
+  }
+  try {
+    const content = localizedContent(location);
+    return content?.accessibilityInfo ?? '';
+  }
+  catch {
+    return '';
+  }
+});
+
+/**
+ * Whether to show the accessibility card (either event or location has info).
+ */
+const hasAccessibilityInfo = computed(() => {
+  return !!(eventAccessibilityInfo.value || locationAccessibilityInfo.value);
+});
+
+/**
+ * Returns the source calendar metadata for reposted events, or null.
+ */
+const sourceCalendar = computed(() => {
+  return props.instance?.event?.sourceCalendar ?? null;
+});
+
+/**
+ * Returns the display label for the source calendar pill (urlName@host).
+ */
+const sourceCalendarLabel = computed(() => {
+  if (!sourceCalendar.value) return '';
+  return `${sourceCalendar.value.urlName}@${sourceCalendar.value.host}`;
+});
+
+/**
+ * Returns true when the source calendar URL is a remote (external) link.
+ */
+const isRemoteSourceCalendar = computed(() => {
+  if (!sourceCalendar.value) return false;
+  return sourceCalendar.value.url.startsWith('http');
+});
+
+/**
+ * Returns true when this specific occurrence has been cancelled by the calendar owner.
+ */
+const isCancelled = computed(() => {
+  return props.instance?.isCancelled === true;
+});
+
+/**
+ * Defense-in-depth safe external URL computed.
+ * Returns the URL only if its protocol is http: or https:, else null.
+ * Guards against javascript:, data:, and other unsafe schemes even if
+ * the service-layer validator is bypassed or misconfigured.
+ */
+const safeExternalUrl = computed<string | null>(() => {
+  const raw = props.instance?.event?.externalUrl;
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+});
+
+/**
+ * Defense-in-depth safe URL prompt computed.
+ * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
+ * Prevents template-key injection via arbitrary strings.
+ */
+const safePrompt = computed<UrlPrompt | null>(() => {
+  const raw = props.instance?.event?.urlPrompt;
+  if (raw == null) return null;
+  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
+});
+</script>
+
+<template>
+  <!-- Hero image -->
+  <div v-if="instance.event.media" class="hero-image-wrapper">
+    <EventImage
+      :media="instance.event.media"
+      context="feature"
+      :alt="localizedContent(instance.event).name"
+      :focal-point-x="instance.event.mediaFocalPointX"
+      :focal-point-y="instance.event.mediaFocalPointY"
+      :zoom="instance.event.mediaZoom"
+    />
+  </div>
+
+  <!-- Cancelled badge -->
+  <div v-if="isCancelled" class="cancelled-badge" role="status">
+    <CalendarX :size="14" aria-hidden="true" />
+    <span>{{ t('event_cancelled') }}</span>
+  </div>
+
+  <!-- Recurrence badge -->
+  <div v-if="recurrenceText" class="recurrence-badge">
+    <Repeat :size="14" aria-hidden="true" />
+    <span>{{ recurrenceText }}</span>
+  </div>
+
+  <!-- Source calendar pill -->
+  <a
+    v-if="sourceCalendar"
+    :href="sourceCalendar.url"
+    class="source-calendar-pill"
+    :aria-label="t('event_source_calendar_label', { name: sourceCalendarLabel })"
+    :target="isRemoteSourceCalendar ? '_blank' : undefined"
+    :rel="isRemoteSourceCalendar ? 'noopener noreferrer' : undefined"
+  >
+    <Calendar :size="14" aria-hidden="true" />
+    <span>{{ sourceCalendarLabel }}</span>
+  </a>
+
+  <!-- Event title -->
+  <h1 class="instance-title">{{ localizedContent(instance.event).name }}</h1>
+
+  <!-- Date + time row -->
+  <div class="datetime-row">
+    <time :datetime="instance.start.toISODate()" class="event-date">
+      <Calendar :size="16" class="datetime-icon datetime-icon--date" aria-hidden="true" />
+      <span>{{ instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY) }}</span>
+    </time>
+    <time :datetime="instance.start.toISO()" class="event-datetime">
+      <Clock :size="16" class="datetime-icon datetime-icon--time" aria-hidden="true" />
+      <span class="event-time-text">
+        {{ instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.TIME_SIMPLE) }}<template v-if="instance.end">
+          – {{ instance.end.toLocal().setLocale(i18next.language).toLocaleString(
+            isSameDay(instance.start, instance.end) ? DateTime.TIME_SIMPLE : DateTime.DATETIME_MED
+          ) }}</template>
+      </span>
+    </time>
+  </div>
+
+  <!-- Two-column content grid -->
+  <div class="detail-grid">
+    <!-- Left column: description + categories -->
+    <div class="detail-main">
+      <h2 class="about-heading">{{ t('about_this_event') }}</h2>
+      <p class="event-description">{{ localizedContent(instance.event).description }}</p>
+
+      <!-- Categories section -->
+      <div v-if="instance.event.categories && instance.event.categories.length" class="categories-section">
+        <h3 class="section-heading">{{ t('event_categories') }}</h3>
+        <div class="category-badges">
+          <template v-for="category in instance.event.categories" :key="category.id">
+            <a
+              v-if="categoryHrefBuilder"
+              :href="categoryHrefBuilder(category)"
+              class="event-category-badge"
+            >
+              {{ localizedContent(category).name }}
+            </a>
+            <span
+              v-else
+              class="event-category-badge"
+            >
+              {{ localizedContent(category).name }}
+            </span>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right sidebar: location, accessibility, recurrence cards -->
+    <aside class="detail-sidebar" :aria-label="t('event_details_sidebar')">
+      <!-- Location card -->
+      <div v-if="instance.event.location" class="sidebar-card event-location">
+        <div class="card-header">
+          <MapPin :size="16" class="card-icon" aria-hidden="true" />
+          <h3 class="card-heading">{{ t('event_location') }}</h3>
+        </div>
+        <p class="location-name">{{ instance.event.location.name }}</p>
+        <p v-if="instance.event.location.address" class="location-address">
+          <a :href="'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent([instance.event.location.address, instance.event.location.city, instance.event.location.state].filter(Boolean).join(', '))"
+             target="_blank"
+             rel="noopener"
+             :aria-label="t('get_directions')"
+          >
+            {{ instance.event.location.address }}
+            <template v-if="instance.event.location.city">
+              <br />{{ instance.event.location.city }}<template v-if="instance.event.location.state">, {{ instance.event.location.state }}</template>
+              <template v-if="instance.event.location.postalCode">{{ ' ' + instance.event.location.postalCode }}</template>
+            </template>
+          </a>
+        </p>
+      </div>
+
+      <!-- Accessibility card -->
+      <div v-if="hasAccessibilityInfo" class="sidebar-card accessibility-card">
+        <div class="card-header">
+          <Accessibility :size="16" class="card-icon" aria-hidden="true" />
+          <h3 class="card-heading">{{ t('event_accessibility') }}</h3>
+        </div>
+        <div v-if="eventAccessibilityInfo && locationAccessibilityInfo">
+          <h4 class="accessibility-subheading">{{ t('event_accessibility_event') }}</h4>
+          <p class="accessibility-info">{{ eventAccessibilityInfo }}</p>
+          <h4 class="accessibility-subheading">{{ t('event_accessibility_venue') }}</h4>
+          <p class="accessibility-info">{{ locationAccessibilityInfo }}</p>
+        </div>
+        <p v-else class="accessibility-info">{{ eventAccessibilityInfo || locationAccessibilityInfo }}</p>
+      </div>
+
+      <!-- Recurrence details card -->
+      <div v-if="recurrenceText" class="sidebar-card recurrence-card">
+        <div class="card-header">
+          <Repeat :size="16" class="card-icon" aria-hidden="true" />
+          <h3 class="card-heading">{{ t('event_recurring') }}</h3>
+        </div>
+        <p class="recurrence-text">{{ recurrenceText }}</p>
+      </div>
+
+      <!-- External link CTA -->
+      <a
+        v-if="safeExternalUrl && safePrompt"
+        :href="safeExternalUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="external-link-button"
+      >
+        {{ t('url_prompt.' + safePrompt) }}<span class="sr-only">, {{ t('opens_in_new_tab') }}</span>
+      </a>
+
+      <!-- Add to Calendar -->
+      <AddToCalendar :event="instance.event" :instance="instance" />
+    </aside>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/site/assets/mixins' as *;
+
+// ================================================================
+// EVENT DETAIL BODY
+// ================================================================
+// Shared body content for site event-instance and widget overlay.
+// Two-column layout with sidebar info cards for location,
+// accessibility, and recurrence. Responsive: single column on
+// mobile/tablet, two-column grid on desktop (>= 1024px).
+// ================================================================
+
+// ================================================================
+// HERO IMAGE
+// ================================================================
+
+.hero-image-wrapper {
+  @include public-hero-image;
+  margin-bottom: $public-space-2xl;
+
+  // Override to let EventImage fill container
+  :deep(.event-image) {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+
+// ================================================================
+// RECURRENCE BADGE
+// ================================================================
+
+.recurrence-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: $public-space-sm;
+  padding: $public-space-xs $public-space-md;
+  border-radius: $public-radius-full;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: $public-text-primary-light;
+  font-size: $public-font-size-sm;
+  font-weight: $public-font-weight-medium;
+  margin-bottom: $public-space-md;
+
+  @include public-dark-mode {
+    background-color: rgba(30, 30, 35, 0.85);
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    background-color: rgba(255, 255, 255, 0.9);
+    color: $public-text-primary-light;
+  }
+}
+
+// ================================================================
+// CANCELLED BADGE
+// ================================================================
+
+.cancelled-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: $public-space-sm;
+  padding: $public-space-xs $public-space-md;
+  border-radius: $public-radius-full;
+  background-color: $public-error-light;
+  color: #fff;
+  font-size: $public-font-size-sm;
+  font-weight: $public-font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: $public-letter-spacing-wide;
+  margin-bottom: $public-space-md;
+  margin-right: $public-space-sm;
+
+  @include public-dark-mode {
+    background-color: $public-error-dark;
+    color: $public-bg-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    background-color: $public-error-light;
+    color: #fff;
+  }
+}
+
+// ================================================================
+// SOURCE CALENDAR PILL
+// ================================================================
+
+.source-calendar-pill {
+  @include public-source-calendar-pill;
+  margin-bottom: $public-space-md;
+}
+
+// ================================================================
+// TITLE
+// ================================================================
+
+.instance-title {
+  font-size: $public-font-size-2xl;
+  font-weight: $public-font-weight-bold;
+  letter-spacing: $public-letter-spacing-tight;
+  line-height: $public-line-height-tight;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-lg 0;
+
+  @include public-tablet-up {
+    font-size: 40px;
+  }
+
+  @include public-desktop-up {
+    font-size: 48px;
+  }
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
+}
+
+// ================================================================
+// DATE + TIME ROW
+// ================================================================
+
+.datetime-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $public-space-sm $public-space-xl;
+  margin-bottom: $public-space-2xl;
+}
+
+.event-date,
+.event-datetime {
+  display: inline-flex;
+  align-items: center;
+  gap: $public-space-sm;
+  font-size: $public-font-size-base;
+  font-weight: $public-font-weight-medium;
+  color: $public-text-secondary-light;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+.datetime-icon {
+  flex-shrink: 0;
+
+  &--date {
+    color: var(--pav-accent-light);
+
+    @include public-dark-mode {
+      color: var(--pav-accent-dark);
+    }
+
+    @include public-light-mode-override {
+      color: var(--pav-accent-light);
+    }
+  }
+
+  &--time {
+    color: $public-text-secondary-light;
+
+    @include public-dark-mode {
+      color: $public-text-secondary-dark;
+    }
+
+    @include public-light-mode-override {
+      color: $public-text-secondary-light;
+    }
+  }
+}
+
+// ================================================================
+// TWO-COLUMN DETAIL GRID
+// ================================================================
+
+.detail-grid {
+  @include public-detail-grid;
+  margin-bottom: $public-space-2xl;
+}
+
+// ================================================================
+// LEFT COLUMN: DESCRIPTION + CATEGORIES
+// ================================================================
+
+.detail-main {
+  min-width: 0; // Prevent grid blowout
+}
+
+.about-heading {
+  font-size: $public-font-size-md;
+  font-weight: $public-font-weight-semibold;
+  color: $public-text-secondary-light;
+  margin: 0 0 $public-space-md 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+.event-description {
+  font-size: $public-font-size-md;
+  line-height: $public-line-height-relaxed;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-xl 0;
+  white-space: pre-line;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
+}
+
+.categories-section {
+  margin-top: $public-space-lg;
+}
+
+.section-heading {
+  font-size: $public-font-size-xs;
+  font-weight: $public-font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: $public-letter-spacing-wide;
+  color: $public-text-secondary-light;
+  margin: 0 0 $public-space-sm 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+.category-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $public-space-sm;
+}
+
+.event-category-badge {
+  @include public-category-badge;
+
+  text-decoration: none;
+  transition: $public-transition-fast;
+
+  // When rendered as <a> (categoryHrefBuilder provided), enable hover affordances.
+  // When rendered as <span> (no builder), hover styles still apply but cursor stays default.
+  &:is(a):hover {
+    background-color: $public-accent-hover-light;
+    transform: translateY(-1px);
+
+    @include public-dark-mode {
+      background-color: $public-accent-hover-dark;
+    }
+
+    @include public-light-mode-override {
+      background-color: $public-accent-hover-light;
+    }
+  }
+
+  &:is(span) {
+    cursor: default;
+  }
+
+  &:focus-visible {
+    @include public-focus-visible;
+  }
+}
+
+// ================================================================
+// RIGHT SIDEBAR: INFO CARDS
+// ================================================================
+
+.detail-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: $public-space-lg;
+}
+
+.sidebar-card {
+  @include public-sidebar-card;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: $public-space-sm;
+  margin-bottom: $public-space-md;
+}
+
+.card-icon {
+  color: $public-text-secondary-light;
+  flex-shrink: 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+.card-heading {
+  font-size: $public-font-size-xs;
+  font-weight: $public-font-weight-semibold;
+  text-transform: uppercase;
+  letter-spacing: $public-letter-spacing-wide;
+  color: $public-text-secondary-light;
+  margin: 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+// Location card
+.location-name {
+  font-size: $public-font-size-base;
+  font-weight: $public-font-weight-medium;
+  color: $public-text-primary-light;
+  margin: 0 0 $public-space-xs 0;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
+}
+
+.location-address {
+  font-size: $public-font-size-sm;
+  color: $public-text-secondary-light;
+  margin: 0;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+// Accessibility card
+.accessibility-subheading {
+  font-size: $public-font-size-sm;
+  font-weight: $public-font-weight-semibold;
+  color: $public-text-secondary-light;
+  margin: 0 0 $public-space-xs 0;
+
+  &:not(:first-child) {
+    margin-top: $public-space-md;
+  }
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
+}
+
+.accessibility-info {
+  font-size: $public-font-size-base;
+  color: $public-text-primary-light;
+  margin: 0;
+  white-space: pre-line;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
+}
+
+// Recurrence card
+.recurrence-text {
+  font-size: $public-font-size-base;
+  color: $public-text-primary-light;
+  margin: 0;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+  }
+}
+
+// ================================================================
+// EXTERNAL LINK CTA BUTTON
+// ================================================================
+
+.external-link-button {
+  @include public-button-primary;
+
+  min-height: 44px;
+  text-decoration: none;
+  text-align: center;
+
+  &:focus-visible {
+    @include public-focus-visible;
+  }
+}
+
+// ================================================================
+// SCREEN READER ONLY UTILITY
+// ================================================================
+
+.sr-only {
+  @include public-sr-only;
+}
+</style>

--- a/src/site/components/event-card.vue
+++ b/src/site/components/event-card.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   instance: CalendarEventInstance;
   calendarUrlName: string;
   defaultImage?: Media | null;
+  detailHref?: string;
 }>();
 
 const { t } = useTranslation('system');
@@ -117,11 +118,18 @@ const isRemoteSourceCalendar = computed(() => {
 });
 
 /**
- * Returns the router-link href for the event detail page.
- * The final path segment is a minute-precision UTC timestamp slug
- * (`yyyymmdd-hhmm`) derived from the instance's start time.
+ * Returns the href for the event detail link.
+ *
+ * When `detailHref` is provided (e.g. by the widget host), it is returned
+ * directly and the `localizedPath`-based site URL is NOT computed. When the
+ * prop is omitted, the site computes its standard `/view/...` path with a
+ * minute-precision UTC timestamp slug (`yyyymmdd-hhmm`) derived from the
+ * instance's start time.
  */
 const detailPath = computed(() => {
+  if (props.detailHref !== undefined) {
+    return props.detailHref;
+  }
   const eventId = props.instance.event.id;
   const slug = formatInstanceSlug(props.instance.start);
   return localizedPath(
@@ -275,6 +283,11 @@ const detailPath = computed(() => {
     background: $public-bg-primary-dark;
     box-shadow: $public-shadow-sm-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-bg-primary-light;
+    box-shadow: $public-shadow-sm-light;
+  }
 }
 
 // ================================================================
@@ -295,6 +308,10 @@ const detailPath = computed(() => {
   @include public-dark-mode {
     background: $public-bg-tertiary-dark;
   }
+
+  @include public-light-mode-override {
+    background: $public-bg-tertiary-light;
+  }
 }
 
 .no-image-fallback {
@@ -308,6 +325,10 @@ const detailPath = computed(() => {
   @include public-dark-mode {
     background: linear-gradient(135deg, $public-bg-secondary-dark 0%, $public-bg-tertiary-dark 100%);
   }
+
+  @include public-light-mode-override {
+    background: linear-gradient(135deg, $public-bg-secondary-light 0%, $public-bg-tertiary-light 100%);
+  }
 }
 
 .fallback-icon {
@@ -317,6 +338,10 @@ const detailPath = computed(() => {
 
   @include public-dark-mode {
     color: $public-text-tertiary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-tertiary-light;
   }
 }
 
@@ -344,6 +369,11 @@ const detailPath = computed(() => {
     background: rgba(30, 30, 35, 0.85);
     color: $public-text-primary-dark;
   }
+
+  @include public-light-mode-override {
+    background: rgba(255, 255, 255, 0.9);
+    color: $public-text-primary-light;
+  }
 }
 
 // ================================================================
@@ -370,6 +400,11 @@ const detailPath = computed(() => {
   @include public-dark-mode {
     background: $public-error-dark;
     color: $public-bg-primary-dark;
+  }
+
+  @include public-light-mode-override {
+    background: $public-error-light;
+    color: #fff;
   }
 }
 
@@ -420,6 +455,10 @@ const detailPath = computed(() => {
   @include public-dark-mode {
     color: $public-accent-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-accent-light;
+  }
 }
 
 h3 {
@@ -454,6 +493,14 @@ h3 {
       color: $public-accent-dark;
     }
   }
+
+  @include public-light-mode-override {
+    color: $public-text-primary-light;
+
+    &:hover {
+      color: $public-accent-light;
+    }
+  }
 }
 
 .event-location {
@@ -470,6 +517,10 @@ h3 {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
+  }
 }
 
 .event-description {
@@ -485,6 +536,10 @@ h3 {
 
   @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
+    color: $public-text-secondary-light;
   }
 }
 

--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
-import { reactive, onBeforeMount, ref, computed } from 'vue';
+import { reactive, onBeforeMount, ref } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useRoute } from 'vue-router';
-import { DateTime } from 'luxon';
-import i18next from 'i18next';
-import { ArrowLeft, Calendar, CalendarX, Clock, Repeat, MapPin, Accessibility } from 'lucide-vue-next';
+import { ArrowLeft } from 'lucide-vue-next';
 
 import CalendarService from '../service/calendar';
 import { useLocalizedContent } from '../composables/useLocalizedContent';
 import NotFound from './not-found.vue';
-import EventImage from './event-image.vue';
 import ReportEvent from './report-event.vue';
+import EventDetailBody from '@/site/components/EventDetailBody.vue';
 import { useLocale } from '@/site/composables/useLocale';
-import { useRecurrenceText } from '@/site/composables/useRecurrenceText';
-import AddToCalendar from './add-to-calendar.vue';
-import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
+import type { EventCategory } from '@/common/model/event_category';
 
 const { t } = useTranslation('system');
 const route = useRoute();
@@ -35,17 +31,6 @@ const state = reactive({
 const calendarService = new CalendarService();
 
 /**
- * Returns true when start and end fall on the same calendar day.
- *
- * @param start - The event start DateTime
- * @param end - The event end DateTime
- * @returns true if both DateTimes share the same local day
- */
-function isSameDay(start: DateTime, end: DateTime): boolean {
-  return start.hasSame(end, 'day');
-}
-
-/**
  * Opens the report event modal dialog.
  */
 function openReportModal() {
@@ -60,109 +45,12 @@ function closeReportModal() {
 }
 
 /**
- * Computed human-readable recurrence text derived from the public API's
- * `recurrenceSummary: { key, params }` intent shape. Day codes and
- * ordinals are resolved against `recurrence.*` translations and
- * multi-day lists are joined via `Intl.ListFormat` in the active locale.
+ * Builds a site-specific category filter href that links to the calendar
+ * view filtered by category id. Locale-aware via `localizedPath`.
  */
-const recurrenceText = useRecurrenceText(
-  () => state.instance?.event?.recurrenceSummary ?? null,
-);
-
-/**
- * Computed event-level accessibility info from event content.
- */
-const eventAccessibilityInfo = computed(() => {
-  if (!state.instance?.event) return '';
-  const content = localizedContent(state.instance.event);
-  return content?.accessibilityInfo ?? '';
-});
-
-/**
- * Computed localized accessibility info for the location.
- * Handles both EventLocation models (TranslatedModel) and plain objects.
- */
-const locationAccessibilityInfo = computed(() => {
-  const location = state.instance?.event?.location;
-  if (!location || typeof location.hasContent !== 'function') {
-    return '';
-  }
-  try {
-    const content = localizedContent(location);
-    return content?.accessibilityInfo ?? '';
-  }
-  catch {
-    return '';
-  }
-});
-
-/**
- * Whether to show the accessibility card (either event or location has info).
- */
-const hasAccessibilityInfo = computed(() => {
-  return !!(eventAccessibilityInfo.value || locationAccessibilityInfo.value);
-});
-
-/**
- * Returns the source calendar metadata for reposted events, or null.
- */
-const sourceCalendar = computed(() => {
-  return state.instance?.event?.sourceCalendar ?? null;
-});
-
-/**
- * Returns the display label for the source calendar pill (urlName@host).
- */
-const sourceCalendarLabel = computed(() => {
-  if (!sourceCalendar.value) return '';
-  return `${sourceCalendar.value.urlName}@${sourceCalendar.value.host}`;
-});
-
-/**
- * Returns true when the source calendar URL is a remote (external) link.
- */
-const isRemoteSourceCalendar = computed(() => {
-  if (!sourceCalendar.value) return false;
-  return sourceCalendar.value.url.startsWith('http');
-});
-
-/**
- * Returns true when this specific occurrence has been cancelled by the calendar owner.
- * Hidden cancellations are filtered server-side and should not reach this component.
- */
-const isCancelled = computed(() => {
-  return state.instance?.isCancelled === true;
-});
-
-/**
- * Defense-in-depth safe external URL computed.
- * Returns the URL only if its protocol is http: or https:, else null.
- * Guards against javascript:, data:, and other unsafe schemes even if
- * the service-layer validator is bypassed or misconfigured.
- */
-const safeExternalUrl = computed<string | null>(() => {
-  const raw = state.instance?.event?.externalUrl;
-  if (!raw || typeof raw !== 'string') return null;
-  try {
-    const parsed = new URL(raw);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed.toString();
-  }
-  catch {
-    return null;
-  }
-});
-
-/**
- * Defense-in-depth safe URL prompt computed.
- * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
- * Prevents template-key injection via arbitrary strings.
- */
-const safePrompt = computed<UrlPrompt | null>(() => {
-  const raw = state.instance?.event?.urlPrompt;
-  if (raw == null) return null;
-  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
-});
+function categoryHrefBuilder(category: EventCategory): string {
+  return localizedPath('/view/' + state.calendar.urlName) + '?category=' + category.id;
+}
 
 onBeforeMount(async () => {
   try {
@@ -235,169 +123,32 @@ onBeforeMount(async () => {
     <main class="instance-main" :aria-busy="state.isLoading">
       <div v-if="state.err" role="alert" class="error">{{ state.err }}</div>
 
-      <!-- Hero image -->
-      <div v-if="state.instance.event.media" class="hero-image-wrapper">
-        <EventImage
-          :media="state.instance.event.media"
-          context="feature"
-          :alt="localizedContent(state.instance.event).name"
-          :focal-point-x="state.instance.event.mediaFocalPointX"
-          :focal-point-y="state.instance.event.mediaFocalPointY"
-          :zoom="state.instance.event.mediaZoom"
-        />
-      </div>
-
-      <!-- Cancelled badge -->
-      <div v-if="isCancelled" class="cancelled-badge" role="status">
-        <CalendarX :size="14" aria-hidden="true" />
-        <span>{{ t('event_cancelled') }}</span>
-      </div>
-
-      <!-- Recurrence badge -->
-      <div v-if="recurrenceText" class="recurrence-badge">
-        <Repeat :size="14" aria-hidden="true" />
-        <span>{{ recurrenceText }}</span>
-      </div>
-
-      <!-- Source calendar pill -->
-      <a
-        v-if="sourceCalendar"
-        :href="sourceCalendar.url"
-        class="source-calendar-pill"
-        :aria-label="t('event_source_calendar_label', { name: sourceCalendarLabel })"
-        :target="isRemoteSourceCalendar ? '_blank' : undefined"
-        :rel="isRemoteSourceCalendar ? 'noopener noreferrer' : undefined"
-      >
-        <Calendar :size="14" aria-hidden="true" />
-        <span>{{ sourceCalendarLabel }}</span>
-      </a>
-
-      <!-- Event title -->
-      <h1 class="instance-title">{{ localizedContent(state.instance.event).name }}</h1>
-
-      <!-- Date + time row -->
-      <div class="datetime-row">
-        <div class="event-date">
-          <Calendar :size="16" class="datetime-icon datetime-icon--date" aria-hidden="true" />
-          <span>{{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY) }}</span>
-        </div>
-        <time :datetime="state.instance.start.toISO()" class="event-datetime">
-          <Clock :size="16" class="datetime-icon datetime-icon--time" aria-hidden="true" />
-          <span class="event-time-text">
-            {{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.TIME_SIMPLE) }}<template v-if="state.instance.end">
-              – {{ state.instance.end.toLocal().setLocale(i18next.language).toLocaleString(
-                isSameDay(state.instance.start, state.instance.end) ? DateTime.TIME_SIMPLE : DateTime.DATETIME_MED
-              ) }}</template>
-          </span>
-        </time>
-      </div>
-
-      <!-- Two-column content grid -->
-      <div class="detail-grid">
-        <!-- Left column: description + categories -->
-        <div class="detail-main">
-          <h2 class="about-heading">{{ t('about_this_event') }}</h2>
-          <p class="event-description">{{ localizedContent(state.instance.event).description }}</p>
-
-          <!-- Categories section -->
-          <div v-if="state.instance.event.categories && state.instance.event.categories.length" class="categories-section">
-            <h3 class="section-heading">{{ t('event_categories') }}</h3>
-            <div class="category-badges">
-              <a v-for="category in state.instance.event.categories"
-                 :key="category.id"
-                 class="event-category-badge"
-                 :href="localizedPath('/view/' + state.calendar.urlName) + '?category=' + category.id"
-              >
-                {{ localizedContent(category).name }}
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Right sidebar: location, accessibility, recurrence cards -->
-        <aside class="detail-sidebar">
-          <!-- Location card -->
-          <div v-if="state.instance.event.location" class="sidebar-card event-location">
-            <div class="card-header">
-              <MapPin :size="16" class="card-icon" aria-hidden="true" />
-              <h3 class="card-heading">{{ t('event_location') }}</h3>
-            </div>
-            <p class="location-name">{{ state.instance.event.location.name }}</p>
-            <p v-if="state.instance.event.location.address" class="location-address">
-              <a :href="'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent([state.instance.event.location.address, state.instance.event.location.city, state.instance.event.location.state].filter(Boolean).join(', '))"
-                 target="_blank"
-                 rel="noopener"
-                 :aria-label="t('get_directions')"
-              >
-                {{ state.instance.event.location.address }}
-                <template v-if="state.instance.event.location.city">
-                  <br />{{ state.instance.event.location.city }}<template v-if="state.instance.event.location.state">, {{ state.instance.event.location.state }}</template>
-                  <template v-if="state.instance.event.location.postalCode">{{ ' ' + state.instance.event.location.postalCode }}</template>
-                </template>
-              </a>
-            </p>
-          </div>
-
-          <!-- Accessibility card -->
-          <div v-if="hasAccessibilityInfo" class="sidebar-card accessibility-card">
-            <div class="card-header">
-              <Accessibility :size="16" class="card-icon" aria-hidden="true" />
-              <h3 class="card-heading">{{ t('event_accessibility') }}</h3>
-            </div>
-            <div v-if="eventAccessibilityInfo && locationAccessibilityInfo">
-              <h4 class="accessibility-subheading">{{ t('event_accessibility_event') }}</h4>
-              <p class="accessibility-info">{{ eventAccessibilityInfo }}</p>
-              <h4 class="accessibility-subheading">{{ t('event_accessibility_venue') }}</h4>
-              <p class="accessibility-info">{{ locationAccessibilityInfo }}</p>
-            </div>
-            <p v-else class="accessibility-info">{{ eventAccessibilityInfo || locationAccessibilityInfo }}</p>
-          </div>
-
-          <!-- Recurrence details card -->
-          <div v-if="recurrenceText" class="sidebar-card recurrence-card">
-            <div class="card-header">
-              <Repeat :size="16" class="card-icon" aria-hidden="true" />
-              <h3 class="card-heading">{{ t('event_recurring') }}</h3>
-            </div>
-            <p class="recurrence-text">{{ recurrenceText }}</p>
-          </div>
-
-          <!-- External link CTA -->
-          <a
-            v-if="safeExternalUrl && safePrompt"
-            :href="safeExternalUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external-link-button"
-          >
-            {{ t('url_prompt.' + safePrompt) }}
-          </a>
-
-          <!-- Add to Calendar -->
-          <AddToCalendar :event="state.instance.event" :instance="state.instance" />
-        </aside>
-      </div>
-
-      <!-- Footer: series link + report button -->
-      <footer>
-        <div
-          v-if="state.instance.event.series"
-          class="series-link-wrapper"
-        >
-          <span class="series-label">{{ t('series.label') }}</span>
-          <a
-            :href="localizedPath('/view/' + state.calendar.urlName + '/series/' + state.instance.event.series.urlName)"
-            class="event-series-link"
-            :aria-label="t('series.part_of', { name: localizedContent(state.instance.event.series).name })"
-          >{{ localizedContent(state.instance.event.series).name }}</a>
-        </div>
-        <button
-          type="button"
-          class="report-link"
-          @click="openReportModal"
-        >{{ t('report.link_text') }}</button>
-      </footer>
+      <EventDetailBody
+        :instance="state.instance"
+        :calendar="state.calendar"
+        :category-href-builder="categoryHrefBuilder"
+      />
     </main>
+
+    <!-- Footer: series link + report button -->
+    <footer class="instance-footer">
+      <div
+        v-if="state.instance.event.series"
+        class="series-link-wrapper"
+      >
+        <span class="series-label">{{ t('series.label') }}</span>
+        <a
+          :href="localizedPath('/view/' + state.calendar.urlName + '/series/' + state.instance.event.series.urlName)"
+          class="event-series-link"
+          :aria-label="t('series.part_of', { name: localizedContent(state.instance.event.series).name })"
+        >{{ localizedContent(state.instance.event.series).name }}</a>
+      </div>
+      <button
+        type="button"
+        class="report-link"
+        @click="openReportModal"
+      >{{ t('report.link_text') }}</button>
+    </footer>
 
     <ReportEvent
       v-if="showReportModal"
@@ -411,11 +162,12 @@ onBeforeMount(async () => {
 @use '../assets/mixins' as *;
 
 // ================================================================
-// EVENT INSTANCE PAGE
+// EVENT INSTANCE PAGE — SHELL
 // ================================================================
-// Two-column layout with sidebar info cards for location,
-// accessibility, and recurrence. Responsive: single column on
-// mobile/tablet, two-column grid on desktop (>= 1024px).
+// Thin shell that composes <EventDetailBody> inside a <main> element.
+// Owns the breadcrumb back-link header, the page-level <main> wrapper,
+// and the footer (series link + report button). Body content styles
+// live in EventDetailBody.vue.
 // ================================================================
 
 // ================================================================
@@ -474,7 +226,7 @@ onBeforeMount(async () => {
 }
 
 // ================================================================
-// MAIN CONTENT
+// MAIN CONTENT WRAPPER
 // ================================================================
 
 .instance-main {
@@ -492,363 +244,22 @@ onBeforeMount(async () => {
 }
 
 // ================================================================
-// HERO IMAGE
-// ================================================================
-
-.hero-image-wrapper {
-  @include public-hero-image;
-  margin-bottom: $public-space-2xl;
-
-  // Override to let EventImage fill container
-  :deep(.event-image) {
-    width: 100%;
-    height: 100%;
-    border-radius: 0;
-  }
-}
-
-// ================================================================
-// RECURRENCE BADGE
-// ================================================================
-
-.recurrence-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: $public-space-sm;
-  padding: $public-space-xs $public-space-md;
-  border-radius: $public-radius-full;
-  background-color: rgba(255, 255, 255, 0.9);
-  color: $public-text-primary-light;
-  font-size: $public-font-size-sm;
-  font-weight: $public-font-weight-medium;
-  margin-bottom: $public-space-md;
-
-  @include public-dark-mode {
-    background-color: rgba(30, 30, 35, 0.85);
-    color: $public-text-primary-dark;
-  }
-}
-
-// ================================================================
-// CANCELLED BADGE
-// ================================================================
-
-.cancelled-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: $public-space-sm;
-  padding: $public-space-xs $public-space-md;
-  border-radius: $public-radius-full;
-  background-color: $public-error-light;
-  color: #fff;
-  font-size: $public-font-size-sm;
-  font-weight: $public-font-weight-semibold;
-  text-transform: uppercase;
-  letter-spacing: $public-letter-spacing-wide;
-  margin-bottom: $public-space-md;
-  margin-right: $public-space-sm;
-
-  @include public-dark-mode {
-    background-color: $public-error-dark;
-    color: $public-bg-primary-dark;
-  }
-}
-
-// ================================================================
-// SOURCE CALENDAR PILL
-// ================================================================
-
-.source-calendar-pill {
-  @include public-source-calendar-pill;
-  margin-bottom: $public-space-md;
-}
-
-// ================================================================
-// TITLE
-// ================================================================
-
-.instance-title {
-  font-size: $public-font-size-2xl;
-  font-weight: $public-font-weight-bold;
-  letter-spacing: $public-letter-spacing-tight;
-  line-height: $public-line-height-tight;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-lg 0;
-
-  @include public-tablet-up {
-    font-size: 40px;
-  }
-
-  @include public-desktop-up {
-    font-size: 48px;
-  }
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-}
-
-// ================================================================
-// DATE + TIME ROW
-// ================================================================
-
-.datetime-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $public-space-sm $public-space-xl;
-  margin-bottom: $public-space-2xl;
-}
-
-.event-date,
-.event-datetime {
-  display: inline-flex;
-  align-items: center;
-  gap: $public-space-sm;
-  font-size: $public-font-size-base;
-  font-weight: $public-font-weight-medium;
-  color: $public-text-secondary-light;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-.datetime-icon {
-  flex-shrink: 0;
-
-  &--date {
-    color: $public-accent-light;
-
-    @include public-dark-mode {
-      color: $public-accent-dark;
-    }
-  }
-
-  &--time {
-    color: $public-text-secondary-light;
-
-    @include public-dark-mode {
-      color: $public-text-secondary-dark;
-    }
-  }
-}
-
-// ================================================================
-// TWO-COLUMN DETAIL GRID
-// ================================================================
-
-.detail-grid {
-  @include public-detail-grid;
-  margin-bottom: $public-space-2xl;
-}
-
-// ================================================================
-// LEFT COLUMN: DESCRIPTION + CATEGORIES
-// ================================================================
-
-.detail-main {
-  min-width: 0; // Prevent grid blowout
-}
-
-.sr-only {
-  @include public-sr-only;
-}
-
-.about-heading {
-  font-size: $public-font-size-md;
-  font-weight: $public-font-weight-semibold;
-  color: $public-text-secondary-light;
-  margin: 0 0 $public-space-md 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-.event-description {
-  font-size: $public-font-size-md;
-  line-height: $public-line-height-relaxed;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-xl 0;
-  white-space: pre-line;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-}
-
-.categories-section {
-  margin-top: $public-space-lg;
-}
-
-.section-heading {
-  font-size: $public-font-size-xs;
-  font-weight: $public-font-weight-semibold;
-  text-transform: uppercase;
-  letter-spacing: $public-letter-spacing-wide;
-  color: $public-text-secondary-light;
-  margin: 0 0 $public-space-sm 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-.category-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $public-space-sm;
-}
-
-.event-category-badge {
-  @include public-category-badge;
-
-  text-decoration: none;
-  transition: $public-transition-fast;
-
-  &:hover {
-    background-color: $public-accent-hover-light;
-    transform: translateY(-1px);
-
-    @include public-dark-mode {
-      background-color: $public-accent-hover-dark;
-    }
-  }
-
-  &:focus-visible {
-    @include public-focus-visible;
-  }
-}
-
-// ================================================================
-// RIGHT SIDEBAR: INFO CARDS
-// ================================================================
-
-.detail-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: $public-space-lg;
-}
-
-.sidebar-card {
-  @include public-sidebar-card;
-}
-
-.card-header {
-  display: flex;
-  align-items: center;
-  gap: $public-space-sm;
-  margin-bottom: $public-space-md;
-}
-
-.card-icon {
-  color: $public-text-secondary-light;
-  flex-shrink: 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-.card-heading {
-  font-size: $public-font-size-xs;
-  font-weight: $public-font-weight-semibold;
-  text-transform: uppercase;
-  letter-spacing: $public-letter-spacing-wide;
-  color: $public-text-secondary-light;
-  margin: 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-// Location card
-.location-name {
-  font-size: $public-font-size-base;
-  font-weight: $public-font-weight-medium;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-xs 0;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-}
-
-.location-address {
-  font-size: $public-font-size-sm;
-  color: $public-text-secondary-light;
-  margin: 0;
-  line-height: $public-line-height-relaxed;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-// Accessibility card
-.accessibility-subheading {
-  font-size: $public-font-size-sm;
-  font-weight: $public-font-weight-semibold;
-  color: $public-text-secondary-light;
-  margin: 0 0 $public-space-xs 0;
-
-  &:not(:first-child) {
-    margin-top: $public-space-md;
-  }
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-}
-
-.accessibility-info {
-  font-size: $public-font-size-base;
-  color: $public-text-primary-light;
-  margin: 0;
-  white-space: pre-line;
-  line-height: $public-line-height-relaxed;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-}
-
-// Recurrence card
-.recurrence-text {
-  font-size: $public-font-size-base;
-  color: $public-text-primary-light;
-  margin: 0;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-}
-
-// ================================================================
-// EXTERNAL LINK CTA BUTTON
-// ================================================================
-
-.external-link-button {
-  @include public-button-primary;
-
-  min-height: 44px;
-  text-decoration: none;
-  text-align: center;
-
-  &:focus-visible {
-    @include public-focus-visible;
-  }
-}
-
-// ================================================================
 // FOOTER: SERIES LINK + REPORT BUTTON
 // ================================================================
 
-footer {
-  margin-top: $public-space-xl;
-  padding-top: $public-space-lg;
+.instance-footer {
+  max-width: 72rem;
+  margin: $public-space-xl auto 0 auto;
+  padding: $public-space-lg $public-space-lg 0 $public-space-lg;
   border-top: 1px solid $public-border-subtle-light;
+
+  @include public-tablet-up {
+    padding: $public-space-lg $public-space-xl 0 $public-space-xl;
+  }
+
+  @include public-desktop-up {
+    padding: $public-space-lg $public-space-2xl 0 $public-space-2xl;
+  }
 
   @include public-dark-mode {
     border-top-color: $public-border-subtle-dark;

--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -49,7 +49,7 @@ function closeReportModal() {
  * view filtered by category id. Locale-aware via `localizedPath`.
  */
 function categoryHrefBuilder(category: EventCategory): string {
-  return localizedPath('/view/' + state.calendar.urlName) + '?category=' + category.id;
+  return localizedPath('/view/' + state.calendar.urlName) + '?categories=' + category.id;
 }
 
 onBeforeMount(async () => {

--- a/src/site/components/event.vue
+++ b/src/site/components/event.vue
@@ -229,7 +229,7 @@ function closeReportModal() {
               <a v-for="category in state.event.categories"
                  :key="category.id"
                  class="event-category-badge"
-                 :href="localizedPath('/view/' + state.calendar.urlName) + '?category=' + category.id"
+                 :href="localizedPath('/view/' + state.calendar.urlName) + '?categories=' + category.id"
               >
                 {{ localizedContent(category).name }}
               </a>

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -85,6 +85,8 @@
     "event_add_to_calendar": "Add to Calendar",
     "event_source_calendar": "Source Calendar",
     "event_source_calendar_label": "View source calendar {{name}}",
+    "event_details_sidebar": "Event details",
+    "opens_in_new_tab": "opens in new tab",
     "url_prompt": {
         "tickets": "Tickets",
         "rsvp": "RSVP",

--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -85,6 +85,8 @@
     "event_add_to_calendar": "Agregar al calendario",
     "event_source_calendar": "Calendario fuente",
     "event_source_calendar_label": "Ver calendario fuente {{name}}",
+    "event_details_sidebar": "Detalles del evento",
+    "opens_in_new_tab": "se abre en una pestaña nueva",
     "report": {
         "link_text": "Reportar evento",
         "form_title": "Reportar este evento",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -80,6 +80,8 @@
     "event_add_to_calendar": "Ajouter au calendrier",
     "event_source_calendar": "Calendrier source",
     "event_source_calendar_label": "Voir le calendrier source {{name}}",
+    "event_details_sidebar": "Détails de l'événement",
+    "opens_in_new_tab": "s'ouvre dans un nouvel onglet",
     "report": {
         "link_text": "Signaler l'événement",
         "form_title": "Signaler cet événement",

--- a/src/site/test/components/EventDetailBody.test.ts
+++ b/src/site/test/components/EventDetailBody.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Tests for EventDetailBody.vue.
+ *
+ * EventDetailBody is the shared presentational body of the event detail
+ * page. It renders the hero image, badges, source-calendar pill, title,
+ * datetime row, and the two-column grid of description/categories +
+ * sidebar info cards (location, accessibility, recurrence) + external
+ * CTA + AddToCalendar.
+ *
+ * Validates:
+ *  - Happy-path rendering of each region given a populated instance.
+ *  - The `categoryHrefBuilder` prop seam: function → categories render as
+ *    `<a>`, undefined → categories render as `<span>`.
+ *  - CTA security guards (moved from the widget overlay test):
+ *    - javascript: / data: / malformed URLs blocked
+ *    - unknown urlPrompt blocked
+ *    - null externalUrl OR null urlPrompt → CTA omitted
+ *    - valid http/https + known prompt → CTA rendered with target=_blank
+ *      and rel=noopener noreferrer
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { mount, VueWrapper } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import I18NextVue from 'i18next-vue';
+import i18next from 'i18next';
+import { DateTime } from 'luxon';
+
+import { Calendar as CalendarModel, CalendarContent } from '@/common/model/calendar';
+import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before component import
+// ---------------------------------------------------------------------------
+
+// Mock useLocale so useLocalizedContent doesn't reach for vue-router; the
+// component is presentational and never builds URLs itself.
+vi.mock('@/site/composables/useLocale', () => ({
+  useLocale: () => ({
+    currentLocale: { value: 'en' },
+    switchLocale: vi.fn(),
+    localizedPath: (path: string) => path,
+  }),
+}));
+
+vi.mock('@/site/components/event-image.vue', () => ({
+  default: {
+    template: '<div class="event-image-stub"></div>',
+    props: ['media', 'context', 'alt', 'focalPointX', 'focalPointY', 'zoom'],
+  },
+}));
+
+vi.mock('@/site/components/add-to-calendar.vue', () => ({
+  default: {
+    template: '<div class="add-to-calendar-stub"></div>',
+    props: ['event', 'instance'],
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Subject under test
+// ---------------------------------------------------------------------------
+import EventDetailBody from '@/site/components/EventDetailBody.vue';
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+interface InstanceOverrides {
+  media?: any;
+  categories?: EventCategory[];
+  location?: any;
+  recurrenceSummary?: any;
+  sourceCalendar?: any;
+  externalUrl?: string | null;
+  urlPrompt?: string | null;
+  isCancelled?: boolean;
+  end?: any;
+  accessibilityInfo?: string;
+}
+
+function makeCategory(id: string, name: string): EventCategory {
+  const cat = new EventCategory(id, 'cal-1');
+  const content = new EventCategoryContent('en', name);
+  cat.addContent(content);
+  return cat;
+}
+
+function makeCalendar(): CalendarModel {
+  const cal = new CalendarModel('cal-1', 'test_calendar');
+  const content = new CalendarContent('en');
+  content.name = 'Test Calendar';
+  cal.addContent(content);
+  return cal;
+}
+
+function makeInstance(overrides: InstanceOverrides = {}): any {
+  const start = DateTime.fromISO('2026-05-08T18:00:00.000Z');
+  const end = overrides.end === undefined ? null : overrides.end;
+
+  return {
+    id: 'inst-1',
+    start,
+    end,
+    isCancelled: overrides.isCancelled ?? false,
+    event: {
+      id: 'evt-1',
+      content: (_lang: string) => ({
+        name: 'Test Event',
+        description: 'A description of the event.',
+        accessibilityInfo: overrides.accessibilityInfo ?? '',
+      }),
+      hasContent: (_lang: string) => true,
+      getLanguages: () => ['en'],
+      media: overrides.media ?? null,
+      mediaFocalPointX: 0.5,
+      mediaFocalPointY: 0.5,
+      mediaZoom: 1.0,
+      categories: overrides.categories ?? [],
+      recurrenceSummary: overrides.recurrenceSummary ?? null,
+      location: overrides.location ?? null,
+      sourceCalendar: overrides.sourceCalendar ?? null,
+      externalUrl: overrides.externalUrl ?? null,
+      urlPrompt: overrides.urlPrompt ?? null,
+    },
+  };
+}
+
+function mountBody(props: {
+  instance: any;
+  calendar?: CalendarModel;
+  categoryHrefBuilder?: (cat: EventCategory) => string;
+}): VueWrapper {
+  const pinia = createPinia();
+  return mount(EventDetailBody, {
+    global: {
+      plugins: [
+        [I18NextVue, { i18next }],
+        pinia,
+      ],
+    },
+    props: {
+      instance: props.instance,
+      calendar: props.calendar ?? makeCalendar(),
+      categoryHrefBuilder: props.categoryHrefBuilder,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// i18next initialisation
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  const resources = {
+    about_this_event: 'About This Event',
+    event_categories: 'Categories',
+    event_location: 'Location',
+    event_accessibility: 'Accessibility',
+    event_accessibility_event: 'Event',
+    event_accessibility_venue: 'Venue',
+    event_recurring: 'Recurring',
+    event_cancelled: 'Cancelled',
+    event_source_calendar_label: 'View source calendar {{name}}',
+    get_directions: 'Get directions',
+    url_prompt: {
+      tickets: 'Tickets',
+      rsvp: 'RSVP',
+      more_info: 'More Information',
+      register: 'Register',
+    },
+  };
+
+  if (!i18next.isInitialized) {
+    await i18next.init({
+      lng: 'en',
+      resources: {
+        en: {
+          system: resources,
+        },
+      },
+    });
+  }
+  else {
+    i18next.addResourceBundle('en', 'system', resources, true, true);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EventDetailBody', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('happy-path rendering', () => {
+    it('renders the hero image when instance.event.media is present', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({ media: { id: 'media-1', url: 'image.jpg' } }),
+      });
+      expect(wrapper.find('.hero-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.event-image-stub').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('does not render the hero image when instance.event.media is null', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.hero-image-wrapper').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('renders the title from localizedContent(instance.event).name', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.instance-title').text()).toBe('Test Event');
+      wrapper.unmount();
+    });
+
+    it('renders the datetime row with date and time elements', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.datetime-row').exists()).toBe(true);
+      expect(wrapper.find('.event-date').exists()).toBe(true);
+      expect(wrapper.find('.event-datetime').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('renders the description', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.event-description').text()).toBe('A description of the event.');
+      wrapper.unmount();
+    });
+
+    it('renders the categories list when categories are present', () => {
+      const cats = [
+        makeCategory('cat-1', 'Music'),
+        makeCategory('cat-2', 'Outdoors'),
+      ];
+      const wrapper = mountBody({ instance: makeInstance({ categories: cats }) });
+      expect(wrapper.find('.categories-section').exists()).toBe(true);
+      const badges = wrapper.findAll('.event-category-badge');
+      expect(badges).toHaveLength(2);
+      expect(badges[0].text()).toBe('Music');
+      expect(badges[1].text()).toBe('Outdoors');
+      wrapper.unmount();
+    });
+
+    it('does not render the categories section when categories are empty', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.categories-section').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('renders the location sidebar card when location is present', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          location: {
+            name: 'Town Hall',
+            address: '123 Main St',
+            city: 'Anytown',
+            state: 'CA',
+            postalCode: '94000',
+          },
+        }),
+      });
+      expect(wrapper.find('.event-location').exists()).toBe(true);
+      expect(wrapper.find('.location-name').text()).toBe('Town Hall');
+      expect(wrapper.find('.location-address').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('renders the accessibility card when event accessibility info is present', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({ accessibilityInfo: 'Wheelchair ramp at side entrance.' }),
+      });
+      expect(wrapper.find('.accessibility-card').exists()).toBe(true);
+      expect(wrapper.find('.accessibility-info').text()).toBe('Wheelchair ramp at side entrance.');
+      wrapper.unmount();
+    });
+
+    it('renders the recurrence card when recurrenceSummary is present', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          recurrenceSummary: { key: 'recurrence.weekly', params: {} },
+        }),
+      });
+      expect(wrapper.find('.recurrence-card').exists()).toBe(true);
+      expect(wrapper.find('.recurrence-badge').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('renders the external CTA when externalUrl + urlPrompt are valid', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'https://example.com/tix',
+          urlPrompt: 'tickets',
+        }),
+      });
+      const cta = wrapper.find('.external-link-button');
+      expect(cta.exists()).toBe(true);
+      expect(cta.attributes('href')).toBe('https://example.com/tix');
+      expect(cta.text()).toContain('Tickets');
+      wrapper.unmount();
+    });
+
+    it('renders <AddToCalendar> in the right column', () => {
+      const wrapper = mountBody({ instance: makeInstance() });
+      expect(wrapper.find('.add-to-calendar-stub').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('renders the cancelled badge when instance.isCancelled is true', () => {
+      const wrapper = mountBody({ instance: makeInstance({ isCancelled: true }) });
+      expect(wrapper.find('.cancelled-badge').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('does not render the cancelled badge when instance.isCancelled is false', () => {
+      const wrapper = mountBody({ instance: makeInstance({ isCancelled: false }) });
+      expect(wrapper.find('.cancelled-badge').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('renders the source-calendar pill when sourceCalendar is present', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          sourceCalendar: {
+            urlName: 'remote_cal',
+            host: 'remote.example',
+            url: 'https://remote.example/view/remote_cal',
+          },
+        }),
+      });
+      const pill = wrapper.find('.source-calendar-pill');
+      expect(pill.exists()).toBe(true);
+      expect(pill.text()).toBe('remote_cal@remote.example');
+      expect(pill.attributes('target')).toBe('_blank');
+      expect(pill.attributes('rel')).toBe('noopener noreferrer');
+      wrapper.unmount();
+    });
+  });
+
+  describe('categoryHrefBuilder seam', () => {
+    it('renders categories as <a> when builder is provided, with builder(cat) as href', () => {
+      const cats = [makeCategory('cat-1', 'Music')];
+      const wrapper = mountBody({
+        instance: makeInstance({ categories: cats }),
+        categoryHrefBuilder: (cat) => `/view/test_calendar?category=${cat.id}`,
+      });
+      const badge = wrapper.find('.event-category-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.element.tagName).toBe('A');
+      expect(badge.attributes('href')).toBe('/view/test_calendar?category=cat-1');
+      wrapper.unmount();
+    });
+
+    it('renders categories as <span> when builder is undefined', () => {
+      const cats = [makeCategory('cat-1', 'Music')];
+      const wrapper = mountBody({ instance: makeInstance({ categories: cats }) });
+      const badge = wrapper.find('.event-category-badge');
+      expect(badge.exists()).toBe(true);
+      expect(badge.element.tagName).toBe('SPAN');
+      expect(badge.attributes('href')).toBeUndefined();
+      wrapper.unmount();
+    });
+  });
+
+  describe('external URL CTA security guards', () => {
+    // Cases moved from src/widget/test/event-detail-overlay.test.ts (the
+    // widget overlay test slimming happens in pv-rtu1.2.4).
+
+    it('should render CTA anchor when externalUrl and urlPrompt are both valid', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'https://tickets.example.com/show/123',
+          urlPrompt: 'tickets',
+        }),
+      });
+      const cta = wrapper.find('.external-link-button');
+      expect(cta.exists()).toBe(true);
+      expect(cta.attributes('href')).toBe('https://tickets.example.com/show/123');
+      wrapper.unmount();
+    });
+
+    it('should use target="_blank" and rel="noopener noreferrer" on the CTA anchor', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'https://rsvp.example.com/party',
+          urlPrompt: 'rsvp',
+        }),
+      });
+      const cta = wrapper.find('.external-link-button');
+      expect(cta.exists()).toBe(true);
+      expect(cta.attributes('target')).toBe('_blank');
+      expect(cta.attributes('rel')).toBe('noopener noreferrer');
+      wrapper.unmount();
+    });
+
+    it('should display the translated label from system:url_prompt.<prompt>', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'https://example.com/info',
+          urlPrompt: 'more_info',
+        }),
+      });
+      const cta = wrapper.find('.external-link-button');
+      expect(cta.exists()).toBe(true);
+      expect(cta.text()).toContain('More Information');
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA when externalUrl is null', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({ externalUrl: null, urlPrompt: 'tickets' }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA when urlPrompt is null', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({ externalUrl: 'https://example.com', urlPrompt: null }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA for javascript: URLs (defense-in-depth)', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'javascript:alert(1)',
+          urlPrompt: 'tickets',
+        }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA for unknown urlPrompt values', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'https://example.com',
+          urlPrompt: 'hack',
+        }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA for malformed URLs', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'not a url at all',
+          urlPrompt: 'tickets',
+        }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should NOT render the CTA for data: URLs (defense-in-depth)', () => {
+      const wrapper = mountBody({
+        instance: makeInstance({
+          externalUrl: 'data:text/html,<script>alert(1)</script>',
+          urlPrompt: 'tickets',
+        }),
+      });
+      expect(wrapper.find('.external-link-button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/site/test/components/event-card.test.ts
+++ b/src/site/test/components/event-card.test.ts
@@ -220,6 +220,34 @@ describe('EventCard', () => {
       expect(href).toContain('/view/my-calendar/events/evt-abc/20260508-1800');
       wrapper.unmount();
     });
+
+    it('should fall back to localizedPath when detailHref is omitted', async () => {
+      const event = makeEvent({ name: 'Default Path Event' });
+      (event as any).id = 'evt-default';
+      const instance = makeInstance(event, '2026-06-10T12:00:00.000Z');
+      const wrapper = await mountEventCard(instance, 'site-cal');
+
+      const link = wrapper.find('.event-title-link');
+      expect(link.exists()).toBe(true);
+      // Without detailHref, the href is the site-computed localizedPath value.
+      expect(link.attributes('href')).toBe('/view/site-cal/events/evt-default/20260610-1200');
+      wrapper.unmount();
+    });
+
+    it('should use detailHref directly when prop is provided', async () => {
+      const event = makeEvent({ name: 'Widget Hosted Event' });
+      (event as any).id = 'evt-widget';
+      const instance = makeInstance(event, '2026-06-10T12:00:00.000Z');
+      const wrapper = await mountEventCard(instance, 'site-cal', {
+        detailHref: '/widget/some/path?event=evt-widget',
+      });
+
+      const link = wrapper.find('.event-title-link');
+      expect(link.exists()).toBe(true);
+      // detailHref short-circuits the localizedPath computation.
+      expect(link.attributes('href')).toBe('/widget/some/path?event=evt-widget');
+      wrapper.unmount();
+    });
   });
 
   describe('time range display', () => {

--- a/src/site/test/components/event-instance.test.ts
+++ b/src/site/test/components/event-instance.test.ts
@@ -116,6 +116,7 @@ vi.mock('@/site/service/calendar', () => {
         Promise.resolve({
           start: {
             toISO: () => '2026-03-01T10:00:00.000Z',
+            toISODate: () => '2026-03-01',
             toLocal: () => ({
               setLocale: (_locale: string) => ({
                 toLocaleString: () => 'March 1, 2026, 10:00 AM',
@@ -1397,7 +1398,10 @@ describe('event instance external URL CTA button', () => {
 
     const cta = wrapper.find('.external-link-button');
     expect(cta.exists()).toBe(true);
-    expect(cta.text()).toBe('More Information');
+    // Visible label is "More Information"; an sr-only span follows with
+    // localized "(opens in new tab)" affordance — use toContain to allow
+    // the sr-only suffix without making the assertion locale-fragile.
+    expect(cta.text()).toContain('More Information');
     wrapper.unmount();
   });
 

--- a/src/site/test/components/event-instance.test.ts
+++ b/src/site/test/components/event-instance.test.ts
@@ -526,7 +526,7 @@ describe('eventInstance category badge locale behaviour', () => {
 
       const badge = wrapper.find('.event-category-badge');
       expect(badge.exists()).toBe(true);
-      expect(badge.attributes('href')).toContain('category=uuid-arts-123');
+      expect(badge.attributes('href')).toContain('?categories=uuid-arts-123');
       wrapper.unmount();
     });
 
@@ -575,7 +575,7 @@ describe('eventInstance category badge locale behaviour', () => {
       expect(badge.exists()).toBe(true);
       const href = badge.attributes('href') ?? '';
       expect(href).toContain('/es/');
-      expect(href).toContain('category=cat-uuid-002');
+      expect(href).toContain('?categories=cat-uuid-002');
       wrapper.unmount();
     });
   });
@@ -658,8 +658,8 @@ describe('eventInstance category badge locale behaviour', () => {
       );
 
       const badges = wrapper.findAll('.event-category-badge');
-      expect(badges[0].attributes('href')).toContain('category=uuid-alpha');
-      expect(badges[1].attributes('href')).toContain('category=uuid-beta');
+      expect(badges[0].attributes('href')).toContain('?categories=uuid-alpha');
+      expect(badges[1].attributes('href')).toContain('?categories=uuid-beta');
       wrapper.unmount();
     });
   });

--- a/src/site/test/components/event.test.ts
+++ b/src/site/test/components/event.test.ts
@@ -498,7 +498,7 @@ describe('event category badge behaviour', () => {
 
     const badge = wrapper.find('.event-category-badge');
     expect(badge.exists()).toBe(true);
-    expect(badge.attributes('href')).toContain('category=uuid-arts-123');
+    expect(badge.attributes('href')).toContain('?categories=uuid-arts-123');
     wrapper.unmount();
   });
 
@@ -606,7 +606,7 @@ describe('event category badge behaviour', () => {
     expect(badge.exists()).toBe(true);
     const href = badge.attributes('href') ?? '';
     expect(href).toContain('/es/');
-    expect(href).toContain('category=cat-uuid-002');
+    expect(href).toContain('?categories=cat-uuid-002');
     wrapper.unmount();
   });
 });

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -1,26 +1,19 @@
 <script setup lang="ts">
-import { reactive, computed, onBeforeMount } from 'vue';
+import { reactive, onBeforeMount } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useRoute, useRouter } from 'vue-router';
-import { DateTime } from 'luxon';
-import i18next from 'i18next';
-import { ArrowLeft, Calendar, Clock, Repeat, MapPin, Accessibility } from 'lucide-vue-next';
+import { ArrowLeft } from 'lucide-vue-next';
 
 import CalendarService from '@/site/service/calendar';
 import { useWidgetStore } from '../stores/widgetStore';
-import { useLocalizedContent } from '@/site/composables/useLocalizedContent';
 import NotFound from '@/site/components/not-found.vue';
-import EventImage from '@/site/components/event-image.vue';
-import AddToCalendar from '@/site/components/add-to-calendar.vue';
-import { useRecurrenceText } from '@/site/composables/useRecurrenceText';
-import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
+import EventDetailBody from '@/site/components/EventDetailBody.vue';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
 
 const { t } = useTranslation('system');
 const route = useRoute();
 const router = useRouter();
 const widgetStore = useWidgetStore();
-const { localizedContent } = useLocalizedContent();
 
 const calendarId = route.params.urlName;
 const eventId = route.params.eventId;
@@ -35,75 +28,6 @@ const state = reactive({
 });
 
 const calendarService = new CalendarService();
-
-/**
- * Returns true when start and end fall on the same calendar day.
- */
-function isSameDay(start: DateTime, end: DateTime): boolean {
-  return start.hasSame(end, 'day');
-}
-
-/**
- * Computed human-readable recurrence text derived from the public API's
- * `recurrenceSummary: { key, params }` intent shape. Day codes, ordinals,
- * and multi-day list joining are resolved in the active locale.
- */
-const recurrenceText = useRecurrenceText(
-  () => state.instance?.event?.recurrenceSummary ?? null,
-);
-
-const locationAccessibilityInfo = computed(() => {
-  const location = state.instance?.event?.location;
-  if (!location || typeof location.hasContent !== 'function') {
-    return '';
-  }
-  try {
-    const content = localizedContent(location);
-    return content?.accessibilityInfo ?? '';
-  }
-  catch {
-    return '';
-  }
-});
-
-const sourceCalendar = computed(() => {
-  return state.instance?.event?.sourceCalendar ?? null;
-});
-
-const sourceCalendarLabel = computed(() => {
-  if (!sourceCalendar.value) return '';
-  return `${sourceCalendar.value.urlName}@${sourceCalendar.value.host}`;
-});
-
-/**
- * Defense-in-depth safe external URL computed.
- * Returns the URL only if its protocol is http: or https:, else null.
- * Guards against javascript:, data:, and other unsafe schemes even if
- * the service-layer validator is bypassed or misconfigured.
- */
-const safeExternalUrl = computed<string | null>(() => {
-  const raw = state.instance?.event?.externalUrl;
-  if (!raw || typeof raw !== 'string') return null;
-  try {
-    const parsed = new URL(raw);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed.toString();
-  }
-  catch {
-    return null;
-  }
-});
-
-/**
- * Defense-in-depth safe URL prompt computed.
- * Returns the prompt value only if it is in URL_PROMPT_VALUES, else null.
- * Prevents template-key injection via arbitrary strings.
- */
-const safePrompt = computed<UrlPrompt | null>(() => {
-  const raw = state.instance?.event?.urlPrompt;
-  if (raw == null) return null;
-  return URL_PROMPT_VALUES.includes(raw as UrlPrompt) ? (raw as UrlPrompt) : null;
-});
 
 const goBack = () => {
   router.push({
@@ -177,7 +101,7 @@ onBeforeMount(async () => {
 <template>
   <div class="event-detail-overlay">
     <!-- Loading State -->
-    <div v-if="state.isLoading" class="loading">
+    <div v-if="state.isLoading" role="status" class="loading">
       {{ t('loading_event') }}
     </div>
 
@@ -188,14 +112,14 @@ onBeforeMount(async () => {
 
     <!-- Error State -->
     <div v-else-if="state.err" class="error-container">
-      <div class="error">{{ state.err }}</div>
+      <div class="error" role="alert">{{ state.err }}</div>
       <button type="button" class="back-button" @click="goBack">
         {{ t('back_to_calendar', { name: widgetStore.calendarUrlName || '' }) }}
       </button>
     </div>
 
     <!-- Event Detail Content -->
-    <div v-else-if="state.instance" class="event-detail-content">
+    <div v-else-if="state.instance && state.calendar" class="event-detail-content">
       <!-- Back link header -->
       <header class="instance-back-header">
         <button type="button"
@@ -208,134 +132,10 @@ onBeforeMount(async () => {
       </header>
 
       <main class="instance-main">
-        <!-- Hero image -->
-        <div v-if="state.instance.event.media" class="hero-image-wrapper">
-          <EventImage
-            :media="state.instance.event.media"
-            context="feature"
-            :alt="localizedContent(state.instance.event).name"
-            :focal-point-x="state.instance.event.mediaFocalPointX"
-            :focal-point-y="state.instance.event.mediaFocalPointY"
-            :zoom="state.instance.event.mediaZoom"
-          />
-        </div>
-
-        <!-- Recurrence badge -->
-        <div v-if="recurrenceText" class="recurrence-badge">
-          <Repeat :size="14" aria-hidden="true" />
-          <span>{{ recurrenceText }}</span>
-        </div>
-
-        <!-- Source calendar pill -->
-        <a
-          v-if="sourceCalendar"
-          :href="sourceCalendar.url"
-          class="source-calendar-pill"
-          :aria-label="t('event_source_calendar_label', { name: sourceCalendarLabel })"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Calendar :size="14" aria-hidden="true" />
-          <span>{{ sourceCalendarLabel }}</span>
-        </a>
-
-        <!-- Event title -->
-        <h1 class="instance-title">{{ localizedContent(state.instance.event).name }}</h1>
-
-        <!-- Date + time row -->
-        <div class="datetime-row">
-          <div class="event-date">
-            <Calendar :size="16" class="datetime-icon datetime-icon--date" aria-hidden="true" />
-            <span>{{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.DATE_MED_WITH_WEEKDAY) }}</span>
-          </div>
-          <time :datetime="state.instance.start.toISO()" class="event-datetime">
-            <Clock :size="16" class="datetime-icon datetime-icon--time" aria-hidden="true" />
-            <span class="event-time-text">
-              {{ state.instance.start.toLocal().setLocale(i18next.language).toLocaleString(DateTime.TIME_SIMPLE) }}<template v-if="state.instance.end">
-                – {{ state.instance.end.toLocal().setLocale(i18next.language).toLocaleString(
-                  isSameDay(state.instance.start, state.instance.end) ? DateTime.TIME_SIMPLE : DateTime.DATETIME_MED
-                ) }}</template>
-            </span>
-          </time>
-        </div>
-
-        <!-- Two-column content grid -->
-        <div class="detail-grid">
-          <!-- Left column: description + categories -->
-          <div class="detail-main">
-            <h2 class="about-heading">{{ t('about_this_event') }}</h2>
-            <p class="event-description">{{ localizedContent(state.instance.event).description }}</p>
-
-            <div v-if="state.instance.event.categories && state.instance.event.categories.length" class="categories-section">
-              <h3 class="section-heading">{{ t('event_categories') }}</h3>
-              <div class="category-badges">
-                <span v-for="category in state.instance.event.categories"
-                      :key="category.id"
-                      class="event-category-badge"
-                >
-                  {{ localizedContent(category).name }}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <!-- Right sidebar: location, accessibility, recurrence cards -->
-          <aside class="detail-sidebar">
-            <!-- Location card -->
-            <div v-if="state.instance.event.location" class="sidebar-card event-location">
-              <div class="card-header">
-                <MapPin :size="16" class="card-icon" aria-hidden="true" />
-                <h3 class="card-heading">{{ t('event_location') }}</h3>
-              </div>
-              <p class="location-name">{{ state.instance.event.location.name }}</p>
-              <p v-if="state.instance.event.location.address" class="location-address">
-                <a :href="'https://www.google.com/maps/search/?api=1&query=' + encodeURIComponent([state.instance.event.location.address, state.instance.event.location.city, state.instance.event.location.state].filter(Boolean).join(', '))"
-                   target="_blank"
-                   rel="noopener"
-                   :aria-label="t('get_directions')"
-                >
-                  {{ state.instance.event.location.address }}
-                  <template v-if="state.instance.event.location.city">
-                    <br />{{ state.instance.event.location.city }}<template v-if="state.instance.event.location.state">, {{ state.instance.event.location.state }}</template>
-                    <template v-if="state.instance.event.location.postalCode">{{ ' ' + state.instance.event.location.postalCode }}</template>
-                  </template>
-                </a>
-              </p>
-            </div>
-
-            <!-- Accessibility card -->
-            <div v-if="locationAccessibilityInfo" class="sidebar-card accessibility-card">
-              <div class="card-header">
-                <Accessibility :size="16" class="card-icon" aria-hidden="true" />
-                <h3 class="card-heading">{{ t('event_accessibility') }}</h3>
-              </div>
-              <p class="accessibility-info">{{ locationAccessibilityInfo }}</p>
-            </div>
-
-            <!-- Recurrence details card -->
-            <div v-if="recurrenceText" class="sidebar-card recurrence-card">
-              <div class="card-header">
-                <Repeat :size="16" class="card-icon" aria-hidden="true" />
-                <h3 class="card-heading">{{ t('event_recurring') }}</h3>
-              </div>
-              <p class="recurrence-text">{{ recurrenceText }}</p>
-            </div>
-
-            <!-- External link CTA -->
-            <a
-              v-if="safeExternalUrl && safePrompt"
-              :href="safeExternalUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="external-link-button"
-            >
-              {{ t('url_prompt.' + safePrompt) }}
-            </a>
-
-            <!-- Add to Calendar -->
-            <AddToCalendar :event="state.instance.event" :instance="state.instance" />
-          </aside>
-        </div>
+        <EventDetailBody
+          :instance="state.instance"
+          :calendar="state.calendar"
+        />
       </main>
     </div>
   </div>
@@ -449,355 +249,6 @@ onBeforeMount(async () => {
 
   @include public-desktop-up {
     padding: 0 $public-space-2xl $public-space-2xl;
-  }
-}
-
-// ================================================================
-// HERO IMAGE
-// ================================================================
-
-.hero-image-wrapper {
-  @include public-hero-image;
-  margin-bottom: $public-space-2xl;
-
-  :deep(.event-image) {
-    width: 100%;
-    height: 100%;
-    border-radius: 0;
-  }
-}
-
-// ================================================================
-// RECURRENCE BADGE
-// ================================================================
-
-.recurrence-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: $public-space-sm;
-  padding: $public-space-xs $public-space-md;
-  border-radius: $public-radius-full;
-  background-color: rgba(255, 255, 255, 0.9);
-  color: $public-text-primary-light;
-  font-size: $public-font-size-sm;
-  font-weight: $public-font-weight-medium;
-  margin-bottom: $public-space-md;
-
-  @include public-dark-mode {
-    background-color: rgba(30, 30, 35, 0.85);
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    background-color: rgba(255, 255, 255, 0.9);
-    color: $public-text-primary-light;
-  }
-}
-
-// ================================================================
-// SOURCE CALENDAR PILL
-// ================================================================
-
-.source-calendar-pill {
-  @include public-source-calendar-pill;
-  margin-bottom: $public-space-md;
-}
-
-// ================================================================
-// TITLE
-// ================================================================
-
-.instance-title {
-  font-size: $public-font-size-2xl;
-  font-weight: $public-font-weight-bold;
-  letter-spacing: $public-letter-spacing-tight;
-  line-height: $public-line-height-tight;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-lg 0;
-
-  @include public-tablet-up {
-    font-size: 40px;
-  }
-
-  @include public-desktop-up {
-    font-size: 48px;
-  }
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-primary-light;
-  }
-}
-
-// ================================================================
-// DATE + TIME ROW
-// ================================================================
-
-.datetime-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $public-space-sm $public-space-xl;
-  margin-bottom: $public-space-2xl;
-}
-
-.event-date,
-.event-datetime {
-  display: inline-flex;
-  align-items: center;
-  gap: $public-space-sm;
-  font-size: $public-font-size-base;
-  font-weight: $public-font-weight-medium;
-  color: $public-text-secondary-light;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-.datetime-icon {
-  flex-shrink: 0;
-
-  &--date {
-    color: var(--pav-accent-light);
-
-    @include public-dark-mode {
-      color: var(--pav-accent-dark);
-    }
-
-    @include public-light-mode-override {
-      color: var(--pav-accent-light);
-    }
-  }
-
-  &--time {
-    color: $public-text-secondary-light;
-
-    @include public-dark-mode {
-      color: $public-text-secondary-dark;
-    }
-
-    @include public-light-mode-override {
-      color: $public-text-secondary-light;
-    }
-  }
-}
-
-// ================================================================
-// TWO-COLUMN DETAIL GRID
-// ================================================================
-
-.detail-grid {
-  @include public-detail-grid;
-  margin-bottom: $public-space-2xl;
-}
-
-// ================================================================
-// LEFT COLUMN: DESCRIPTION + CATEGORIES
-// ================================================================
-
-.detail-main {
-  min-width: 0;
-}
-
-.about-heading {
-  font-size: $public-font-size-md;
-  font-weight: $public-font-weight-semibold;
-  color: $public-text-secondary-light;
-  margin: 0 0 $public-space-md 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-.event-description {
-  font-size: $public-font-size-md;
-  line-height: $public-line-height-relaxed;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-xl 0;
-  white-space: pre-line;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-primary-light;
-  }
-}
-
-.categories-section {
-  margin-top: $public-space-lg;
-}
-
-.section-heading {
-  font-size: $public-font-size-xs;
-  font-weight: $public-font-weight-semibold;
-  text-transform: uppercase;
-  letter-spacing: $public-letter-spacing-wide;
-  color: $public-text-secondary-light;
-  margin: 0 0 $public-space-sm 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-.category-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $public-space-sm;
-}
-
-.event-category-badge {
-  @include public-category-badge;
-
-  text-decoration: none;
-  cursor: default;
-}
-
-// ================================================================
-// RIGHT SIDEBAR: INFO CARDS
-// ================================================================
-
-.detail-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: $public-space-lg;
-}
-
-.sidebar-card {
-  @include public-sidebar-card;
-}
-
-.card-header {
-  display: flex;
-  align-items: center;
-  gap: $public-space-sm;
-  margin-bottom: $public-space-md;
-}
-
-.card-icon {
-  color: $public-text-secondary-light;
-  flex-shrink: 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-.card-heading {
-  font-size: $public-font-size-xs;
-  font-weight: $public-font-weight-semibold;
-  text-transform: uppercase;
-  letter-spacing: $public-letter-spacing-wide;
-  color: $public-text-secondary-light;
-  margin: 0;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-// Location card
-.location-name {
-  font-size: $public-font-size-base;
-  font-weight: $public-font-weight-medium;
-  color: $public-text-primary-light;
-  margin: 0 0 $public-space-xs 0;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-primary-light;
-  }
-}
-
-.location-address {
-  font-size: $public-font-size-sm;
-  color: $public-text-secondary-light;
-  margin: 0;
-  line-height: $public-line-height-relaxed;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-secondary-light;
-  }
-}
-
-// Accessibility card
-.accessibility-info {
-  font-size: $public-font-size-base;
-  color: $public-text-primary-light;
-  margin: 0;
-  white-space: pre-line;
-  line-height: $public-line-height-relaxed;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-primary-light;
-  }
-}
-
-// Recurrence card
-.recurrence-text {
-  font-size: $public-font-size-base;
-  color: $public-text-primary-light;
-  margin: 0;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
-
-  @include public-light-mode-override {
-    color: $public-text-primary-light;
-  }
-}
-
-// ================================================================
-// EXTERNAL LINK CTA BUTTON
-// ================================================================
-
-.external-link-button {
-  @include public-button-primary;
-
-  min-height: 44px;
-  text-decoration: none;
-  text-align: center;
-
-  &:focus-visible {
-    @include public-focus-visible;
   }
 }
 

--- a/src/widget/components/list-view.vue
+++ b/src/widget/components/list-view.vue
@@ -1,81 +1,80 @@
 <script setup lang="ts">
-import { computed, onBeforeMount } from 'vue';
+import { computed } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useRouter } from 'vue-router';
 import { DateTime } from 'luxon';
 import { usePublicCalendarStore } from '@/site/stores/publicCalendarStore';
 import { useWidgetStore } from '../stores/widgetStore';
-import EventImage from '@/site/components/event-image.vue';
+import EventCard from '@/site/components/event-card.vue';
 import { formatInstanceSlug } from '@/common/utils/instance-slug';
+import type CalendarEventInstance from '@/common/model/event_instance';
 
 const { t } = useTranslation('system');
 const router = useRouter();
 const publicStore = usePublicCalendarStore();
 const widgetStore = useWidgetStore();
 
-// Computed properties for store data
+// Events are loaded by WidgetContainer/SearchFilterPublic; this component
+// just displays them via the day-grouped EventCard list pattern shared
+// with the site (src/site/components/calendar.vue).
 const filteredEventsByDay = computed(() => publicStore.getFilteredEventsByDay);
+const defaultEventImage = computed(() => publicStore.defaultEventImage);
 
 /**
- * Resolves the effective image for an event instance.
- * Falls back to the calendar's default event image for locally-owned events.
- * Reposted events do NOT get the local calendar's default image.
+ * Builds the widget-router-resolved href for an event instance.
+ * EventCard receives this via its detailHref prop and renders it
+ * as an anchor href, so navigation flows through the widget router
+ * (no openEvent click handler needed on the list view).
  */
-const resolveEventImage = (instance: any) => {
-  if (instance.event.media) {
-    return instance.event.media;
-  }
-  if (instance.event.isRepost) {
-    return null;
-  }
-  return publicStore.defaultEventImage ?? null;
-};
-
-const openEvent = (instance: any) => {
-  router.push({
+const buildDetailHref = (instance: CalendarEventInstance): string => {
+  return router.resolve({
     name: 'widget-event-detail',
     params: {
       urlName: widgetStore.calendarUrlName!,
       eventId: instance.event.id,
       startTime: formatInstanceSlug(instance.start),
     },
-  });
+  }).href;
 };
-
-onBeforeMount(() => {
-  // Events are loaded by WidgetContainer/SearchFilterPublic
-  // This component just displays them
-});
 </script>
 
 <template>
   <div class="list-view">
     <!-- Events Display -->
-    <div v-if="Object.keys(filteredEventsByDay).length > 0">
-      <section class="day" v-for="day in Object.keys(filteredEventsByDay).sort()" :key="day">
-        <h2>{{ DateTime.fromISO(day).toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' }) }}</h2>
-        <ul class="events">
-          <li class="event"
-              v-for="instance in filteredEventsByDay[day]"
-              :key="instance.id"
-              @click="openEvent(instance)">
-            <EventImage
-              :media="resolveEventImage(instance)"
-              :focal-point-x="instance.event.mediaFocalPointX"
-              :focal-point-y="instance.event.mediaFocalPointY"
-              :zoom="instance.event.mediaZoom"
-              context="card"
-              :lazy="true"
+    <div
+      v-if="Object.keys(filteredEventsByDay).length > 0"
+      class="events-container"
+    >
+      <section
+        v-for="day in Object.keys(filteredEventsByDay).sort()"
+        :key="day"
+        class="day"
+      >
+        <h2 class="day-heading">
+          {{ DateTime.fromISO(day).toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' }) }}
+        </h2>
+        <ul class="day-events">
+          <li
+            v-for="instance in filteredEventsByDay[day]"
+            :key="instance.id"
+            class="day-event-item"
+          >
+            <EventCard
+              :instance="instance"
+              :calendar-url-name="widgetStore.calendarUrlName!"
+              :default-image="defaultEventImage"
+              :detail-href="buildDetailHref(instance)"
             />
-            <h3>{{ instance.event.content("en").name }}</h3>
-            <div class="event-time">{{ instance.start.toLocal().toLocaleString(DateTime.TIME_SIMPLE) }}</div>
           </li>
         </ul>
       </section>
     </div>
 
     <!-- Empty State: suppress when search is pending (1-2 chars typed) to avoid conflicting messages -->
-    <div v-else-if="!publicStore.isLoadingEvents && !publicStore.isSearchPending" class="empty-state">
+    <div
+      v-else-if="!publicStore.isLoadingEvents && !publicStore.isSearchPending"
+      class="empty-state"
+    >
       <p v-if="publicStore.hasActiveFilters">
         {{ t('no_events_with_filters') }}
       </p>
@@ -85,7 +84,12 @@ onBeforeMount(() => {
     </div>
 
     <!-- Loading State -->
-    <div v-if="publicStore.isLoadingEvents" class="loading">
+    <div
+      v-if="publicStore.isLoadingEvents"
+      class="loading"
+      role="status"
+      aria-live="polite"
+    >
       {{ t('loading_events') }}
     </div>
   </div>
@@ -101,165 +105,52 @@ onBeforeMount(() => {
 }
 
 // ================================================================
-// EVENTS DISPLAY (adapted from site calendar.vue)
+// EVENTS DISPLAY (mirrors site/components/calendar.vue)
 // ================================================================
-// A horizontally scrollable list of event cards.
-// Cards adapt gracefully whether they have images or not.
-// Optimized for iframe context.
+// Day-grouped vertical list of EventCards. The widget reuses the
+// site's EventCard component directly so it shares all card content
+// (image, title, time, location, description, categories,
+// source-calendar pill, recurrence/cancelled badges, no-image
+// fallback) and benefits from the same dark/light pairing audit.
 // ================================================================
 
-section.day {
-  margin: $public-space-lg 0;
+.events-container {
+  display: flex;
+  flex-direction: column;
+  gap: $public-space-2xl;
+}
 
-  h2 {
-    font-size: $public-font-size-sm;
-    margin: 0;
-    padding: 0;
-    font-weight: $public-font-weight-semibold;
-    text-transform: uppercase;
-    letter-spacing: $public-letter-spacing-wide;
+.day {
+  // No extra margin needed; events-container gap handles spacing
+}
+
+.day-heading {
+  @include public-sticky-date-heading;
+
+  padding: $public-space-sm 0;
+  margin: 0 0 $public-space-lg 0;
+  color: $public-text-secondary-light;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+
+  @include public-light-mode-override {
     color: $public-text-secondary-light;
-
-    @include public-dark-mode {
-      color: $public-text-secondary-dark;
-    }
-
-    @include public-light-mode-override {
-      color: $public-text-secondary-light;
-    }
   }
+}
 
-  ul.events {
-    @include public-horizontal-scroll;
+.day-events {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: $public-space-lg;
+}
 
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: stretch;
-    padding: $public-space-md 0 $public-space-xl 0;
-    gap: $public-space-md;
-
-    li.event {
-      @include public-event-card-compact;
-
-      list-style-type: none;
-      margin-right: 0;
-      position: relative;
-      cursor: pointer;
-
-      // ============================================================
-      // CONTENT-FIRST CARD DESIGN
-      // ============================================================
-      // When no image is present, the card becomes a refined
-      // text-focused card with a subtle accent treatment.
-      // ============================================================
-
-      // Check if card has no image (EventImage renders nothing)
-      &:not(:has(.event-image)) {
-        // Add a warm accent bar at top for visual weight
-        &::before {
-          content: '';
-          position: absolute;
-          top: 0;
-          left: $public-space-md;
-          right: $public-space-md;
-          height: 3px;
-          background: linear-gradient(
-            90deg,
-            var(--pav-accent-light) 0%,
-            color-mix(in srgb, var(--pav-accent-light) 40%, transparent) 100%
-          );
-          border-radius: 0 0 2px 2px;
-          opacity: 0.7;
-
-          @include public-dark-mode {
-            background: linear-gradient(
-              90deg,
-              var(--pav-accent-dark) 0%,
-              color-mix(in srgb, var(--pav-accent-dark) 40%, transparent) 100%
-            );
-          }
-
-          @include public-light-mode-override {
-            background: linear-gradient(
-              90deg,
-              var(--pav-accent-light) 0%,
-              color-mix(in srgb, var(--pav-accent-light) 40%, transparent) 100%
-            );
-          }
-        }
-
-        // Adjust padding to account for accent bar
-        padding-top: $public-space-lg;
-
-        // Title gets more visual prominence
-        h3 {
-          font-size: $public-font-size-lg;
-          font-weight: $public-font-weight-medium;
-          margin-top: 0;
-        }
-      }
-
-      // ============================================================
-      // CARD WITH IMAGE
-      // ============================================================
-      // Standard card with image thumbnail above text.
-      // ============================================================
-
-      &:has(.event-image) {
-        h3 {
-          margin-top: $public-space-sm;
-        }
-      }
-
-      h3 {
-        order: 1;
-        font-size: $public-font-size-md;
-        font-weight: $public-font-weight-regular;
-        line-height: $public-line-height-tight;
-        margin: 0;
-        color: $public-text-primary-light;
-        text-decoration: none;
-        transition: $public-transition-fast;
-
-        @include public-dark-mode {
-          color: $public-text-primary-dark;
-        }
-
-        @include public-light-mode-override {
-          color: $public-text-primary-light;
-        }
-      }
-
-      &:hover h3 {
-        color: var(--pav-accent-light);
-
-        @include public-dark-mode {
-          color: var(--pav-accent-dark);
-        }
-
-        @include public-light-mode-override {
-          color: var(--pav-accent-light);
-        }
-      }
-
-      .event-time {
-        order: 2;
-        font-size: $public-font-size-sm;
-        font-weight: $public-font-weight-medium;
-        color: $public-text-secondary-light;
-        margin-top: $public-space-xs;
-
-        @include public-dark-mode {
-          color: $public-text-secondary-dark;
-        }
-
-        @include public-light-mode-override {
-          color: $public-text-secondary-light;
-        }
-      }
-    }
-  }
+.day-event-item {
+  // No extra styles needed; EventCard handles its own layout
 }
 
 // Loading and error states
@@ -269,14 +160,5 @@ section.day {
 
 .empty-state {
   @include public-empty-state;
-}
-
-// Responsive design
-@include public-mobile-only {
-  section.day ul.events {
-    li.event {
-      width: 120px;
-    }
-  }
 }
 </style>

--- a/src/widget/components/test/viewComponents.test.ts
+++ b/src/widget/components/test/viewComponents.test.ts
@@ -8,6 +8,7 @@ import { DateTime } from 'luxon';
 import WeekView from '../week-view.vue';
 import MonthView from '../month-view.vue';
 import ListView from '../list-view.vue';
+import EventCard from '@/site/components/event-card.vue';
 import { usePublicCalendarStore } from '@/site/stores/publicCalendarStore';
 import { useWidgetStore } from '../../stores/widgetStore';
 
@@ -170,31 +171,49 @@ describe('Widget View Components', () => {
   });
 
   describe('ListView', () => {
-    it('adapts calendar.vue pattern for widget', async () => {
-      const publicStore = usePublicCalendarStore();
-
-      // FIXED: Component uses publicStore.allEvents and getFilteredEventsByDay getter
-      publicStore.allEvents = [
-        { id: '1', start: { toLocal: () => ({ toISODate: () => '2026-01-06', toLocaleString: () => '10:00 AM' }) }, event: { id: 'e1', content: () => ({ name: 'Event 1' }), media: null, categories: [] } },
-      ] as any;
-
-      const wrapper = mount(ListView, {
-        global: {
-          plugins: [[I18NextVue, { i18next }], router],
-        },
-      });
-
-      // Should have day sections
-      const daySection = wrapper.find('.day');
-      expect(daySection.exists()).toBe(true);
+    // Build a minimal instance fixture compatible with both the day-grouping
+    // getter (which calls instance.start.toLocal().toISODate()) and the
+    // EventCard detailHref builder (which calls formatInstanceSlug, hitting
+    // start.toUTC().toFormat(...)).
+    const buildListInstance = (
+      id: string,
+      eventId: string,
+      start: DateTime,
+      dayKey: string,
+    ) => ({
+      id,
+      start: {
+        toLocal: () => ({
+          toISODate: () => dayKey,
+          toLocaleString: () => '10:00 AM',
+        }),
+        toUTC: () => start.toUTC(),
+        toFormat: (fmt: string) => start.toUTC().toFormat(fmt),
+      },
+      end: null,
+      isCancelled: false,
+      event: {
+        id: eventId,
+        content: () => ({ name: `Event ${eventId}`, description: '' }),
+        hasContent: () => true,
+        getLanguages: () => ['en'],
+        media: null,
+        categories: [],
+        location: null,
+        isRecurring: false,
+        isRepost: false,
+        sourceCalendar: null,
+      },
     });
 
-    it('shows horizontal-scroll day groups', async () => {
+    it('adapts calendar.vue pattern for widget by rendering an EventCard per instance', async () => {
       const publicStore = usePublicCalendarStore();
+      const widgetStore = useWidgetStore();
+      widgetStore.setCalendarUrlName('mycal');
 
-      // FIXED: Set allEvents so getFilteredEventsByDay has data
+      const start = DateTime.fromISO('2026-01-06T18:00:00.000Z', { zone: 'utc' });
       publicStore.allEvents = [
-        { id: '1', start: { toLocal: () => ({ toISODate: () => '2026-01-06', toLocaleString: () => '10:00 AM' }) }, event: { id: 'e1', content: () => ({ name: 'Event 1' }), media: null, categories: [] } },
+        buildListInstance('1', 'e1', start, '2026-01-06'),
       ] as any;
 
       const wrapper = mount(ListView, {
@@ -203,9 +222,42 @@ describe('Widget View Components', () => {
         },
       });
 
-      // Should have events list with horizontal scroll
-      const eventsList = wrapper.find('.events');
-      expect(eventsList.exists()).toBe(true);
+      // Should have a day section
+      expect(wrapper.find('.day').exists()).toBe(true);
+
+      // Should render exactly one EventCard for the single instance
+      const eventCards = wrapper.findAllComponents(EventCard);
+      expect(eventCards.length).toBe(1);
+    });
+
+    it('renders distinct EventCards with distinct detailHref props for two instances', async () => {
+      const publicStore = usePublicCalendarStore();
+      const widgetStore = useWidgetStore();
+      widgetStore.setCalendarUrlName('mycal');
+
+      const start1 = DateTime.fromISO('2026-01-06T18:00:00.000Z', { zone: 'utc' });
+      const start2 = DateTime.fromISO('2026-01-07T19:00:00.000Z', { zone: 'utc' });
+      publicStore.allEvents = [
+        buildListInstance('1', 'e1', start1, '2026-01-06'),
+        buildListInstance('2', 'e2', start2, '2026-01-07'),
+      ] as any;
+
+      const wrapper = mount(ListView, {
+        global: {
+          plugins: [[I18NextVue, { i18next }], router],
+        },
+      });
+
+      const eventCards = wrapper.findAllComponents(EventCard);
+      expect(eventCards.length).toBe(2);
+
+      const href1 = eventCards[0].props('detailHref') as string;
+      const href2 = eventCards[1].props('detailHref') as string;
+      expect(href1).toBeTruthy();
+      expect(href2).toBeTruthy();
+      expect(href1).toContain('e1');
+      expect(href2).toContain('e2');
+      expect(href1).not.toBe(href2);
     });
   });
 
@@ -228,11 +280,20 @@ describe('Widget View Components', () => {
         // Luxon passthrough fields needed by formatInstanceSlug
         toFormat: (fmt: string) => start.toUTC().toFormat(fmt),
       },
+      end: null,
+      isCancelled: false,
       event: {
         id: 'evt-1',
-        content: () => ({ name: 'Test Event' }),
+        content: () => ({ name: 'Test Event', description: '' }),
+        // EventCard uses useLocalizedContent → hasContent / getLanguages
+        hasContent: () => true,
+        getLanguages: () => ['en'],
         media: null,
         categories: [],
+        location: null,
+        isRecurring: false,
+        isRepost: false,
+        sourceCalendar: null,
       },
     });
 
@@ -294,14 +355,12 @@ describe('Widget View Components', () => {
       });
     });
 
-    it('ListView openEvent pushes route params including startTime slug', async () => {
+    it('ListView EventCard detailHref includes the startTime slug', async () => {
       const publicStore = usePublicCalendarStore();
       const widgetStore = useWidgetStore();
       widgetStore.setCalendarUrlName('mycal');
 
       publicStore.allEvents = [buildInstance(fixedStart)] as any;
-
-      const pushSpy = vi.spyOn(router, 'push');
 
       const wrapper = mount(ListView, {
         global: {
@@ -309,18 +368,12 @@ describe('Widget View Components', () => {
         },
       });
 
-      const eventEl = wrapper.find('.event');
-      expect(eventEl.exists()).toBe(true);
-      await eventEl.trigger('click');
-
-      expect(pushSpy).toHaveBeenCalledWith({
-        name: 'widget-event-detail',
-        params: {
-          urlName: 'mycal',
-          eventId: 'evt-1',
-          startTime: fixedSlug,
-        },
-      });
+      const cards = wrapper.findAllComponents(EventCard);
+      expect(cards.length).toBe(1);
+      const detailHref = cards[0].props('detailHref') as string;
+      expect(detailHref).toContain(fixedSlug);
+      expect(detailHref).toContain('mycal');
+      expect(detailHref).toContain('evt-1');
     });
   });
 

--- a/src/widget/test/event-detail-overlay.test.ts
+++ b/src/widget/test/event-detail-overlay.test.ts
@@ -1,14 +1,24 @@
 /**
- * Tests for the widget's event detail overlay external-URL CTA button.
+ * Tests for the widget's event detail overlay shell.
  *
- * Validates defense-in-depth computed guards and rendering rules ported
- * from the public-site event-instance implementation (pv-itux.5.1):
- *   - javascript: URLs are blocked before reaching the DOM
- *   - unknown urlPrompt values are blocked before reaching the DOM
- *   - valid (http/https) URL + known prompt → CTA anchor rendered with
- *     target="_blank" rel="noopener noreferrer" and translated label
- *   - null externalUrl OR null urlPrompt → CTA is omitted
- *   - malformed URL strings → CTA is omitted
+ * The overlay is now a thin shell that owns:
+ *   - The back-button header
+ *   - The <main class="instance-main"> wrapper
+ *   - <EventDetailBody> composition inside <main>
+ *   - Loading / error / not-found states
+ *
+ * Per-region body coverage (hero image, badges, source pill, datetime row,
+ * description + categories, sidebar cards, external CTA security guards,
+ * AddToCalendar) lives in src/site/test/components/EventDetailBody.test.ts.
+ *
+ * Validates:
+ *   - Back button renders and navigates to the widget calendar route.
+ *   - <EventDetailBody> is composed inside <main> with the correct props
+ *     (categoryHrefBuilder is omitted, so categories render as <span>).
+ *   - Slug routing: parseInstanceSlug + service-call selection between
+ *     loadEventInstance (slug present) and loadCalendarEvents (slug absent).
+ *   - Not-found rendering when slug is unparseable or instance lookup
+ *     returns null.
  */
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
@@ -20,10 +30,6 @@ import i18next from 'i18next';
 // ---------------------------------------------------------------------------
 // Mocks — declared before component import
 // ---------------------------------------------------------------------------
-
-// Mutable externalUrl / urlPrompt so tests can inject CTA data
-let mockExternalUrl: string | null = null;
-let mockUrlPrompt: string | null = null;
 
 // Spy hooks for assertions about which fetch path was taken. Hoisted so
 // they are defined before vi.mock factories (which vitest runs at module
@@ -61,8 +67,8 @@ function buildFallbackInstanceMock() {
       recurrenceSummary: null,
       location: null,
       sourceCalendar: null,
-      externalUrl: mockExternalUrl,
-      urlPrompt: mockUrlPrompt,
+      externalUrl: null,
+      urlPrompt: null,
     },
   };
 }
@@ -89,10 +95,11 @@ vi.mock('@/site/components/not-found.vue', () => ({
   default: { template: '<div class="not-found-stub"></div>' },
 }));
 
-vi.mock('@/site/components/event-image.vue', () => ({
+vi.mock('@/site/components/EventDetailBody.vue', () => ({
   default: {
-    template: '<div class="event-image-stub"></div>',
-    props: ['media', 'context', 'alt', 'focalPointX', 'focalPointY', 'zoom'],
+    name: 'EventDetailBody',
+    props: ['instance', 'calendar', 'categoryHrefBuilder'],
+    template: '<div data-test="event-detail-body" class="event-detail-body-stub"></div>',
   },
 }));
 
@@ -128,7 +135,7 @@ async function buildRouter(initialPath: string): Promise<Router> {
   return router;
 }
 
-async function mountOverlay(initialPath: string): Promise<VueWrapper> {
+async function mountOverlay(initialPath: string): Promise<{ wrapper: VueWrapper; router: Router }> {
   const router = await buildRouter(initialPath);
   const pinia = createPinia();
 
@@ -143,7 +150,7 @@ async function mountOverlay(initialPath: string): Promise<VueWrapper> {
   });
 
   await flushPromises();
-  return wrapper;
+  return { wrapper, router };
 }
 
 // ---------------------------------------------------------------------------
@@ -181,13 +188,8 @@ beforeAll(async () => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('widget event-detail-overlay external URL CTA button', () => {
+describe('widget event-detail-overlay shell', () => {
   beforeEach(() => {
-    mockExternalUrl = null;
-    mockUrlPrompt = null;
-    // Reset and re-install default lazy implementations so the per-test
-    // mockExternalUrl / mockUrlPrompt mutations are picked up at call
-    // time, and so per-test mockResolvedValue overrides take effect.
     loadCalendarEventsMock.mockReset();
     loadEventInstanceMock.mockReset();
     loadCalendarEventsMock.mockImplementation(
@@ -202,111 +204,54 @@ describe('widget event-detail-overlay external URL CTA button', () => {
     vi.clearAllMocks();
   });
 
-  it('should render CTA anchor when externalUrl and urlPrompt are both valid', async () => {
-    mockExternalUrl = 'https://tickets.example.com/show/123';
-    mockUrlPrompt = 'tickets';
+  it('renders the back button when an instance is loaded', async () => {
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    const cta = wrapper.find('.external-link-button');
-    expect(cta.exists()).toBe(true);
-    expect(cta.attributes('href')).toBe('https://tickets.example.com/show/123');
+    const backButton = wrapper.find('.instance-back-header .back-link');
+    expect(backButton.exists()).toBe(true);
     wrapper.unmount();
   });
 
-  it('should use target="_blank" and rel="noopener noreferrer" on the CTA anchor', async () => {
-    mockExternalUrl = 'https://rsvp.example.com/party';
-    mockUrlPrompt = 'rsvp';
+  it('back-button click navigates to the widget-calendar route', async () => {
+    const { wrapper, router } = await mountOverlay('/widget/test_calendar/events/evt-1');
+    const pushSpy = vi.spyOn(router, 'push');
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+    const backButton = wrapper.find('.instance-back-header .back-link');
+    expect(backButton.exists()).toBe(true);
+    await backButton.trigger('click');
 
-    const cta = wrapper.find('.external-link-button');
-    expect(cta.exists()).toBe(true);
-    expect(cta.attributes('target')).toBe('_blank');
-    expect(cta.attributes('rel')).toBe('noopener noreferrer');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    const arg = pushSpy.mock.calls[0][0];
+    expect(arg).toMatchObject({ name: 'widget-calendar' });
     wrapper.unmount();
   });
 
-  it('should display the translated label from system:url_prompt.<prompt>', async () => {
-    mockExternalUrl = 'https://example.com/info';
-    mockUrlPrompt = 'more_info';
+  it('renders <EventDetailBody> inside <main> when instance and calendar are loaded', async () => {
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    const cta = wrapper.find('.external-link-button');
-    expect(cta.exists()).toBe(true);
-    expect(cta.text()).toBe('More Information');
+    const main = wrapper.find('main.instance-main');
+    expect(main.exists()).toBe(true);
+    const body = main.find('[data-test="event-detail-body"]');
+    expect(body.exists()).toBe(true);
     wrapper.unmount();
   });
 
-  it('should NOT render the CTA when externalUrl is null', async () => {
-    mockExternalUrl = null;
-    mockUrlPrompt = 'tickets';
+  it('passes the loaded instance and calendar to EventDetailBody, and omits categoryHrefBuilder', async () => {
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('should NOT render the CTA when urlPrompt is null', async () => {
-    mockExternalUrl = 'https://example.com';
-    mockUrlPrompt = null;
-
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('should NOT render the CTA for javascript: URLs (defense-in-depth)', async () => {
-    mockExternalUrl = 'javascript:alert(1)';
-    mockUrlPrompt = 'tickets';
-
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('should NOT render the CTA for unknown urlPrompt values', async () => {
-    mockExternalUrl = 'https://example.com';
-    mockUrlPrompt = 'hack';
-
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('should NOT render the CTA for malformed URLs', async () => {
-    mockExternalUrl = 'not a url at all';
-    mockUrlPrompt = 'tickets';
-
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
-    wrapper.unmount();
-  });
-
-  it('should NOT render the CTA for data: URLs (defense-in-depth)', async () => {
-    mockExternalUrl = 'data:text/html,<script>alert(1)</script>';
-    mockUrlPrompt = 'tickets';
-
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
-
-    expect(wrapper.find('.external-link-button').exists()).toBe(false);
+    const body = wrapper.findComponent({ name: 'EventDetailBody' });
+    expect(body.exists()).toBe(true);
+    expect(body.props('instance')).toBeTruthy();
+    expect((body.props('instance') as any).id).toBe('inst-1');
+    expect((body.props('calendar') as any).urlName).toBe('test_calendar');
+    // Widget shell omits categoryHrefBuilder so categories render as <span>.
+    expect(body.props('categoryHrefBuilder')).toBeUndefined();
     wrapper.unmount();
   });
 });
 
 describe('widget event-detail-overlay slug routing', () => {
   beforeEach(() => {
-    mockExternalUrl = null;
-    mockUrlPrompt = null;
-    // Reset and re-install default lazy implementations so the per-test
-    // mockExternalUrl / mockUrlPrompt mutations are picked up at call
-    // time, and so per-test mockResolvedValue overrides take effect.
     loadCalendarEventsMock.mockReset();
     loadEventInstanceMock.mockReset();
     loadCalendarEventsMock.mockImplementation(
@@ -353,7 +298,7 @@ describe('widget event-detail-overlay slug routing', () => {
       },
     });
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1/20260508-1800');
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1/20260508-1800');
 
     expect(loadEventInstanceMock).toHaveBeenCalledTimes(1);
     const [calledEventId, calledStartTime] = loadEventInstanceMock.mock.calls[0];
@@ -366,7 +311,7 @@ describe('widget event-detail-overlay slug routing', () => {
   });
 
   it('falls back to the event list scan when startTime is absent (no redundant detail fetch)', async () => {
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1');
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
     // Fallback path uses loadCalendarEvents once; no second detail fetch
     // (the list response already carries enough data for the overlay).
@@ -378,7 +323,7 @@ describe('widget event-detail-overlay slug routing', () => {
   it('renders not-found when startTime is semantically invalid (parseInstanceSlug returns null)', async () => {
     // The router regex only enforces \d{8}-\d{4}; parseInstanceSlug is the
     // semantic gate (month 13, day 32, bad year, etc.).
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1/20261301-2500');
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1/20261301-2500');
 
     expect(wrapper.find('.not-found-stub').exists()).toBe(true);
     // Neither the slug fetch nor the fallback list scan should run when the
@@ -391,7 +336,7 @@ describe('widget event-detail-overlay slug routing', () => {
   it('renders not-found when loadEventInstance returns null (instance not found)', async () => {
     loadEventInstanceMock.mockResolvedValue(null);
 
-    const wrapper = await mountOverlay('/widget/test_calendar/events/evt-1/20260508-1800');
+    const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1/20260508-1800');
 
     expect(loadEventInstanceMock).toHaveBeenCalledTimes(1);
     expect(wrapper.find('.not-found-stub').exists()).toBe(true);

--- a/src/widget/test/integration/widget_integration.test.ts
+++ b/src/widget/test/integration/widget_integration.test.ts
@@ -235,6 +235,7 @@ describe('Widget Integration Tests', () => {
         history: createMemoryHistory(),
         routes: [
           { path: '/widget/:urlName', name: 'widget-calendar', component: { template: '<div></div>' } },
+          { path: '/widget/:urlName/events/:eventId/:startTime(\\d{8}-\\d{4})?', name: 'widget-event-detail', component: { template: '<div></div>' } },
         ],
       });
     };
@@ -272,13 +273,37 @@ describe('Widget Integration Tests', () => {
     it('should render list view with day groups', async () => {
       const router = createMockRouter();
       const publicStore = usePublicCalendarStore();
+      const widgetStore = useWidgetStore();
+      widgetStore.setCalendarUrlName('mycal');
 
-      // Mock an event - use allEvents property (not events)
+      const start = DateTime.fromISO('2026-01-06T18:00:00.000Z', { zone: 'utc' });
+      // Mock an event - use allEvents property (not events).
+      // ListView reuses the site EventCard, so the fixture must satisfy
+      // both day-grouping (toLocal().toISODate()) and EventCard's
+      // useLocalizedContent (hasContent / getLanguages) plus the
+      // formatInstanceSlug path (toUTC / toFormat).
       publicStore.allEvents = [
         {
           id: '1',
-          start: { toLocal: () => ({ toISODate: () => '2026-01-06', toLocaleString: () => '10:00 AM' }) },
-          event: { id: 'e1', content: () => ({ name: 'Test Event' }), media: null, categories: [] },
+          start: {
+            toLocal: () => ({ toISODate: () => '2026-01-06', toLocaleString: () => '10:00 AM' }),
+            toUTC: () => start.toUTC(),
+            toFormat: (fmt: string) => start.toUTC().toFormat(fmt),
+          },
+          end: null,
+          isCancelled: false,
+          event: {
+            id: 'e1',
+            content: () => ({ name: 'Test Event', description: '' }),
+            hasContent: () => true,
+            getLanguages: () => ['en'],
+            media: null,
+            categories: [],
+            location: null,
+            isRecurring: false,
+            isRepost: false,
+            sourceCalendar: null,
+          },
         },
       ] as any;
 
@@ -288,8 +313,8 @@ describe('Widget Integration Tests', () => {
         },
       });
 
-      // The events are in a ul.events element inside a conditional block
-      const eventsList = wrapper.find('ul.events');
+      // The events are now in a ul.day-events element inside the conditional block
+      const eventsList = wrapper.find('ul.day-events');
       expect(eventsList.exists()).toBe(true);
     });
   });

--- a/tests/e2e/widget-embedding.spec.ts
+++ b/tests/e2e/widget-embedding.spec.ts
@@ -87,13 +87,21 @@ test.describe('Widget Embedding', () => {
     await expect(iframe.locator('body')).toBeVisible({ timeout: 20000 });
 
     // Step 5: Verify events display inside the iframe
-    // The widget ListView renders events as li.event elements
+    // The widget ListView renders events as <li class="day-event-item"> wrappers
+    // around the shared site EventCard (an <article class="event-card">).
     // The seeded test_calendar has multiple events - wait for at least one to appear
-    await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 15000 });
+    await expect(iframe.locator('article.event-card').first()).toBeVisible({ timeout: 15000 });
 
     // Confirm multiple events exist in the seeded test data
-    const eventCount = await iframe.locator('li.event').count();
+    const eventCount = await iframe.locator('article.event-card').count();
     expect(eventCount).toBeGreaterThanOrEqual(1);
+
+    // Smoke-level parity check: widget list view now renders the full site
+    // EventCard, so seeded events should produce at least one location pill
+    // or category badge in the iframe DOM.
+    await expect(
+      iframe.locator('.event-location, .category-badge').first(),
+    ).toBeVisible({ timeout: 15000 });
 
     // Step 6: Verify no CSP or CORS errors occurred during the entire test
     // This provides a safety net to catch any security violations that slipped through
@@ -163,11 +171,12 @@ test.describe('Widget Embedding', () => {
     await page.waitForSelector('iframe[src*="/widget/"]', { timeout: 15000 });
     const iframe = page.frameLocator('iframe[src*="/widget/"]');
 
-    // Wait for events to render in list view
-    await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 15000 });
+    // Wait for events to render in list view (EventCard articles)
+    await expect(iframe.locator('article.event-card').first()).toBeVisible({ timeout: 15000 });
 
-    // Click the first event to open detail overlay
-    await iframe.locator('li.event').first().click();
+    // Click the first event title link to navigate to the detail overlay.
+    // EventCard navigates via the anchor href computed by the widget router.
+    await iframe.locator('article.event-card .event-title-link').first().click();
 
     // Verify event detail overlay appears with event name
     await expect(iframe.locator('.event-detail-overlay')).toBeVisible({ timeout: 10000 });
@@ -177,7 +186,7 @@ test.describe('Widget Embedding', () => {
     await iframe.locator('.back-link').first().click();
 
     // Verify list view is restored
-    await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 10000 });
+    await expect(iframe.locator('article.event-card').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('default server config drives accent color CSS variable', async ({ page }) => {
@@ -209,7 +218,7 @@ test.describe('Widget Embedding', () => {
     const iframe = page.frameLocator('iframe[src*="/widget/"]');
 
     // Wait for widget to fully load with events
-    await expect(iframe.locator('li.event').first()).toBeVisible({ timeout: 15000 });
+    await expect(iframe.locator('article.event-card').first()).toBeVisible({ timeout: 15000 });
 
     // Wait for at least one pavillion:resize message to arrive on the embedding page.
     // The widget debounces resize notifications by 100ms, so poll until one appears.


### PR DESCRIPTION
## Summary

Refactors the widget app to compose shared site components instead of reimplementing them, bringing widget feature parity with the public site for both list view and event detail. Also fixes two `?category=` → `?categories=` deep-link bugs discovered during implementation.

- Extracts `EventDetailBody` from `event-instance.vue`; both site `event-instance.vue` and widget `event-detail-overlay.vue` are now thin shells over it.
- Replaces the widget's bare inline list-card markup with the site's full `EventCard` (location, description, categories, source-calendar pill, recurrence/cancelled badges).
- Replaces the widget's horizontal-scroll-per-day track with the site-style day-grouped vertical card list.
- Audits `public-light-mode-override` pairings on shared mixins (`public-event-card-stacked`, `public-sticky-date-heading`, `public-sidebar-card`, `public-hero-image`) so forced-light theme renders correctly on dark-system-preference user agents.
- Fixes the singular `?category=` deep-link param on category badges (search filter expects plural `?categories=`); tightens test assertions so the singular form would fail.

## Beads closed

- pv-rtu1 — Sync widget layouts with site layouts via shared components (epic)
- pv-rtu1.1.1 — Pair light-mode overrides for stacked card and sticky date heading mixins
- pv-rtu1.1.2 — Add detailHref prop and light-mode-override pairings to EventCard
- pv-rtu1.1.3 — Adopt site EventCard for day-grouped widget list view
- pv-rtu1.2.1 — Pair light-mode overrides for public-sidebar-card and public-hero-image mixins
- pv-rtu1.2.2 — Extract EventDetailBody as shared presentational body component
- pv-rtu1.2.3 / pv-rtu1.2.4 — Thin event-instance and event-detail-overlay shells over EventDetailBody
- pv-9q5t — Fix category deep-link param on event-instance category badges
- pv-q7sc — Fix category deep-link param on event.vue category badges (sibling of pv-9q5t)

## Test plan

- [ ] `npm run lint`
- [ ] `npm run test:unit`
- [ ] `npm run test:integration`
- [ ] `npm run build`
- [ ] Widget list view shows full event-card content (image, title, time, location, description, categories, badges)
- [ ] Widget detail view matches site detail body (minus site-only chrome)
- [ ] Forced light theme (`.widget-theme-light`) renders correctly on a dark-OS user agent
- [ ] Clicking a category badge on event detail engages the calendar's category filter (deep link)