### PR TITLE
feat(site): indicate categories with no events in current filter window (pv-sosx)

### DIFF
--- a/src/common/model/event_category.ts
+++ b/src/common/model/event_category.ts
@@ -9,6 +9,15 @@ import { EventCategoryContent as EventCategoryContent } from './event_category_c
 export class EventCategory extends TranslatedModel<EventCategoryContent> {
   _content: Record<string, EventCategoryContent> = {};
 
+  /**
+   * Wire-only count of events currently assigned to this category within the
+   * scope of the API response that produced it (e.g. matching a date window
+   * or search filter). Not persisted on the category itself; populated by the
+   * server when the category is returned alongside category-stats endpoints.
+   * Defaults to 0 when the wire payload does not include it.
+   */
+  eventCount: number = 0;
+
   constructor(
     id: string,
     public calendarId: string,
@@ -45,6 +54,7 @@ export class EventCategory extends TranslatedModel<EventCategoryContent> {
     return {
       id: this.id,
       calendarId: this.calendarId,
+      eventCount: this.eventCount,
       content: Object.fromEntries(
         Object.entries(this._content)
           .map(([language, content]: [string, EventCategoryContent]) => [language, content.toObject()]),
@@ -60,6 +70,10 @@ export class EventCategory extends TranslatedModel<EventCategoryContent> {
       obj.id,
       obj.calendarId,
     );
+
+    if (typeof obj.eventCount === 'number') {
+      category.eventCount = obj.eventCount;
+    }
 
     if (obj.content) {
       for (const [language, contentObj] of Object.entries(obj.content)) {

--- a/src/common/test/event_category_translated.test.ts
+++ b/src/common/test/event_category_translated.test.ts
@@ -149,6 +149,45 @@ describe('EventCategoryModel', () => {
     expect(category.hasContent('es')).toBe(true);
   });
 
+  test('roundtrips eventCount through toObject/fromObject when present', () => {
+    const obj = {
+      id: 'cat-123',
+      calendarId: 'cal-456',
+      eventCount: 5,
+      content: {
+        en: {
+          language: 'en',
+          name: 'Meeting',
+        },
+      },
+    };
+
+    const category = EventCategory.fromObject(obj);
+    expect(category.eventCount).toBe(5);
+
+    const serialized = category.toObject();
+    expect(serialized.eventCount).toBe(5);
+  });
+
+  test('defaults eventCount to 0 when missing from wire payload', () => {
+    const obj = {
+      id: 'cat-123',
+      calendarId: 'cal-456',
+      content: {
+        en: {
+          language: 'en',
+          name: 'Meeting',
+        },
+      },
+    };
+
+    const category = EventCategory.fromObject(obj);
+    expect(category.eventCount).toBe(0);
+
+    const serialized = category.toObject();
+    expect(serialized.eventCount).toBe(0);
+  });
+
   test('handles empty calendar ID validation', () => {
     const category = new EventCategory(
       'cat-123',

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -146,7 +146,38 @@ export default class CalendarRoutes {
     }
 
     try {
-      const categoriesWithCounts = await this.service.listCategoriesForCalendar(calendar);
+      // Parse optional query parameters for filtering. Mirrors the parsing
+      // pattern in listInstances so eventCount can be windowed to match the
+      // visible event list when the sidebar is filtered.
+      const options: {
+        startDate?: string;
+        endDate?: string;
+        search?: string;
+      } = {};
+
+      if (req.query.startDate && typeof req.query.startDate === 'string') {
+        const startDate = req.query.startDate.trim();
+        if (startDate.length > 0) {
+          options.startDate = startDate;
+        }
+      }
+
+      if (req.query.endDate && typeof req.query.endDate === 'string') {
+        const endDate = req.query.endDate.trim();
+        if (endDate.length > 0) {
+          options.endDate = endDate;
+        }
+      }
+
+      if (req.query.search && typeof req.query.search === 'string') {
+        const searchTerm = req.query.search.trim();
+        if (searchTerm.length > 0) {
+          options.search = searchTerm;
+        }
+      }
+
+      const categoriesWithCounts = await this.service.listCategoriesForCalendar(calendar, options);
+
       res.json(
         categoriesWithCounts.map(({ category, eventCount }) => {
           return {
@@ -156,10 +187,20 @@ export default class CalendarRoutes {
         }),
       );
     }
-    catch {
-      res.status(500).json({
-        "error": "Failed to retrieve categories",
-      });
+    catch (error: any) {
+      logError(error, 'Error in listCategories');
+
+      if (error.message === 'Invalid date format') {
+        res.status(400).json({
+          "error": "Invalid date format. Please use YYYY-MM-DD format.",
+          errorName: 'ValidationError',
+        });
+      }
+      else {
+        res.status(500).json({
+          "error": "Failed to retrieve categories",
+        });
+      }
     }
   }
 

--- a/src/server/public/interface/index.ts
+++ b/src/server/public/interface/index.ts
@@ -59,8 +59,11 @@ export default class PublicCalendarInterface {
     return this.publicCalendarService.findOrMaterializeInstanceWithDetails(eventId, startTime);
   }
 
-  async listCategoriesForCalendar(calendar: Calendar): Promise<Array<{category: EventCategory, eventCount: number}>> {
-    return this.publicCalendarService.listCategoriesForCalendar(calendar);
+  async listCategoriesForCalendar(
+    calendar: Calendar,
+    options?: { startDate?: string; endDate?: string; search?: string },
+  ): Promise<Array<{category: EventCategory, eventCount: number}>> {
+    return this.publicCalendarService.listCategoriesForCalendar(calendar, options);
   }
 
   async listEventInstancesWithCategoryFilter(calendar: Calendar, categoryIds: string[]): Promise<CalendarEventInstance[]> {

--- a/src/server/public/service/calendar.ts
+++ b/src/server/public/service/calendar.ts
@@ -16,16 +16,77 @@ export default class PublicCalendarService {
     private calendarInterface: CalendarInterface,
   ) {}
 
-  async listCategoriesForCalendar(calendar: Calendar): Promise<Array<{category: EventCategory, eventCount: number}>> {
+  /**
+   * List categories for a calendar, each annotated with the number of
+   * matching events. Without options, eventCount reflects every event
+   * assigned to the category. When date/search options are supplied,
+   * eventCount reflects only those events whose instances match the same
+   * predicates the public events query uses (mirrors
+   * listEventInstancesWithFilters), so the categories sidebar stays in
+   * sync with the visible event list.
+   *
+   * @param calendar - The calendar whose categories to list
+   * @param options - Optional date/search filters
+   * @returns EventCategory domain models annotated with eventCount
+   */
+  async listCategoriesForCalendar(
+    calendar: Calendar,
+    options?: { startDate?: string; endDate?: string; search?: string },
+  ): Promise<Array<{category: EventCategory, eventCount: number}>> {
     const categories = await this.calendarInterface.getCategories(calendar.id);
 
-    // Get event count for each category
+    const hasFilters = !!(options && (options.startDate || options.endDate || options.search));
+
+    if (!hasFilters) {
+      // Backward-compatible path: count every event assigned to each category.
+      const categoriesWithCounts = await Promise.all(
+        categories.map(async (category) => {
+          const eventIds = await this.calendarInterface.getCategoryEvents(category.id);
+          return {
+            category,
+            eventCount: eventIds.length,
+          };
+        }),
+      );
+
+      return categoriesWithCounts;
+    }
+
+    const { startDate, endDate, search } = options!;
+
+    // Validate date formats if provided (mirrors listEventInstancesWithFilters).
+    if (startDate && !this.isValidISODate(startDate)) {
+      throw new Error('Invalid date format');
+    }
+    if (endDate && !this.isValidISODate(endDate)) {
+      throw new Error('Invalid date format');
+    }
+
+    // Cap search length at the service boundary to protect against
+    // pathological-pattern DoS once the API handler is wired up.
+    const cappedSearch = search ? search.substring(0, 200) : search;
+
+    // Reuse the canonical filtered events query so category counts match the
+    // visible event list exactly. We then bucket each category's assigned
+    // events against the filtered set rather than hand-rolling new SQL.
+    const filteredInstances = await this.calendarInterface.listEventInstancesWithFilters(calendar, {
+      startDate,
+      endDate,
+      search: cappedSearch,
+    });
+
+    const filteredEventIds = new Set<string>(filteredInstances.map(instance => instance.event.id));
+
     const categoriesWithCounts = await Promise.all(
       categories.map(async (category) => {
-        const eventIds = await this.calendarInterface.getCategoryEvents(category.id);
+        const assignedEventIds = await this.calendarInterface.getCategoryEvents(category.id);
+        const matchingCount = assignedEventIds.reduce(
+          (count, eventId) => count + (filteredEventIds.has(eventId) ? 1 : 0),
+          0,
+        );
         return {
           category,
-          eventCount: eventIds.length,
+          eventCount: matchingCount,
         };
       }),
     );

--- a/src/server/public/test/api.test.ts
+++ b/src/server/public/test/api.test.ts
@@ -113,6 +113,80 @@ describe('Public Calendar API', () => {
       expect(calendarStub.called).toBe(true);
       expect(categoriesStub.called).toBe(true);
     });
+
+    it('should forward startDate and endDate options to the service', async () => {
+      let calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
+      let categoriesStub = apiSandbox.stub(publicInterface, 'listCategoriesForCalendar');
+
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const category1 = new EventCategory('cat-1', 'cal-id');
+      calendarStub.resolves(calendar);
+      categoriesStub.resolves([{ category: category1, eventCount: 2 }]);
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        req.query.startDate = '2026-01-01';
+        req.query.endDate = '2026-12-31';
+        routes.listCategories(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body[0].eventCount).toBe(2);
+      expect(categoriesStub.calledWith(
+        calendar,
+        sinon.match({ startDate: '2026-01-01', endDate: '2026-12-31' }),
+      )).toBe(true);
+    });
+
+    it('should forward search option to the service', async () => {
+      let calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
+      let categoriesStub = apiSandbox.stub(publicInterface, 'listCategoriesForCalendar');
+
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const category1 = new EventCategory('cat-1', 'cal-id');
+      calendarStub.resolves(calendar);
+      categoriesStub.resolves([{ category: category1, eventCount: 1 }]);
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        req.query.search = 'workshop';
+        routes.listCategories(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body[0].eventCount).toBe(1);
+      expect(categoriesStub.calledWith(
+        calendar,
+        sinon.match({ search: 'workshop' }),
+      )).toBe(true);
+    });
+
+    it('should return 400 for invalid date format', async () => {
+      let calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
+      let categoriesStub = apiSandbox.stub(publicInterface, 'listCategoriesForCalendar');
+
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      calendarStub.resolves(calendar);
+      categoriesStub.throws(new Error('Invalid date format'));
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        req.query.startDate = 'not-a-date';
+        routes.listCategories(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .get('/handler');
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+    });
   });
 
   describe('GET /calendar/:calendar/events with category filtering', () => {

--- a/src/server/public/test/calendar.service.test.ts
+++ b/src/server/public/test/calendar.service.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sinon from 'sinon';
+import { DateTime } from 'luxon';
+
+import { Calendar } from '@/common/model/calendar';
+import { EventCategory } from '@/common/model/event_category';
+import { CalendarEvent } from '@/common/model/events';
+import CalendarEventInstance from '@/common/model/event_instance';
+import CalendarInterface from '@/server/calendar/interface';
+import PublicCalendarService from '@/server/public/service/calendar';
+
+/**
+ * Unit tests for PublicCalendarService.listCategoriesForCalendar option support.
+ * Verifies that:
+ *  - No options (legacy callers): per-category counts come from getCategoryEvents.
+ *  - Date-range only / search-only / both: counts come from the canonical
+ *    listEventInstancesWithFilters query, bucketed against each category's
+ *    assigned event ids.
+ */
+describe('PublicCalendarService.listCategoriesForCalendar', () => {
+  let sandbox: sinon.SinonSandbox;
+  let calendarInterface: sinon.SinonStubbedInstance<CalendarInterface>;
+  let service: PublicCalendarService;
+  let calendar: Calendar;
+  let category1: EventCategory;
+  let category2: EventCategory;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    calendarInterface = sandbox.createStubInstance(CalendarInterface);
+    service = new PublicCalendarService(calendarInterface as unknown as CalendarInterface);
+
+    calendar = new Calendar('cal-id', 'test-calendar');
+    category1 = new EventCategory('cat-1', 'cal-id');
+    category2 = new EventCategory('cat-2', 'cal-id');
+
+    calendarInterface.getCategories.resolves([category1, category2]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('without options, returns counts from getCategoryEvents and does not query filtered instances', async () => {
+    calendarInterface.getCategoryEvents.withArgs('cat-1').resolves(['e1', 'e2', 'e3']);
+    calendarInterface.getCategoryEvents.withArgs('cat-2').resolves(['e4']);
+
+    const result = await service.listCategoriesForCalendar(calendar);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].category.id).toBe('cat-1');
+    expect(result[0].eventCount).toBe(3);
+    expect(result[1].category.id).toBe('cat-2');
+    expect(result[1].eventCount).toBe(1);
+    // Backward-compatibility check: the filtered query is not used in this path.
+    expect(calendarInterface.listEventInstancesWithFilters.called).toBe(false);
+  });
+
+  it('with date range only, counts only events whose instances fall in the window', async () => {
+    // Events assigned to each category.
+    calendarInterface.getCategoryEvents.withArgs('cat-1').resolves(['e1', 'e2', 'e3']);
+    calendarInterface.getCategoryEvents.withArgs('cat-2').resolves(['e4', 'e5']);
+
+    // Filtered events from the canonical query — only e1, e3, e5 are in window.
+    const inWindowInstances = [
+      makeInstance('inst-a', 'e1'),
+      makeInstance('inst-b', 'e3'),
+      makeInstance('inst-c', 'e5'),
+    ];
+    calendarInterface.listEventInstancesWithFilters.resolves(inWindowInstances);
+
+    const result = await service.listCategoriesForCalendar(calendar, {
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].eventCount).toBe(2); // e1, e3 in window; e2 excluded
+    expect(result[1].eventCount).toBe(1); // e5 in window; e4 excluded
+    expect(calendarInterface.listEventInstancesWithFilters.calledOnce).toBe(true);
+  });
+
+  it('with search only, counts only events whose content matches the search', async () => {
+    calendarInterface.getCategoryEvents.withArgs('cat-1').resolves(['e1', 'e2']);
+    calendarInterface.getCategoryEvents.withArgs('cat-2').resolves(['e3', 'e4']);
+
+    // Search returns e2 and e4 only.
+    calendarInterface.listEventInstancesWithFilters.resolves([
+      makeInstance('inst-a', 'e2'),
+      makeInstance('inst-b', 'e4'),
+    ]);
+
+    const result = await service.listCategoriesForCalendar(calendar, {
+      search: 'workshop',
+    });
+
+    expect(result[0].eventCount).toBe(1);
+    expect(result[1].eventCount).toBe(1);
+    expect(calendarInterface.listEventInstancesWithFilters.calledOnce).toBe(true);
+  });
+
+  it('with date range and search, composes both filters', async () => {
+    calendarInterface.getCategoryEvents.withArgs('cat-1').resolves(['e1', 'e2', 'e3']);
+    calendarInterface.getCategoryEvents.withArgs('cat-2').resolves(['e4', 'e5']);
+
+    // Combined filter narrows to e2 only.
+    calendarInterface.listEventInstancesWithFilters.resolves([
+      makeInstance('inst-a', 'e2'),
+    ]);
+
+    const result = await service.listCategoriesForCalendar(calendar, {
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+      search: 'workshop',
+    });
+
+    expect(result[0].eventCount).toBe(1); // only e2
+    expect(result[1].eventCount).toBe(0); // none
+    expect(calendarInterface.listEventInstancesWithFilters.calledOnce).toBe(true);
+  });
+
+  it('counts each event once per category even when multiple instances match (recurring events)', async () => {
+    calendarInterface.getCategoryEvents.withArgs('cat-1').resolves(['e1']);
+    calendarInterface.getCategoryEvents.withArgs('cat-2').resolves([]);
+
+    // Recurring event e1 produces three instances in window.
+    calendarInterface.listEventInstancesWithFilters.resolves([
+      makeInstance('inst-a', 'e1'),
+      makeInstance('inst-b', 'e1'),
+      makeInstance('inst-c', 'e1'),
+    ]);
+
+    const result = await service.listCategoriesForCalendar(calendar, {
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+    });
+
+    expect(result[0].eventCount).toBe(1);
+    expect(result[1].eventCount).toBe(0);
+  });
+
+  it('rejects invalid startDate format without invoking the filtered query', async () => {
+    await expect(
+      service.listCategoriesForCalendar(calendar, { startDate: 'not-a-date' }),
+    ).rejects.toThrow('Invalid date format');
+    expect(calendarInterface.listEventInstancesWithFilters.called).toBe(false);
+  });
+
+  it('rejects invalid endDate format without invoking the filtered query', async () => {
+    await expect(
+      service.listCategoriesForCalendar(calendar, { endDate: '2026/05/31' }),
+    ).rejects.toThrow('Invalid date format');
+    expect(calendarInterface.listEventInstancesWithFilters.called).toBe(false);
+  });
+
+  it('rejects a date that matches the YYYY-MM-DD shape but is not a real calendar date', async () => {
+    // 2026-02-30 passes the regex gate but Luxon's .isValid second gate rejects it.
+    await expect(
+      service.listCategoriesForCalendar(calendar, { startDate: '2026-02-30' }),
+    ).rejects.toThrow('Invalid date format');
+    expect(calendarInterface.listEventInstancesWithFilters.called).toBe(false);
+  });
+});
+
+function makeInstance(instanceId: string, eventId: string): CalendarEventInstance {
+  const event = new CalendarEvent(eventId, 'cal-id');
+  return new CalendarEventInstance(instanceId, event, DateTime.now(), null);
+}

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -281,6 +281,26 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
     transform: scale(0.97);
   }
 
+  // Absent state: pill represents a filter value with no matching events.
+  // Declared before .selected so a selected-but-absent pill stays styled
+  // as selected via source-order specificity.
+  &.absent {
+    opacity: 0.4;
+    cursor: not-allowed;
+    color: $public-text-tertiary-light;
+
+    &:hover,
+    &:focus {
+      background-color: $public-bg-tertiary-light;
+      color: $public-text-tertiary-light;
+      box-shadow: $public-shadow-xs-light;
+    }
+
+    &:active {
+      transform: none;
+    }
+  }
+
   &.selected {
     background-color: $public-accent-light;
     color: white;
@@ -303,6 +323,23 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
       box-shadow: $public-shadow-sm-dark;
     }
 
+    &.absent {
+      opacity: 0.4;
+      cursor: not-allowed;
+      color: $public-text-tertiary-dark;
+
+      &:hover,
+      &:focus {
+        background-color: $public-bg-tertiary-dark;
+        color: $public-text-tertiary-dark;
+        box-shadow: $public-shadow-xs-dark;
+      }
+
+      &:active {
+        transform: none;
+      }
+    }
+
     &.selected {
       background-color: $public-accent-dark;
       box-shadow: $public-shadow-md-dark;
@@ -322,6 +359,23 @@ $public-transition-slow: all $public-duration-slow $public-ease-in-out;
       background-color: rgba(0, 0, 0, 0.08);
       color: rgba(0, 0, 0, 0.75);
       box-shadow: $public-shadow-sm-light;
+    }
+
+    &.absent {
+      opacity: 0.4;
+      cursor: not-allowed;
+      color: $public-text-tertiary-light;
+
+      &:hover,
+      &:focus {
+        background-color: $public-bg-tertiary-light;
+        color: $public-text-tertiary-light;
+        box-shadow: $public-shadow-xs-light;
+      }
+
+      &:active {
+        transform: none;
+      }
     }
 
     &.selected {

--- a/src/site/components/calendar.vue
+++ b/src/site/components/calendar.vue
@@ -87,11 +87,10 @@ onBeforeMount(async () => {
     // Set current calendar in store
     publicCalendarStore.setCurrentCalendar(calendarUrlName);
 
-    // Load calendar settings (including defaultDateRange) before loading events
+    // Load calendar settings (including defaultDateRange) before loading events.
+    // SearchFilterPublic's mount/watcher then triggers reloadWithFilters(), which
+    // loads events AND categories together against the resolved default date window.
     await publicCalendarStore.loadCalendar(calendarUrlName);
-
-    // Load categories - SearchFilterPublic will handle URL params and event loading
-    await publicCalendarStore.loadCategories(calendarUrlName);
   }
   catch (error) {
     console.error('Error loading calendar data:', error);

--- a/src/site/components/category-pill-selector.vue
+++ b/src/site/components/category-pill-selector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { EventCategory } from '@/common/model/event_category';
 import { useLocalizedContent } from '../composables/useLocalizedContent';
@@ -9,6 +9,8 @@ export interface CategoryPillSelectorProps {
   selectedCategories: string[];
   disabled?: boolean;
   maxDisplayRows?: number;
+  presentCategoryIds?: string[];
+  absentTooltip?: string;
 }
 
 export interface CategoryPillSelectorEmits {
@@ -34,6 +36,15 @@ const { t } = useTranslation('system');
 const { localizedContent } = useLocalizedContent();
 
 /**
+ * Set of category IDs known to be present in the current result window.
+ * Resolves to null when presentCategoryIds is undefined (presence gating
+ * is opt-in: callers that don't pass this prop get no absent state).
+ */
+const presentSet = computed(() => {
+  return props.presentCategoryIds ? new Set(props.presentCategoryIds) : null;
+});
+
+/**
  * Check if a category is currently selected by ID (per DEC-005)
  */
 const isCategorySelected = (category: EventCategory): boolean => {
@@ -41,10 +52,23 @@ const isCategorySelected = (category: EventCategory): boolean => {
 };
 
 /**
+ * A category is absent when presence data is provided, the category is not
+ * in the present set, and it is not currently selected. Selected always
+ * wins so the user can still see what they have filtered to.
+ */
+const isCategoryAbsent = (category: EventCategory): boolean => {
+  const set = presentSet.value;
+  if (set === null) return false;
+  if (isCategorySelected(category)) return false;
+  return !set.has(category.id);
+};
+
+/**
  * Toggle category selection state using category ID
  */
 const toggleCategory = (category: EventCategory): void => {
   if (props.disabled) return;
+  if (isCategoryAbsent(category)) return;
 
   const currentSelection = [...props.selectedCategories];
   const index = currentSelection.indexOf(category.id);
@@ -64,6 +88,7 @@ const toggleCategory = (category: EventCategory): void => {
  */
 const handleKeydown = (event: KeyboardEvent, category: EventCategory): void => {
   if (props.disabled) return;
+  if (isCategoryAbsent(category)) return;
 
   if (event.key === ' ' || event.key === 'Enter') {
     event.preventDefault();
@@ -85,14 +110,24 @@ const getCategoryDisplayName = (category: EventCategory): string => {
 };
 
 /**
- * Generate ARIA label for accessibility, translated to the current locale
+ * Generate ARIA label for accessibility, translated to the current locale.
+ * State precedence: selected wins, then absent, otherwise not_selected.
  */
 const getCategoryAriaLabel = (category: EventCategory): string => {
   const name = getCategoryDisplayName(category);
-  const isSelected = isCategorySelected(category);
+  let stateKey: 'selected' | 'category_absent' | 'not_selected';
+  if (isCategorySelected(category)) {
+    stateKey = 'selected';
+  }
+  else if (isCategoryAbsent(category)) {
+    stateKey = 'category_absent';
+  }
+  else {
+    stateKey = 'not_selected';
+  }
   return t('category_filter_aria_label', {
     name,
-    state: isSelected ? t('selected') : t('not_selected'),
+    state: t(stateKey),
   });
 };
 
@@ -198,10 +233,15 @@ onUnmounted(() => {
         v-for="category in categories"
         :key="category.id"
         class="category-pill"
-        :class="{ selected: isCategorySelected(category) }"
+        :class="{
+          selected: isCategorySelected(category),
+          absent: isCategoryAbsent(category),
+        }"
         :disabled="disabled"
         :aria-pressed="isCategorySelected(category)"
+        :aria-disabled="isCategoryAbsent(category) || null"
         :aria-label="getCategoryAriaLabel(category)"
+        :title="isCategoryAbsent(category) ? absentTooltip : undefined"
         role="button"
         tabindex="0"
         @click="toggleCategory(category)"

--- a/src/site/components/search-filter-public.vue
+++ b/src/site/components/search-filter-public.vue
@@ -207,6 +207,8 @@
         :categories="publicStore.availableCategories"
         :selected-categories="publicStore.selectedCategoryIds"
         :disabled="publicStore.isLoadingCategories"
+        :present-category-ids="publicStore.presentCategoryIds"
+        :absent-tooltip="tSystem('category_absent_tooltip')"
         @update:selected-categories="handleCategoryChange"
       />
     </div>
@@ -243,6 +245,10 @@ const props = defineProps<{
 const { t } = useTranslation('system', {
   keyPrefix: 'public_search_filter',
 });
+
+// Root-namespace translator for keys shared with the pill selector
+// (category_absent_tooltip lives at the root of the system namespace).
+const { t: tSystem } = useTranslation('system');
 
 const route = useRoute();
 const router = useRouter();

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -32,6 +32,8 @@
     "category_filter_aria_label": "{{name}} category filter, {{state}}",
     "selected": "selected",
     "not_selected": "not selected",
+    "category_absent": "unavailable",
+    "category_absent_tooltip": "No events in this date range",
     "back_to_calendar": "Back to {{name}}",
     "series_events": "Events in this series",
     "series_no_events": "No events in this series",

--- a/src/site/stores/publicCalendarStore.ts
+++ b/src/site/stores/publicCalendarStore.ts
@@ -31,11 +31,18 @@ export interface PublicCalendarState {
 
   // UI state
   isLoadingCategories: boolean;
+  hasLoadedCategories: boolean;
   isLoadingEvents: boolean;
   hasLoadedEvents: boolean;
   isSearchPending: boolean;
   categoryError: string | null;
   eventError: string | null;
+}
+
+export interface CategoryFilterOptions {
+  search?: string;
+  startDate?: string | null;
+  endDate?: string | null;
 }
 
 export interface FilterOptions {
@@ -60,6 +67,7 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
     allEvents: [],
     filteredEvents: [],
     isLoadingCategories: false,
+    hasLoadedCategories: false,
     isLoadingEvents: false,
     hasLoadedEvents: false,
     isSearchPending: false,
@@ -146,6 +154,24 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
     filteredEventCount(): number {
       return this.getFilteredEvents.length;
     },
+
+    /**
+     * IDs of categories that have at least one event in the current
+     * date/search window.
+     *
+     * Returns `undefined` when categories are still loading OR before the
+     * first successful fetch — callers MUST treat `undefined` as "presence
+     * data not yet available" rather than "no categories present".
+     * Returning an empty array would falsely flag every pill as absent.
+     */
+    presentCategoryIds(): string[] | undefined {
+      if (this.isLoadingCategories || !this.hasLoadedCategories) {
+        return undefined;
+      }
+      return this.availableCategories
+        .filter(c => (c.eventCount ?? 0) > 0)
+        .map(c => c.id);
+    },
   },
 
   actions: {
@@ -204,9 +230,15 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
     },
 
     /**
-     * Load categories for the current calendar
+     * Load categories for the current calendar.
+     *
+     * Optional filters scope which events the server includes when computing
+     * each category's eventCount. The filters do NOT include
+     * selectedCategoryIds — category-presence must be independent of the
+     * user's current category selection (otherwise selecting a category
+     * would hide all the others).
      */
-    async loadCategories(calendarUrlName: string) {
+    async loadCategories(calendarUrlName: string, filters?: CategoryFilterOptions) {
       if (this.currentCalendarUrlName !== calendarUrlName) {
         this.setCurrentCalendar(calendarUrlName);
       }
@@ -215,13 +247,32 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
       this.categoryError = null;
 
       try {
-        const categoriesData = await ModelService.listModels(
-          `/api/public/v1/calendar/${calendarUrlName}/categories`,
-        );
+        let url = `/api/public/v1/calendar/${calendarUrlName}/categories`;
+        const params = new URLSearchParams();
+
+        // Add search parameter if provided (minimum 3 characters; matches loadEvents)
+        if (filters?.search && filters.search.trim().length >= 3) {
+          params.append('search', filters.search.trim());
+        }
+
+        if (filters?.startDate) {
+          params.append('startDate', filters.startDate);
+        }
+
+        if (filters?.endDate) {
+          params.append('endDate', filters.endDate);
+        }
+
+        if (params.toString()) {
+          url += `?${params.toString()}`;
+        }
+
+        const categoriesData = await ModelService.listModels(url);
 
         this.availableCategories = categoriesData.items.map(categoryData =>
           EventCategory.fromObject(categoryData),
         );
+        this.hasLoadedCategories = true;
       }
       catch (error) {
         console.error('Error loading categories:', error);
@@ -366,13 +417,19 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
       this.categoryError = null;
       this.eventError = null;
       this.isLoadingCategories = false;
+      this.hasLoadedCategories = false;
       this.isLoadingEvents = false;
       this.hasLoadedEvents = false;
       this.isSearchPending = false;
     },
 
     /**
-     * Reload events with current filter settings
+     * Reload events AND categories with current filter settings.
+     *
+     * Categories are reloaded with the SAME date/search context so that
+     * eventCount (and thus presentCategoryIds) reflects the current window.
+     * Categories are NOT reloaded with selectedCategoryIds — category
+     * presence must be independent of the user's category selection.
      */
     async reloadWithFilters() {
       if (this.currentCalendarUrlName) {
@@ -392,7 +449,21 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
           filters.endDate = this.endDate;
         }
 
-        await this.loadEvents(this.currentCalendarUrlName, filters);
+        const categoryFilters: CategoryFilterOptions = {};
+        if (this.searchQuery.trim().length >= 3) {
+          categoryFilters.search = this.searchQuery;
+        }
+        if (this.startDate) {
+          categoryFilters.startDate = this.startDate;
+        }
+        if (this.endDate) {
+          categoryFilters.endDate = this.endDate;
+        }
+
+        await Promise.all([
+          this.loadEvents(this.currentCalendarUrlName, filters),
+          this.loadCategories(this.currentCalendarUrlName, categoryFilters),
+        ]);
       }
     },
   },

--- a/src/site/stores/publicCalendarStore.ts
+++ b/src/site/stores/publicCalendarStore.ts
@@ -430,10 +430,23 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
      * eventCount (and thus presentCategoryIds) reflects the current window.
      * Categories are NOT reloaded with selectedCategoryIds — category
      * presence must be independent of the user's category selection.
+     *
+     * When the user has not picked an explicit date filter, both branches
+     * fall back to the calendar's default date window. Without this, the
+     * categories endpoint would count events across all time on initial
+     * load and every pill would render as "active" even when the default
+     * window contains no events for some categories.
      */
     async reloadWithFilters() {
       if (this.currentCalendarUrlName) {
-        const filters: FilterOptions = {};
+        const defaultRange = getDefaultDateRange(this.calendarDefaultDateRange);
+        const effectiveStartDate = this.startDate ?? defaultRange.startDate;
+        const effectiveEndDate = this.endDate ?? defaultRange.endDate;
+
+        const filters: FilterOptions = {
+          startDate: effectiveStartDate,
+          endDate: effectiveEndDate,
+        };
 
         // Only include search filter if it has at least 3 characters
         if (this.searchQuery.trim().length >= 3) {
@@ -442,22 +455,13 @@ export const usePublicCalendarStore = defineStore('publicCalendar', {
         if (this.selectedCategoryIds.length > 0) {
           filters.categories = this.selectedCategoryIds;
         }
-        if (this.startDate) {
-          filters.startDate = this.startDate;
-        }
-        if (this.endDate) {
-          filters.endDate = this.endDate;
-        }
 
-        const categoryFilters: CategoryFilterOptions = {};
+        const categoryFilters: CategoryFilterOptions = {
+          startDate: effectiveStartDate,
+          endDate: effectiveEndDate,
+        };
         if (this.searchQuery.trim().length >= 3) {
           categoryFilters.search = this.searchQuery;
-        }
-        if (this.startDate) {
-          categoryFilters.startDate = this.startDate;
-        }
-        if (this.endDate) {
-          categoryFilters.endDate = this.endDate;
         }
 
         await Promise.all([

--- a/src/site/test/components/category-pill-selector.test.ts
+++ b/src/site/test/components/category-pill-selector.test.ts
@@ -107,6 +107,8 @@ describe('CategoryPillSelector Component', () => {
             category_filter_aria_label: '{{name}} category filter, {{state}}',
             selected: 'selected',
             not_selected: 'not selected',
+            category_absent: 'unavailable',
+            category_absent_tooltip: 'No events in this date range',
           },
         },
         es: {
@@ -116,6 +118,8 @@ describe('CategoryPillSelector Component', () => {
             category_filter_aria_label: '{{name}} filtro de categoría, {{state}}',
             selected: 'seleccionado',
             not_selected: 'no seleccionado',
+            category_absent: 'unavailable',
+            category_absent_tooltip: 'No events in this date range',
           },
         },
         fr: { system: {} },
@@ -1216,6 +1220,208 @@ describe('CategoryPillSelector Component', () => {
 
       pill = wrapper.find('.category-pill');
       expect(pill.attributes('aria-label')).toBe('Artes filtro de categoría, no seleccionado');
+    });
+  });
+
+  describe('Absent category state (presentCategoryIds gating)', () => {
+    beforeEach(() => {
+      stubMatchMedia();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('renders absent class on a category not present in the result window', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      // Arts is present, Sports is absent
+      expect(pills[0].classes()).not.toContain('absent');
+      expect(pills[1].classes()).toContain('absent');
+    });
+
+    it('renders aria-disabled="true" on absent pills', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      expect(pills[0].attributes('aria-disabled')).toBeUndefined();
+      expect(pills[1].attributes('aria-disabled')).toBe('true');
+    });
+
+    it('does not emit on click when pill is absent', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      await pills[1].trigger('click');
+
+      expect(wrapper.emitted('update:selectedCategories')).toBeFalsy();
+    });
+
+    it('does not emit on Enter key when pill is absent', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      await pills[1].trigger('keydown', { key: 'Enter' });
+
+      expect(wrapper.emitted('update:selectedCategories')).toBeFalsy();
+    });
+
+    it('does not emit on Space key when pill is absent', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      await pills[1].trigger('keydown', { key: ' ' });
+
+      expect(wrapper.emitted('update:selectedCategories')).toBeFalsy();
+    });
+
+    it('renders selected (not absent) when a pill is selected but not present in the window', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      // Sports is selected but not in presentCategoryIds — selected wins
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: ['2'],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      expect(pills[1].classes()).toContain('selected');
+      expect(pills[1].classes()).not.toContain('absent');
+      expect(pills[1].attributes('aria-disabled')).toBeUndefined();
+    });
+
+    it('marks no pill absent when presentCategoryIds is undefined', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        // presentCategoryIds intentionally omitted
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      pills.forEach((pill) => {
+        expect(pill.classes()).not.toContain('absent');
+        expect(pill.attributes('aria-disabled')).toBeUndefined();
+      });
+    });
+
+    it('binds title attribute to absentTooltip when pill is absent', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+        absentTooltip: 'No events in this date range',
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      // Present pill: no title
+      expect(pills[0].attributes('title')).toBeUndefined();
+      // Absent pill: title equals absentTooltip
+      expect(pills[1].attributes('title')).toBe('No events in this date range');
+    });
+
+    it('omits title when pill is absent but absentTooltip is undefined', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+        // absentTooltip intentionally omitted
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      expect(pills[1].attributes('title')).toBeUndefined();
+    });
+
+    it('aria-label uses category_absent token in the state slot when pill is absent', async () => {
+      const categories = [
+        createTestCategory('1', 'Arts'),
+        createTestCategory('2', 'Sports'),
+      ];
+
+      const { wrapper } = await mountCategoryPillSelector({
+        categories,
+        selectedCategories: [],
+        presentCategoryIds: ['1'],
+      });
+      currentWrapper = wrapper;
+
+      const pills = wrapper.findAll('.category-pill');
+      expect(pills[1].attributes('aria-label')).toBe('Sports category filter, unavailable');
+      // Present pill should still use not_selected token
+      expect(pills[0].attributes('aria-label')).toBe('Arts category filter, not selected');
     });
   });
 });

--- a/src/site/test/stores/publicCalendarStore.test.ts
+++ b/src/site/test/stores/publicCalendarStore.test.ts
@@ -757,10 +757,30 @@ describe('publicCalendarStore - Search and Date Filter Extensions', () => {
 
       await store.reloadWithFilters();
 
-      expect(loadCategoriesSpy).toHaveBeenCalledWith('test-calendar', {});
       const passedFilters = loadCategoriesSpy.mock.calls[0][1] as Record<string, unknown> | undefined;
       expect(passedFilters).toBeDefined();
       expect(passedFilters).not.toHaveProperty('categories');
+    });
+
+    it('falls back to the calendar default date window when no dates are set', async () => {
+      // Regression: without this fallback the categories endpoint counted
+      // events across all time on initial load, so every pill rendered as
+      // active even when the default window had no events for some categories.
+      store.currentCalendarUrlName = 'test-calendar';
+      store.calendarDefaultDateRange = '2weeks';
+
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories').mockResolvedValue();
+      const loadEventsSpy = vi.spyOn(store, 'loadEvents').mockResolvedValue();
+
+      await store.reloadWithFilters();
+
+      const eventsFilters = loadEventsSpy.mock.calls[0][1] as Record<string, unknown>;
+      const categoryFilters = loadCategoriesSpy.mock.calls[0][1] as Record<string, unknown>;
+
+      expect(eventsFilters.startDate).toBeDefined();
+      expect(eventsFilters.endDate).toBeDefined();
+      expect(categoryFilters.startDate).toBe(eventsFilters.startDate);
+      expect(categoryFilters.endDate).toBe(eventsFilters.endDate);
     });
 
     it('omits search from category filters when shorter than 3 chars', async () => {

--- a/src/site/test/stores/publicCalendarStore.test.ts
+++ b/src/site/test/stores/publicCalendarStore.test.ts
@@ -371,6 +371,7 @@ describe('publicCalendarStore - Search and Date Filter Extensions', () => {
       store.setSelectedCategories(['Arts']);
 
       const loadEventsSpy = vi.spyOn(store, 'loadEvents');
+      vi.spyOn(store, 'loadCategories').mockResolvedValue();
 
       await store.reloadWithFilters();
 
@@ -387,6 +388,7 @@ describe('publicCalendarStore - Search and Date Filter Extensions', () => {
       store.setDateRange('2025-11-15', '2025-11-21');
 
       const loadEventsSpy = vi.spyOn(store, 'loadEvents');
+      vi.spyOn(store, 'loadCategories').mockResolvedValue();
 
       await store.reloadWithFilters();
 
@@ -400,10 +402,12 @@ describe('publicCalendarStore - Search and Date Filter Extensions', () => {
       store.currentCalendarUrlName = null;
 
       const loadEventsSpy = vi.spyOn(store, 'loadEvents');
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories');
 
       await store.reloadWithFilters();
 
       expect(loadEventsSpy).not.toHaveBeenCalled();
+      expect(loadCategoriesSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -513,6 +517,276 @@ describe('publicCalendarStore - Search and Date Filter Extensions', () => {
       const byDay = store.getFilteredEventsByDay;
 
       expect(Object.keys(byDay).length).toBe(0);
+    });
+  });
+
+  describe('loadCategories action', () => {
+    /**
+     * Build a minimal category wire payload with optional eventCount.
+     */
+    const makeCategoryPayload = (id: string, eventCount?: number) => ({
+      id,
+      calendarId: 'cal-1',
+      ...(eventCount !== undefined ? { eventCount } : {}),
+      content: {
+        en: { language: 'en', name: `Category ${id}` },
+      },
+    });
+
+    it('appends no query params when called without filters', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      await store.loadCategories('test-calendar');
+
+      expect(ModelService.default.listModels).toHaveBeenCalledWith(
+        '/api/public/v1/calendar/test-calendar/categories',
+      );
+    });
+
+    it('appends startDate and endDate query params when provided', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      await store.loadCategories('test-calendar', {
+        startDate: '2025-11-15',
+        endDate: '2025-11-21',
+      });
+
+      expect(ModelService.default.listModels).toHaveBeenCalledWith(
+        '/api/public/v1/calendar/test-calendar/categories?startDate=2025-11-15&endDate=2025-11-21',
+      );
+    });
+
+    it('appends search query param when provided (>= 3 chars)', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      await store.loadCategories('test-calendar', { search: 'yoga' });
+
+      expect(ModelService.default.listModels).toHaveBeenCalledWith(
+        '/api/public/v1/calendar/test-calendar/categories?search=yoga',
+      );
+    });
+
+    it('does not append search when shorter than 3 chars', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      await store.loadCategories('test-calendar', { search: 'yo' });
+
+      expect(ModelService.default.listModels).toHaveBeenCalledWith(
+        '/api/public/v1/calendar/test-calendar/categories',
+      );
+    });
+
+    it('appends all filters together when provided', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      await store.loadCategories('test-calendar', {
+        search: 'yoga class',
+        startDate: '2025-11-15',
+        endDate: '2025-11-21',
+      });
+
+      const callArg = (ModelService.default.listModels as any).mock.calls[0][0] as string;
+      expect(callArg).toContain('/api/public/v1/calendar/test-calendar/categories?');
+      expect(callArg).toContain('search=yoga+class');
+      expect(callArg).toContain('startDate=2025-11-15');
+      expect(callArg).toContain('endDate=2025-11-21');
+    });
+
+    it('sets hasLoadedCategories to true after a successful fetch', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({ items: [] });
+
+      expect(store.hasLoadedCategories).toBe(false);
+      await store.loadCategories('test-calendar');
+      expect(store.hasLoadedCategories).toBe(true);
+    });
+
+    it('does NOT set hasLoadedCategories to true when fetch fails', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockRejectedValue(new Error('boom'));
+
+      // Suppress noisy error log
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await store.loadCategories('test-calendar');
+
+      expect(store.hasLoadedCategories).toBe(false);
+      expect(store.categoryError).toBe('Failed to load categories');
+
+      errSpy.mockRestore();
+    });
+
+    it('parses eventCount from wire payload onto availableCategories', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({
+        items: [
+          makeCategoryPayload('cat-a', 5),
+          makeCategoryPayload('cat-b', 0),
+          makeCategoryPayload('cat-c'), // no eventCount field — defaults to 0
+        ],
+      });
+
+      await store.loadCategories('test-calendar');
+
+      expect(store.availableCategories).toHaveLength(3);
+      expect(store.availableCategories[0].eventCount).toBe(5);
+      expect(store.availableCategories[1].eventCount).toBe(0);
+      expect(store.availableCategories[2].eventCount).toBe(0);
+    });
+  });
+
+  describe('presentCategoryIds getter', () => {
+    it('returns undefined before any fetch has occurred (first-fetch invariant)', () => {
+      // Default state: hasLoadedCategories=false, isLoadingCategories=false
+      expect(store.hasLoadedCategories).toBe(false);
+      expect(store.isLoadingCategories).toBe(false);
+      expect(store.presentCategoryIds).toBeUndefined();
+    });
+
+    it('returns undefined while categories are loading', () => {
+      // Simulate mid-flight: isLoadingCategories=true (regardless of hasLoadedCategories)
+      store.isLoadingCategories = true;
+      store.hasLoadedCategories = true;
+      // Even if some stale categories are sitting in state, the getter must hide them
+      const cat = new EventCategory('cat-1', 'cal-1');
+      cat.eventCount = 3;
+      store.availableCategories = [cat];
+
+      expect(store.presentCategoryIds).toBeUndefined();
+    });
+
+    it('returns ids of categories with eventCount > 0 after a successful fetch', () => {
+      const present = new EventCategory('cat-present', 'cal-1');
+      present.eventCount = 4;
+      const absent = new EventCategory('cat-absent', 'cal-1');
+      absent.eventCount = 0;
+      const alsoPresent = new EventCategory('cat-also', 'cal-1');
+      alsoPresent.eventCount = 1;
+
+      store.hasLoadedCategories = true;
+      store.isLoadingCategories = false;
+      store.availableCategories = [present, absent, alsoPresent];
+
+      expect(store.presentCategoryIds).toEqual(['cat-present', 'cat-also']);
+    });
+
+    it('treats missing eventCount as zero (excludes from present list)', () => {
+      const cat = new EventCategory('cat-no-count', 'cal-1');
+      // eventCount defaults to 0 on the model — explicitly verify
+      expect(cat.eventCount).toBe(0);
+
+      store.hasLoadedCategories = true;
+      store.isLoadingCategories = false;
+      store.availableCategories = [cat];
+
+      expect(store.presentCategoryIds).toEqual([]);
+    });
+
+    it('returns empty array (not undefined) when fetch loaded zero categories', () => {
+      store.hasLoadedCategories = true;
+      store.isLoadingCategories = false;
+      store.availableCategories = [];
+
+      // Empty array is correct here: fetch completed and the answer is "no categories present"
+      expect(store.presentCategoryIds).toEqual([]);
+    });
+
+    it('integrates end-to-end: undefined → ids after loadCategories resolves', async () => {
+      const ModelService = await import('@/client/service/models');
+      (ModelService.default.listModels as any).mockResolvedValue({
+        items: [
+          {
+            id: 'cat-1',
+            calendarId: 'cal-1',
+            eventCount: 2,
+            content: { en: { language: 'en', name: 'Music' } },
+          },
+          {
+            id: 'cat-2',
+            calendarId: 'cal-1',
+            eventCount: 0,
+            content: { en: { language: 'en', name: 'Sports' } },
+          },
+        ],
+      });
+
+      expect(store.presentCategoryIds).toBeUndefined();
+
+      await store.loadCategories('test-calendar');
+
+      expect(store.presentCategoryIds).toEqual(['cat-1']);
+    });
+  });
+
+  describe('reloadWithFilters reloads categories', () => {
+    it('reloads categories with the same date/search context as events', async () => {
+      store.currentCalendarUrlName = 'test-calendar';
+      store.setSearchQuery('yoga');
+      store.setDateRange('2025-11-15', '2025-11-21');
+      store.setSelectedCategories(['cat-selected']);
+
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories').mockResolvedValue();
+      const loadEventsSpy = vi.spyOn(store, 'loadEvents').mockResolvedValue();
+
+      await store.reloadWithFilters();
+
+      expect(loadEventsSpy).toHaveBeenCalledWith('test-calendar', {
+        search: 'yoga',
+        categories: ['cat-selected'],
+        startDate: '2025-11-15',
+        endDate: '2025-11-21',
+      });
+      expect(loadCategoriesSpy).toHaveBeenCalledWith('test-calendar', {
+        search: 'yoga',
+        startDate: '2025-11-15',
+        endDate: '2025-11-21',
+      });
+    });
+
+    it('does NOT pass selectedCategoryIds to the categories endpoint', async () => {
+      store.currentCalendarUrlName = 'test-calendar';
+      store.setSelectedCategories(['cat-selected-a', 'cat-selected-b']);
+
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories').mockResolvedValue();
+      vi.spyOn(store, 'loadEvents').mockResolvedValue();
+
+      await store.reloadWithFilters();
+
+      expect(loadCategoriesSpy).toHaveBeenCalledWith('test-calendar', {});
+      const passedFilters = loadCategoriesSpy.mock.calls[0][1] as Record<string, unknown> | undefined;
+      expect(passedFilters).toBeDefined();
+      expect(passedFilters).not.toHaveProperty('categories');
+    });
+
+    it('omits search from category filters when shorter than 3 chars', async () => {
+      store.currentCalendarUrlName = 'test-calendar';
+      store.setSearchQuery('yo');
+      store.setDateRange('2025-11-15', '2025-11-21');
+
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories').mockResolvedValue();
+      vi.spyOn(store, 'loadEvents').mockResolvedValue();
+
+      await store.reloadWithFilters();
+
+      expect(loadCategoriesSpy).toHaveBeenCalledWith('test-calendar', {
+        startDate: '2025-11-15',
+        endDate: '2025-11-21',
+      });
+    });
+
+    it('does not call loadCategories if no calendar is set', async () => {
+      store.currentCalendarUrlName = null;
+
+      const loadCategoriesSpy = vi.spyOn(store, 'loadCategories').mockResolvedValue();
+
+      await store.reloadWithFilters();
+
+      expect(loadCategoriesSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a third **"absent"** state to the category filter pills on the public site (`/view/:calendarName`) and the embeddable widget. Categories with no events in the current date+search window now render at reduced opacity, are non-actionable, and surface a tooltip explaining why — so visitors no longer click a pill expecting results and find an empty list.

Closes the **pv-sosx** epic (7 leaf beads across 6 waves: backend service + API → common model → site store → SCSS + i18n → component wiring).

## What changed

**Backend (additive, fully backward-compatible):**
- `listCategoriesForCalendar(calendar, options?)` accepts optional `{ startDate?, endDate?, search? }` and pipes filters into the `eventCount` aggregation by reusing `calendarInterface.listEventInstancesWithFilters` (no new SQL).
- `GET /api/public/v1/calendar/:urlName/categories` parses and forwards the new optional query params; existing callers (no params) keep their behavior.
- `search` is capped at 200 chars at the service boundary; dates validated via regex + Luxon.

**Frontend:**
- `EventCategory` common model gained a wire-only `eventCount: number = 0` field with `fromObject`/`toObject` hydration.
- `publicCalendarStore` exposes a new `presentCategoryIds: string[] | undefined` getter. **The `undefined`-while-loading invariant is load-bearing** — returning an empty array would falsely flag every pill as absent. The store reloads categories in parallel with events on filter change.
- `category-pill-selector` accepts `presentCategoryIds` + `absentTooltip` props. When present, pills with no events render with `.absent` class, `aria-disabled="true"`, a native `title` tooltip; click and Enter/Space become no-ops; the aria-label state slot uses the new `category_absent` token.
- **Selected wins over absent** — a pill that was selected before the filter narrowed stays interactive and styled as selected.
- New SCSS `.absent` rules in `@mixin public-filter-pill` cover all three theme blocks (default, public-dark-mode, public-light-mode-override) so the widget light-theme override renders correctly on dark-OS devices. `:active` transform suppressed so press feedback doesn't fire on disabled pills.
- New i18n keys `category_absent` ("unavailable") and `category_absent_tooltip` ("No events in this date range") added to `en/system.json`. es/fr fall back via i18next runtime per project convention.

## Notable design decisions

- **`undefined` means "don't know yet"** is enforced end-to-end (model → store getter → component → SCSS opt-in). Consumers that don't pass `presentCategoryIds` see no behavior change.
- **`aria-disabled` (NOT native `disabled`)** preserves tab order so keyboard/screen-reader users can reach the tooltip. Matches the existing `funding.vue:769` and `_accessibility.scss:132-136` pattern.
- **Server-side derivation** (extending the categories endpoint) was chosen over client-side derivation from `allEvents` to avoid removing the `/events` `categories` filter and incurring a perf regression on event-dense calendars.
- **Dual `useTranslation('system')`** in `search-filter-public.vue` (one with `keyPrefix: 'public_search_filter'`, one root `tSystem`) is intentional and inline-documented — not cleanup-bait.

## Follow-ups created during this epic

- **pv-qynz** (P1 bug) — Fix SQL injection in `listEventInstancesWithFilters` search predicate (`event_instance.ts:320` uses `Sequelize.literal()` with single-quote-only escaping). Surfaced by the security audit on pv-sosx.1.1; out of scope for this epic since the public categories handler now routes search through the same path, the fix should land before any further public search surface ships.

## Test plan

- [x] Unit: `src/server/public/test/calendar.service.test.ts` — service filter combinations, recurring-event de-duplication, invalid-date guards (regex + Luxon)
- [x] Unit: `src/server/public/test/api.test.ts` — handler param parsing, options forwarding, 400 on invalid date
- [x] Unit: `src/common/test/event_category_translated.test.ts` — eventCount roundtrip
- [x] Unit: `src/site/test/stores/publicCalendarStore.test.ts` — loadCategories URL params, presentCategoryIds undefined/loading/loaded/empty contract, reloadWithFilters parallel reload
- [x] Unit: `src/site/test/components/category-pill-selector.test.ts` — absent class, aria-disabled, click/Enter/Space no-ops, selected-wins-over-absent, undefined-presentCategoryIds case, title attribute, aria-label token
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — green
- [x] Manual browser verification on `/view/:calendarName` — narrow date range, observe pills fade for empty categories, hover/focus shows tooltip, click is a no-op, selected pill stays interactive
- [x] Manual widget verification — same three-state behavior in light + dark themes

## Acceptance criteria (from epic spec)

- [x] Categories with no events render in a de-emphasized "absent" state
- [x] Absent pills do not toggle on click or Enter/Space
- [x] Absent pills show the tooltip on hover and on keyboard focus
- [x] Selected pills always render as selected, even when no longer present
- [x] Selecting one category does not flip every other category to absent
- [x] Initial page load shows all pills as present until categories have loaded once
- [x] Public site and widget render the new states identically (single shared component)
- [x] Keyboard and screen-reader users perceive all three states
- [x] Existing `GET .../categories` callers (no params) unchanged
- [x] All three mixin locations carry the absent rules
- [x] Lint, unit, integration, build all pass