### PR TITLE
fix(i18n): add missing site locale keys for es/fr parity (pv-i1ej)

### DIFF
--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -32,6 +32,8 @@
     "category_filter_aria_label": "{{name}} filtro de categoría, {{state}}",
     "selected": "seleccionado",
     "not_selected": "no seleccionado",
+    "category_absent": "no disponible",
+    "category_absent_tooltip": "No hay eventos en este rango de fechas",
     "back_to_calendar": "Volver a {{name}}",
     "series_events": "Eventos en esta serie",
     "series_no_events": "No hay eventos en esta serie",
@@ -87,6 +89,12 @@
     "event_source_calendar_label": "Ver calendario fuente {{name}}",
     "event_details_sidebar": "Detalles del evento",
     "opens_in_new_tab": "se abre en una pestaña nueva",
+    "url_prompt": {
+        "tickets": "Entradas",
+        "rsvp": "Confirmar asistencia",
+        "more_info": "Más información",
+        "register": "Registrarse"
+    },
     "report": {
         "link_text": "Reportar evento",
         "form_title": "Reportar este evento",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -27,6 +27,13 @@
     "next_week": "Semaine suivante",
     "previous_month": "Mois précédent",
     "next_month": "Mois suivant",
+    "scroll_categories_left": "Faire défiler les catégories vers la gauche",
+    "scroll_categories_right": "Faire défiler les catégories vers la droite",
+    "category_filter_aria_label": "Filtre de catégorie {{name}}, {{state}}",
+    "selected": "sélectionné",
+    "not_selected": "non sélectionné",
+    "category_absent": "non disponible",
+    "category_absent_tooltip": "Aucun événement dans cette plage de dates",
     "public_search_filter": {
         "search_events": "Rechercher des événements",
         "search_placeholder": "Rechercher des événements...",
@@ -82,6 +89,12 @@
     "event_source_calendar_label": "Voir le calendrier source {{name}}",
     "event_details_sidebar": "Détails de l'événement",
     "opens_in_new_tab": "s'ouvre dans un nouvel onglet",
+    "url_prompt": {
+        "tickets": "Billets",
+        "rsvp": "Confirmer ma présence",
+        "more_info": "Plus d'informations",
+        "register": "S'inscrire"
+    },
     "report": {
         "link_text": "Signaler l'événement",
         "form_title": "Signaler cet événement",


### PR DESCRIPTION
## Summary
- Brings `es/system.json` and `fr/system.json` to parity with `en/system.json` so Spanish and French visitors see translated strings instead of key-path fallbacks on the public event detail page and category filter.
- Closes pv-i1ej (i18n locale parity gap surfaced by pv-rtu1 epic completion sweep).

## Changes
- **es:** add `url_prompt` block (`tickets`, `rsvp`, `more_info`, `register`), `category_absent`, `category_absent_tooltip`
- **fr:** add `scroll_categories_left`, `scroll_categories_right`, `category_filter_aria_label`, `selected`, `not_selected`, `category_absent`, `category_absent_tooltip`, `url_prompt` block

All three site locales now have 58 top-level keys.

## Test plan
- [ ] Visit a public event detail page with `lang=es` and an event that has an external URL — verify CTA label is translated (e.g. "Entradas" instead of `url_prompt.tickets`)
- [ ] Visit a public calendar page with `lang=fr` — verify category filter pill aria labels and scroll buttons are translated
- [ ] Verify `category_absent` tooltip displays in es/fr when a category has no events in the selected date range