### PR TITLE
chore(orchestrator): strip bead IDs from branchName, commitMsg, and prBody output

### DIFF
--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -34,7 +34,6 @@ import {
   commitMsg,
   prBody,
   type MatchedAgent as HelperMatchedAgent,
-  type BeadRef,
 } from './helpers.js';
 import { buildAgentSelectorPrompt, parseAgentSelectorVerdict } from './phases.js';
 
@@ -137,9 +136,9 @@ export const PR_MESSAGES = {
   bdShowFailed: (beadId: string, code: number, stderr: string) =>
     `bd show --json failed for "${beadId}" (exit ${code}): ${stderr.trim()}`,
   prBodyFailed: (code: number, stderr: string) =>
-    `pr-body.sh failed (exit ${code}): ${stderr.trim()}`,
+    `prBody helper failed (exit ${code}): ${stderr.trim()}`,
   commitMsgFailed: (code: number, stderr: string) =>
-    `commit-msg.sh failed (exit ${code}): ${stderr.trim()}`,
+    `commitMsg helper failed (exit ${code}): ${stderr.trim()}`,
   pushFailed: (branch: string, stderr: string) =>
     `git push failed for branch "${branch}": ${stderr.trim()}`,
   ghPrFailed: (code: number, stderr: string) =>
@@ -156,6 +155,7 @@ type MatchedAgent = HelperMatchedAgent;
 
 interface BeadJson {
   title?: string;
+  description?: string;
   status?: string;
   issue_type?: string;
   children?: Array<{ id?: string }>;
@@ -1763,11 +1763,7 @@ export async function runPR(
   }
 
   // Step 2: Generate PR body (pure function)
-  const beadRefs: BeadRef[] = beadsClosed.map(id => ({
-    id,
-    title: id === ctx.beadId ? (bead.title ?? id) : id,
-  }));
-  const generatedPrBody = prBody(bead.title ?? ctx.beadId, '', beadRefs);
+  const generatedPrBody = prBody(bead.title ?? ctx.beadId, bead.description ?? '');
 
   // Step 3: Derive PR title
   let prTitle: string;
@@ -1776,7 +1772,7 @@ export async function runPR(
     prTitle = derivePrTitleFromBead(bead.title ?? ctx.beadId, 'epic');
   }
   else {
-    prTitle = commitMsg(ctx.beadId, bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
+    prTitle = commitMsg(bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
   }
 
   // Step 4: Push branch

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -191,12 +191,16 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
 // =============================================================================
 
 /**
- * Orchestrator-generated branch pattern. Matches the format produced by
- * `branchName()`: `<type>/<kebab-title>-<beadId-with-dashes>`.
+ * Orchestrator-generated branch pattern. Matches legacy branches that still
+ * carry a `-pv-<beadId>` suffix from before pv-p85n stripped bead IDs out of
+ * git artifacts. New `branchName()` output (`<type>/<kebab-title>`) will not
+ * match — the orphan-recovery shortcut is intentionally legacy-only because
+ * a no-suffix pattern is too loose to safely distinguish abandoned
+ * orchestrator branches from real user work.
  *
- * Loose by design — a branch that matches this pattern still has to pass
- * every other recovery guard (clean tree, no commits ahead of main, no open
- * PR) before preflight will touch it.
+ * A branch that matches this pattern still has to pass every other recovery
+ * guard (clean tree, no commits ahead of main, no open PR) before preflight
+ * will touch it.
  */
 const ORCHESTRATOR_BRANCH_PATTERN = /^(chore|feat|fix)\/[a-z0-9][a-z0-9-]*-pv-[a-z0-9-]+$/;
 
@@ -926,18 +930,20 @@ const BRANCH_PREFIX_MAP: Record<string, string> = {
 /**
  * Derive a branch name from bead metadata. Pure function.
  *
- * Format: <prefix>/<kebab-title>-<id-slug>
+ * Format: <prefix>/<kebab-title>
  * Max length: 60 chars total.
- * Dots in beadId are replaced with hyphens.
+ *
+ * Bead IDs do not appear in branch names — see git-workflow skill's
+ * foundational principle: GitHub artifacts are self-contained for GitHub
+ * readers, so local tracker references stay out of branch names, commits,
+ * and PR bodies.
  */
 export function branchName(
-  beadId: string,
   title: string,
   issueType: string,
 ): string {
   const MAX_LEN = 60;
   const prefix = BRANCH_PREFIX_MAP[issueType] ?? 'chore';
-  const idSlug = beadId.replace(/\./g, '-');
 
   // Kebab-case the title
   const kebabFull = title
@@ -945,15 +951,15 @@ export function branchName(
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 
-  // Reserve space: prefix + "/" + "-" + idSlug
-  const reserved = prefix.length + 1 + 1 + idSlug.length;
+  // Reserve space: prefix + "/"
+  const reserved = prefix.length + 1;
   const budget = Math.max(8, MAX_LEN - reserved);
 
-  let kebab = kebabFull.length > budget
+  const kebab = kebabFull.length > budget
     ? kebabFull.slice(0, budget).replace(/-+$/, '')
     : kebabFull;
 
-  return `${prefix}/${kebab}-${idSlug}`;
+  return `${prefix}/${kebab}`;
 }
 
 // =============================================================================
@@ -969,13 +975,15 @@ const COMMIT_TYPE_MAP: Record<string, string> = {
 };
 
 /**
- * Format a conventional commit message. Pure function.
+ * Format a conventional commit message header. Pure function.
  *
- * Format: <type>(<scope>): <summary> (<beadId>)
- *      or <type>: <summary> (<beadId>)
+ * Format: <type>(<scope>): <summary>
+ *      or <type>: <summary>
+ *
+ * Bead IDs do not appear in commit messages — see git-workflow skill's
+ * foundational principle.
  */
 export function commitMsg(
-  beadId: string,
   summary: string,
   issueType: string,
   scope?: string,
@@ -984,9 +992,9 @@ export function commitMsg(
   const cleanSummary = summary.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
 
   if (scope) {
-    return `${type}(${scope}): ${cleanSummary} (${beadId})`;
+    return `${type}(${scope}): ${cleanSummary}`;
   }
-  return `${type}: ${cleanSummary} (${beadId})`;
+  return `${type}: ${cleanSummary}`;
 }
 
 // =============================================================================
@@ -996,34 +1004,29 @@ export function commitMsg(
 /**
  * Generate PR markdown body. Pure function.
  *
- * Sections: ## Summary, ## Beads closed, ## Test plan.
+ * Sections: ## Motivation, ## Approach, ## Validation. Matches the template
+ * in the git-workflow skill's pull-requests.md. No Summary, no Beads-closed
+ * list — bead IDs and other local tracker references must not appear in
+ * GitHub-visible artifacts.
  */
 export function prBody(
-  primaryTitle: string,
-  primaryDesc: string,
-  beads: BeadRef[],
+  title: string,
+  description: string,
 ): string {
-  // Extract first sentence from description
-  const summaryLine = (() => {
-    const flat = primaryDesc.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim();
-    const dotIdx = flat.indexOf('. ');
-    if (dotIdx >= 0) {
-      return flat.slice(0, dotIdx + 1);
-    }
-    return flat.endsWith('.') ? flat : flat + '.';
-  })();
+  const motivation = description.trim().length > 0
+    ? description.trim()
+    : title;
 
   const lines: string[] = [
-    '## Summary',
+    '## Motivation',
     '',
-    `- ${primaryTitle}`,
-    ...(primaryDesc ? [`- ${summaryLine}`] : []),
+    motivation,
     '',
-    '## Beads closed',
+    '## Approach',
     '',
-    ...beads.map(b => `- ${b.id} - ${b.title}`),
+    title,
     '',
-    '## Test plan',
+    '## Validation',
     '',
     '- [ ] `npm run lint`',
     '- [ ] `npm run test:unit`',

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -1338,7 +1338,7 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
   }
 
   // Step 3: Derive branch name (pure function)
-  const derivedBranchName = branchName(ctx.beadId, title, issueType);
+  const derivedBranchName = branchName(title, issueType);
 
   // Step 4: Check if already on target branch
   const currentCmd = spawnCmd('git', ['branch', '--show-current'], logger, PhaseName.Branch, spawn);

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -55,12 +55,12 @@ function enrichedBeadText(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Branch name that branchName() would derive for pv-test.1 / 'task' / title
+// Branch name that branchName() would derive for 'task' + title
 // ---------------------------------------------------------------------------
-// branchName('pv-test.1', 'Implement widget feature', 'task')
-// → prefix='chore', idSlug='pv-test-1', kebab='implement-widget-feature'
-// → 'chore/implement-widget-feature-pv-test-1'
-const EXPECTED_BRANCH = 'chore/implement-widget-feature-pv-test-1';
+// branchName('Implement widget feature', 'task')
+// → prefix='chore', kebab='implement-widget-feature'
+// → 'chore/implement-widget-feature'
+const EXPECTED_BRANCH = 'chore/implement-widget-feature';
 
 describe('Integration: leaf happy path', () => {
   let scripts: ScriptRouter;

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -18,13 +18,13 @@ vi.mock('../../lib/helpers.js', async (importOriginal) => {
     bdEscalate: vi.fn(),
     bdEnrichmentCheck: vi.fn().mockReturnValue(false),
     commitMsg: vi.fn().mockImplementation(
-      (beadId: string, summary: string, issueType: string) => {
+      (summary: string, issueType: string) => {
         const typeMap: Record<string, string> = { bug: 'fix', feature: 'feat', epic: 'feat', task: 'chore' };
         const type = typeMap[issueType] ?? 'chore';
-        return `${type}: ${summary} (${beadId})`;
+        return `${type}: ${summary}`;
       },
     ),
-    prBody: vi.fn().mockReturnValue('## Summary\n\n- title\n'),
+    prBody: vi.fn().mockReturnValue('## Motivation\n\nWhy.\n\n## Approach\n\ntitle\n\n## Validation\n\n- [ ] checks\n'),
   };
 });
 
@@ -944,13 +944,13 @@ describe('runPR', () => {
     vi.mocked(helpers.bdEscalate).mockReturnValue(undefined);
     vi.mocked(helpers.bdEnrichmentCheck).mockReturnValue(false);
     vi.mocked(helpers.commitMsg).mockImplementation(
-      (beadId: string, summary: string, issueType: string) => {
+      (summary: string, issueType: string) => {
         const typeMap: Record<string, string> = { bug: 'fix', feature: 'feat', epic: 'feat', task: 'chore' };
         const type = typeMap[issueType] ?? 'chore';
-        return `${type}: ${summary} (${beadId})`;
+        return `${type}: ${summary}`;
       },
     );
-    vi.mocked(helpers.prBody).mockReturnValue('## Summary\n\n- title\n');
+    vi.mocked(helpers.prBody).mockReturnValue('## Motivation\n\nWhy.\n\n## Approach\n\ntitle\n\n## Validation\n\n- [ ] checks\n');
   });
 
   function makeDeps(results: SpawnSyncReturns<Buffer>[]): ExecuteDeps {
@@ -997,7 +997,7 @@ describe('runPR', () => {
   it('should create PR and route to Report for a closed leaf bead', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
-    const branchName = 'chore/fix-widget-pv-test-1';
+    const branchName = 'chore/fix-widget';
     const prUrl = 'https://github.com/owner/repo/pull/42';
 
     // Sequence: git branch, bd show, git push, gh pr create

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -545,37 +545,47 @@ describe('bdEnrichmentCheck', () => {
 
 describe('branchName', () => {
   it('derives chore prefix for task type', () => {
-    const result = branchName('pv-abc1', 'Fix the broken widget', 'task');
-    expect(result).toMatch(/^chore\//);
-    expect(result).toContain('fix-the-broken-widget');
-    expect(result).toContain('pv-abc1');
+    const result = branchName('Fix the broken widget', 'task');
+    expect(result).toBe('chore/fix-the-broken-widget');
   });
 
   it('uses feat prefix for feature type', () => {
-    const result = branchName('pv-abc2', 'Add calendar discovery', 'feature');
+    const result = branchName('Add calendar discovery', 'feature');
+    expect(result).toMatch(/^feat\//);
+  });
+
+  it('uses feat prefix for epic type', () => {
+    const result = branchName('Build search', 'epic');
     expect(result).toMatch(/^feat\//);
   });
 
   it('uses fix prefix for bug type', () => {
-    const result = branchName('pv-abc3', 'Fix broken links', 'bug');
+    const result = branchName('Fix broken links', 'bug');
     expect(result).toMatch(/^fix\//);
   });
 
-  it('replaces dots in bead id with hyphens', () => {
-    const result = branchName('pv-abc1.3', 'Some task', 'task');
-    expect(result).toContain('pv-abc1-3');
-    expect(result).not.toContain('pv-abc1.3');
+  it('does not embed bead IDs in output', () => {
+    // Bead IDs must not appear in branch names — git-workflow principle.
+    const result = branchName('Some task', 'task');
+    expect(result).not.toMatch(/pv-/);
   });
 
   it('truncates long titles to stay within 60 chars', () => {
-    const longTitle = 'This is a very long title that would exceed the maximum length limit easily';
-    const result = branchName('pv-abc1', longTitle, 'task');
+    const longTitle = 'This is a very long title that would exceed the maximum length limit easily and should be truncated cleanly';
+    const result = branchName(longTitle, 'task');
     expect(result.length).toBeLessThanOrEqual(60);
+    expect(result).toMatch(/^chore\//);
+    expect(result.endsWith('-')).toBe(false);
   });
 
   it('defaults to chore for unknown issue type', () => {
-    const result = branchName('pv-abc1', 'Some work', 'unknown');
+    const result = branchName('Some work', 'unknown');
     expect(result).toMatch(/^chore\//);
+  });
+
+  it('strips leading and trailing non-alphanumerics from the title', () => {
+    const result = branchName('  --Add Search-- ', 'feature');
+    expect(result).toBe('feat/add-search');
   });
 });
 
@@ -585,24 +595,35 @@ describe('branchName', () => {
 
 describe('commitMsg', () => {
   it('formats correctly without scope', () => {
-    const result = commitMsg('pv-abc1', 'Add event search', 'feature');
-    expect(result).toBe('feat: Add event search (pv-abc1)');
+    const result = commitMsg('Add event search', 'feature');
+    expect(result).toBe('feat: Add event search');
   });
 
   it('includes scope when provided', () => {
-    const result = commitMsg('pv-abc1', 'Fix calendar API', 'bug', 'calendar');
-    expect(result).toBe('fix(calendar): Fix calendar API (pv-abc1)');
+    const result = commitMsg('Fix calendar API', 'bug', 'calendar');
+    expect(result).toBe('fix(calendar): Fix calendar API');
   });
 
   it('maps epic to feat', () => {
-    const result = commitMsg('pv-abc1', 'Implement federation', 'epic');
+    const result = commitMsg('Implement federation', 'epic');
     expect(result).toMatch(/^feat:/);
   });
 
+  it('does not embed bead IDs in output', () => {
+    // Bead IDs must not appear in commit messages — git-workflow principle.
+    const result = commitMsg('Add event search', 'feature');
+    expect(result).not.toMatch(/pv-/);
+  });
+
   it('collapses newlines in summary', () => {
-    const result = commitMsg('pv-abc1', 'Line one\nLine two', 'task');
+    const result = commitMsg('Line one\nLine two', 'task');
     expect(result).not.toContain('\n');
     expect(result).toContain('Line one Line two');
+  });
+
+  it('defaults to chore for unknown issue type', () => {
+    const result = commitMsg('Some work', 'unknown');
+    expect(result).toBe('chore: Some work');
   });
 });
 
@@ -611,47 +632,59 @@ describe('commitMsg', () => {
 // =============================================================================
 
 describe('prBody', () => {
-  it('includes all three sections', () => {
+  it('renders the three required template sections', () => {
+    // The git-workflow PR template requires Motivation, Approach, Validation.
+    // No Summary, no Beads-closed list, no Test plan section.
     const body = prBody(
       'Add event search',
-      'This feature allows users to search for events.',
-      [{ id: 'pv-abc1', title: 'Add event search' }],
+      'Users have asked for a way to search calendar events.',
     );
-    expect(body).toContain('## Summary');
-    expect(body).toContain('## Beads closed');
-    expect(body).toContain('## Test plan');
+    expect(body).toContain('## Motivation');
+    expect(body).toContain('## Approach');
+    expect(body).toContain('## Validation');
+    expect(body).not.toContain('## Summary');
+    expect(body).not.toContain('## Beads closed');
+    expect(body).not.toContain('## Test plan');
   });
 
-  it('lists all beads in Beads closed section', () => {
-    const body = prBody(
-      'Epic: Build search',
-      'Description text.',
-      [
-        { id: 'pv-abc1', title: 'Parent epic' },
-        { id: 'pv-abc1.1', title: 'Child one' },
-        { id: 'pv-abc1.2', title: 'Child two' },
-      ],
-    );
-    expect(body).toContain('pv-abc1');
-    expect(body).toContain('pv-abc1.1');
-    expect(body).toContain('pv-abc1.2');
+  it('does not include any bead IDs in the rendered body', () => {
+    // Bead IDs must not appear in PR bodies — git-workflow principle.
+    const body = prBody('Add feature', 'Why this work was needed.');
+    expect(body).not.toMatch(/pv-[a-z0-9]+/);
   });
 
-  it('uses first sentence of description in summary', () => {
-    const body = prBody(
-      'Add feature',
-      'First sentence text. Second sentence should be excluded.',
-      [{ id: 'pv-abc1', title: 'Add feature' }],
-    );
-    expect(body).toContain('First sentence text.');
-    expect(body).not.toContain('Second sentence');
+  it('uses the description for the Motivation section', () => {
+    const description = 'Users have asked for a way to search calendar events.';
+    const body = prBody('Add event search', description);
+    const motivationStart = body.indexOf('## Motivation');
+    const approachStart = body.indexOf('## Approach');
+    const motivationBody = body.slice(motivationStart, approachStart);
+    expect(motivationBody).toContain(description);
   });
 
-  it('omits description line when no description', () => {
-    const body = prBody('Add feature', '', [{ id: 'pv-abc1', title: 'Add feature' }]);
-    // Should still have summary with just the title
-    expect(body).toContain('## Summary');
-    expect(body).toContain('- Add feature');
+  it('uses the title for the Approach section', () => {
+    const body = prBody('Add event search', 'Why...');
+    const approachStart = body.indexOf('## Approach');
+    const validationStart = body.indexOf('## Validation');
+    const approachBody = body.slice(approachStart, validationStart);
+    expect(approachBody).toContain('Add event search');
+  });
+
+  it('falls back to title for Motivation when description is empty', () => {
+    const body = prBody('Add feature', '');
+    const motivationStart = body.indexOf('## Motivation');
+    const approachStart = body.indexOf('## Approach');
+    const motivationBody = body.slice(motivationStart, approachStart);
+    expect(motivationBody).toContain('Add feature');
+  });
+
+  it('includes the standard validation checklist', () => {
+    const body = prBody('Add feature', 'Why.');
+    expect(body).toContain('`npm run lint`');
+    expect(body).toContain('`npm run test:unit`');
+    expect(body).toContain('`npm run test:integration`');
+    expect(body).toContain('`npm run build`');
+    expect(body).toContain('build-guardian');
   });
 });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -1119,8 +1119,8 @@ describe('branch', () => {
 
   it('should skip checkout if already on target branch', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
-    // branchName('pv-test-1', 'A Task', 'task') = 'chore/a-task-pv-test-1'
-    const expectedBranch = 'chore/a-task-pv-test-1';
+    // branchName('A Task', 'task') = 'chore/a-task'
+    const expectedBranch = 'chore/a-task';
     const spawn = seqSpawn(
       // gitSafeToStart:
       fakeSpawn('true', '', 0),

--- a/.claude/skills/bead-branch-and-pr/SKILL.md
+++ b/.claude/skills/bead-branch-and-pr/SKILL.md
@@ -1,114 +1,62 @@
 ---
 name: bead-branch-and-pr
-description: Git branch, commit, and PR conventions for bead-scoped work. Use when creating a branch for a bead, writing commit messages that reference a bead id, drafting a PR that closes one or more beads, or verifying the working tree is safe to start new bead work.
+description: Orchestrator-internal helper functions that turn a bead into a branch, commit message, and PR body. Use when an orchestrator (or test that simulates one) needs to call branchName, commitMsg, prBody, or gitSafeToStart programmatically. NOT a source of truth for git or PR conventions — see the git-workflow skill for those.
 ---
 
-# Bead Branch and PR Skill
+# Bead Branch and PR Helpers
 
-This skill captures the git and GitHub conventions used when turning a bead (or a chain of beads) into shippable work. It pairs prose guidance with four deterministic functions that do the actual formatting so every branch, commit, and PR body is generated the same way, whether a human or an orchestrator is running the workflow.
+This skill documents the deterministic helper functions that orchestrators call when they need to turn a bead into git artifacts. The conventions those artifacts must follow are defined elsewhere — this skill is purely about the helper API.
 
-The functions live in `.claude/orchestrators/lib/helpers.ts`:
+**Source of truth for git/PR conventions:** the `git-workflow` skill at `.claude/skills/git-workflow/`. That skill defines branch naming, commit format, PR template, and the foundational principle that GitHub artifacts must be self-contained for GitHub readers (no bead IDs in branches, commits, or PR bodies).
 
-- `branchName(beadId, typeOverride, deps)` — Generate kebab-case branch name with bead id
-- `commitMsg(beadId, summary, scope)` — Format conventional commit message with bead id
-- `prBody(primaryBeadId, additionalBeadIds, deps)` — Render markdown PR body with summary and test plan
-- `gitSafeToStart(deps)` — Check if working tree is clean and on main
+## When to use
 
-All functions accept an injectable `spawnFn` dependency for testability and fail loudly on invalid input.
+Invoke this skill when:
 
-## Branch naming
+- An orchestrator phase needs to derive a branch name, commit message, or PR body from bead metadata.
+- A test fixtures the helpers' output and needs to know the call signature.
+- You are evolving one of the four helpers and need to keep the implementation aligned with `git-workflow`.
 
-Branches follow the pattern:
+Do **not** use this skill to look up git or PR conventions. For those, read `git-workflow/branches.md`, `commits.md`, `pull-requests.md`, or `releases.md` directly.
 
-```
-<prefix>/<kebab-title>-<bead-id-with-dashes>
-```
+## The four helpers
 
-The prefix is derived from the bead's `issue_type` so that the branch name hints at the kind of change that's landing. It also lines up with the conventional-commit prefixes used in commit messages, keeping the vocabulary consistent from branch → commit → PR.
+The functions live in `.claude/orchestrators/lib/helpers.ts` and are pure (no I/O) except for `gitSafeToStart`, which shells out to `git`.
 
-| Bead type  | Branch prefix | Conventional commit type |
-|------------|---------------|--------------------------|
-| `bug`      | `fix/`        | `fix`                    |
-| `feature`  | `feat/`       | `feat`                   |
-| `epic`     | `feat/`       | `feat`                   |
-| `task`     | `chore/`      | `chore`                  |
-| (unknown)  | `chore/`      | `chore`                  |
+### `branchName(title, issueType)`
 
-If a task is really an enhancement or refactor rather than housekeeping, override the prefix explicitly:
+Returns `<type>/<kebab-title>`, capped at 60 characters total. The type prefix maps from the bead's `issue_type`:
 
-```bash
-./branch-name.sh pv-9cfj.3 --type-override=refactor
-# -> refactor/<kebab-title>-<id>
-```
+| `issue_type` | Branch prefix |
+|--------------|---------------|
+| `bug`        | `fix/`        |
+| `feature`    | `feat/`       |
+| `epic`       | `feat/`       |
+| `task`       | `chore/`      |
+| (anything else) | `chore/`   |
 
-**Rules enforced by `branch-name.sh`:**
+Bead IDs are not embedded in the output. The orchestrator's bookkeeping of which bead a branch belongs to is tracked in its run-context, not in the branch name.
 
-- Kebab-case the bead title: lowercase, any run of non-alphanumerics collapses to a single hyphen, leading/trailing hyphens stripped.
-- Replace dots in the bead id (`pv-9cfj.3` → `pv-9cfj-3`) so the branch name is safe for `git rev-parse --abbrev-ref` and wildcard globs.
-- Total branch name length is capped at 60 characters. When the title is too long, only the kebab-title segment is truncated; the prefix and id slug are always preserved, and a trailing hyphen left over from mid-word truncation is trimmed.
-- Output is deterministic: the same bead always produces the same branch name.
+### `commitMsg(summary, issueType, scope?)`
 
-## Commit message format
+Returns a conventional-commit header — `<type>(<scope>): <summary>` or `<type>: <summary>` when no scope is given. The same `issue_type → type` map as `branchName` applies. Newlines and runs of whitespace in `summary` are flattened so multi-line input still produces a one-line header.
 
-Commit messages follow the conventional-commit shape with a `(pv-xxxx)` id suffix that ties the commit to a bead. This matches the existing git history — see commit `a810e16`:
+Bead IDs are not embedded in the output. GitHub's squash-merge UI auto-appends the `(#PR)` form when the branch lands on `main`.
 
-```
-fix(events): persist and display event accessibility info (pv-xhzn)
-```
+### `prBody(title, description)`
 
-**`commit-msg.sh` emits exactly one line:**
-
-```
-<type>(<scope>): <summary> (<bead-id>)
-```
-
-The scope parenthetical is omitted when no scope is provided:
-
-```
-<type>: <summary> (<bead-id>)
-```
-
-The `<type>` is derived from the bead's `issue_type` using the same mapping as branch naming (`bug → fix`, `feature → feat`, `epic → feat`, `task → chore`). The `<summary>` is flattened to a single line (newlines and runs of whitespace collapse to single spaces) so multi-line summaries passed in from orchestrators don't break the commit header.
-
-### Two commit conventions, don't confuse them
-
-Two commit shapes appear in this repo's history, and they mean different things:
-
-1. **In-branch commits:** individual commits on a feature branch use the `(pv-xxxx)` suffix. This is what `commit-msg.sh` produces. Example:
-
-   ```
-   fix(calendar): preserve repost-target context in reassign-categories dialog (pv-xxxx)
-   ```
-
-2. **Merge commits on `main`:** GitHub's squash/merge UI appends `(#PR)` automatically. Example:
-
-   ```
-   fix(widget): bring event detail page to parity with public site (#199)
-   ```
-
-When writing commits directly, **always use `(pv-xxxx)`** — let GitHub add the `(#PR)` form when the branch merges.
-
-### Never add assistant trailers
-
-Commit messages must not contain `Co-authored-by: Claude`, `Claude-Code`, or any other assistant-generated trailer. The script never emits one, and human commit bodies must not add one either.
-
-## PR body template
-
-`pr-body.sh <primary-bead-id> [additional-bead-ids...]` renders a PR body in markdown with three sections:
+Returns a markdown body with the three sections defined by the `git-workflow` PR template:
 
 ```markdown
-## Summary
+## Motivation
 
-- <primary bead title>
-- <first sentence of the primary bead's description>
+<description, or title if description is empty>
 
-## Beads closed
+## Approach
 
-- <primary-id> - <primary title>
-- <additional-id> - <additional title>
-  ...
+<title>
 
-## Test plan
+## Validation
 
 - [ ] `npm run lint`
 - [ ] `npm run test:unit`
@@ -117,50 +65,32 @@ Commit messages must not contain `Co-authored-by: Claude`, `Claude-Code`, or any
 - [ ] Relevant e2e specs passing via build-guardian
 ```
 
-**Single-bead PR:** pass only the primary id. The "Beads closed" section is a one-line list.
+No Summary section, no Beads-closed list, no Test plan — those would either duplicate template content or leak local tracker references into a GitHub-visible artifact.
 
-**Epic-closing or multi-bead PR:** pass every closed bead id. The primary id (first argument) still drives the Summary section; the other ids are looked up via `bd show --json` and rendered as `- <id> - <title>` entries.
+### `gitSafeToStart(deps?)`
 
-The PR title is not rendered by this script. Use `commit-msg.sh` output as the PR title when there's exactly one bead, or hand-write one for multi-bead PRs (typically the epic's title without the `Epic:` prefix).
+Returns `{ ok: boolean, reason?: string }`. The orchestrator calls this at the branch-creation step as a narrow re-check (clean tree + on `main`). It is intentionally cheaper than the full `preflight()` that runs at the start of `/process-backlog`.
 
-## When to push: after build-guardian, never before
+The expected main-branch name defaults to `main` and can be overridden by the `GIT_SAFE_MAIN_BRANCH` env var for test rigs.
 
-A branch may not be pushed to `origin` until the wave's build-guardian agent has reported PASS. This rule exists because:
+## Push gate: build-guardian before `git push`
 
-- Build-guardian is the last line of defence before CI sees the code. Pushing before it runs risks flipping a red CI badge on a PR that could have been fixed locally.
-- Pushing triggers webhooks (deploy previews, bots) which assume the branch is at least locally-verified.
-- An autonomous orchestrator pushing broken code wastes real-world cycles on retries.
-
-**Concrete sequence for a wave:**
+A branch may not be pushed to `origin` until the wave's build-guardian agent has reported PASS. This is enforced by the orchestrator's pipeline, not by these helpers, but it is documented here because it is the rule that closes the loop on safe branch handling:
 
 1. Implementers land commits on the branch.
-2. Per-bead auditors run (via `agent-discovery`'s `match-agents.sh auditor`).
+2. Per-bead auditors run.
 3. Build-guardian runs once per wave across all committed changes.
-4. Only if build-guardian reports PASS does the orchestrator `git push -u origin <branch>` and open the PR.
+4. Only after build-guardian PASS does the orchestrator `git push -u origin <branch>` and open the PR.
 
 If build-guardian reports FAIL, do not push. Fix locally, re-run build-guardian, and push only once it passes.
 
-## `gitSafeToStart()`: phase-6 gate
-
-When the orchestrator reaches the branch-creation step, the working tree should still be clean and still on `main` — but the full preflight (`bead-backlog-selection/preflight()`) ran in Phase 0, which may have been many phases ago. `gitSafeToStart()` is the narrow re-check: clean tree + on main, nothing else. It is intentionally cheaper than a full preflight.
-
-Returns `{ok: boolean, reason?: string}`. The `ok` field is true if safe to branch, false otherwise. The `reason` field explains why if not safe (wrong branch or dirty tree).
-
-The expected main-branch name is `main` by default but can be overridden via the `GIT_SAFE_MAIN_BRANCH` env var, which is useful for test rigs and for repositories that use a non-`main` trunk.
-
 ## Testing
 
-Tests are co-located with the orchestrator codebase in `.claude/orchestrators/lib/__tests__/`. The test suite covers:
-
-- Branch naming for each bead type, including epic, weird titles with apostrophes and slashes, and titles long enough to exercise the 60-char truncation.
-- Commit message generation with and without scope, including multi-line summary flattening.
-- PR body rendering for both single-bead and multi-bead (epic-closing) cases, with the primary bead's title and description driving the Summary block.
-- `gitSafeToStart()` against real temporary git repos: clean+main, dirty+main, clean+wrong-branch, clean+custom-main, and non-repo directories.
-
-Functions accept an injectable `spawnFn` for testing; fixtures mock `bd show` output. All functions are deterministic — the same input always produces the same output — and throw clearly on invalid input.
+Tests live alongside the orchestrator codebase at `.claude/orchestrators/test/unit/helpers.test.ts`. The suite covers each helper's pure-function behavior and the spawn-mocking dance for `gitSafeToStart`. Helpers must not embed bead IDs in any rendered output — the tests assert this directly.
 
 ## Related skills
 
-- `bead-backlog-selection` — owns the full preflight that this skill's `git-safe-to-start.sh` re-checks narrowly.
-- `bead-wave-orchestration` — consumes these scripts when the orchestrator is about to set up a branch or open a PR.
-- `epic-bead-workflow` — source of truth for how beads relate to branches and PRs.
+- `git-workflow` — canonical source for branch, commit, PR, and release conventions. These helpers exist to produce output that conforms to it.
+- `bead-backlog-selection` — owns the full `preflight()` that this skill's `gitSafeToStart` re-checks narrowly.
+- `bead-wave-orchestration` — consumes these helpers when the orchestrator is about to set up a branch or open a PR.
+- `epic-bead-workflow` — source of truth for how beads relate to branches and PRs at the workflow level.


### PR DESCRIPTION
## Motivation

The recently-landed `git-workflow` skill establishes a foundational principle: GitHub artifacts must be self-contained for GitHub readers, so local tracker references (bead IDs, personal IDs) do not appear in branch names, commits, PR titles or bodies, or release notes. The orchestrator's `branchName`, `commitMsg`, and `prBody` helpers were the source of truth for these conventions before the skill landed and they actively embed bead IDs into every git artifact they produce. The new skill's spec called this cleanup out as out-of-scope follow-up work; this PR is that follow-up.

## Approach

In `.claude/orchestrators/lib/helpers.ts`:

- `branchName(title, issueType)` — dropped the `beadId` argument and the `-<beadId>` output suffix. Output is now `<type>/<kebab-title>`, capped at 60 chars.
- `commitMsg(summary, issueType, scope?)` — dropped the `beadId` argument and the `(<beadId>)` output suffix. Output is `<type>(<scope>): <summary>` or `<type>: <summary>`.
- `prBody(title, description)` — dropped the `beads: BeadRef[]` argument and the entire `## Beads closed` section. The body now renders the three-section template defined in `git-workflow/pull-requests.md`: `## Motivation`, `## Approach`, `## Validation`.
- The `BeadRef` interface and its `execute.ts` import are gone with `prBody`.

Call sites in `phases.ts` (branch creation) and `execute.ts` (PR finalization) updated to the new signatures. Orchestrator-internal bookkeeping such as `ctx.beadsClosed` is preserved — bead IDs still live in the runtime context and run-log; the principle is about what reaches git artifacts on disk.

The orphan-recovery shortcut in `preflight()` keeps its existing legacy `<type>/<title>-pv-<id>` regex with a comment explaining why: a no-suffix pattern would be too loose to safely distinguish abandoned orchestrator branches from real user feature branches, so new branches will simply not auto-recover. That is an acceptable, honest tradeoff — the orchestrator halts with a clear message instead of silently checking the user out of unrelated work.

The `bead-branch-and-pr` skill was also rewritten so the resolver no longer double-matches with `git-workflow` on branch/commit/PR queries. Its description now positions it as orchestrator-internal helper API, not as a parallel source of truth for conventions.

## Validation

- `npx vitest run .claude/orchestrators/test/` — 284 tests passed (10 files). Updated unit tests for `branchName`, `commitMsg`, `prBody` to assert the new outputs and to add explicit "no bead IDs in output" guards. Updated mocks in `execute.test.ts` and the `EXPECTED_BRANCH` fixture in the leaf-happy-path integration test.
- `npm run test:unit` — 7449 tests passed (439 files). No regressions outside the orchestrator suite.
- `npx eslint` on every changed file — no new errors or warnings beyond the two brace-style errors that were already present in `execute.ts` lines 551 and 735 on `main`.
- `npx tsc --noEmit` — zero TypeScript errors in `.claude/orchestrators/`.