### PR TITLE
feat(client): modal focus trap and return focus in useDialog (pv-2pon)

### DIFF
--- a/src/client/assets/style/base/_accessibility.scss
+++ b/src/client/assets/style/base/_accessibility.scss
@@ -257,18 +257,6 @@ button:disabled,
   }
 }
 
-/* ===== FOCUS TRAP SUPPORT FOR DIALOGS ===== */
-
-[role="dialog"] {
-  /* Ensure dialog is in focus trap */
-  &[aria-modal="true"] {
-    /* Hide background content from screen readers when modal */
-    ~ * {
-      aria-hidden: true;
-    }
-  }
-}
-
 /* ===== ARIA LIVE REGIONS ===== */
 
 /* aria-live regions must remain in normal flow so their visible content

--- a/src/client/components/common/Sheet.vue
+++ b/src/client/components/common/Sheet.vue
@@ -1,7 +1,6 @@
 <template>
   <dialog
     ref="dialogRef"
-    role="dialog"
     class="sheet-dialog"
     :aria-labelledby="titleId"
     :aria-modal="true"

--- a/src/client/components/common/modal.vue
+++ b/src/client/components/common/modal.vue
@@ -1,7 +1,6 @@
 <template>
   <dialog
     ref="dialogRef"
-    role="dialog"
     :class="['modal', 'modal-dialog', `modal-size-${size}`, props.modalClass]"
     :aria-labelledby="titleId"
     :aria-modal="true"

--- a/src/client/composables/useDialog.ts
+++ b/src/client/composables/useDialog.ts
@@ -5,10 +5,29 @@ import { ref, computed, Ref, ComputedRef } from 'vue';
  *
  * Encapsulates the open/close lifecycle, Escape handling, backdrop clicks,
  * `document.body.classList` toggle for `modal-open`, a first-focusable focus
- * trap, and deterministic title id generation.
+ * trap, Tab/Shift+Tab focus cycling, return-focus on close, and deterministic
+ * title id generation.
  *
  * Intentionally minimal: no configuration options, no extension points.
  */
+
+/**
+ * Standard tabbable-elements selector. Acknowledged 90% solution; covers the
+ * tabbable surface a Pavillion modal is expected to expose. Post-query filtering
+ * removes disabled / [tabindex="-1"] / [hidden] / display:none / visibility:hidden
+ * elements (the selector cannot express computed-style filters).
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
 
 export interface UseDialogOptions {
   /**
@@ -52,6 +71,11 @@ export function useDialog(
   const dialogId = ref(Math.random().toString(36).substring(2, 11));
   const titleId = computed(() => `${idPrefix}-title-${dialogId.value}`);
 
+  // Element that held focus immediately before open() ran. Restored on close()
+  // when still attached to the document, nulled on close()/cleanup() to avoid
+  // stale references across open/close cycles or when the trigger is unmounted.
+  let previouslyFocused: HTMLElement | null = null;
+
   const trapFocus = () => {
     // Fallback only: <dialog>.showModal() already focuses the first [autofocus]
     // or focusable descendant per spec. Only focus the dialog element itself
@@ -65,13 +89,70 @@ export function useDialog(
     }, 0);
   };
 
+  /**
+   * Returns the currently tabbable descendants of the dialog, in document order.
+   * Filters out elements that match the selector but are not actually tabbable:
+   * disabled, tabindex="-1", hidden attribute, display:none, visibility:hidden.
+   */
+  const getFocusableElements = (el: HTMLDialogElement): HTMLElement[] => {
+    const candidates = Array.from(
+      el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    );
+    return candidates.filter((node) => {
+      if (node.hasAttribute('disabled')) return false;
+      if (node.getAttribute('tabindex') === '-1') return false;
+      if (node.hasAttribute('hidden')) return false;
+      const style = typeof window !== 'undefined' ? window.getComputedStyle(node) : null;
+      if (style && (style.display === 'none' || style.visibility === 'hidden')) return false;
+      return true;
+    });
+  };
+
+  /**
+   * Tab-key handler that cycles focus within the dialog. Bound to the dialog
+   * element in open(), removed in close() and cleanup() (idempotent — duplicate
+   * removeEventListener is a no-op).
+   */
+  const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== 'Tab') return;
+    const el = dialogRef.value;
+    if (!el) return;
+
+    const focusable = getFocusableElements(el);
+
+    // Empty list: prevent focus from escaping the dialog. There is nothing to
+    // cycle to inside, so the only correct behavior is to swallow the Tab.
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    }
+    else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   const open = () => {
     const el = dialogRef.value;
     // No-op when the DOM target is missing or already open (concurrent open).
     if (!el || el.open) {
       return;
     }
+    // Capture the trigger so close() can restore focus to it.
+    previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
     el.showModal();
+    el.addEventListener('keydown', handleKeydown);
     trapFocus();
     if (typeof document !== 'undefined') {
       document.body.classList.add('modal-open');
@@ -84,9 +165,17 @@ export function useDialog(
       return;
     }
     el.close();
+    el.removeEventListener('keydown', handleKeydown);
     if (typeof document !== 'undefined') {
       document.body.classList.remove('modal-open');
     }
+    // Restore focus only when the trigger is still in the DOM. If it was
+    // unmounted while the modal was open, skip restoration to avoid focusing
+    // a detached element.
+    if (previouslyFocused && document.body.contains(previouslyFocused)) {
+      previouslyFocused.focus();
+    }
+    previouslyFocused = null;
     emit('close');
   };
 
@@ -97,9 +186,15 @@ export function useDialog(
   };
 
   const cleanup = () => {
+    const el = dialogRef.value;
+    if (el) {
+      // Idempotent: safe even if open() never registered the listener.
+      el.removeEventListener('keydown', handleKeydown);
+    }
     if (typeof document !== 'undefined') {
       document.body.classList.remove('modal-open');
     }
+    previouslyFocused = null;
   };
 
   return {

--- a/src/client/test/composables/useDialog.test.ts
+++ b/src/client/test/composables/useDialog.test.ts
@@ -198,4 +198,298 @@ describe('useDialog', () => {
       expect(document.body.classList.contains('modal-open')).toBe(false);
     });
   });
+
+  describe('focus trap', () => {
+    /**
+     * Helper: dispatch a keydown to the dialog element with controllable
+     * activeElement so we can simulate focus cycling without relying on
+     * happy-dom's full focus model. preventDefault is observable via the
+     * returned spy.
+     */
+    function dispatchTab(
+      el: HTMLDialogElement,
+      activeEl: Element | null,
+      options: { shift?: boolean } = {},
+    ) {
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => activeEl,
+      });
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: !!options.shift,
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      el.dispatchEvent(event);
+      return { preventDefault };
+    }
+
+    it('Tab on the last focusable cycles to the first', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+      open();
+
+      const { preventDefault } = dispatchTab(el, last);
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(firstFocus).toHaveBeenCalledTimes(1);
+      expect(lastFocus).not.toHaveBeenCalled();
+    });
+
+    it('Shift+Tab on the first focusable cycles to the last', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+      open();
+
+      const { preventDefault } = dispatchTab(el, first, { shift: true });
+
+      expect(preventDefault).toHaveBeenCalled();
+      expect(lastFocus).toHaveBeenCalledTimes(1);
+      expect(firstFocus).not.toHaveBeenCalled();
+    });
+
+    it('Tab in the middle of the list lets default behavior run', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const middle = document.createElement('button');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const middleFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      middle.focus = middleFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(middle);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+      open();
+
+      const { preventDefault } = dispatchTab(el, middle);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(firstFocus).not.toHaveBeenCalled();
+      expect(middleFocus).not.toHaveBeenCalled();
+      expect(lastFocus).not.toHaveBeenCalled();
+    });
+
+    it('Tab with no focusable elements calls preventDefault only', () => {
+      const { el } = makeDialogStub();
+      // No focusable descendants — the dialog is empty.
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+      open();
+
+      const { preventDefault } = dispatchTab(el, document.body);
+
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('Tab listener removed after close()', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open, close } = useDialog(dialogRef, emit);
+      open();
+      close();
+
+      const { preventDefault } = dispatchTab(el, last);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(firstFocus).not.toHaveBeenCalled();
+    });
+
+    it('Tab listener removed after cleanup() without an explicit close()', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open, cleanup } = useDialog(dialogRef, emit);
+      open();
+      cleanup();
+
+      const { preventDefault } = dispatchTab(el, last);
+
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(firstFocus).not.toHaveBeenCalled();
+    });
+
+    it('cycles only between enabled focusable elements (filters disabled / tabindex=-1)', () => {
+      const { el } = makeDialogStub();
+      const first = document.createElement('button');
+      const disabled = document.createElement('button');
+      disabled.setAttribute('disabled', '');
+      const skipped = document.createElement('input');
+      skipped.setAttribute('tabindex', '-1');
+      const last = document.createElement('button');
+      const firstFocus = vi.fn();
+      const lastFocus = vi.fn();
+      first.focus = firstFocus;
+      last.focus = lastFocus;
+      el.appendChild(first);
+      el.appendChild(disabled);
+      el.appendChild(skipped);
+      el.appendChild(last);
+      dialogRef.value = el;
+      const { open } = useDialog(dialogRef, emit);
+      open();
+
+      // Tab on last should cycle to first (disabled and tabindex=-1 are ignored).
+      const { preventDefault: pd1 } = dispatchTab(el, last);
+      expect(pd1).toHaveBeenCalled();
+      expect(firstFocus).toHaveBeenCalledTimes(1);
+
+      // Shift+Tab on first should cycle to last.
+      const { preventDefault: pd2 } = dispatchTab(el, first, { shift: true });
+      expect(pd2).toHaveBeenCalled();
+      expect(lastFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('return focus', () => {
+    it('restores focus to the trigger on close (real-DOM round-trip)', () => {
+      const trigger = document.createElement('button');
+      const triggerFocus = vi.fn();
+      trigger.focus = triggerFocus;
+      document.body.appendChild(trigger);
+      // Make activeElement report the trigger before open().
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => trigger,
+      });
+
+      const { el } = makeDialogStub();
+      dialogRef.value = el;
+      const { open, close } = useDialog(dialogRef, emit);
+
+      open();
+      close();
+
+      expect(triggerFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips restoration when the captured element is no longer in document.body', () => {
+      const trigger = document.createElement('button');
+      const triggerFocus = vi.fn();
+      trigger.focus = triggerFocus;
+      document.body.appendChild(trigger);
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => trigger,
+      });
+
+      const { el } = makeDialogStub();
+      dialogRef.value = el;
+      const { open, close } = useDialog(dialogRef, emit);
+
+      open();
+      // Detach the trigger while the modal is open.
+      trigger.remove();
+      close();
+
+      expect(triggerFocus).not.toHaveBeenCalled();
+    });
+
+    it('a second open/close cycle uses the new trigger, not a stale reference', () => {
+      const triggerA = document.createElement('button');
+      const triggerB = document.createElement('button');
+      const focusA = vi.fn();
+      const focusB = vi.fn();
+      triggerA.focus = focusA;
+      triggerB.focus = focusB;
+      document.body.appendChild(triggerA);
+      document.body.appendChild(triggerB);
+
+      const { el } = makeDialogStub();
+      dialogRef.value = el;
+      const { open, close } = useDialog(dialogRef, emit);
+
+      // First cycle: trigger A is active.
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => triggerA,
+      });
+      open();
+      close();
+
+      expect(focusA).toHaveBeenCalledTimes(1);
+      expect(focusB).not.toHaveBeenCalled();
+
+      // Second cycle: trigger B is active.
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => triggerB,
+      });
+      open();
+      close();
+
+      expect(focusA).toHaveBeenCalledTimes(1); // still only once — no stale reference
+      expect(focusB).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleanup() clears the captured reference', () => {
+      const trigger = document.createElement('button');
+      const triggerFocus = vi.fn();
+      trigger.focus = triggerFocus;
+      document.body.appendChild(trigger);
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => trigger,
+      });
+
+      const { el } = makeDialogStub();
+      dialogRef.value = el;
+      const { open, close, cleanup } = useDialog(dialogRef, emit);
+
+      open();
+      // cleanup() clears the captured reference; a subsequent close() should
+      // not restore focus to the trigger (it was nulled).
+      cleanup();
+      // Re-open and close to prove the reference was nulled (open captures
+      // the current activeElement, but if we point activeElement at body,
+      // capture is null and no restoration happens).
+      Object.defineProperty(document, 'activeElement', {
+        configurable: true,
+        get: () => document.body,
+      });
+      open();
+      close();
+
+      expect(triggerFocus).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/e2e/admin-moderation.spec.ts
+++ b/tests/e2e/admin-moderation.spec.ts
@@ -375,7 +375,7 @@ test.describe('Admin Create Report', () => {
       await page.waitForTimeout(500);
 
       // Verify modal opened
-      const modal = page.locator('.modal, [role="dialog"]').first();
+      const modal = page.locator('.modal, dialog').first();
       const hasModal = await modal.isVisible().catch(() => false);
 
       expect(hasModal).toBeTruthy();

--- a/tests/e2e/bulk-operations.spec.ts
+++ b/tests/e2e/bulk-operations.spec.ts
@@ -139,7 +139,7 @@ test.describe('Bulk Event Operations', () => {
     await page.locator('[data-testid="assign-categories-btn"]').click();
 
     // Verify category selection dialog opens
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     // Verify dialog has proper ARIA attributes (title labelled via aria-labelledby)

--- a/tests/e2e/event-location-management.spec.ts
+++ b/tests/e2e/event-location-management.spec.ts
@@ -313,7 +313,7 @@ test.describe('Event Location Management End-to-End', () => {
     await page.waitForTimeout(500);
 
     // Check ARIA attributes on dialog
-    const pickerDialog = page.locator('[role="dialog"]');
+    const pickerDialog = page.locator('dialog');
     await expect(pickerDialog).toHaveAttribute('aria-modal', 'true');
     await expect(pickerDialog).toHaveAttribute('aria-labelledby', /.+/);
 

--- a/tests/e2e/modal-focus.spec.ts
+++ b/tests/e2e/modal-focus.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+import { startTestServer, TestEnvironment } from './helpers/test-server';
+
+/**
+ * E2E Test: Modal Focus Trap & Return Focus (WCAG 2.1.2 / ARIA APGR 3.8)
+ *
+ * This is a platform-invariant regression guard for the focus trap and
+ * return-focus behavior implemented in `useDialog`. The unit tests in
+ * `src/client/test/composables/useDialog.test.ts` cover the composable's
+ * branching logic, but only an end-to-end Chromium dialog can verify that
+ * the live `keydown` listener registration and `showModal` integration
+ * still work together.
+ *
+ * Justification (criterion-3, "Previously-Broken Code Path"): the original
+ * bug was a Playwright finding on `SessionExpiredModal`. If `handleKeydown`
+ * is ever silently dropped from the listener registration in `useDialog`,
+ * only an e2e test in a real browser will catch it.
+ *
+ * Scope: ONE test. The unit tests cover variation cases (empty list,
+ * disabled filter, etc.). Adding more here dilutes the regression-guard
+ * purpose.
+ */
+
+let env: TestEnvironment;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Modal Focus Trap & Return Focus', () => {
+  test.beforeAll(async () => {
+    env = await startTestServer();
+  });
+
+  test.afterAll(async () => {
+    if (env?.cleanup) {
+      await env.cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page, env.baseURL);
+    await page.goto(env.baseURL + '/profile');
+    await page.waitForSelector('h1:has-text("Settings")', { timeout: 5000 });
+  });
+
+  test('keyboard focus stays trapped inside modal and returns to trigger on close', async ({ page }) => {
+    // Focus the trigger so we can later assert return-focus restoration.
+    const trigger = page.getByRole('button', { name: 'Change Email' });
+    await trigger.focus();
+    await expect(trigger).toBeFocused();
+
+    // Open the modal.
+    await trigger.click();
+    const modal = page.locator('dialog[aria-modal="true"]');
+    await expect(modal).toBeVisible({ timeout: 3000 });
+
+    // Tab through every focusable element ~10 times, comfortably exceeding
+    // the count of focusable elements in any current modal so the focus
+    // cycles back to the start at least once. After each Tab, focus must
+    // never escape to document.body.
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press('Tab');
+      const isOnBody = await page.evaluate(() => document.activeElement === document.body);
+      expect(isOnBody, `Tab #${i + 1} let focus escape to document.body`).toBe(false);
+    }
+
+    // Close via Escape and assert return-focus restored to the trigger.
+    await page.keyboard.press('Escape');
+    await expect(modal).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+});

--- a/tests/e2e/modals-consolidation.spec.ts
+++ b/tests/e2e/modals-consolidation.spec.ts
@@ -7,7 +7,7 @@ import { startTestServer, TestEnvironment } from './helpers/test-server';
  *
  * Lightweight smoke test for the 9-site migration to <Modal> / <Sheet>.
  * Opens 2-3 representative migrated dialogs and asserts:
- * - [role="dialog"] + aria-modal="true" present (a11y intact)
+ * - native `<dialog>` element with aria-modal="true" present (a11y intact)
  * - Escape dismisses the dialog
  * - No JS console errors thrown while the dialog is open
  *
@@ -58,7 +58,7 @@ test.describe('Modal/Sheet Consolidation Smoke Tests', () => {
     if (hasUnblockButton) {
       await unblockButton.click();
 
-      const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+      const dialog = page.locator('dialog[aria-modal="true"]');
       await expect(dialog).toBeVisible({ timeout: 5000 });
 
       // Escape dismisses
@@ -112,7 +112,7 @@ test.describe('Modal/Sheet Consolidation Smoke Tests', () => {
 
     await addLangButton.click();
 
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     // Language picker is labelled (has aria-labelledby pointing at title)
@@ -147,7 +147,7 @@ test.describe('Modal/Sheet Consolidation Smoke Tests', () => {
 
     await addLocationButton.click();
 
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     // aria-labelledby points at the Sheet's generated title id

--- a/tests/e2e/recurring-events.spec.ts
+++ b/tests/e2e/recurring-events.spec.ts
@@ -60,7 +60,7 @@ test.describe('Recurring Event Management', () => {
     await addRecurrenceBtn.click();
 
     // Verify the sheet opens with dialog semantics and the recurrence form inside
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     const repeatForm = dialog.locator('form.repeats');
@@ -87,7 +87,7 @@ test.describe('Recurring Event Management', () => {
     await page.getByRole('button', { name: /add recurrence/i }).click();
 
     // Wait for the sheet/form
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     const repeatForm = dialog.locator('form.repeats');
@@ -147,7 +147,7 @@ test.describe('Recurring Event Management', () => {
     // Open the recurrence sheet
     await page.getByRole('button', { name: /add recurrence/i }).click();
 
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     const repeatForm = dialog.locator('form.repeats');
@@ -216,7 +216,7 @@ test.describe('Recurring Event Management', () => {
     await expect(recurrenceTrigger.first()).toBeVisible({ timeout: 5000 });
     await recurrenceTrigger.first().click();
 
-    const dialog = page.locator('[role="dialog"][aria-modal="true"]');
+    const dialog = page.locator('dialog[aria-modal="true"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
     const repeatForm = dialog.locator('form.repeats');


### PR DESCRIPTION
## Summary

Closes epic **pv-2pon** — Modal focus-trap and return-focus for useDialog. Platform-wide accessibility fix that benefits every modal consumer (`modal.vue`, `Sheet.vue`, and downstream wrappers like `confirm-delete-dialog`, `password_modal`, `add_calendar_modal`, `location-picker-modal`, recurrence Sheet, etc.).

- **WCAG 2.1.2 / ARIA APGR 3.8 fix** — Tab/Shift-Tab now cycles within the modal instead of escaping to the background BODY.
- **Return focus restored** — `document.activeElement` is captured on `open()` and restored on `close()`, so users continue their in-progress action without losing focus.
- **Cleanup** — removed redundant `role=\"dialog\"` (implicit per HTML-AAM on native `<dialog>`) from `modal.vue` and `Sheet.vue`, and a dead CSS block in `_accessibility.scss` that used `aria-hidden` as an invalid CSS property.
- **E2E selectors updated** — five specs migrated from `[role=\"dialog\"]` to the native `dialog` element selector.
- **Regression guard** — one new Playwright test (`tests/e2e/modal-focus.spec.ts`) protects WCAG 2.1.2 + APGR 3.8 in live Chromium.
- **Tests** — 11 new unit tests covering focus-trap branches and return-focus round-trip.

## Beads closed
- pv-2pon (epic) — auto-closed
- pv-2pon.1 — useDialog focus trap + return focus + unit tests
- pv-2pon.2 — Remove redundant role=\"dialog\" and dead aria-hidden CSS block
- pv-2pon.3 — Playwright modal-focus regression test

## Follow-ups filed
- pv-mkp0 — Sweep two orphan `[role=\"dialog\"]` selectors in `_accessibility.scss` (lines 227, 255)
- pv-e8r9 — Migrate `report-event.vue` to `useDialog`
- pv-jqxg — Migrate `feed-event-detail-modal.vue` to `useDialog`
- pv-0wyu — Update unit-test stubs that emit `role=\"dialog\"` on stub `<div>`s

## Test plan
- [x] `npm run lint` — 0 errors
- [x] Unit suite — 7454 passed
- [x] Build — frontend + widget SDK pass
- [x] E2E — `tests/e2e/modal-focus.spec.ts` passed 3 consecutive runs (no flake); 5 updated specs pass
- [x] Manual: Tab cycles within a Modal (add-calendar) and a Sheet (recurrence editor); Esc/close restores focus to trigger
- [ ] Pre-existing failures NOT caused by this PR: `feed-workflow.test.ts` (localStorage), `admin-moderation` Pattern Warning Indicators (login timeout), `import-sources.spec.ts:471` (missing federation cert)