### PR TITLE
fix(federation): address outbox activities to public timeline

### DIFF
--- a/src/server/activitypub/events/index.ts
+++ b/src/server/activitypub/events/index.ts
@@ -97,7 +97,7 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
     // Local followers are routed in-process via ProcessInboxService.
     await this.service.addToOutbox(
       payload.calendar,
-      new AnnounceActivity(actorUrl, eventUrl),
+      new AnnounceActivity(actorUrl, eventUrl).addressPublic(`${actorUrl}/followers`),
     );
   }
 
@@ -119,7 +119,7 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
       new UpdateActivity(
         actorUrl,
         new EventObject(payload.calendar, payload.event),
-      ),
+      ).addressPublic(`${actorUrl}/followers`),
     );
   }
 
@@ -130,7 +130,7 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
       new DeleteActivity(
         actorUrl,
         EventObject.eventUrl(payload.calendar, payload.event),
-      ),
+      ).addressPublic(`${actorUrl}/followers`),
     );
   }
 

--- a/src/server/activitypub/model/action/announce.ts
+++ b/src/server/activitypub/model/action/announce.ts
@@ -27,6 +27,15 @@ class AnnounceActivity extends ActivityPubActivity {
     if ( object.id ) {
       activity.id = object.id;
     }
+    if ( Array.isArray(object.to) ) {
+      activity.to = object.to;
+    }
+    if ( Array.isArray(object.cc) ) {
+      activity.cc = object.cc;
+    }
+    if ( object.published ) {
+      activity.published = new Date(object.published);
+    }
 
     return activity;
   }

--- a/src/server/activitypub/model/action/delete.ts
+++ b/src/server/activitypub/model/action/delete.ts
@@ -48,6 +48,9 @@ class DeleteActivity extends ActivityPubActivity {
     if ( object.cc ) {
       activity.cc = object.cc;
     }
+    if ( object.published ) {
+      activity.published = new Date(object.published);
+    }
 
     return activity;
   }

--- a/src/server/activitypub/model/action/update.ts
+++ b/src/server/activitypub/model/action/update.ts
@@ -36,6 +36,9 @@ class UpdateActivity extends ActivityPubActivity {
     if (json.cc) {
       activity.cc = json.cc;
     }
+    if (json.published) {
+      activity.published = new Date(json.published);
+    }
 
     return activity;
   }

--- a/src/server/activitypub/model/base.ts
+++ b/src/server/activitypub/model/base.ts
@@ -1,6 +1,8 @@
 import config from 'config';
 import { Calendar } from '@/common/model/calendar';
 
+const AS_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
+
 class ActivityPubActivity {
   context: string[] = ['https://www.w3.org/ns/activitystreams'];
   id: string = '';
@@ -26,7 +28,7 @@ class ActivityPubActivity {
    * public when it addresses as:Public in to or cc.
    */
   addressPublic(followersUrl: string): this {
-    this.to = ['https://www.w3.org/ns/activitystreams#Public'];
+    this.to = [AS_PUBLIC];
     this.cc = [followersUrl];
     this.published = new Date();
     return this;
@@ -93,4 +95,4 @@ class ActivityPubActor {
   }
 }
 
-export { ActivityPubActivity, ActivityPubActor, ActivityPubObject };
+export { ActivityPubActivity, ActivityPubActor, ActivityPubObject, AS_PUBLIC };

--- a/src/server/activitypub/model/base.ts
+++ b/src/server/activitypub/model/base.ts
@@ -15,6 +15,23 @@ class ActivityPubActivity {
     this.actor = actorUrl;
   }
 
+  /**
+   * Address this activity to the public timeline, with the actor's followers
+   * collection in cc. Sets published to the current time. Returns this so the
+   * call can be chained onto the constructor.
+   *
+   * Required for public outbound activities (Announce/Create/Update/Delete) so
+   * that AP consumers — including Mastodon — can render them on actor profiles
+   * and timelines. Per ActivityPub §5.6 / §6, an activity is only treated as
+   * public when it addresses as:Public in to or cc.
+   */
+  addressPublic(followersUrl: string): this {
+    this.to = ['https://www.w3.org/ns/activitystreams#Public'];
+    this.cc = [followersUrl];
+    this.published = new Date();
+    return this;
+  }
+
   toObject(): Record<string, any> {
     const result: Record<string, any> = {
       '@context': this.context,

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -919,7 +919,8 @@ class ProcessInboxService {
     logger.info('Creating SharedEventEntity and adding to outbox...');
 
     // Create SharedEventEntity with auto_posted: true
-    const announceActivity = new AnnounceActivity(localActorUrl, eventApId);
+    const announceActivity = new AnnounceActivity(localActorUrl, eventApId)
+      .addressPublic(`${localActorUrl}/followers`);
     await SharedEventEntity.create({
       id: announceActivity.id,
       event_id: eventObject.event_id,  // Use local event UUID, not AP URL

--- a/src/server/activitypub/service/members.ts
+++ b/src/server/activitypub/service/members.ts
@@ -403,7 +403,8 @@ class ActivityPubService {
     }
 
     let actor = await this.actorUrl(calendar);
-    let shareActivity = new AnnounceActivity(actor, canonicalEventUrl);
+    let shareActivity = new AnnounceActivity(actor, canonicalEventUrl)
+      .addressPublic(`${actor}/followers`);
 
     // A manual (or auto) share is an explicit opt-in that supersedes any prior
     // dismissal. Delete any existing RepostDismissalEntity for this

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -19,7 +19,7 @@ import AnnounceActivity from "@/server/activitypub/model/action/announce";
 import CreateActivity from "@/server/activitypub/model/action/create";
 import UndoActivity from "@/server/activitypub/model/action/undo";
 import FlagActivity from "@/server/activitypub/model/action/flag";
-import { ActivityPubActivity, ActivityPubObject } from "@/server/activitypub/model/base";
+import { ActivityPubActivity, ActivityPubObject, AS_PUBLIC } from "@/server/activitypub/model/base";
 import CalendarInterface from "@/server/calendar/interface";
 import CalendarActorService from "@/server/activitypub/service/calendar_actor";
 import UserActorService from "@/server/activitypub/service/user_actor";
@@ -235,14 +235,19 @@ class ProcessOutboxService {
           throw new Error('Failed to parse Update activity');
         }
         // Honor explicit `to` for targeted single-recipient delivery (e.g.,
-        // notifying the remote calendar that owns an event). Fall back to
-        // follower fan-out for the back-compat broadcast case.
-        if (activity.to && activity.to.length > 0) {
-          recipients = activity.to;
-          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Update activity');
-        }
-        else {
-          recipients = await this.getRecipients(calendar, activity.object);
+        // notifying the remote calendar that owns an event). The as:Public
+        // IRI is an addressing marker, not a delivery target, so filter it
+        // out before deciding. Fall back to follower fan-out for the
+        // public-broadcast case.
+        {
+          const explicitTo = (activity.to ?? []).filter(uri => uri !== AS_PUBLIC);
+          if (explicitTo.length > 0) {
+            recipients = explicitTo;
+            logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Update activity');
+          }
+          else {
+            recipients = await this.getRecipients(calendar, activity.object);
+          }
         }
         break;
       case 'Delete':
@@ -250,14 +255,19 @@ class ProcessOutboxService {
         if (!activity) {
           throw new Error('Failed to parse Delete activity');
         }
-        // Honor explicit `to` for targeted single-recipient delivery. Fall back
-        // to follower fan-out for the back-compat broadcast case.
-        if (activity.to && activity.to.length > 0) {
-          recipients = activity.to;
-          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Delete activity');
-        }
-        else {
-          recipients = await this.getRecipients(calendar, activity.object);
+        // Honor explicit `to` for targeted single-recipient delivery. The
+        // as:Public IRI is an addressing marker, not a delivery target, so
+        // filter it out before deciding. Fall back to follower fan-out for
+        // the public-broadcast case.
+        {
+          const explicitTo = (activity.to ?? []).filter(uri => uri !== AS_PUBLIC);
+          if (explicitTo.length > 0) {
+            recipients = explicitTo;
+            logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Delete activity');
+          }
+          else {
+            recipients = await this.getRecipients(calendar, activity.object);
+          }
         }
         break;
       case 'Add':

--- a/src/server/activitypub/test/events.test.ts
+++ b/src/server/activitypub/test/events.test.ts
@@ -191,7 +191,14 @@ describe('handleEventUpdated guard', () => {
 
     const outboxCall = addToOutboxStub.getCall(0);
     expect(outboxCall.args[0]).toBe(calendar);
-    expect(outboxCall.args[1].type).toBe('Update');
+    const update = outboxCall.args[1];
+    expect(update.type).toBe('Update');
+    // Update activities must be addressed publicly so AP consumers (Mastodon
+    // included) treat them as visible profile timeline activity rather than
+    // private/addressless updates.
+    expect(update.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(update.cc).toEqual(['https://example.com/calendars/my_calendar/followers']);
+    expect(update.published).toBeInstanceOf(Date);
   });
 });
 
@@ -232,6 +239,15 @@ describe('handleEventCreated', () => {
     expect(eventObject, 'EventObjectEntity must exist for local event').not.toBeNull();
     expect(eventObject!.attributed_to).toBe(actorUrl);
     expect(addToOutboxStub.calledOnce).toBe(true);
+
+    // Announce envelope must be addressed publicly with followers in cc and a
+    // populated published timestamp — without these, Mastodon ignores the
+    // activity in profile timelines and HTTP delivery loses audience info.
+    const announce = addToOutboxStub.getCall(0).args[1];
+    expect(announce.type).toBe('Announce');
+    expect(announce.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(announce.cc).toEqual([`${actorUrl}/followers`]);
+    expect(announce.published).toBeInstanceOf(Date);
   });
 
   it('logs a warning but does not overwrite EventObjectEntity when a pre-existing row has mismatched attributed_to', async () => {

--- a/src/server/activitypub/test/model/action/activities.test.ts
+++ b/src/server/activitypub/test/model/action/activities.test.ts
@@ -7,6 +7,8 @@ import FollowActivity from '@/server/activitypub/model/action/follow';
 import AcceptActivity from '@/server/activitypub/model/action/accept';
 import UndoActivity from '@/server/activitypub/model/action/undo';
 
+const PUBLIC_URI = 'https://www.w3.org/ns/activitystreams#Public';
+
 describe('Activity Model fromObject Null Checks', () => {
 
   describe('CreateActivity', () => {
@@ -152,6 +154,16 @@ describe('Activity Model fromObject Null Checks', () => {
       expect(result?.object).toEqual(tombstone);
       expect(result?.id).toBe('https://example.com/activities/delete/1');
     });
+
+    it('preserves published timestamp when present in source object', () => {
+      const result = DeleteActivity.fromObject({
+        actor: 'https://example.com/users/1',
+        object: 'https://example.com/event/123',
+        id: 'https://example.com/activities/delete/1',
+        published: '2026-04-30T12:34:56.000Z',
+      });
+      expect(result?.published).toEqual(new Date('2026-04-30T12:34:56.000Z'));
+    });
   });
 
   describe('UpdateActivity', () => {
@@ -206,6 +218,16 @@ describe('Activity Model fromObject Null Checks', () => {
       expect(result?.id).toBe('https://example.com/activities/update/1');
       expect(result?.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
       expect(result?.cc).toEqual(['https://example.com/users/1/followers']);
+    });
+
+    it('preserves published timestamp when present in source object', () => {
+      const result = UpdateActivity.fromObject({
+        actor: 'https://example.com/users/1',
+        object: { id: 'https://example.com/event/123', type: 'Event' },
+        id: 'https://example.com/activities/update/1',
+        published: '2026-04-30T12:34:56.000Z',
+      });
+      expect(result?.published).toEqual(new Date('2026-04-30T12:34:56.000Z'));
     });
   });
 
@@ -266,6 +288,23 @@ describe('Activity Model fromObject Null Checks', () => {
       expect(result?.actor).toBe('https://example.com/users/1');
       expect(result?.object).toBe('https://example.com/event/123');
       expect(result?.id).toBe('https://example.com/activities/announce/1');
+    });
+
+    // Round-tripping must preserve the envelope addressing fields, otherwise
+    // an outbox-stored Announce loses its public addressing when reparsed for
+    // HTTP delivery and Mastodon refuses to render the activity.
+    it('preserves to/cc/published when present in source object', () => {
+      const result = AnnounceActivity.fromObject({
+        actor: 'https://example.com/users/1',
+        object: 'https://example.com/event/123',
+        id: 'https://example.com/activities/announce/1',
+        to: [PUBLIC_URI],
+        cc: ['https://example.com/users/1/followers'],
+        published: '2026-04-30T12:34:56.000Z',
+      });
+      expect(result?.to).toEqual([PUBLIC_URI]);
+      expect(result?.cc).toEqual(['https://example.com/users/1/followers']);
+      expect(result?.published).toEqual(new Date('2026-04-30T12:34:56.000Z'));
     });
   });
 
@@ -484,5 +523,34 @@ describe('Activity Model fromObject Null Checks', () => {
       // The base class initializes 'to' as an empty array
       expect(result?.to).toEqual([]);
     });
+  });
+});
+
+describe('ActivityPubActivity.addressPublic', () => {
+  it('addresses Announce activities to as:Public with followers in cc and stamps published', () => {
+    const before = Date.now();
+    const activity = new AnnounceActivity(
+      'https://example.com/calendars/cal',
+      'https://example.com/calendars/cal/events/abc',
+    ).addressPublic('https://example.com/calendars/cal/followers');
+    const after = Date.now();
+
+    expect(activity.to).toEqual([PUBLIC_URI]);
+    expect(activity.cc).toEqual(['https://example.com/calendars/cal/followers']);
+    expect(activity.published).toBeInstanceOf(Date);
+    expect(activity.published!.getTime()).toBeGreaterThanOrEqual(before);
+    expect(activity.published!.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it('emits to/cc/published in the serialized activity body', () => {
+    const activity = new AnnounceActivity(
+      'https://example.com/calendars/cal',
+      'https://example.com/calendars/cal/events/abc',
+    ).addressPublic('https://example.com/calendars/cal/followers');
+
+    const serialized = activity.toObject();
+    expect(serialized.to).toEqual([PUBLIC_URI]);
+    expect(serialized.cc).toEqual(['https://example.com/calendars/cal/followers']);
+    expect(serialized.published).toBeInstanceOf(Date);
   });
 });

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -668,6 +668,43 @@ describe('processOutboxMessage — explicit `to` honoring for Update/Delete/Add'
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 
+  it('Update: treats `to: [as:Public]` as a broadcast (filters public IRI, fans out to followers)', async () => {
+    // Regression: addressPublic() puts as:Public in `to` for public broadcast.
+    // The outbox must not treat the public IRI as a literal delivery target;
+    // it must fall through to follower fan-out.
+    const updateMsg = createMockUpdateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/upd-public`,
+      name: 'Public Broadcast Update',
+    });
+    updateMsg.to = ['https://www.w3.org/ns/activitystreams#Public'];
+    updateMsg.cc = [`${LOCAL_ACTOR_URL}/followers`];
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Update',
+      message: updateMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.calledOnce, 'getRecipients must be called when `to` is only as:Public').toBe(true);
+    expect(resolveStub.calledOnceWith(REMOTE_CALENDAR_HANDLE)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
   // ---------- Delete ----------
 
   it('Delete: honors explicit `to` and skips follower fan-out', async () => {
@@ -722,6 +759,39 @@ describe('processOutboxMessage — explicit `to` honoring for Update/Delete/Add'
     await service.processOutboxMessage(message);
 
     expect(getRecipientsStub.calledOnce, 'getRecipients must be called for fan-out fallback').toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Delete: treats `to: [as:Public]` as a broadcast (filters public IRI, fans out to followers)', async () => {
+    // Regression: addressPublic() puts as:Public in `to` for public broadcast.
+    // The outbox must not treat the public IRI as a literal delivery target;
+    // it must fall through to follower fan-out.
+    const deleteMsg = createMockDeleteActivity(LOCAL_ACTOR_URL, `${LOCAL_ACTOR_URL}/events/del-public`);
+    deleteMsg.to = ['https://www.w3.org/ns/activitystreams#Public'];
+    deleteMsg.cc = [`${LOCAL_ACTOR_URL}/followers`];
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Delete',
+      message: deleteMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([REMOTE_CALENDAR_HANDLE]);
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.calledOnce, 'getRecipients must be called when `to` is only as:Public').toBe(true);
+    expect(resolveStub.calledOnceWith(REMOTE_CALENDAR_HANDLE)).toBe(true);
     expect(postStub.calledOnce).toBe(true);
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });


### PR DESCRIPTION
## Motivation

A Pavillion calendar's Mastodon profile shows the actor card but no posts on the timeline (e.g. `@mitown@demo.pavillion.events` viewed from `planetearth.social`). Investigation found that every `Announce` activity in the outbox carried `to: []`, `cc: []`, and `published: null`. Per ActivityPub §5.6/§6, an activity is only public-timeline-visible when it addresses `as:Public` in `to` or `cc`. With both empty, Mastodon silently drops the activities.

This same hygiene issue affects `Update` and `Delete` activities and any AP consumer (Mobilizon, Gancio, Friendica), not just Mastodon. Fixing it is a precondition for any further Mastodon-rendering work — even a perfectly Mastodon-shaped object would be ignored without public addressing.

## Approach

Adds a small helper on the activity base class and chains it onto every outbound construction site:

- New `addressPublic(followersUrl)` method on `ActivityPubActivity` sets `to: [as:Public]`, `cc: [<followers>]`, and `published: now`. Returns `this` so it can be chained onto the constructor.
- All five outbound construction sites use it:
  - `events/index.ts` `handleEventCreated` (Announce), `handleEventUpdated` (Update), `handleEventDeleted` (Delete)
  - `service/inbox.ts` auto-repost path (Announce)
  - `service/members.ts` manual share path (Announce)
- `AnnounceActivity.fromObject` now preserves `to`, `cc`, and `published`. `UpdateActivity` and `DeleteActivity` already preserved `to`/`cc` but not `published`; that's added too.

The `fromObject` change is required because the outbox processor reparses the stored activity through `fromObject` before calling `toObject()` for HTTP delivery. Without preservation, even a publicly-addressed Announce would arrive at the recipient inbox stripped of audience information.

`CreateActivity` is intentionally not changed in this PR — Pavillion does not currently emit any outbound `Create` activities for events. Adding a `Create(Note)` companion for Mastodon-class consumers is the natural follow-up and will own that change.

## Validation

- All 943 ActivityPub unit tests pass, including new tests covering `addressPublic()`, `Announce`/`Update`/`Delete` `fromObject` round-tripping, and the publicly-addressed envelope assertion in the existing `handleEventCreated`/`handleEventUpdated` handler tests.
- Lint clean (0 errors).
- Production build succeeds.
- Full unit suite: 7455 passed; one unrelated flake in `rate-limiters.test.ts` that passes in isolation and is documented as pre-existing.