### PR TITLE
feat(activitypub): populate published on EventObject AP serialization

### DIFF
--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -100,6 +100,13 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
   urlPrompt: UrlPrompt | null = null;
 
   /**
+   * Canonical publication timestamp: when the event was first created/published.
+   * Populated from the DB entity's createdAt on local events, or from the AP
+   * `published` field on remote federated events.
+   */
+  createdAt: Date | null = null;
+
+  /**
    * Derived flag: true when this event was obtained via a repost (auto or manual)
    * rather than direct ownership. Backed by {@link repostStatus}.
    */
@@ -226,6 +233,7 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
     event.sourceCalendar = obj.sourceCalendar ?? null;
     event.externalUrl = obj.externalUrl ?? null;
     event.urlPrompt = URL_PROMPT_VALUES.includes(obj.urlPrompt) ? obj.urlPrompt : null;
+    event.createdAt = obj.createdAt ? new Date(obj.createdAt) : null;
     event.isRecurring = obj.isRecurring === true;
     event.recurrenceSummary = obj.recurrenceSummary ?? null;
 

--- a/src/server/activitypub/model/object/event.ts
+++ b/src/server/activitypub/model/object/event.ts
@@ -151,6 +151,11 @@ class EventObject extends ActivityPubObject {
       cc: [`https://${domain}/calendars/${calendar.urlName}/followers`],
     };
 
+    // published: when the event was originally created (AS 2.0 vocabulary)
+    if (event.createdAt) {
+      result.published = event.createdAt.toISOString();
+    }
+
     // summary: only when primary-language description is non-empty
     const primaryDescription = primaryContent?.description || '';
     if (primaryDescription.trim().length > 0) {
@@ -418,6 +423,16 @@ class EventObject extends ActivityPubObject {
           }
           return s;
         });
+      }
+    }
+
+    // --- published → createdAt mapping ---
+    // Map the AP `published` field to `createdAt` so CalendarEvent.fromObject()
+    // can populate the canonical publication timestamp. Guards against invalid dates.
+    if (apObject.published && typeof apObject.published === 'string') {
+      const publishedDate = new Date(apObject.published);
+      if (!isNaN(publishedDate.getTime())) {
+        result.createdAt = publishedDate;
       }
     }
 

--- a/src/server/activitypub/test/model/object/event.test.ts
+++ b/src/server/activitypub/test/model/object/event.test.ts
@@ -1425,4 +1425,110 @@ describe('EventObject', () => {
 
   });
 
+  describe('published field', () => {
+
+    describe('toActivityPubObject()', () => {
+
+      it('should emit published when event.createdAt is set', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Test Event', ''));
+        event.createdAt = new Date('2026-03-01T10:00:00.000Z');
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result.published).toBe('2026-03-01T10:00:00.000Z');
+      });
+
+      it('should omit published when event.createdAt is null', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Test Event', ''));
+        event.createdAt = null;
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        expect(result).not.toHaveProperty('published');
+      });
+
+      it('should be distinct from the envelope published (object vs activity timestamp)', () => {
+        // The EventObject's published = when the object was originally created.
+        // The Activity envelope's published = when the activity was sent.
+        // These are separate concerns and must not be confused.
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Test Event', ''));
+        event.createdAt = new Date('2025-01-15T08:00:00.000Z');
+
+        const obj = new EventObject(calendar, event);
+        const result = obj.toActivityPubObject();
+
+        // published exists and reflects the object creation time, not "now"
+        expect(result.published).toBe('2025-01-15T08:00:00.000Z');
+      });
+
+    });
+
+    describe('fromActivityPubObject()', () => {
+
+      it('should map published to createdAt in the result', () => {
+        const apObject = {
+          name: 'Remote Event',
+          startTime: '2026-04-15T09:00:00Z',
+          published: '2026-03-01T10:00:00.000Z',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.createdAt).toBeInstanceOf(Date);
+        expect((result.createdAt as Date).toISOString()).toBe('2026-03-01T10:00:00.000Z');
+      });
+
+      it('should not set createdAt when published is absent', () => {
+        const apObject = {
+          name: 'Event Without Published',
+          startTime: '2026-04-15T09:00:00Z',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result).not.toHaveProperty('createdAt');
+      });
+
+      it('should not set createdAt when published is an invalid date string', () => {
+        const apObject = {
+          name: 'Event With Bad Published',
+          startTime: '2026-04-15T09:00:00Z',
+          published: 'not-a-date',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result).not.toHaveProperty('createdAt');
+      });
+
+      it('should survive round-trip: toActivityPubObject → fromActivityPubObject preserves published', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Round-trip Event', ''));
+        event.createdAt = new Date('2026-02-15T12:00:00.000Z');
+        const startDt = DateTime.fromISO('2026-04-15T09:00:00.000Z');
+        event.schedules = [new CalendarEventSchedule('s1', startDt)];
+
+        const obj = new EventObject(calendar, event);
+        const apRepresentation = obj.toActivityPubObject();
+
+        // Simulate receiving this AP representation
+        const parsed = EventObject.fromActivityPubObject(apRepresentation);
+
+        expect(parsed.createdAt).toBeInstanceOf(Date);
+        expect((parsed.createdAt as Date).toISOString()).toBe('2026-02-15T12:00:00.000Z');
+      });
+
+    });
+
+  });
+
 });

--- a/src/server/calendar/entity/event.ts
+++ b/src/server/calendar/entity/event.ts
@@ -1,4 +1,4 @@
-import { Model, Table, Column, PrimaryKey, BelongsTo, DataType, ForeignKey, HasMany, Index } from 'sequelize-typescript';
+import { Model, Table, Column, PrimaryKey, BelongsTo, DataType, ForeignKey, HasMany, Index, CreatedAt } from 'sequelize-typescript';
 import { DateTime } from 'luxon';
 
 import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, UrlPrompt, language } from '@/common/model/events';
@@ -68,6 +68,9 @@ class EventEntity extends Model {
   @Column({ type: DataType.STRING(32), allowNull: true })
   declare url_prompt: string | null;
 
+  @CreatedAt
+  declare createdAt: Date;
+
   @BelongsTo(() => EventEntity)
   declare parentEvent: EventEntity;
 
@@ -94,6 +97,7 @@ class EventEntity extends Model {
 
   toModel(): CalendarEvent {
     let model = new CalendarEvent(this.id, this.calendar_id, this.event_source_url);
+    model.createdAt = this.createdAt ?? null;
     model.locationId = this.location_id || null;
     model.mediaFocalPointX = this.media_focal_point_x;
     model.mediaFocalPointY = this.media_focal_point_y;


### PR DESCRIPTION
## Summary

- Adds the AS 2.0 `published` field to the `EventObject` AP wire format, sourced from the event's canonical creation timestamp (`CalendarEvent.createdAt`)
- Wires `@CreatedAt` onto `EventEntity` so the DB timestamp flows through to the domain model
- Maps inbound `published` → `createdAt` in `fromActivityPubObject()` for round-trip fidelity
- 7 new tests covering emission, omission, distinctness from envelope `published`, and the full round-trip

## Background

Pavillion's `EventObject` had no `published` field on the wrapped Event object, even though the Activity envelope (Create/Announce) now carries one. AP consumers like Mobilizon and Gancio rely on `Event.published` for chronological ordering and display. This gap was identified during investigation of the Mastodon empty-timeline bug (pv-qfyl).

The `published` on the object is the event's own creation timestamp — distinct from the envelope `published` which records when the activity was sent.

## Test plan

- [ ] `npm test -- src/server/activitypub/test/model/object/event.test.ts` — all 93 tests pass
- [ ] `npm run lint` — no new errors