### PR TITLE
refactor(moderation): convert ForwardStatus to TypeScript enum

### DIFF
--- a/src/common/model/report.ts
+++ b/src/common/model/report.ts
@@ -41,7 +41,11 @@ type EscalationType = 'manual' | 'automatic';
 /**
  * Acknowledgment status for forwarded reports.
  */
-type ForwardStatus = 'pending' | 'acknowledged' | 'no_response';
+enum ForwardStatus {
+  PENDING = 'pending',
+  ACKNOWLEDGED = 'acknowledged',
+  NO_RESPONSE = 'no_response',
+}
 
 /**
  * Represents a report filed against an event.
@@ -296,5 +300,5 @@ class Report extends PrimaryModel {
   }
 }
 
-export { Report, ReportCategory, ReportStatus };
-export type { ReporterType, AdminPriority, EscalationType, ForwardStatus };
+export { Report, ReportCategory, ReportStatus, ForwardStatus };
+export type { ReporterType, AdminPriority, EscalationType };

--- a/src/server/activitypub/test/integration/accept-flag.test.ts
+++ b/src/server/activitypub/test/integration/accept-flag.test.ts
@@ -7,7 +7,7 @@ import ProcessInboxService from '@/server/activitypub/service/inbox';
 import CalendarInterface from '@/server/calendar/interface';
 import ModerationInterface from '@/server/moderation/interface';
 import { Calendar } from '@/common/model/calendar';
-import { Report, ReportCategory, ReportStatus } from '@/common/model/report';
+import { Report, ReportCategory, ReportStatus, ForwardStatus } from '@/common/model/report';
 import AcceptActivity from '@/server/activitypub/model/action/accept';
 
 describe('ProcessInboxService - Accept Flag Activity', () => {
@@ -36,7 +36,7 @@ describe('ProcessInboxService - Accept Flag Activity', () => {
     testReport.status = ReportStatus.SUBMITTED;
     testReport.forwardedReportId = 'https://local.instance/flags/original-flag-id';
     testReport.forwardedToActorUri = 'https://remote.instance/calendars/remote-calendar';
-    testReport.forwardStatus = 'pending';
+    testReport.forwardStatus = ForwardStatus.PENDING;
 
     // Mock CalendarInterface
     calendarInterface = {} as any;

--- a/src/server/moderation/entity/report.ts
+++ b/src/server/moderation/entity/report.ts
@@ -9,8 +9,8 @@ import {
   Index,
 } from 'sequelize-typescript';
 
-import { Report, ReportCategory, ReportStatus } from '@/common/model/report';
-import type { ReporterType, AdminPriority, EscalationType, ForwardStatus } from '@/common/model/report';
+import { Report, ReportCategory, ReportStatus, ForwardStatus } from '@/common/model/report';
+import type { ReporterType, AdminPriority, EscalationType } from '@/common/model/report';
 import db from '@/server/common/entity/db';
 
 /**

--- a/src/server/moderation/service/moderation.ts
+++ b/src/server/moderation/service/moderation.ts
@@ -4,8 +4,8 @@ import { Op, UniqueConstraintError, fn, col } from 'sequelize';
 import config from 'config';
 
 import { Account } from '@/common/model/account';
-import { Report, ReportCategory, ReportStatus } from '@/common/model/report';
-import type { ReporterType, EscalationType, ForwardStatus } from '@/common/model/report';
+import { Report, ReportCategory, ReportStatus, ForwardStatus } from '@/common/model/report';
+import type { ReporterType, EscalationType } from '@/common/model/report';
 import { BlockedInstance } from '@/common/model/blocked_instance';
 import { BlockedReporter } from '@/common/model/blocked_reporter';
 import { EventNotFoundError } from '@/common/exceptions/calendar';
@@ -1725,7 +1725,7 @@ class ModerationService {
     if (reportEntity) {
       await reportEntity.update({
         forwarded_report_id: flagActivity.id,
-        forward_status: 'pending',
+        forward_status: ForwardStatus.PENDING,
         forwarded_to_actor_uri: targetActorUri,
       });
     }
@@ -1780,7 +1780,7 @@ class ModerationService {
    * instance has acknowledged receipt of the forwarded Flag activity.
    *
    * @param reportId - Report UUID
-   * @returns Forward status ('pending' | 'acknowledged' | 'no_response') or null if not found or not forwarded
+   * @returns {ForwardStatus | null} Forward status enum value, or null if not found or not forwarded
    */
   async checkForwardStatus(reportId: string): Promise<ForwardStatus | null> {
     const entity = await ReportEntity.findByPk(reportId);
@@ -1791,7 +1791,7 @@ class ModerationService {
   }
 
   /**
-   * Acknowledges a forwarded report by updating its forward_status to 'acknowledged'.
+   * Acknowledges a forwarded report by updating its forward_status to ForwardStatus.ACKNOWLEDGED.
    * Used when a remote instance sends an Accept activity for a Flag we forwarded.
    * Validates that the sender's hostname matches the instance the report was forwarded to.
    *
@@ -1844,11 +1844,11 @@ class ModerationService {
       return false;
     }
     // Idempotency: if already acknowledged, return true without updating
-    if (entity.forward_status === 'acknowledged') {
+    if (entity.forward_status === ForwardStatus.ACKNOWLEDGED) {
       return true;
     }
 
-    await entity.update({ forward_status: 'acknowledged' });
+    await entity.update({ forward_status: ForwardStatus.ACKNOWLEDGED });
     return true;
   }
 

--- a/src/server/moderation/test/service/moderation-forward-status.test.ts
+++ b/src/server/moderation/test/service/moderation-forward-status.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 
 import ModerationService from '@/server/moderation/service/moderation';
 import { ReportEntity } from '@/server/moderation/entity/report';
-import { Report, ReportStatus } from '@/common/model/report';
+import { Report, ReportStatus, ForwardStatus } from '@/common/model/report';
 
 describe('ModerationService.checkForwardStatus', () => {
   let sandbox: sinon.SinonSandbox;
@@ -42,34 +42,35 @@ describe('ModerationService.checkForwardStatus', () => {
 
   it('should return "pending" status', async () => {
     const mockEntity = {
-      forward_status: 'pending',
+      forward_status: ForwardStatus.PENDING,
     };
     sandbox.stub(ReportEntity, 'findByPk').resolves(mockEntity as any);
 
     const status = await service.checkForwardStatus('report-id');
 
     expect(status).toBe('pending');
+    expect(status).toBe(ForwardStatus.PENDING);
   });
 
   it('should return "acknowledged" status', async () => {
     const mockEntity = {
-      forward_status: 'acknowledged',
+      forward_status: ForwardStatus.ACKNOWLEDGED,
     };
     sandbox.stub(ReportEntity, 'findByPk').resolves(mockEntity as any);
 
     const status = await service.checkForwardStatus('report-id');
 
-    expect(status).toBe('acknowledged');
+    expect(status).toBe(ForwardStatus.ACKNOWLEDGED);
   });
 
   it('should return "no_response" status', async () => {
     const mockEntity = {
-      forward_status: 'no_response',
+      forward_status: ForwardStatus.NO_RESPONSE,
     };
     sandbox.stub(ReportEntity, 'findByPk').resolves(mockEntity as any);
 
     const status = await service.checkForwardStatus('report-id');
 
-    expect(status).toBe('no_response');
+    expect(status).toBe(ForwardStatus.NO_RESPONSE);
   });
 });


### PR DESCRIPTION
## Motivation

`ForwardStatus` in `src/common/model/report.ts` was the only status field in that file still defined as a string-literal union (`'pending' | 'acknowledged' | 'no_response'`), while its siblings `ReportCategory` and `ReportStatus` are proper TypeScript enums. The moderation service and tests referenced the underlying string literals directly, so there was no single source of truth for the three valid values.

## Approach

Convert `ForwardStatus` to a TypeScript enum following the exact pattern of the two sibling enums in the same file (`SCREAMING_SNAKE_CASE` members with lowercase string values). Move the export from the value-only `export type { ... }` line to the runtime `export { ... }` line, since enums are values.

Update every call site to reference enum members:

- `moderation.ts` — three string-literal sites (`forward_status: 'pending'`, equality check `=== 'acknowledged'`, update `forward_status: 'acknowledged'`) and two JSDoc tags.
- `entity/report.ts` — split the import so `ForwardStatus` is a value import. The Sequelize `DataType.ENUM('pending', 'acknowledged', 'no_response')` column declaration intentionally keeps string literals to match the convention used by every other enum-backed column in the codebase.
- `accept-flag.test.ts` and `moderation-forward-status.test.ts` — replace literals with enum members in fixtures and assertions. One assertion in `moderation-forward-status.test.ts` retains the raw `'pending'` string alongside the enum reference, so a silent backing-value drift would still fail the test.

No behavior change.

## Validation

- `npm run lint` — 0 errors (pre-existing warning count unchanged)
- `npx tsc --noEmit` — pre-existing errors only, none introduced
- `npx vitest run` — 1,181 unit tests + 522 integration tests pass
  - `moderation-forward-status.test.ts` — 5/5 pass
  - `moderation.test.ts` — 114/114 pass
  - `accept-flag.test.ts` — 7/7 pass
- Build — frontend and widget SDK build clean
- E2E — refactor-touched paths pass; the two pre-existing e2e failures (`import-sources.spec.ts`, `profile-display-name.spec.ts`) are unrelated and contain no `ForwardStatus` references