### PR TITLE
fix(calendar): populate authoritative repostStatus on bulk/replace category methods

### DIFF
--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -80,10 +80,15 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
    * for events shared to the querying calendar, or 'manual' for legacy EventRepostEntity
    * entries, or 'none' for owned events.
    *
-   * NOT populated by: EventService.getEventById(), EventService.updateEvent(), or
-   * EventService.bulkAssignCategories() (which calls getEventById() internally). Events
-   * returned by those methods will always have repostStatus='none' regardless of actual
-   * repost state.
+   * Also populated by: EventService.bulkAssignCategories() and
+   * EventService.replaceEventCategories(). After commit each method issues a
+   * single getSharedEventStatusMap + EventRepostEntity lookup against the
+   * acting (resolved) calendar and assigns the resolved status to each
+   * returned event, mirroring the listEvents resolution.
+   *
+   * NOT populated by: EventService.getEventById() or EventService.updateEvent().
+   * Events returned by those methods will always have repostStatus='none'
+   * regardless of actual repost state. (Tracked by follow-up bead pv-n1uy.)
    *
    * Default: 'none'. Must be explicitly set after retrieval if needed.
    */

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1739,9 +1739,12 @@ class EventService {
     }
 
 
-    let wasRepost = false;
-
     const transaction = await db.transaction();
+
+    // The acting calendar id (the reposter for repost events; the source
+    // calendar otherwise) is captured here so the post-commit repostStatus
+    // lookup can target the same calendar that owned the assignment write.
+    let actingCalendarId: string;
 
     try {
       // 1. Validate that all events exist
@@ -1771,11 +1774,10 @@ class EventService {
       // we need the reposter's calendar (which the user controls) instead.
       const {
         effectiveCalendarId,
-        wasRepost: resolvedAsRepost,
         userCalendars,
       } = await this.resolveEffectiveCalendarId(account, calendarIds[0] as string, eventIds, transaction);
       let calendarId = effectiveCalendarId;
-      wasRepost = resolvedAsRepost;
+      actingCalendarId = effectiveCalendarId;
 
       const calendar = await this.calendarService.getCalendar(calendarId);
 
@@ -1844,13 +1846,39 @@ class EventService {
       throw error;
     }
 
-    // 8. Return updated events with their categories (after successful commit)
+    // 8. Build authoritative repostStatus map for the acting calendar.
+    // Mirrors the resolution pattern in listEvents (~lines 285-307): consult
+    // SharedEventEntity (via AP interface) for auto/manual distinction, fall
+    // back to EventRepostEntity-only entries as 'manual'. A single pair of
+    // queries is issued per call regardless of event count.
+    const [reposts, sharedStatusMap] = await Promise.all([
+      EventRepostEntity.findAll({
+        where: { calendar_id: actingCalendarId },
+        attributes: ['event_id'],
+      }),
+      this.activityPubInterface!.getSharedEventStatusMap(actingCalendarId),
+    ]);
+
+    const repostStatusByEventId = new Map<string, 'auto' | 'manual'>();
+    for (const [eventId, status] of sharedStatusMap.entries()) {
+      if (UUID_REGEX.test(eventId)) {
+        repostStatusByEventId.set(eventId, status);
+      }
+    }
+    for (const r of reposts) {
+      if (!repostStatusByEventId.has(r.event_id)) {
+        repostStatusByEventId.set(r.event_id, 'manual');
+      }
+    }
+
+    // 9. Return updated events with their categories (after successful commit).
+    // repostStatus is populated authoritatively from the SharedEventEntity +
+    // EventRepostEntity union above; events not in either collection (owned by
+    // the acting calendar) default to 'none'.
     const updatedEvents = [];
     for (const eventId of eventIds) {
       const updatedEvent = await this.getEventById(eventId);
-      // wasRepost is derived from resolveEffectiveCalendarId(); preserve the
-      // legacy boolean by mapping true → 'manual' (no auto/manual context here).
-      updatedEvent.repostStatus = wasRepost ? 'manual' : 'none';
+      updatedEvent.repostStatus = repostStatusByEventId.get(eventId) ?? 'none';
       updatedEvents.push(updatedEvent);
     }
 
@@ -1888,9 +1916,12 @@ class EventService {
     // Deduplicate categoryIds to prevent false count mismatches
     const uniqueCategoryIds = [...new Set(categoryIds)];
 
-    let wasRepost = false;
-
     const transaction = await db.transaction();
+
+    // The acting calendar id (the reposter for repost events; the source
+    // calendar otherwise) is captured here so the post-commit repostStatus
+    // lookup can target the same calendar that owned the assignment write.
+    let actingCalendarId: string;
 
     try {
       // 1. Find the event
@@ -1906,10 +1937,9 @@ class EventService {
       // 2. Resolve effective calendar (handles repost lookup)
       const {
         effectiveCalendarId,
-        wasRepost: resolvedAsRepost,
         userCalendars,
       } = await this.resolveEffectiveCalendarId(account, event.calendar_id, [eventId], transaction, calendarId);
-      wasRepost = resolvedAsRepost;
+      actingCalendarId = effectiveCalendarId;
 
       // 3. Check user has permission
       const hasPermission = userCalendars.some(cal => cal.id === effectiveCalendarId);
@@ -1956,11 +1986,32 @@ class EventService {
       throw error;
     }
 
-    // Return updated event (after successful commit)
+    // 7. Build authoritative repostStatus map for the acting calendar.
+    // Mirrors the resolution pattern in listEvents (~lines 285-307): consult
+    // SharedEventEntity (via AP interface) for auto/manual distinction, fall
+    // back to EventRepostEntity-only entries as 'manual'. Owned events default
+    // to 'none'.
+    const [reposts, sharedStatusMap] = await Promise.all([
+      EventRepostEntity.findAll({
+        where: { calendar_id: actingCalendarId },
+        attributes: ['event_id'],
+      }),
+      this.activityPubInterface!.getSharedEventStatusMap(actingCalendarId),
+    ]);
+
+    let resolvedStatus: 'none' | 'manual' | 'auto' = 'none';
+    const sharedEntry = sharedStatusMap.get(eventId);
+    if (sharedEntry && UUID_REGEX.test(eventId)) {
+      resolvedStatus = sharedEntry;
+    }
+    else if (reposts.some(r => r.event_id === eventId)) {
+      resolvedStatus = 'manual';
+    }
+
+    // Return updated event (after successful commit) with authoritative
+    // repostStatus populated.
     const updatedEvent = await this.getEventById(eventId);
-    // wasRepost is derived from resolveEffectiveCalendarId(); map true → 'manual'
-    // (no auto/manual context available here).
-    updatedEvent.repostStatus = wasRepost ? 'manual' : 'none';
+    updatedEvent.repostStatus = resolvedStatus;
 
     return updatedEvent;
   }

--- a/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
+++ b/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
@@ -15,6 +15,33 @@ import { BulkEventsNotFoundError, MixedCalendarEventsError, CategoriesNotFoundEr
 import db from '@/server/common/entity/db';
 import type { Transaction } from 'sequelize';
 
+/**
+ * Builds a stub ActivityPubInterface that returns the supplied SharedEventEntity
+ * status map from getSharedEventStatusMap. Mirrors the helper used in
+ * event_service.test.ts so authoritative repostStatus resolution can be driven
+ * from the test inputs.
+ */
+function buildMockApInterface(
+  sharedEventIds: string[] = [],
+  statusOverrides: Record<string, 'auto' | 'manual'> = {},
+  calendarIdsForEvent: Record<string, string[]> = {},
+) {
+  const statusMap = new Map<string, 'auto' | 'manual'>();
+  for (const id of sharedEventIds) {
+    statusMap.set(id, statusOverrides[id] ?? 'manual');
+  }
+  const getCalendarIdsForSharedEvent = sinon.stub();
+  // Default behavior: return [] for any event id not explicitly mapped.
+  getCalendarIdsForSharedEvent.callsFake(async (eventId: string) => {
+    return calendarIdsForEvent[eventId] ?? [];
+  });
+  return {
+    getSharedEventIds: sinon.stub().resolves(sharedEventIds),
+    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
+    getCalendarIdsForSharedEvent,
+  } as any;
+}
+
 describe('EventService.bulkAssignCategories', () => {
   let service: EventService;
   let sandbox = sinon.createSandbox();
@@ -22,6 +49,9 @@ describe('EventService.bulkAssignCategories', () => {
 
   beforeEach(() => {
     service = new EventService(new EventEmitter());
+    // Default AP interface returns no shared events; tests that need
+    // SharedEventEntity-driven repostStatus override this in-test.
+    service.setActivityPubInterface(buildMockApInterface());
     mockAccount = new Account('test-account-id', 'test@example.com');
   });
 
@@ -66,6 +96,11 @@ describe('EventService.bulkAssignCategories', () => {
     const findExistingStub = sandbox.stub(EventCategoryAssignmentEntity, 'findAll');
     findExistingStub.resolves([]);
 
+    // Post-commit repostStatus lookup queries EventRepostEntity by calendar_id;
+    // for owned events there are no rows, so the resolved status falls back
+    // to 'none' (matched by getSharedEventStatusMap returning empty in beforeEach).
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([]);
+
     // Mock transaction
     const mockTransaction = {
       commit: sandbox.stub().resolves(),
@@ -83,11 +118,9 @@ describe('EventService.bulkAssignCategories', () => {
     // Mock getEventById for the return values
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
     eventIds.forEach(id => {
-      getEventByIdStub.withArgs(id).resolves({
-        id,
-        calendarId,
-        categories: mockCategories.map(cat => cat.toModel()),
-      } as any);
+      const ev = new CalendarEvent(id, calendarId);
+      ev.categories = mockCategories.map(cat => cat.toModel());
+      getEventByIdStub.withArgs(id).resolves(ev);
     });
 
     // Act
@@ -99,6 +132,12 @@ describe('EventService.bulkAssignCategories', () => {
     expect(result[0].id).toBe('11111111-1111-4111-8111-111111111111');
     expect(result[1].id).toBe('22222222-2222-4222-8222-222222222222');
     expect(result[2].id).toBe('33333333-3333-4333-8333-333333333333');
+    // Owned events: authoritative repostStatus is 'none' (no SharedEventEntity
+    // or EventRepostEntity row matching the acting calendar).
+    result.forEach(r => {
+      expect(r.repostStatus).toBe('none');
+      expect(r.isRepost).toBe(false);
+    });
     expect(bulkCreateStub.calledOnce).toBe(true);
     expect(mockTransaction.commit.calledOnce).toBe(true);
   });
@@ -213,6 +252,9 @@ describe('EventService.bulkAssignCategories', () => {
     const findExistingStub = sandbox.stub(EventCategoryAssignmentEntity, 'findAll');
     findExistingStub.resolves(existingAssignments);
 
+    // Post-commit repostStatus lookup: owned event, no repost rows.
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([]);
+
     const mockTransaction = {
       commit: sandbox.stub().resolves(),
       rollback: sandbox.stub().resolves(),
@@ -227,11 +269,9 @@ describe('EventService.bulkAssignCategories', () => {
 
     // Mock getEventById for the return values
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
-    getEventByIdStub.withArgs('11111111-1111-4111-8111-111111111111').resolves({
-      id: '11111111-1111-4111-8111-111111111111',
-      calendarId,
-      categories: mockCategories.map(cat => cat.toModel()),
-    } as any);
+    const returnedEvent = new CalendarEvent('11111111-1111-4111-8111-111111111111', calendarId);
+    returnedEvent.categories = mockCategories.map(cat => cat.toModel());
+    getEventByIdStub.withArgs('11111111-1111-4111-8111-111111111111').resolves(returnedEvent);
 
     // Act
     const result = await service.bulkAssignCategories(mockAccount, eventIds, categoryIds);
@@ -240,6 +280,8 @@ describe('EventService.bulkAssignCategories', () => {
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('11111111-1111-4111-8111-111111111111');
+    // Owned event: authoritative repostStatus is 'none'.
+    expect(result[0].repostStatus).toBe('none');
     expect(mockTransaction.commit.calledOnce).toBe(true);
     // Only cat2 should be newly assigned (cat1 was already assigned)
   });
@@ -295,7 +337,8 @@ describe('EventService.bulkAssignCategories', () => {
     const bulkCreateStub = sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
-    getEventByIdStub.withArgs(eventId).resolves({ id: eventId, calendarId: reposterCalendarId, categories: [] } as any);
+    const returnedEvent = new CalendarEvent(eventId, reposterCalendarId);
+    getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
 
     const result = await service.bulkAssignCategories(mockAccount, [eventId], [categoryId]);
 
@@ -303,17 +346,95 @@ describe('EventService.bulkAssignCategories', () => {
     expect(result).toHaveLength(1);
     expect(bulkCreateStub.calledOnce).toBe(true);
     expect(mockTransaction.commit.calledOnce).toBe(true);
+    // The event lives in EventRepostEntity (legacy direct-repost link) but not
+    // in SharedEventEntity (the AP mock returns an empty status map). The
+    // legacy fallback resolves to 'manual'.
+    expect(result[0].repostStatus).toBe('manual');
+    expect(result[0].isRepost).toBe(true);
   });
 
-  it('should set isRepost=true on returned events when a repost resolution occurred', async () => {
-    // Verifies Bug 2 fix: getEventById never sets isRepost, so after bulkAssignCategories
-    // resolves through the repost path, returned events must have isRepost=true set
-    // explicitly so the store reflects the correct state without requiring a page refresh.
+  it('should set repostStatus="auto" when SharedEventEntity reports auto_posted (pv-7kxw.1)', async () => {
+    // pv-7kxw.1 (option b): bulkAssignCategories now consults
+    // getSharedEventStatusMap post-commit and sets repostStatus
+    // authoritatively. An event reported as 'auto' by SharedEventEntity must
+    // surface as 'auto' in the return shape — the lossy 'manual' synthesis is
+    // gone. Companion bead pv-7kxw.2 will add additional lock-in coverage.
     const eventId = '11111111-1111-4111-8111-111111111111';
     const categoryId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
     const originalCalendarId = 'original-calendar-uuid';
     const reposterCalendarId = 'reposter-calendar-uuid';
 
+    // SharedEventEntity reports the event as auto-posted on the reposter.
+    service.setActivityPubInterface(
+      buildMockApInterface([eventId], { [eventId]: 'auto' }),
+    );
+
+    const mockEvent = EventEntity.build({
+      id: eventId,
+      calendar_id: originalCalendarId,
+      account_id: 'other-account-id',
+    });
+
+    const mockCategory = EventCategoryEntity.build({
+      id: categoryId,
+      calendar_id: reposterCalendarId,
+    });
+
+    const mockRepost = EventRepostEntity.build({
+      id: 'repost-uuid',
+      event_id: eventId,
+      calendar_id: reposterCalendarId,
+    });
+
+    sandbox.stub(EventEntity, 'findAll').resolves([mockEvent]);
+
+    sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser')
+      .resolves([new Calendar(reposterCalendarId, 'reposter-calendar')]);
+
+    // EventRepostEntity.findAll is consulted twice: once inside
+    // resolveEffectiveCalendarId (event_id filter) and once post-commit
+    // (calendar_id filter). The flat stub satisfies both shapes.
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([mockRepost]);
+
+    sandbox.stub(CalendarService.prototype, 'getCalendar')
+      .resolves(new Calendar(reposterCalendarId, 'reposter-calendar'));
+
+    sandbox.stub(EventCategoryEntity, 'findAll').resolves([mockCategory]);
+    sandbox.stub(EventCategoryAssignmentEntity, 'findAll').resolves([]);
+
+    const mockTransaction = {
+      commit: sandbox.stub().resolves(),
+      rollback: sandbox.stub().resolves(),
+      afterCommit: sandbox.stub(),
+      LOCK: {},
+    } as unknown as Transaction;
+    sandbox.stub(db, 'transaction').resolves(mockTransaction);
+
+    sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
+
+    const returnedEvent = new CalendarEvent(eventId, reposterCalendarId);
+    const getEventByIdStub = sandbox.stub(service, 'getEventById');
+    getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
+
+    const result = await service.bulkAssignCategories(mockAccount, [eventId], [categoryId]);
+
+    // SharedEventEntity takes precedence over EventRepostEntity legacy fallback.
+    expect(result).toHaveLength(1);
+    expect(result[0].repostStatus).toBe('auto');
+    expect(result[0].isRepost).toBe(true);
+  });
+
+  it('should set repostStatus="manual" via EventRepostEntity legacy fallback (pv-7kxw.1)', async () => {
+    // pv-7kxw.1 (option b): when SharedEventEntity has no entry but
+    // EventRepostEntity does (legacy direct-repost link), the resolved
+    // repostStatus is 'manual'. This proves the fallback chain matches the
+    // listEvents resolution.
+    const eventId = '11111111-1111-4111-8111-111111111111';
+    const categoryId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const originalCalendarId = 'original-calendar-uuid';
+    const reposterCalendarId = 'reposter-calendar-uuid';
+
+    // beforeEach already wires an empty getSharedEventStatusMap.
     const mockEvent = EventEntity.build({
       id: eventId,
       calendar_id: originalCalendarId,
@@ -354,23 +475,21 @@ describe('EventService.bulkAssignCategories', () => {
 
     sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
-    // getEventById returns an event with isRepost=false (as it always does, since it
-    // doesn't know about the repost relationship)
     const returnedEvent = new CalendarEvent(eventId, reposterCalendarId);
-    returnedEvent.repostStatus = 'none';
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
     getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
 
     const result = await service.bulkAssignCategories(mockAccount, [eventId], [categoryId]);
 
-    // The service must correct isRepost to true since repost resolution occurred
     expect(result).toHaveLength(1);
+    expect(result[0].repostStatus).toBe('manual');
     expect(result[0].isRepost).toBe(true);
   });
 
-  it('should set isRepost=false on returned events when no repost resolution occurred', async () => {
-    // Verifies that the wasRepost flag stays false for normal (non-repost) events,
-    // so local events continue to have isRepost=false after category assignment.
+  it('should set repostStatus="none" for owned events with no repost rows (pv-7kxw.1)', async () => {
+    // pv-7kxw.1 (option b): owned events have no SharedEventEntity entry and
+    // no EventRepostEntity row matching the acting calendar — repostStatus
+    // resolves to 'none' (the default from the resolved status map).
     const eventId = '11111111-1111-4111-8111-111111111111';
     const categoryId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
     const calendarId = 'local-calendar-uuid';
@@ -388,7 +507,7 @@ describe('EventService.bulkAssignCategories', () => {
 
     sandbox.stub(EventEntity, 'findAll').resolves([mockEvent]);
 
-    // User owns the calendar directly — no repost resolution needed
+    // User owns the calendar directly — no repost resolution needed.
     sandbox.stub(CalendarService.prototype, 'editableCalendarsForUser')
       .resolves([new Calendar(calendarId, 'local-calendar')]);
 
@@ -397,6 +516,9 @@ describe('EventService.bulkAssignCategories', () => {
 
     sandbox.stub(EventCategoryEntity, 'findAll').resolves([mockCategory]);
     sandbox.stub(EventCategoryAssignmentEntity, 'findAll').resolves([]);
+
+    // Post-commit lookup queries EventRepostEntity by calendar_id; no rows.
+    sandbox.stub(EventRepostEntity, 'findAll').resolves([]);
 
     const mockTransaction = {
       commit: sandbox.stub().resolves(),
@@ -409,13 +531,13 @@ describe('EventService.bulkAssignCategories', () => {
     sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
     const returnedEvent = new CalendarEvent(eventId, calendarId);
-    returnedEvent.repostStatus = 'none';
     const getEventByIdStub = sandbox.stub(service, 'getEventById');
     getEventByIdStub.withArgs(eventId).resolves(returnedEvent);
 
     const result = await service.bulkAssignCategories(mockAccount, [eventId], [categoryId]);
 
     expect(result).toHaveLength(1);
+    expect(result[0].repostStatus).toBe('none');
     expect(result[0].isRepost).toBe(false);
   });
 

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -16,6 +16,31 @@ import { ValidationError } from '@/common/exceptions/base';
 import db from '@/server/common/entity/db';
 import type { Transaction } from 'sequelize';
 
+/**
+ * Builds a stub ActivityPubInterface mirroring the helper in
+ * event_service.test.ts. getSharedEventStatusMap drives authoritative
+ * repostStatus resolution post-commit.
+ */
+function buildMockApInterface(
+  sharedEventIds: string[] = [],
+  statusOverrides: Record<string, 'auto' | 'manual'> = {},
+  calendarIdsForEvent: Record<string, string[]> = {},
+) {
+  const statusMap = new Map<string, 'auto' | 'manual'>();
+  for (const id of sharedEventIds) {
+    statusMap.set(id, statusOverrides[id] ?? 'manual');
+  }
+  const getCalendarIdsForSharedEvent = sinon.stub();
+  getCalendarIdsForSharedEvent.callsFake(async (eventId: string) => {
+    return calendarIdsForEvent[eventId] ?? [];
+  });
+  return {
+    getSharedEventIds: sinon.stub().resolves(sharedEventIds),
+    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
+    getCalendarIdsForSharedEvent,
+  } as any;
+}
+
 describe('EventService.replaceEventCategories', () => {
   let service: EventService;
   let sandbox = sinon.createSandbox();
@@ -73,6 +98,9 @@ describe('EventService.replaceEventCategories', () => {
 
   beforeEach(() => {
     service = new EventService(new EventEmitter());
+    // Default AP interface: empty status map. Tests that need a SharedEventEntity
+    // signal override this in-test.
+    service.setActivityPubInterface(buildMockApInterface());
     mockAccount = new Account('test-account-id', 'test@example.com');
   });
 
@@ -95,6 +123,8 @@ describe('EventService.replaceEventCategories', () => {
       eventEntity: mockEvent,
       categories: mockCategories,
       userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Owned event: no repost rows. Authoritative repostStatus = 'none'.
+      repostEntity: [],
     });
 
     const destroyStub = sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
@@ -109,6 +139,7 @@ describe('EventService.replaceEventCategories', () => {
 
     expect(result).toBeDefined();
     expect(result.id).toBe(validEventId);
+    expect(result.repostStatus).toBe('none');
     expect(destroyStub.calledOnce).toBe(true);
     expect(bulkCreateStub.calledOnce).toBe(true);
     expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
@@ -124,6 +155,8 @@ describe('EventService.replaceEventCategories', () => {
     const mockTransaction = stubCommonDependencies({
       eventEntity: mockEvent,
       userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Owned event: no repost rows for the post-commit lookup.
+      repostEntity: [],
     });
 
     const destroyStub = sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
@@ -251,7 +284,11 @@ describe('EventService.replaceEventCategories', () => {
     );
 
     expect(result).toBeDefined();
-    expect(result.isRepost).toBe(true);
+    // pv-7kxw.1 (option b): repostStatus is now populated authoritatively
+    // post-commit. EventRepostEntity has a row matching the acting calendar
+    // and SharedEventEntity has no entry, so the legacy fallback resolves
+    // to 'manual'.
+    expect(result.repostStatus).toBe('manual');
     expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
   });
 
@@ -287,7 +324,6 @@ describe('EventService.replaceEventCategories', () => {
     sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
 
     const returnedEvent = new CalendarEvent(validEventId, reposterCalendarId);
-    returnedEvent.repostStatus = 'none';
     sandbox.stub(service, 'getEventById').resolves(returnedEvent);
 
     const result = await service.replaceEventCategories(
@@ -295,6 +331,10 @@ describe('EventService.replaceEventCategories', () => {
     );
 
     expect(result).toBeDefined();
+    // pv-7kxw.1 (option b): EventRepostEntity has a row on the reposter
+    // calendar and SharedEventEntity has no entry, so the legacy fallback
+    // resolves repostStatus to 'manual'.
+    expect(result.repostStatus).toBe('manual');
     expect(result.isRepost).toBe(true);
     expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
   });
@@ -330,16 +370,71 @@ describe('EventService.replaceEventCategories', () => {
     stubCommonDependencies({
       eventEntity: mockEvent,
       userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Owned event: post-commit lookup finds no repost rows.
+      repostEntity: [],
     });
 
     sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
 
     const returnedEvent = new CalendarEvent(validEventId, calendarId);
-    returnedEvent.repostStatus = 'none';
     sandbox.stub(service, 'getEventById').resolves(returnedEvent);
 
     const result = await service.replaceEventCategories(mockAccount, validEventId, []);
 
+    // pv-7kxw.1 (option b): repostStatus is populated authoritatively from
+    // SharedEventEntity + EventRepostEntity. Owned events resolve to 'none'.
+    expect(result.repostStatus).toBe('none');
     expect(result.isRepost).toBe(false);
+  });
+
+  it('should set repostStatus="auto" when SharedEventEntity reports auto_posted (pv-7kxw.1)', async () => {
+    // pv-7kxw.1 (option b): SharedEventEntity takes precedence over the
+    // EventRepostEntity legacy fallback. An auto-posted share must surface
+    // as 'auto' on the return shape.
+    const originalCalendarId = 'original-0000-4000-8000-000000000001';
+    const reposterCalendarId = 'reposter-0000-4000-8000-000000000001';
+
+    service.setActivityPubInterface(
+      buildMockApInterface([validEventId], { [validEventId]: 'auto' }),
+    );
+
+    const mockEvent = EventEntity.build({
+      id: validEventId,
+      calendar_id: originalCalendarId,
+      account_id: 'other-account-id',
+    });
+
+    const mockCategory = EventCategoryEntity.build({
+      id: validCategoryId1,
+      calendar_id: reposterCalendarId,
+    });
+
+    const mockRepost = EventRepostEntity.build({
+      id: 'repost-uuid',
+      event_id: validEventId,
+      calendar_id: reposterCalendarId,
+    });
+
+    const mockTransaction = stubCommonDependencies({
+      eventEntity: mockEvent,
+      categories: [mockCategory],
+      userCalendars: [new Calendar(reposterCalendarId, 'reposter-calendar')],
+      repostEntity: [mockRepost],
+    });
+
+    sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
+    sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
+
+    const returnedEvent = new CalendarEvent(validEventId, reposterCalendarId);
+    sandbox.stub(service, 'getEventById').resolves(returnedEvent);
+
+    const result = await service.replaceEventCategories(
+      mockAccount, validEventId, [validCategoryId1],
+    );
+
+    // SharedEventEntity 'auto' wins over the EventRepostEntity legacy row.
+    expect(result.repostStatus).toBe('auto');
+    expect(result.isRepost).toBe(true);
+    expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
   });
 });

--- a/src/server/calendar/test/integration/bulk_category_assignment.test.ts
+++ b/src/server/calendar/test/integration/bulk_category_assignment.test.ts
@@ -32,6 +32,13 @@ describe('CalendarInterface.bulkAssignCategories', () => {
 
     eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
+    calendarInterface.setActivityPubInterface({
+      getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
+      getCalendarIdsForSharedEvent: async () => [],
+      getEventSourceActorUris: async () => new Map<string, string>(),
+      findCalendarActorByCalendarId: async () => null,
+    } as never);
     const configurationInterface = new ConfigurationInterface();
     const setupInterface = new SetupInterface();
     const accountService = new AccountService(eventBus, configurationInterface, setupInterface);


### PR DESCRIPTION
## Motivation

`bulkAssignCategories` and `replaceEventCategories` previously synthesized `repostStatus` from a boolean `wasRepost` flag, mislabeling auto-reposted events as `'manual'` on every response. The naive fix — strip the field — turned out to silently regress the `event.isRepost` invariant in the client store: `eventStore.updateEvent` does whole-slot replacement, so events round-tripped through the bulk/replace methods lost their repost-state. That broke the unpost button (DEC-008 community-control surface), the repost badge, the calendar-default-image suppression for reposts, and the editor routing into the repost modal — all silently, until the user refreshed.

## Approach

Wire `activityPubInterface.getSharedEventStatusMap` plus an `EventRepostEntity` fallback into both methods post-commit, mirroring the resolution pattern in `listEvents`. Each method now issues a single parallel `Promise.all` against the acting (resolved) calendar and assigns the authoritative `repostStatus` to each returned event:

- `'auto'` when `SharedEventEntity.auto_posted = true`
- `'manual'` for legacy `EventRepostEntity` rows or `SharedEventEntity.auto_posted = false`
- `'none'` for owned/non-reposted events

Updated the `CalendarEvent.repostStatus` JSDoc to document the new authoritative population (and to call out the remaining gap on `getEventById` / `updateEvent`, tracked separately). Wired a stub AP interface into the `bulk_category_assignment` integration test, matching the pattern used by sibling integration tests.

## Validation

- `npm run lint` — 0 errors (279 pre-existing warnings, no new ones).
- Targeted unit tests: 42/42 pass across `bulk_assign_categories.test.ts`, `replace_event_categories.test.ts`, and `event_service.test.ts` (listEvents reference pattern green).
- Calendar integration suite: 272/272 pass, including the eight `bulk_category_assignment.test.ts` integration tests after the AP-interface stub wiring fix.
- Test fixtures explicitly cover all three repostStatus paths (auto via SharedEventEntity, manual via legacy EventRepostEntity, none for owned events) on both methods, so the previous lossy mapping cannot be reintroduced without test failures.