### PR TITLE
feat(validation): wire field-level error pipeline (pv-oih.5)

### DIFF
--- a/src/client/components/common/create-location-form.vue
+++ b/src/client/components/common/create-location-form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, reactive } from 'vue';
+import { ref, computed, reactive, nextTick, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import Sheet from '@/client/components/common/Sheet.vue';
 import PillButton from '@/client/components/common/pill-button.vue';
@@ -7,9 +7,14 @@ import LanguageTabSelector from '@/client/components/common/language-tab-selecto
 
 const { t } = useTranslation('event_editor', { keyPrefix: 'create_location' });
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   languages: string[];
-}>();
+  fieldErrors?: Record<string, string>;
+  submissionError?: string;
+}>(), {
+  fieldErrors: () => ({}),
+  submissionError: '',
+});
 
 const emit = defineEmits<{
   (e: 'create-location', data: any): void;
@@ -20,6 +25,14 @@ const emit = defineEmits<{
 
 const currentLanguage = ref(props.languages[0] || 'en');
 const accessibilityLangTabs = ref<InstanceType<typeof LanguageTabSelector> | null>(null);
+const submissionErrorEl = ref<HTMLElement | null>(null);
+
+watch(() => props.submissionError, async (newVal) => {
+  if (newVal) {
+    await nextTick();
+    submissionErrorEl.value?.focus();
+  }
+});
 
 // Form state
 const formData = reactive({
@@ -97,13 +110,26 @@ const handleSubmit = () => {
 
         <div class="form-field">
           <input
+            id="create-location-name"
             v-model="formData.name"
             type="text"
             class="form-input"
+            :class="{ 'form-input--error': props.fieldErrors?.name }"
             :placeholder="t('name_placeholder')"
             :aria-label="t('name_aria_label')"
+            :aria-invalid="props.fieldErrors?.name ? 'true' : undefined"
+            :aria-describedby="props.fieldErrors?.name ? 'create-location-name-error' : undefined"
             required
           />
+          <div
+            v-if="props.fieldErrors?.name"
+            id="create-location-name-error"
+            class="form__error"
+            role="alert"
+            aria-live="polite"
+          >
+            {{ props.fieldErrors.name }}
+          </div>
         </div>
 
         <div class="form-field">
@@ -167,6 +193,17 @@ const handleSubmit = () => {
         </div>
       </section>
 
+      <div
+        v-if="props.submissionError"
+        ref="submissionErrorEl"
+        class="alert alert--error"
+        role="alert"
+        aria-live="polite"
+        tabindex="-1"
+      >
+        {{ props.submissionError }}
+      </div>
+
       <footer class="modal-actions">
         <PillButton
           variant="ghost"
@@ -216,6 +253,10 @@ const handleSubmit = () => {
 .form-input {
   @include form-input-rounded;
   width: 100%;
+
+  &--error {
+    border-color: var(--pav-color-error);
+  }
 
   &--state {
     width: 6rem;

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -1160,6 +1160,8 @@ button {
   <CreateLocationForm
     v-if="showCreateLocationForm"
     :languages="languages"
+    :field-errors="locationFieldErrors"
+    :submission-error="locationSubmissionError"
     @create-location="handleLocationCreated"
     @back-to-search="backToSearch"
     @close="showCreateLocationForm = false"
@@ -1212,6 +1214,7 @@ import LanguageTabSelector from '@/client/components/common/language-tab-selecto
 import LocationDisplayCard from '@/client/components/common/location-display-card.vue';
 import LocationPickerModal from '@/client/components/common/location-picker-modal.vue';
 import CreateLocationForm from '@/client/components/common/create-location-form.vue';
+import { ValidationError } from '@/common/exceptions';
 import iso6391 from 'iso-639-1-dir';
 
 // Composables
@@ -1263,6 +1266,8 @@ const {
   availableLocations,
   showLocationPicker,
   showCreateLocationForm,
+  locationFieldErrors,
+  locationSubmissionError,
   fetchLocations,
   openLocationPicker,
   selectLocation,
@@ -1473,8 +1478,12 @@ const handleLocationCreated = async (locationData) => {
       await createLocation(editorState.event.calendarId, locationData, editorState.event);
     }
     catch (error) {
-      console.error('Error creating location:', error);
-      editorState.err = 'Failed to create location';
+      // ValidationError populates locationFieldErrors / locationSubmissionError
+      // in the composable; surface a generic toast only for non-validation failures.
+      if (!(error instanceof ValidationError)) {
+        console.error('Error creating location:', error);
+        editorState.err = 'Failed to create location';
+      }
     }
   }
 };

--- a/src/client/composables/useLocationManagement.ts
+++ b/src/client/composables/useLocationManagement.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue';
 import { EventLocation } from '@/common/model/location';
 import LocationService from '@/client/service/location';
 import { CalendarEvent } from '@/common/model/events';
+import { ValidationError } from '@/common/exceptions';
 
 /**
  * Composable for managing event location selection and creation.
@@ -16,6 +17,13 @@ export function useLocationManagement() {
   const availableLocations = ref<EventLocation[]>([]);
   const showLocationPicker = ref(false);
   const showCreateLocationForm = ref(false);
+  const locationFieldErrors = ref<Record<string, string>>({});
+  const locationSubmissionError = ref('');
+
+  const clearLocationErrors = (): void => {
+    locationFieldErrors.value = {};
+    locationSubmissionError.value = '';
+  };
 
   /**
    * Fetch all locations for a specific calendar
@@ -84,21 +92,38 @@ export function useLocationManagement() {
     locationData: Record<string, any>,
     event: CalendarEvent,
   ): Promise<void> => {
+    clearLocationErrors();
+
     // Convert raw form data to an EventLocation instance
     const location = EventLocation.fromObject(locationData);
 
-    // Create the location via API
-    const newLocation = await locationService.createLocation(calendarId, location);
+    try {
+      // Create the location via API
+      const newLocation = await locationService.createLocation(calendarId, location);
 
-    // Add to available locations
-    availableLocations.value.push(newLocation);
+      // Add to available locations
+      availableLocations.value.push(newLocation);
 
-    // Auto-select the newly created location
-    event.locationId = newLocation.id;
-    event.location = newLocation;
+      // Auto-select the newly created location
+      event.locationId = newLocation.id;
+      event.location = newLocation;
 
-    // Close the create form
-    showCreateLocationForm.value = false;
+      // Close the create form
+      showCreateLocationForm.value = false;
+    }
+    catch (error: unknown) {
+      if (error instanceof ValidationError) {
+        if (error.fields) {
+          const flattened: Record<string, string> = {};
+          for (const [field, messages] of Object.entries(error.fields)) {
+            if (messages.length > 0) flattened[field] = messages[0];
+          }
+          locationFieldErrors.value = flattened;
+        }
+        locationSubmissionError.value = error.message;
+      }
+      throw error;
+    }
   };
 
   /**
@@ -127,11 +152,14 @@ export function useLocationManagement() {
     availableLocations,
     showLocationPicker,
     showCreateLocationForm,
+    locationFieldErrors,
+    locationSubmissionError,
     fetchLocations,
     openLocationPicker,
     selectLocation,
     createNewLocation,
     createLocation,
+    clearLocationErrors,
     removeLocation,
     backToSearch,
   };

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -82,7 +82,8 @@
     "accessibility_placeholder": "Accessibility information (optional)",
     "accessibility_aria_label": "Accessibility information in {{language}}",
     "back_button": "Back to search",
-    "submit_button": "Create Location"
+    "submit_button": "Create Location",
+    "error_submission": "Failed to create location. Please correct the errors and try again."
   },
   "external_link": {
     "section_title": "External Link",

--- a/src/client/service/location.ts
+++ b/src/client/service/location.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { EventLocation } from '@/common/model/location';
 import { CalendarNotFoundError, InsufficientCalendarPermissionsError } from '@/common/exceptions/calendar';
-import { UnauthenticatedError, UnknownError } from '@/common/exceptions';
+import { UnauthenticatedError, UnknownError, ValidationError } from '@/common/exceptions';
 import { useLocationStore } from '@/client/stores/locationStore';
 import ModelService from '@/client/service/models';
 import { validateAndEncodeId, handleApiError } from '@/client/service/utils';
@@ -11,6 +11,7 @@ const errorMap = {
   InsufficientCalendarPermissionsError,
   UnauthenticatedError,
   UnknownError,
+  ValidationError,
 };
 
 /**

--- a/src/client/test/components/create-location-form.test.ts
+++ b/src/client/test/components/create-location-form.test.ts
@@ -356,4 +356,90 @@ describe('CreateLocationForm', () => {
       expect(wrapper.emitted('back-to-search')).toBeTruthy();
     });
   });
+
+  describe('field-level errors', () => {
+    it('should show a field error for the name input when fieldErrors.name is set', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+          fieldErrors: { name: 'Location name is required' },
+        },
+      });
+
+      const errorEl = wrapper.find('#create-location-name-error');
+      expect(errorEl.exists()).toBe(true);
+      expect(errorEl.text()).toBe('Location name is required');
+    });
+
+    it('should not render the name error element when fieldErrors.name is absent', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+        },
+      });
+
+      expect(wrapper.find('#create-location-name-error').exists()).toBe(false);
+    });
+
+    it('should set aria-invalid on the name input when fieldErrors.name is set', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+          fieldErrors: { name: 'Location name is required' },
+        },
+      });
+
+      const nameInput = wrapper.find('input#create-location-name');
+      expect(nameInput.attributes('aria-invalid')).toBe('true');
+    });
+
+    it('should set aria-describedby on the name input pointing to the error element', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+          fieldErrors: { name: 'Location name is required' },
+        },
+      });
+
+      const nameInput = wrapper.find('input#create-location-name');
+      expect(nameInput.attributes('aria-describedby')).toBe('create-location-name-error');
+    });
+
+    it('should not set aria-invalid or aria-describedby when there is no field error', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+        },
+      });
+
+      const nameInput = wrapper.find('input#create-location-name');
+      expect(nameInput.attributes('aria-invalid')).toBeUndefined();
+      expect(nameInput.attributes('aria-describedby')).toBeUndefined();
+    });
+
+    it('should display submission error when submissionError prop is set', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+          submissionError: 'Failed to create location. Please correct the errors and try again.',
+        },
+      });
+
+      const errorEl = wrapper.find('[role="alert"]');
+      expect(errorEl.exists()).toBe(true);
+      expect(errorEl.text()).toContain('Failed to create location');
+    });
+
+    it('should not display submission error when submissionError prop is empty', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          languages: ['en'],
+        },
+      });
+
+      // No submission error element — only name error is absent too
+      const alerts = wrapper.findAll('[role="alert"]');
+      expect(alerts.length).toBe(0);
+    });
+  });
 });

--- a/src/client/test/service/utils.test.ts
+++ b/src/client/test/service/utils.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { handleApiError } from '@/client/service/utils';
+import { ValidationError, UnknownError } from '@/common/exceptions/base';
+import { CalendarNotFoundError } from '@/common/exceptions/calendar';
+
+const errorMap = {
+  CalendarNotFoundError,
+  UnknownError,
+};
+
+function makeAxiosError(data: Record<string, unknown>) {
+  return { response: { data } };
+}
+
+describe('handleApiError', () => {
+  it('throws UnknownError for non-axios errors', () => {
+    expect(() => handleApiError(new Error('generic'), errorMap)).toThrow(UnknownError);
+  });
+
+  it('throws UnknownError when errorName is not in map', () => {
+    const error = makeAxiosError({ errorName: 'SomeOtherError' });
+    expect(() => handleApiError(error, errorMap)).toThrow(UnknownError);
+  });
+
+  it('throws the mapped error class when errorName matches', () => {
+    const error = makeAxiosError({ errorName: 'CalendarNotFoundError' });
+    expect(() => handleApiError(error, errorMap)).toThrow(CalendarNotFoundError);
+  });
+
+  describe('ValidationError with fields', () => {
+    it('throws ValidationError with the server error message', () => {
+      const error = makeAxiosError({
+        errorName: 'ValidationError',
+        error: 'Validation failed',
+      });
+      let thrown: ValidationError | undefined;
+      try {
+        handleApiError(error, { ValidationError, UnknownError });
+      }
+      catch (e) {
+        thrown = e as ValidationError;
+      }
+      expect(thrown).toBeInstanceOf(ValidationError);
+      expect(thrown?.message).toBe('Validation failed');
+    });
+
+    it('throws ValidationError with fields map when backend supplies fields', () => {
+      const fields = {
+        email: ['Email is required'],
+        password: ['Password must be at least 8 characters'],
+      };
+      const error = makeAxiosError({
+        errorName: 'ValidationError',
+        error: 'Validation failed',
+        fields,
+      });
+      let thrown: ValidationError | undefined;
+      try {
+        handleApiError(error, { ValidationError, UnknownError });
+      }
+      catch (e) {
+        thrown = e as ValidationError;
+      }
+      expect(thrown).toBeInstanceOf(ValidationError);
+      expect(thrown?.fields).toEqual(fields);
+    });
+
+    it('throws ValidationError with no fields when backend omits fields', () => {
+      const error = makeAxiosError({
+        errorName: 'ValidationError',
+        error: 'Validation failed',
+      });
+      let thrown: ValidationError | undefined;
+      try {
+        handleApiError(error, { ValidationError, UnknownError });
+      }
+      catch (e) {
+        thrown = e as ValidationError;
+      }
+      expect(thrown).toBeInstanceOf(ValidationError);
+      expect(thrown?.fields).toBeUndefined();
+    });
+
+    it('uses default message when backend omits error string', () => {
+      const error = makeAxiosError({ errorName: 'ValidationError' });
+      let thrown: ValidationError | undefined;
+      try {
+        handleApiError(error, { ValidationError, UnknownError });
+      }
+      catch (e) {
+        thrown = e as ValidationError;
+      }
+      expect(thrown).toBeInstanceOf(ValidationError);
+      expect(thrown?.message).toBe('Validation failed');
+    });
+  });
+});

--- a/src/common/exceptions/test/base.test.ts
+++ b/src/common/exceptions/test/base.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+
+import { ValidationError } from '@/common/exceptions/base';
+
+describe('ValidationError', () => {
+  describe('constructor', () => {
+    it('creates with a single string error', () => {
+      const error = new ValidationError('Email is required');
+
+      expect(error.message).toBe('Email is required');
+      expect(error.errors).toEqual(['Email is required']);
+      expect(error.name).toBe('ValidationError');
+      expect(error.fields).toBeUndefined();
+    });
+
+    it('creates with an array of error messages', () => {
+      const error = new ValidationError(['Email is required', 'Password too short']);
+
+      expect(error.message).toBe('Email is required; Password too short');
+      expect(error.errors).toEqual(['Email is required', 'Password too short']);
+      expect(error.name).toBe('ValidationError');
+      expect(error.fields).toBeUndefined();
+    });
+
+    it('creates with default message when no arguments provided', () => {
+      const error = new ValidationError();
+
+      expect(error.message).toBe('Validation failed');
+      expect(error.errors).toEqual(['Validation failed']);
+      expect(error.fields).toBeUndefined();
+    });
+
+    it('creates with field-level error mapping', () => {
+      const fields = {
+        email: ['Email is required', 'Email format invalid'],
+        password: ['Too short'],
+      };
+      const error = new ValidationError('Validation failed', fields);
+
+      expect(error.fields).toEqual(fields);
+      expect(error.fields?.email).toEqual(['Email is required', 'Email format invalid']);
+      expect(error.fields?.password).toEqual(['Too short']);
+    });
+
+    it('creates with field-level errors and array of messages', () => {
+      const fields = { username: ['Username taken'] };
+      const error = new ValidationError(['Invalid form', 'Check fields'], fields);
+
+      expect(error.errors).toEqual(['Invalid form', 'Check fields']);
+      expect(error.fields).toEqual(fields);
+    });
+
+    it('is an instance of Error', () => {
+      const error = new ValidationError('test');
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it('maintains proper prototype chain', () => {
+      const error = new ValidationError('test');
+      expect(error).toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('fields property', () => {
+    it('is undefined when no fields provided', () => {
+      const error = new ValidationError('error');
+      expect(error.fields).toBeUndefined();
+    });
+
+    it('supports multiple errors per field', () => {
+      const fields: Record<string, string[]> = {
+        email: ['Invalid format', 'Already exists'],
+        name: ['Too short'],
+      };
+      const error = new ValidationError('Validation failed', fields);
+
+      expect(error.fields?.email).toHaveLength(2);
+      expect(error.fields?.name).toHaveLength(1);
+    });
+
+    it('preserves field error arrays exactly', () => {
+      const fieldErrors = ['Error one', 'Error two', 'Error three'];
+      const error = new ValidationError('test', { myField: fieldErrors });
+
+      expect(error.fields?.myField).toEqual(fieldErrors);
+    });
+  });
+});

--- a/src/server/common/decorators/test/validation.test.ts
+++ b/src/server/common/decorators/test/validation.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect } from 'vitest';
+import { ValidationError } from '@/common/exceptions/base';
+import {
+  Required,
+  Email,
+  UUID,
+  MinLength,
+  MaxLength,
+  validate,
+  validateOrThrow,
+} from '@/server/common/decorators/validation';
+
+// ---------------------------------------------------------------------------
+// Helper: small classes decorated for each test group
+// ---------------------------------------------------------------------------
+
+class RequiredFixture {
+  @Required()
+  name: string | null | undefined = 'default';
+}
+
+class EmailFixture {
+  @Email()
+  email: string = '';
+}
+
+class RequiredEmailFixture {
+  @Required()
+  @Email()
+  email: string = '';
+}
+
+class UUIDFixture {
+  @UUID()
+  id: string = '';
+}
+
+class MinLengthFixture {
+  @MinLength(5)
+  value: string = '';
+}
+
+class MaxLengthFixture {
+  @MaxLength(10)
+  value: string = '';
+}
+
+class ComposedFixture {
+  @Required()
+  @Email()
+  email: string = '';
+
+  @Required()
+  @MinLength(8)
+  @MaxLength(100)
+  password: string = '';
+
+  @UUID()
+  calendarId: string = '';
+}
+
+// ---------------------------------------------------------------------------
+// @Required()
+// ---------------------------------------------------------------------------
+
+describe('@Required()', () => {
+  it('passes for a non-empty string', () => {
+    const f = new RequiredFixture();
+    f.name = 'hello';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('fails for null', () => {
+    const f = new RequiredFixture();
+    f.name = null;
+    const errors = validate(f);
+    expect(errors.name).toContain('is required');
+  });
+
+  it('fails for undefined', () => {
+    const f = new RequiredFixture();
+    f.name = undefined;
+    const errors = validate(f);
+    expect(errors.name).toContain('is required');
+  });
+
+  it('fails for empty string', () => {
+    const f = new RequiredFixture();
+    f.name = '';
+    const errors = validate(f);
+    expect(errors.name).toContain('is required');
+  });
+
+  it('fails for whitespace-only string', () => {
+    const f = new RequiredFixture();
+    f.name = '   ';
+    const errors = validate(f);
+    expect(errors.name).toContain('is required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @Email()
+// ---------------------------------------------------------------------------
+
+describe('@Email()', () => {
+  const validEmails = [
+    'user@example.com',
+    'user+tag@sub.domain.org',
+    'first.last@company.co.uk',
+  ];
+
+  for (const email of validEmails) {
+    it(`passes for valid email: ${email}`, () => {
+      const f = new EmailFixture();
+      f.email = email;
+      expect(validate(f)).toEqual({});
+    });
+  }
+
+  const invalidEmails = [
+    'notanemail',
+    '@nodomain',
+    'missing@',
+    'two@@signs.com',
+  ];
+
+  for (const email of invalidEmails) {
+    it(`fails for invalid email: ${email}`, () => {
+      const f = new EmailFixture();
+      f.email = email;
+      const errors = validate(f);
+      expect(errors.email).toContain('must be a valid email address');
+    });
+  }
+
+  it('skips validation for empty string (absence not enforced without @Required)', () => {
+    const f = new EmailFixture();
+    f.email = '';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('skips validation for null', () => {
+    const f = new EmailFixture();
+    (f as Record<string, unknown>).email = null;
+    expect(validate(f)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @Required() + @Email() composed
+// ---------------------------------------------------------------------------
+
+describe('@Required() + @Email() composed', () => {
+  it('fails with required error when email is empty', () => {
+    const f = new RequiredEmailFixture();
+    f.email = '';
+    const errors = validate(f);
+    expect(errors.email).toContain('is required');
+  });
+
+  it('fails with format error when email is invalid and non-empty', () => {
+    const f = new RequiredEmailFixture();
+    f.email = 'notvalid';
+    const errors = validate(f);
+    expect(errors.email).toContain('must be a valid email address');
+  });
+
+  it('passes for valid non-empty email', () => {
+    const f = new RequiredEmailFixture();
+    f.email = 'user@example.com';
+    expect(validate(f)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @UUID()
+// ---------------------------------------------------------------------------
+
+describe('@UUID()', () => {
+  const validUUIDs = [
+    '550e8400-e29b-41d4-a716-446655440000',
+    '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    'A987FBC9-4BED-3078-AF07-9141BA07C9F3', // uppercase, variant bits a/b/8/9
+  ];
+
+  for (const uuid of validUUIDs) {
+    it(`passes for valid UUID: ${uuid}`, () => {
+      const f = new UUIDFixture();
+      f.id = uuid;
+      expect(validate(f)).toEqual({});
+    });
+  }
+
+  const invalidUUIDs = [
+    'not-a-uuid',
+    '550e8400-e29b-41d4-a716',               // too short
+    '550e8400-e29b-41d4-a716-4466554400001', // too long
+    '00000000-0000-0000-0000-000000000000',  // version 0 not valid
+  ];
+
+  for (const uuid of invalidUUIDs) {
+    it(`fails for invalid UUID: ${uuid}`, () => {
+      const f = new UUIDFixture();
+      f.id = uuid;
+      const errors = validate(f);
+      expect(errors.id).toContain('must be a valid UUID');
+    });
+  }
+
+  it('skips validation for empty string (absence not enforced without @Required)', () => {
+    const f = new UUIDFixture();
+    f.id = '';
+    expect(validate(f)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @MinLength(n)
+// ---------------------------------------------------------------------------
+
+describe('@MinLength(n)', () => {
+  it('passes when value meets the minimum', () => {
+    const f = new MinLengthFixture();
+    f.value = 'hello'; // exactly 5
+    expect(validate(f)).toEqual({});
+  });
+
+  it('passes when value exceeds the minimum', () => {
+    const f = new MinLengthFixture();
+    f.value = 'hello world';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('fails when value is shorter than the minimum', () => {
+    const f = new MinLengthFixture();
+    f.value = 'hi';
+    const errors = validate(f);
+    expect(errors.value).toContain('must be at least 5 characters');
+  });
+
+  it('uses singular "character" for min=1', () => {
+    class SingleCharFixture {
+      @MinLength(1)
+      v: string = '';
+    }
+    const f = new SingleCharFixture();
+    f.v = '';
+    // empty string is skipped (absence); set a non-empty too-short value isn't possible for length 1
+    // Instead verify message wording when failing
+    f.v = 'x';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('skips validation for empty string', () => {
+    const f = new MinLengthFixture();
+    f.value = '';
+    expect(validate(f)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @MaxLength(n)
+// ---------------------------------------------------------------------------
+
+describe('@MaxLength(n)', () => {
+  it('passes when value meets the maximum', () => {
+    const f = new MaxLengthFixture();
+    f.value = '1234567890'; // exactly 10
+    expect(validate(f)).toEqual({});
+  });
+
+  it('passes when value is shorter than the maximum', () => {
+    const f = new MaxLengthFixture();
+    f.value = 'short';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('fails when value exceeds the maximum', () => {
+    const f = new MaxLengthFixture();
+    f.value = '12345678901'; // 11 chars
+    const errors = validate(f);
+    expect(errors.value).toContain('must be at most 10 characters');
+  });
+
+  it('uses singular "character" for max=1', () => {
+    class SingleCharFixture {
+      @MaxLength(1)
+      v: string = '';
+    }
+    const f = new SingleCharFixture();
+    f.v = 'ab';
+    const errors = validate(f);
+    expect(errors.v).toContain('must be at most 1 character');
+  });
+
+  it('skips validation for empty string', () => {
+    const f = new MaxLengthFixture();
+    f.value = '';
+    expect(validate(f)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple decorators composable on one field
+// ---------------------------------------------------------------------------
+
+describe('composable decorators (multiple on same field)', () => {
+  it('collects all rule failures for one field', () => {
+    class MultiFixture {
+      @Required()
+      @MinLength(8)
+      @MaxLength(10)
+      value: string = '';
+    }
+    const f = new MultiFixture();
+    f.value = ''; // fails Required (and MinLength is skipped for empty)
+    const errors = validate(f);
+    expect(errors.value).toContain('is required');
+  });
+
+  it('reports both MinLength and MaxLength independently', () => {
+    // Set a value that is non-empty so @Required passes; pick a value < min
+    class LengthOnlyFixture {
+      @MinLength(5)
+      @MaxLength(3)
+      value: string = '';
+    }
+    const f = new LengthOnlyFixture();
+    f.value = 'abcd'; // length 4: fails MinLength(5) AND exceeds MaxLength(3)
+    const errors = validate(f);
+    expect(errors.value).toContain('must be at least 5 characters');
+    expect(errors.value).toContain('must be at most 3 characters');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validate() — full ComposedFixture
+// ---------------------------------------------------------------------------
+
+describe('validate()', () => {
+  it('returns an empty object for a fully valid instance', () => {
+    const f = new ComposedFixture();
+    f.email = 'user@example.com';
+    f.password = 'securepassword';
+    f.calendarId = '550e8400-e29b-41d4-a716-446655440000';
+    expect(validate(f)).toEqual({});
+  });
+
+  it('returns errors only for invalid fields', () => {
+    const f = new ComposedFixture();
+    f.email = 'not-an-email';
+    f.password = 'securepassword';
+    f.calendarId = '550e8400-e29b-41d4-a716-446655440000';
+    const errors = validate(f);
+    expect(Object.keys(errors)).toEqual(['email']);
+  });
+
+  it('returns errors for multiple invalid fields', () => {
+    const f = new ComposedFixture();
+    f.email = '';
+    f.password = 'short';
+    f.calendarId = 'not-a-uuid';
+    const errors = validate(f);
+    expect(errors.email).toContain('is required');
+    expect(errors.password).toContain('must be at least 8 characters');
+    expect(errors.calendarId).toContain('must be a valid UUID');
+  });
+
+  it('returns empty map for object without any rules', () => {
+    class Plain {
+      value: string = 'hello';
+    }
+    expect(validate(new Plain())).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateOrThrow()
+// ---------------------------------------------------------------------------
+
+describe('validateOrThrow()', () => {
+  it('does not throw when instance is valid', () => {
+    const f = new ComposedFixture();
+    f.email = 'user@example.com';
+    f.password = 'securepassword';
+    f.calendarId = '550e8400-e29b-41d4-a716-446655440000';
+    expect(() => validateOrThrow(f)).not.toThrow();
+  });
+
+  it('throws ValidationError when instance is invalid', () => {
+    const f = new ComposedFixture();
+    f.email = '';
+    f.password = '';
+    f.calendarId = '';
+    expect(() => validateOrThrow(f)).toThrow(ValidationError);
+  });
+
+  it('thrown ValidationError contains field-level errors', () => {
+    const f = new ComposedFixture();
+    f.email = 'bad-email';
+    f.password = 'ok-pass-length';
+    f.calendarId = '';
+
+    let caught: ValidationError | undefined;
+    try {
+      validateOrThrow(f);
+    }
+    catch (err) {
+      caught = err as ValidationError;
+    }
+
+    expect(caught).toBeInstanceOf(ValidationError);
+    expect(caught?.fields?.email).toContain('must be a valid email address');
+    expect(caught?.errors).toContain('Validation failed');
+  });
+
+  it('thrown ValidationError has the correct name', () => {
+    const f = new RequiredFixture();
+    f.name = '';
+    let caught: Error | undefined;
+    try {
+      validateOrThrow(f);
+    }
+    catch (err) {
+      caught = err as Error;
+    }
+    expect(caught?.name).toBe('ValidationError');
+  });
+});

--- a/src/server/common/decorators/validation.ts
+++ b/src/server/common/decorators/validation.ts
@@ -1,0 +1,267 @@
+/**
+ * Validation Decorators
+ *
+ * Property decorators for common validation patterns.
+ * Decorators attach metadata to class properties; call `validate(instance)` to
+ * run all attached rules and collect field-level errors.
+ *
+ * @example
+ * class CreateUserInput {
+ *   @Required()
+ *   @Email()
+ *   email: string = '';
+ *
+ *   @Required()
+ *   @MinLength(8)
+ *   @MaxLength(100)
+ *   password: string = '';
+ *
+ *   @UUID()
+ *   calendarId: string = '';
+ * }
+ *
+ * const input = new CreateUserInput();
+ * input.email = 'not-an-email';
+ * input.password = 'short';
+ *
+ * const errors = validate(input);
+ * // errors => { email: ['must be a valid email address'], password: ['must be at least 8 characters'] }
+ *
+ * if (Object.keys(errors).length > 0) {
+ *   throw new ValidationError('Validation failed', errors);
+ * }
+ */
+
+import { ValidationError } from '@/common/exceptions/base';
+
+// ------------------------------------------------------------------
+// Internal metadata registry
+// ------------------------------------------------------------------
+
+/** A single validation rule attached to one property. */
+interface ValidationRule {
+  /** Human-readable name of the rule, e.g. 'required'. */
+  rule: string;
+  /** Validates the raw value; returns an error message or null. */
+  check: (value: unknown) => string | null;
+}
+
+const RULES_KEY = Symbol('validation:rules');
+
+/**
+ * Retrieve the list of rules stored on a prototype for a given property.
+ * Creates the array on first access.
+ */
+function getRules(target: object, propertyKey: string): ValidationRule[] {
+  const map: Map<string, ValidationRule[]> = (target as Record<symbol, unknown>)[RULES_KEY] as Map<string, ValidationRule[]> ?? new Map();
+  (target as Record<symbol, unknown>)[RULES_KEY] = map;
+  if (!map.has(propertyKey)) {
+    map.set(propertyKey, []);
+  }
+  return map.get(propertyKey)!;
+}
+
+/**
+ * Attach a validation rule to a property via a property decorator.
+ */
+function addRule(rule: ValidationRule) {
+  return function (target: object, propertyKey: string): void {
+    getRules(target, propertyKey).push(rule);
+  };
+}
+
+// ------------------------------------------------------------------
+// Decorators
+// ------------------------------------------------------------------
+
+/**
+ * Marks a field as required. Validation fails when the value is `null`,
+ * `undefined`, or an empty string (after trimming).
+ *
+ * @example
+ * @Required()
+ * name: string = '';
+ */
+export function Required() {
+  return addRule({
+    rule: 'required',
+    check(value: unknown): string | null {
+      if (value === null || value === undefined) {
+        return 'is required';
+      }
+      if (typeof value === 'string' && value.trim() === '') {
+        return 'is required';
+      }
+      return null;
+    },
+  });
+}
+
+/**
+ * Validates that a field contains a valid RFC 5322-compatible email address.
+ * Empty / absent values are allowed — combine with `@Required()` to enforce
+ * presence.
+ *
+ * @example
+ * @Required()
+ * @Email()
+ * email: string = '';
+ */
+export function Email() {
+  // Matches most valid email addresses while rejecting obvious typos.
+  const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return addRule({
+    rule: 'email',
+    check(value: unknown): string | null {
+      if (value === null || value === undefined || value === '') {
+        return null; // absence is handled by @Required
+      }
+      if (typeof value !== 'string' || !EMAIL_REGEX.test(value)) {
+        return 'must be a valid email address';
+      }
+      return null;
+    },
+  });
+}
+
+/**
+ * Validates that a field contains a valid UUID (v1–v5, case-insensitive).
+ * Empty / absent values are allowed — combine with `@Required()` to enforce
+ * presence.
+ *
+ * @example
+ * @UUID()
+ * calendarId: string = '';
+ */
+export function UUID() {
+  const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return addRule({
+    rule: 'uuid',
+    check(value: unknown): string | null {
+      if (value === null || value === undefined || value === '') {
+        return null; // absence is handled by @Required
+      }
+      if (typeof value !== 'string' || !UUID_REGEX.test(value)) {
+        return 'must be a valid UUID';
+      }
+      return null;
+    },
+  });
+}
+
+/**
+ * Validates that a string field has at least `min` characters.
+ * Empty / absent values are skipped — combine with `@Required()` to enforce
+ * presence.
+ *
+ * @param min - Minimum number of characters (inclusive).
+ *
+ * @example
+ * @Required()
+ * @MinLength(8)
+ * password: string = '';
+ */
+export function MinLength(min: number) {
+  return addRule({
+    rule: 'minLength',
+    check(value: unknown): string | null {
+      if (value === null || value === undefined || value === '') {
+        return null; // absence is handled by @Required
+      }
+      if (typeof value !== 'string' || value.length < min) {
+        return `must be at least ${min} character${min === 1 ? '' : 's'}`;
+      }
+      return null;
+    },
+  });
+}
+
+/**
+ * Validates that a string field has no more than `max` characters.
+ * Empty / absent values are skipped — combine with `@Required()` to enforce
+ * presence.
+ *
+ * @param max - Maximum number of characters (inclusive).
+ *
+ * @example
+ * @MaxLength(100)
+ * name: string = '';
+ */
+export function MaxLength(max: number) {
+  return addRule({
+    rule: 'maxLength',
+    check(value: unknown): string | null {
+      if (value === null || value === undefined || value === '') {
+        return null; // absence is handled by @Required
+      }
+      if (typeof value !== 'string' || value.length > max) {
+        return `must be at most ${max} character${max === 1 ? '' : 's'}`;
+      }
+      return null;
+    },
+  });
+}
+
+// ------------------------------------------------------------------
+// Validation runner
+// ------------------------------------------------------------------
+
+/**
+ * Run all decorator-attached validation rules on `instance` and return a
+ * field-keyed error map.  An empty map means the object is valid.
+ *
+ * @param instance - An instance of any class decorated with validation rules.
+ * @returns A map of `{ fieldName: string[] }` containing error messages.
+ *
+ * @example
+ * const errors = validate(input);
+ * if (Object.keys(errors).length > 0) {
+ *   throw new ValidationError('Validation failed', errors);
+ * }
+ */
+export function validate(instance: object): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+
+  const proto = Object.getPrototypeOf(instance) as Record<symbol, unknown>;
+  const rulesMap = proto[RULES_KEY] as Map<string, ValidationRule[]> | undefined;
+
+  if (!rulesMap) {
+    return result;
+  }
+
+  for (const [field, rules] of rulesMap.entries()) {
+    const value = (instance as Record<string, unknown>)[field];
+    const fieldErrors: string[] = [];
+
+    for (const rule of rules) {
+      const message = rule.check(value);
+      if (message !== null) {
+        fieldErrors.push(message);
+      }
+    }
+
+    if (fieldErrors.length > 0) {
+      result[field] = fieldErrors;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convenience wrapper: run `validate()` and throw a `ValidationError` if any
+ * errors are found.  Callers that want fine-grained control should use
+ * `validate()` directly.
+ *
+ * @param instance - An instance of any class decorated with validation rules.
+ * @throws {ValidationError} when one or more fields fail validation.
+ *
+ * @example
+ * validateOrThrow(input); // throws if invalid
+ */
+export function validateOrThrow(instance: object): void {
+  const errors = validate(instance);
+  if (Object.keys(errors).length > 0) {
+    throw new ValidationError('Validation failed', errors);
+  }
+}

--- a/src/server/common/helper/test/express.test.ts
+++ b/src/server/common/helper/test/express.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import sinon from 'sinon';
+
+import { ValidationError } from '@/common/exceptions/base';
+import expressHelper from '@/server/common/helper/express';
+
+describe('sendValidationError', () => {
+  it('includes error and errorName in response', () => {
+    const error = new ValidationError('Email is required');
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    expect(res.status.calledWith(400)).toBe(true);
+    const body = res.json.firstCall.args[0];
+    expect(body.error).toBe('Email is required');
+    expect(body.errorName).toBe('ValidationError');
+  });
+
+  it('omits fields property when no fields provided', () => {
+    const error = new ValidationError('Something went wrong');
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    const body = res.json.firstCall.args[0];
+    expect(body.fields).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(body, 'fields')).toBe(false);
+  });
+
+  it('includes fields in response when field-level errors are present', () => {
+    const fields = {
+      email: ['Email is required', 'Email format invalid'],
+      password: ['Too short'],
+    };
+    const error = new ValidationError('Validation failed', fields);
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    const body = res.json.firstCall.args[0];
+    expect(body.fields).toEqual(fields);
+    expect(body.fields.email).toEqual(['Email is required', 'Email format invalid']);
+    expect(body.fields.password).toEqual(['Too short']);
+  });
+
+  it('returns 400 status for all validation errors', () => {
+    const error = new ValidationError('test');
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    expect(res.status.calledWith(400)).toBe(true);
+  });
+
+  it('response format matches expected shape with fields', () => {
+    const fields = { email: ['Email is required'] };
+    const error = new ValidationError('Validation failed', fields);
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    const body = res.json.firstCall.args[0];
+    // Verify the exact response shape: { error, errorName, fields? }
+    expect(body).toEqual({
+      error: 'Validation failed',
+      errorName: 'ValidationError',
+      fields: { email: ['Email is required'] },
+    });
+  });
+
+  it('response format matches expected shape without fields', () => {
+    const error = new ValidationError('Simple error');
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    const body = res.json.firstCall.args[0];
+    // Verify the exact response shape without fields
+    expect(body).toEqual({
+      error: 'Simple error',
+      errorName: 'ValidationError',
+    });
+  });
+
+  it('works with subclasses of ValidationError', () => {
+    class CustomValidationError extends ValidationError {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomValidationError';
+      }
+    }
+
+    const error = new CustomValidationError('Custom error');
+    const res = { status: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    expressHelper.sendValidationError(res as any, error);
+
+    const body = res.json.firstCall.args[0];
+    expect(body.errorName).toBe('CustomValidationError');
+    expect(body.error).toBe('Custom error');
+  });
+});

--- a/src/server/common/middleware/validation.ts
+++ b/src/server/common/middleware/validation.ts
@@ -1,0 +1,135 @@
+import { Request, Response, NextFunction } from 'express';
+import { DateTime } from 'luxon';
+import { ValidationError } from '@/common/exceptions/base';
+import expressHelper from '@/server/common/helper/express';
+
+/**
+ * Middleware factory that validates a named route parameter is a valid UUID v4.
+ *
+ * Calls next() with a ValidationError if the parameter is missing or malformed,
+ * which is handled by the global error handler and results in a 400 response.
+ *
+ * @param paramName - Name of the route parameter to validate (e.g. 'eventId')
+ * @returns Express middleware function
+ *
+ * @example
+ * router.get('/reports/:reportId',
+ *   validateUUID('reportId'),
+ *   async (req, res) => { ... }
+ * );
+ */
+export function validateUUID(paramName: string) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const value = req.params[paramName];
+
+    if (!value || !expressHelper.isValidUUID(value)) {
+      return next(new ValidationError(`Invalid UUID for parameter '${paramName}'`));
+    }
+
+    next();
+  };
+}
+
+/**
+ * Middleware factory that validates required fields are present in the request
+ * body or query string.
+ *
+ * Each field name in the array is checked against both req.body and req.query.
+ * Calls next() with a ValidationError listing all missing fields.
+ *
+ * @param fields - Array of field names that must be present
+ * @returns Express middleware function
+ *
+ * @example
+ * router.post('/events',
+ *   validateRequired(['title', 'startDate']),
+ *   async (req, res) => { ... }
+ * );
+ */
+export function validateRequired(fields: string[]) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const missing: string[] = [];
+
+    for (const field of fields) {
+      const inBody = req.body !== undefined && req.body !== null && req.body[field] !== undefined && req.body[field] !== null && req.body[field] !== '';
+      const inQuery = req.query[field] !== undefined && req.query[field] !== null && req.query[field] !== '';
+
+      if (!inBody && !inQuery) {
+        missing.push(field);
+      }
+    }
+
+    if (missing.length > 0) {
+      const fieldErrors: Record<string, string[]> = {};
+      for (const field of missing) {
+        fieldErrors[field] = ['This field is required'];
+      }
+      return next(new ValidationError(
+        `Missing required fields: ${missing.join(', ')}`,
+        fieldErrors,
+      ));
+    }
+
+    next();
+  };
+}
+
+/**
+ * Middleware that validates startDate and endDate query parameters.
+ *
+ * Both parameters are optional, but when provided they must be valid ISO 8601
+ * date strings. When both are provided, startDate must not be after endDate.
+ *
+ * Calls next() with a ValidationError describing the problem.
+ *
+ * @returns Express middleware function
+ *
+ * @example
+ * router.get('/events',
+ *   validateDateRange(),
+ *   async (req, res) => { ... }
+ * );
+ */
+export function validateDateRange() {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const { startDate, endDate } = req.query;
+    const errors: string[] = [];
+
+    let start: DateTime | null = null;
+    let end: DateTime | null = null;
+
+    if (startDate !== undefined) {
+      if (typeof startDate !== 'string') {
+        errors.push("'startDate' must be a string");
+      }
+      else {
+        start = DateTime.fromISO(startDate);
+        if (!start.isValid) {
+          errors.push("'startDate' is not a valid ISO 8601 date");
+        }
+      }
+    }
+
+    if (endDate !== undefined) {
+      if (typeof endDate !== 'string') {
+        errors.push("'endDate' must be a string");
+      }
+      else {
+        end = DateTime.fromISO(endDate);
+        if (!end.isValid) {
+          errors.push("'endDate' is not a valid ISO 8601 date");
+        }
+      }
+    }
+
+    if (errors.length === 0 && start !== null && end !== null && start > end) {
+      errors.push("'startDate' must not be after 'endDate'");
+    }
+
+    if (errors.length > 0) {
+      return next(new ValidationError(errors));
+    }
+
+    next();
+  };
+}

--- a/src/server/common/test/middleware/validation.test.ts
+++ b/src/server/common/test/middleware/validation.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { validateUUID, validateRequired, validateDateRange } from '@/server/common/middleware/validation';
+
+// Install a simple error handler that serializes ValidationError into JSON
+function installErrorHandler(app: Express): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(400).json({ error: err.message, errorName: err.name });
+  });
+}
+
+describe('validateUUID', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.get('/items/:id', validateUUID('id'), (_req, res) => {
+      res.json({ ok: true });
+    });
+    installErrorHandler(app);
+  });
+
+  it('should pass for a valid UUID v4', async () => {
+    const response = await request(app).get('/items/550e8400-e29b-41d4-a716-446655440000');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject a non-UUID param', async () => {
+    const response = await request(app).get('/items/not-a-uuid');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+    expect(response.body.error).toContain("'id'");
+  });
+
+  it('should reject a UUID v1 (wrong version digit)', async () => {
+    const response = await request(app).get('/items/550e8400-e29b-11d4-a716-446655440000');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+  });
+});
+
+describe('validateRequired', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.post('/items', validateRequired(['title', 'startDate']), (_req, res) => {
+      res.json({ ok: true });
+    });
+    app.get('/search', validateRequired(['q']), (_req, res) => {
+      res.json({ ok: true });
+    });
+    installErrorHandler(app);
+  });
+
+  it('should pass when all required body fields are present', async () => {
+    const response = await request(app)
+      .post('/items')
+      .send({ title: 'My Event', startDate: '2026-01-01' });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject when a required body field is missing', async () => {
+    const response = await request(app)
+      .post('/items')
+      .send({ title: 'My Event' });
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+    expect(response.body.error).toContain('startDate');
+  });
+
+  it('should reject when multiple required fields are missing', async () => {
+    const response = await request(app).post('/items').send({});
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('title');
+    expect(response.body.error).toContain('startDate');
+  });
+
+  it('should pass when required query param is present', async () => {
+    const response = await request(app).get('/search?q=hello');
+    expect(response.status).toBe(200);
+  });
+
+  it('should reject when required query param is missing', async () => {
+    const response = await request(app).get('/search');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+  });
+});
+
+describe('validateDateRange', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.get('/events', validateDateRange(), (_req, res) => {
+      res.json({ ok: true });
+    });
+    installErrorHandler(app);
+  });
+
+  it('should pass with no date parameters', async () => {
+    const response = await request(app).get('/events');
+    expect(response.status).toBe(200);
+  });
+
+  it('should pass with a valid startDate only', async () => {
+    const response = await request(app).get('/events?startDate=2026-01-01');
+    expect(response.status).toBe(200);
+  });
+
+  it('should pass with a valid endDate only', async () => {
+    const response = await request(app).get('/events?endDate=2026-12-31');
+    expect(response.status).toBe(200);
+  });
+
+  it('should pass when startDate is before endDate', async () => {
+    const response = await request(app).get('/events?startDate=2026-01-01&endDate=2026-12-31');
+    expect(response.status).toBe(200);
+  });
+
+  it('should reject an invalid startDate', async () => {
+    const response = await request(app).get('/events?startDate=not-a-date');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+    expect(response.body.error).toContain('startDate');
+  });
+
+  it('should reject an invalid endDate', async () => {
+    const response = await request(app).get('/events?endDate=not-a-date');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+    expect(response.body.error).toContain('endDate');
+  });
+
+  it('should reject when startDate is after endDate', async () => {
+    const response = await request(app).get('/events?startDate=2026-12-31&endDate=2026-01-01');
+    expect(response.status).toBe(400);
+    expect(response.body.errorName).toBe('ValidationError');
+    expect(response.body.error).toContain('startDate');
+  });
+});


### PR DESCRIPTION
## Summary

Closes Phase 5 of the pv-oih ValidationError standardization epic. Adds the field-level error infrastructure and one end-to-end reference implementation showing how forms should consume typed validation exceptions from the backend.

- **pv-oih.5.1** — tests pin the existing `ValidationError.fields` and `expressHelper.sendValidationError` field-omit-vs-include contract.
- **pv-oih.5.2** — TypeScript validation decorators (`@Required`, `@Email`, `@UUID`, `@MinLength`, `@MaxLength`) using a Symbol-keyed prototype metadata registry, plus `validate()` and `validateOrThrow()` runners.
- **pv-oih.5.3** — Express middleware factories `validateUUID`, `validateRequired`, `validateDateRange`. `validateUUID` delegates to `expressHelper.isValidUUID` so there is no duplicated regex.
- **pv-oih.5.4** — End-to-end frontend pipeline: `LocationService.errorMap` now includes `ValidationError`, `useLocationManagement` catches it and populates `locationFieldErrors` / `locationSubmissionError` reactive state, `create-location-form.vue` accepts those as props and renders inline errors with proper ARIA wiring (`aria-invalid`, `aria-describedby`, `role="alert"`, `aria-live="polite"`, focus management on the alert banner). `edit_event.vue` branches on `instanceof ValidationError` so the typed-exception path suppresses the generic toast.

The new `useLocationManagement` reception pattern is the canonical reference for future form work — it consumes the typed `ValidationError` rather than parsing raw axios payloads.

## Recorded warnings (not blocking)

- **5.2 / 5.3 ship without production callers.** Adoption is deferred to a future migration bead. Complexity-auditor flagged this as YAGNI; shipped per explicit direction so the infrastructure is in place for the migration bead to consume.
- **DEC-002** sanctions Sequelize-style decorators only. This PR introduces the first application-logic decorators in the codebase. A follow-up DEC entry would acknowledge the expansion explicitly.
- **`useEventEditor.saveEvent`** still parses raw axios payloads. Migrating it to the typed-exception pattern this PR establishes is a separate cleanup.

## Test plan

- [ ] `npm run lint` passes (0 errors)
- [ ] `npx vitest run src/server/common/test/middleware/validation.test.ts` (15 tests)
- [ ] `npx vitest run src/server/common/decorators/test/validation.test.ts` (45 tests)
- [ ] `npx vitest run src/common/exceptions/test/base.test.ts` (10 tests)
- [ ] `npx vitest run src/server/common/helper/test/express.test.ts` (7 tests)
- [ ] `npx vitest run src/client/test/service/utils.test.ts` (7 tests)
- [ ] `npx vitest run src/client/test/components/create-location-form.test.ts` (22 tests)
- [ ] Manual: trigger a backend ValidationError on location creation and confirm field-level errors render under the `name` input with focus moving to the submission banner