### PR TITLE
fix(housekeeping): install postgresql-client in production image so backups can run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,17 @@ FROM node:22-slim AS production
 
 # Install required system packages
 # - dumb-init: proper signal handling for Node.js in containers
+# - postgresql-client-17: provides pg_dump/pg_restore for the worker's backup job
+#   (must match the postgres:17 server version; pulled from pgdg apt repo)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
     dumb-init \
+    postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security

--- a/src/server/housekeeping/test/docker-config.test.ts
+++ b/src/server/housekeeping/test/docker-config.test.ts
@@ -8,6 +8,26 @@ import { parse as parseYaml } from 'yaml';
  * These tests verify that the Docker Compose configuration and entrypoint script
  * are correctly set up for the web/worker architecture.
  */
+
+/**
+ * Returns the body of a named multi-stage build target from a Dockerfile.
+ * The body runs from the matching FROM ... AS <name> line up to (but not
+ * including) the next FROM line, or end of file.
+ */
+function extractStage(dockerfile: string, stageName: string): string {
+  const startPattern = new RegExp(`^FROM\\s+\\S+\\s+AS\\s+${stageName}\\b`, 'mi');
+  const startMatch = dockerfile.match(startPattern);
+  if (!startMatch || startMatch.index === undefined) {
+    throw new Error(`Stage "${stageName}" not found in Dockerfile`);
+  }
+
+  const after = dockerfile.slice(startMatch.index + startMatch[0].length);
+  const nextStageMatch = after.match(/^FROM\s+/m);
+  return nextStageMatch && nextStageMatch.index !== undefined
+    ? after.slice(0, nextStageMatch.index)
+    : after;
+}
+
 describe('Docker Configuration', () => {
   describe('docker-compose.yml', () => {
     it('should include both app and worker services', () => {
@@ -159,6 +179,35 @@ describe('Docker Configuration', () => {
       expect(healthcheck.timeout).toBeDefined();
       expect(healthcheck.retries).toBeGreaterThanOrEqual(1);
       expect(healthcheck.start_period).toBeDefined();
+    });
+  });
+
+  describe('Dockerfile production stage', () => {
+    // The worker container runs the production stage and must include the
+    // postgres client binaries (pg_dump/pg_restore) for backup:daily to succeed.
+    // Without this, the job throws "spawn pg_dump ENOENT" every night.
+    it('should install postgresql-client in the production stage', () => {
+      const dockerfile = readFileSync('Dockerfile', 'utf-8');
+      const productionStage = extractStage(dockerfile, 'production');
+
+      expect(productionStage).toMatch(/postgresql-client-\d+/);
+    });
+
+    it('should install a postgresql-client major version matching the postgres server', () => {
+      const dockerfile = readFileSync('Dockerfile', 'utf-8');
+      const compose = parseYaml(readFileSync('docker-compose.yml', 'utf-8'));
+
+      const productionStage = extractStage(dockerfile, 'production');
+      const clientVersionMatch = productionStage.match(/postgresql-client-(\d+)/);
+      expect(clientVersionMatch).not.toBeNull();
+      const clientMajor = clientVersionMatch![1];
+
+      const dbImage = compose.services.db.image as string;
+      const dbVersionMatch = dbImage.match(/postgres:(\d+)/);
+      expect(dbVersionMatch).not.toBeNull();
+      const dbMajor = dbVersionMatch![1];
+
+      expect(clientMajor).toBe(dbMajor);
     });
   });
 


### PR DESCRIPTION
## Summary

- Daily database backups have been silently failing on staging (and any other server running the production image) since the housekeeping feature shipped. Root cause: the production stage of `Dockerfile` only installed `dumb-init` — `postgresql-client-17` was only present in the development stage. Every `backup:daily` pg-boss job at 02:00 UTC threw `spawn pg_dump ENOENT` for the initial attempt and both retries.
- Fix mirrors the dev stage's pgdg apt repo + `postgresql-client-17` install in the production stage, so the worker container has `pg_dump`/`pg_restore` matching the `postgres:17` server.
- Added two regression tests in `docker-config.test.ts` that statically assert the production stage installs `postgresql-client-N` and that N matches the `postgres:N` server pinned in `docker-compose.yml`.

## Evidence (staging worker logs, 2026-05-03 02:00 UTC)

```
backup:daily processed 3 times
each attempt: spawn pg_dump ENOENT, errno -2
/opt/pavillion/backups: empty
backup_metadata table: 0 rows
disk:check fires hourly and completes — only the backup job is failing
```

## Verification

- Built `--target production` locally; `pg_dump 17.9 (Debian 17.9-1.pgdg12+1)` is on PATH and matches `postgres:17`.
- All 18 tests in `docker-config.test.ts` pass (16 existing + 2 new). Lint clean.
- Production image grew ~186 MB (637 → 823 MB) for the postgres-17 client tools.

## Related beads

- `pv-39rb` — the bug this PR closes.
- `pv-zcos` (follow-up) — alert path is missing from `AlertsService`. Backups failed for weeks without surfacing because alerts only fire on disk thresholds. Tracked as a separate bead so this fix stays small.

## Test plan

- [x] `npx vitest run src/server/housekeeping/test/docker-config.test.ts` — all 18 pass
- [x] `npx eslint src/server/housekeeping/test/docker-config.test.ts` — clean
- [x] `docker build --target production` — succeeds, `pg_dump --version` works inside the image
- [ ] After merge & redeploy: trigger `./scripts/backup.sh create` on staging, confirm a `.dump` file appears in `/opt/pavillion/backups` and a row appears in `backup_metadata`
- [ ] Confirm the next `backup:daily` (02:00 UTC) completes, with retention enforcement logging afterward