### PR TITLE
ci: deploy docs site to Cloudflare Pages on release

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -1,0 +1,83 @@
+name: Deploy Docs Site
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (tag/branch/sha) to deploy. Defaults to the workflow run ref.'
+        required: false
+        default: ''
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy docs to Cloudflare Pages
+    runs-on: ubuntu-latest
+    environment:
+      name: docs-production
+      url: https://docs.pavillion.social
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Stamp build with version.json
+        run: |
+          mkdir -p docs/public
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          TAG="${GITHUB_REF_NAME}"
+          cat > docs/public/version.json <<EOF
+          {
+            "sha": "${GITHUB_SHA}",
+            "shortSha": "${SHORT_SHA}",
+            "tag": "${TAG}",
+            "builtAt": "${BUILT_AT}",
+            "repo": "${GITHUB_REPOSITORY}"
+          }
+          EOF
+          echo "Stamped version.json:"
+          cat docs/public/version.json
+
+      - name: Build VitePress site
+        run: npm run docs:build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: pages deploy docs/.vitepress/dist --project-name=pavillion-docs --branch=main --commit-dirty=true
+
+      - name: Verify deployed version.json
+        run: |
+          for i in 1 2 3 4 5; do
+            DEPLOYED=$(curl -fsSL https://docs.pavillion.social/version.json | jq -r .sha 2>/dev/null || echo "")
+            if [ "$DEPLOYED" = "$GITHUB_SHA" ]; then
+              echo "Deployed sha matches: $DEPLOYED"
+              exit 0
+            fi
+            echo "Attempt $i: deployed=$DEPLOYED expected=$GITHUB_SHA — waiting for edge propagation"
+            sleep 10
+          done
+          echo "::warning::version.json sha did not match within 50s; deploy may still be propagating"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 coverage
 docs/.vitepress/dist
 docs/.vitepress/cache
+docs/public/version.json
 .claude/orchestrators/logs/
 logs
 .vscode


### PR DESCRIPTION
## Summary

- New release-triggered GH Actions workflow `.github/workflows/deploy_docs.yaml` builds the VitePress docs site under `docs/` and deploys it to `docs.pavillion.social` on Cloudflare Pages via `cloudflare/wrangler-action@v3` (Direct Upload).
- Stamps `/version.json` with `{ sha, shortSha, tag, builtAt, repo }` before each build so deployment drift can be verified with a single `curl`.
- Triggers on `release: [released]` (non-prerelease publishes only) plus `workflow_dispatch` for manual deploys.
- `.gitignore` updated to ignore the CI-generated `docs/public/version.json`.

## Conscious deviation from the research doc

The hosting research doc recommended Cloudflare's native Git integration on push to `main`. This PR uses release-triggered Direct Upload instead, on the rationale that Pavillion is a versioned self-hostable product — operators reading docs should see the version they run, not bleeding-edge main. PR previews are sacrificed for that alignment.

## Required out-of-band setup

The full Cloudflare runbook lives on bead `pv-gdui` (`bd show pv-gdui`). Short version:

1. Create Cloudflare Pages project `pavillion-docs` via Direct Upload (no Git connection); set production branch `main`.
2. Add custom domain `docs.pavillion.social` (Cloudflare auto-creates the proxied CNAME + Universal SSL).
3. Mint a scoped API token with `Account → Cloudflare Pages → Edit`.
4. Add GH repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.
5. (Optional) `Settings → Environments → docs-production` for manual approval gates.

## Test plan

- [ ] Steps 1–4 of the runbook completed in Cloudflare and GitHub
- [ ] Cut a test release (or use `workflow_dispatch`) and confirm the workflow run succeeds end-to-end
- [ ] `curl https://docs.pavillion.social/version.json` returns the expected `sha` and `tag` after deploy
- [ ] Deployments tab on the repo home shows the `docs-production` deployment with the correct commit SHA
- [ ] Verify rollback procedure (Cloudflare dashboard → pavillion-docs → Deployments → ⋯ → Rollback)