### PR TITLE
docs: scaffold calendar-owners guide section with quickstart and recurring-events

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,8 +22,74 @@ export default defineConfig({
     logo: '/pavillion-logo.svg',
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'Calendar owners', link: '/guides/calendar-owners/' },
     ],
-    sidebar: [],
+    sidebar: {
+      '/guides/calendar-owners/': [
+        {
+          text: 'For calendar owners',
+          link: '/guides/calendar-owners/',
+        },
+        {
+          text: 'Quickstart',
+          items: [
+            { text: 'From login to a published event', link: '/guides/calendar-owners/quickstart' },
+          ],
+        },
+        {
+          text: 'Build out your calendar',
+          items: [
+            { text: 'Run a recurring event', link: '/guides/calendar-owners/recurring-events' },
+            { text: 'Organize events with categories', link: '/guides/calendar-owners/categories' },
+            { text: 'Reuse venues with places', link: '/guides/calendar-owners/places' },
+            { text: 'Group related events into a series', link: '/guides/calendar-owners/series' },
+            { text: "Customize your calendar's identity", link: '/guides/calendar-owners/identity' },
+            { text: 'Publish in multiple languages', link: '/guides/calendar-owners/multilingual' },
+          ],
+        },
+        {
+          text: 'Work with collaborators',
+          items: [
+            { text: 'Invite editors and manage their access', link: '/guides/calendar-owners/editors' },
+          ],
+        },
+        {
+          text: 'Connect with other calendars',
+          items: [
+            { text: 'Follow other calendars and repost their events', link: '/guides/calendar-owners/follow-and-repost' },
+            { text: 'Match categories from other calendars to yours', link: '/guides/calendar-owners/category-matching' },
+            { text: 'Be a good neighbor across calendars', link: '/guides/calendar-owners/federation-etiquette' },
+          ],
+        },
+        {
+          text: 'Bring events in from elsewhere',
+          items: [
+            { text: 'Migrate from another calendar via ICS import', link: '/guides/calendar-owners/ics-import' },
+          ],
+        },
+        {
+          text: 'Share your calendar',
+          items: [
+            { text: 'Share your public calendar URL', link: '/guides/calendar-owners/public-url' },
+            { text: 'Embed your calendar on your own website', link: '/guides/calendar-owners/embed' },
+          ],
+        },
+        {
+          text: 'Sustain your calendar',
+          items: [
+            { text: 'Set up community funding', link: '/guides/calendar-owners/funding' },
+          ],
+        },
+        {
+          text: 'Day-to-day operations',
+          items: [
+            { text: 'Cancel an event the right way', link: '/guides/calendar-owners/cancel-event' },
+            { text: 'Handle reports and content moderation', link: '/guides/calendar-owners/moderation' },
+            { text: 'Manage your account', link: '/guides/calendar-owners/account' },
+          ],
+        },
+      ],
+    },
     socialLinks: [
       { icon: 'github', link: 'https://github.com/stephenhoward/pavilion' },
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -39,7 +39,7 @@ export default defineConfig({
         {
           text: 'Build out your calendar',
           items: [
-            { text: 'Run a recurring event', link: '/guides/calendar-owners/recurring-events' },
+            { text: 'Post a recurring event', link: '/guides/calendar-owners/recurring-events' },
             { text: 'Organize events with categories', link: '/guides/calendar-owners/categories' },
             { text: 'Reuse venues with places', link: '/guides/calendar-owners/places' },
             { text: 'Group related events into a series', link: '/guides/calendar-owners/series' },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
         {
           text: 'Connect with other calendars',
           items: [
+            { text: 'Decide when to make a calendar', link: '/guides/calendar-owners/when-to-create-a-calendar' },
             { text: 'Follow other calendars and repost their events', link: '/guides/calendar-owners/follow-and-repost' },
             { text: 'Match categories from other calendars to yours', link: '/guides/calendar-owners/category-matching' },
             { text: 'Be a good neighbor across calendars', link: '/guides/calendar-owners/federation-etiquette' },

--- a/docs/.vitepress/theme/components/Btn.vue
+++ b/docs/.vitepress/theme/components/Btn.vue
@@ -1,0 +1,18 @@
+<template>
+  <span class="doc-btn"><slot /></span>
+</template>
+
+<style scoped>
+.doc-btn {
+  display: inline-block;
+  padding: 0.05em 0.55em;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  background: transparent;
+  font-size: 0.88em;
+  font-weight: 500;
+  line-height: 1.4;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+</style>

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,4 +1,10 @@
 import DefaultTheme from 'vitepress/theme';
+import { Lightbulb } from 'lucide-vue-next';
 import './pavillion.css';
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('Lightbulb', Lightbulb);
+  },
+};

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -1,10 +1,12 @@
 import DefaultTheme from 'vitepress/theme';
 import { Lightbulb } from 'lucide-vue-next';
+import Btn from './components/Btn.vue';
 import './pavillion.css';
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     app.component('Lightbulb', Lightbulb);
+    app.component('Btn', Btn);
   },
 };

--- a/docs/.vitepress/theme/pavillion.css
+++ b/docs/.vitepress/theme/pavillion.css
@@ -42,6 +42,13 @@
   /* Inline code chip uses the orange-soft tint */
   --vp-code-bg: var(--vp-c-brand-soft);
   --vp-code-color: #C2410C;            /* orange-700 */
+
+  /* Tip blocks borrow the Pavillion blue secondary so they stay
+     visually distinct from the orange brand-tinted info blocks. */
+  --vp-custom-block-tip-border: transparent;
+  --vp-custom-block-tip-text: #115293;        /* brand-secondary-dark — AA on tinted bg */
+  --vp-custom-block-tip-bg: rgba(25, 118, 210, 0.10);
+  --vp-custom-block-tip-code-bg: rgba(25, 118, 210, 0.10);
 }
 
 .dark {
@@ -72,4 +79,22 @@
   /* Inline code chip */
   --vp-code-bg: var(--vp-c-brand-soft);
   --vp-code-color: #FDBA74;            /* orange-300 */
+
+  /* Tip blocks — blue secondary, lifted to brand-secondary-light
+     so it stays readable on the dark surface. */
+  --vp-custom-block-tip-text: #63A4FF;        /* brand-secondary-light */
+  --vp-custom-block-tip-bg: rgba(99, 164, 255, 0.14);
+  --vp-custom-block-tip-code-bg: rgba(99, 164, 255, 0.14);
+}
+
+.custom-block-title .lucide {
+  display: inline-block;
+  vertical-align: -0.2em;
+  margin-inline-end: 0.4em;
+  width: 1.1em;
+  height: 1.1em;
+}
+
+.custom-block:has(.custom-block-title .lucide) .custom-block-title ~ * {
+  margin-inline-start: 1.5em;
 }

--- a/docs/guides/calendar-owners/account.md
+++ b/docs/guides/calendar-owners/account.md
@@ -1,0 +1,13 @@
+# Manage your account
+
+> Status: placeholder. This guide may be written after launch if it's needed; the account UI is mostly self-explanatory.
+
+Account-level settings — the things that are about *you* rather than about a particular calendar. Password, email, notification preferences.
+
+## Planned scope
+
+- Changing your password
+- Changing your email address
+- Account-level settings
+
+For now, these settings live in the account section of the editor UI.

--- a/docs/guides/calendar-owners/cancel-event.md
+++ b/docs/guides/calendar-owners/cancel-event.md
@@ -1,0 +1,25 @@
+# Cancel an event the right way
+
+> Status: stub. Full guide coming before launch.
+
+When an event won't happen as planned, you have two options that look similar but behave very differently: cancel it, or delete it. Almost always the right call is to cancel — that leaves an audit trail, tells anyone who was planning to attend that the event isn't happening, and propagates correctly to any calendar that's reposting from yours. Deletion is for a smaller, more specific set of cases.
+
+## Cancel an event
+
+The mechanics. What changes for visitors. What changes for any calendar reposting yours.
+
+## Delete an event
+
+When deletion is appropriate — typically when the event was created in error, not when a real event won't happen.
+
+## Cancellation vs. deletion at a glance
+
+A short reference for the call you'll have to make under time pressure.
+
+## Cancel a single occurrence of a recurring event
+
+Different from cancelling the whole series. The single-occurrence case.
+
+## End a recurring event entirely
+
+When the program is done, how to wind it down without disturbing the history.

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -1,0 +1,29 @@
+# Organize events with categories
+
+> Status: stub. Full guide coming before launch.
+
+Categories are how visitors filter your calendar — and how other calendars decide which of your events match theirs when you're sharing across communities. A small, durable category vocabulary is one of the highest-leverage decisions you'll make as a calendar owner. This guide is about designing that vocabulary so it serves you over time.
+
+## What categories do
+
+Two jobs: filter UI for visitors browsing your public calendar, and the basis for matching when you share events with other calendars.
+
+## Create a category
+
+The mechanics, briefly.
+
+## Designing your vocabulary
+
+The harder, more important part. How to keep the list short, durable, and meaningful — and how to recognize when you're about to add a category you'll regret.
+
+## When to add a new category vs. extend an existing one
+
+The judgment call most calendar owners eventually face.
+
+## Why no free-form tags
+
+Pavillion deliberately doesn't have tags. The reasons, and what to do when you'd reach for one.
+
+## The cost of churning category names later
+
+Why renaming a category isn't free, especially once other calendars are reposting your events.

--- a/docs/guides/calendar-owners/category-matching.md
+++ b/docs/guides/calendar-owners/category-matching.md
@@ -1,0 +1,12 @@
+# Match categories from other calendars to yours
+
+> Status: placeholder. This guide will be written after launch.
+
+When you repost events from another calendar, their categories rarely line up with yours one-to-one. The music venue tags everything "Live Music"; you split "Concerts" from "Open Mic" from "DJ Sets." This guide will cover how Pavillion handles that mismatch — and how to set up rules so you're not making the same call by hand every time.
+
+## Planned scope
+
+- When category matching is required vs. optional
+- Setting up automatic mapping rules
+- What happens to events whose source categories don't map to anything you have
+- Reviewing and adjusting rules over time

--- a/docs/guides/calendar-owners/editors.md
+++ b/docs/guides/calendar-owners/editors.md
@@ -1,0 +1,29 @@
+# Invite editors and manage their access
+
+> Status: stub. Full guide coming before launch.
+
+Most calendars worth running aren't run by one person. This guide is about adding people to the team — inviting editors, understanding what they can and can't do, and shaping access in ways that scale from a two-person project to a larger collective without losing track of who's allowed to do what.
+
+## What an editor can do
+
+The permission model: what an editor can do that a visitor can't, and what only the owner can do.
+
+## Invite an editor
+
+The invitation flow. What the invited person sees. What happens if they don't have a Pavillion account yet.
+
+## Revoke editor access
+
+How to remove someone, and what happens to events they've created or edited.
+
+## Patterns for small teams
+
+One owner plus a couple of editors. The straightforward case.
+
+## Patterns for larger collectives
+
+When the team is big enough that ad-hoc coordination breaks down.
+
+## Shared accounts vs. individual accounts
+
+A best-practice note on the temptation to create one shared account for the whole team — and why individual editor accounts are almost always the right call.

--- a/docs/guides/calendar-owners/embed.md
+++ b/docs/guides/calendar-owners/embed.md
@@ -1,0 +1,12 @@
+# Embed your calendar on your own website
+
+> Status: placeholder. This guide will be written after launch.
+
+If your community already has a website — an organization page, a venue site, a project landing page — you can put your Pavillion calendar directly on it instead of asking visitors to click through to a separate URL. This guide will cover the embed widget.
+
+## Planned scope
+
+- Generating the embed snippet
+- Configuring allowed domains (and the security reason this list exists, rather than glossing it)
+- What the widget shows vs. the full public site
+- Basic styling and sizing guidance

--- a/docs/guides/calendar-owners/federation-etiquette.md
+++ b/docs/guides/calendar-owners/federation-etiquette.md
@@ -1,0 +1,13 @@
+# Be a good neighbor across calendars
+
+> Status: placeholder. This guide will be written after launch.
+
+This is the etiquette guide, not a feature walkthrough. Once your calendar is connected to others, the day-to-day question stops being *can I do this* and starts being *should I*. This guide will cover the unwritten rules of being a calendar that other calendars are glad to be connected to.
+
+## Planned scope
+
+- Attributing reposted events
+- When *not* to repost
+- Asking before pulling someone's whole calendar onto yours
+- What "unpost" means from the source's perspective
+- What calendar owners should expect from instance administrators when something goes wrong between connected calendars

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -1,0 +1,35 @@
+# Follow other calendars and repost their events
+
+> Status: stub. Full guide coming before launch.
+
+The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about connecting your calendar to theirs — finding the calendars that matter to your community, deciding what to do with what shows up in your feed, and choosing what to share back.
+
+The mechanism underneath is ActivityPub federation, but you don't have to think in those terms. Most of the time the right words are *follow*, *share*, *connect*, and *repost*.
+
+## Find calendars to follow
+
+Where to look — nearby communities, partner organizations, allied groups in your topic area.
+
+## Follow a calendar
+
+What happens when you do. What appears in your feed and inbox afterward.
+
+## Seeing an event vs. reposting it
+
+Following a calendar lets you *see* their events. Reposting puts those events on *your* calendar for your visitors to see. Different actions.
+
+## Repost an event manually
+
+The one-at-a-time path. When this is the right approach.
+
+## Set up auto-repost rules
+
+The automatic path. When this is the right approach, and the kinds of rules that work well.
+
+## Undo a repost
+
+How "unpost" works, and why it sticks — once you've said no to an event, the source can re-broadcast it without it reappearing on your calendar.
+
+## Aggregator vs. curated: a framing decision
+
+The early call most calendar owners face. An aggregator calendar pulls broadly and automatically; a curated calendar selects deliberately. The consequences of each posture, and how to change your mind later.

--- a/docs/guides/calendar-owners/funding.md
+++ b/docs/guides/calendar-owners/funding.md
@@ -1,0 +1,14 @@
+# Set up community funding
+
+> Status: placeholder. This guide will be written after launch.
+
+Pavillion's funding model is community contributions to keep community infrastructure running — closer to how a public radio station funds itself than to a software subscription. This guide will cover how to enable a funding plan on your calendar, what visitors see when they decide to contribute, and what calendar owners should and shouldn't promise the people who pitch in.
+
+## Planned scope
+
+- Enabling a funding plan on your calendar
+- What the public contribution surface looks like to visitors
+- What you can and shouldn't promise contributors
+- The role Stripe plays at the level a non-developer needs (you don't host the payment surface; the instance does)
+
+The term you'll see throughout is "funding plan" — never "subscription," which means something else in a federated system.

--- a/docs/guides/calendar-owners/ics-import.md
+++ b/docs/guides/calendar-owners/ics-import.md
@@ -1,0 +1,33 @@
+# Migrate from another calendar via ICS import
+
+> Status: stub. Full guide coming before launch.
+
+Most new calendar owners arrive with events already living somewhere — a Google Calendar, a Nextcloud instance, a WordPress events plugin, a Gancio or Mobilizon calendar. This guide covers the path for getting that history into Pavillion using ICS, the standard calendar-data format that almost every calendar tool can export.
+
+## What ICS import does (and doesn't) do today
+
+The shape of the v1 import: you point Pavillion at an ICS feed, prove you control the source via a DNS TXT record, and pull events on demand. No background polling. No hosted-provider OAuth. Those will arrive later as advanced sync features.
+
+## Add an import source
+
+The mechanics of pointing Pavillion at an ICS feed.
+
+## Verify ownership via DNS TXT record
+
+Why the verification exists, where to add the record, and what to do if you don't control DNS for the source domain.
+
+## Run a "Sync now" pull
+
+The manual sync. What happens during the pull, what gets created, what gets skipped.
+
+## What happens on subsequent syncs
+
+How the import handles events that have changed at the source, events that have been deleted, and events you've edited locally after import.
+
+## Common migration foot-guns
+
+The places imports most often go sideways — timezone drift, recurrence-rule fidelity, place deduplication.
+
+## What's coming later
+
+The advanced sync features that aren't in v1: background polling, hosted-provider OAuth (Google, Outlook, iCloud), mirror mode with ongoing source precedence.

--- a/docs/guides/calendar-owners/identity.md
+++ b/docs/guides/calendar-owners/identity.md
@@ -1,0 +1,16 @@
+# Customize your calendar's identity
+
+> Status: placeholder. This guide will be written after launch, once the identity-customization surface stabilizes.
+
+Your calendar has a public face: the name, description, languages, and visual branding that visitors and other calendar owners see when they decide whether to follow you or repost from you. This guide will cover how to shape that face deliberately.
+
+## Planned scope
+
+- Display name and description
+- Primary language and added languages
+- Branding: logo, avatar, banner
+- Public bio
+- The URL handle (and the cost of changing it later)
+- Writing a description that helps other communities decide whether to follow
+
+In the meantime, the relevant settings live in your calendar's settings panel.

--- a/docs/guides/calendar-owners/index.md
+++ b/docs/guides/calendar-owners/index.md
@@ -1,0 +1,32 @@
+# For calendar owners
+
+These guides are for the people running calendars on a Pavillion instance — community organizers, venue staff, neighborhood associations, regional councils, anyone whose job it is to publish events that other people can find.
+
+Two ways to read this section:
+
+- **New to Pavillion?** Start with the [Quickstart](./quickstart). It takes you from a fresh login to a published calendar with one real event in about ten minutes. Everything else in this section is reference material you can come back to as you need it.
+- **Already running a calendar?** Browse the sidebar. Each guide answers a specific goal — running a recurring event, inviting an editor, importing from another calendar, sharing your public URL. Read the one you need.
+
+## What's in this section
+
+**Quickstart** — the on-ramp, login to first published event.
+
+**Build out your calendar** — recurring events, categories, places, series, identity, multilingual content. Everything that shapes what's *on* the calendar.
+
+**Work with collaborators** — editors and shared calendar management.
+
+**Connect with other calendars** — following neighbors, reposting events, the social side of running a calendar in a federated network.
+
+**Bring events in from elsewhere** — migrating from existing calendars (Google, Nextcloud, WordPress, Gancio, Mobilizon) via ICS import.
+
+**Share your calendar** — public URLs, embeddable widgets, the distribution surface.
+
+**Sustain your calendar** — community funding plans for keeping the lights on.
+
+**Day-to-day operations** — cancellations, moderation, account management.
+
+## What's not here
+
+- **Running a Pavillion server.** That belongs to the administrator guides.
+- **Contributing to Pavillion itself.** That belongs to the developer guides.
+- **The ActivityPub protocol.** Referenced where it surfaces, but not taught here. Pavillion uses ActivityPub the way email uses SMTP — you don't need to know the protocol to send a message.

--- a/docs/guides/calendar-owners/index.md
+++ b/docs/guides/calendar-owners/index.md
@@ -1,11 +1,11 @@
 # For calendar owners
 
-These guides are for the people running calendars on a Pavillion instance — community organizers, venue staff, neighborhood associations, regional councils, anyone whose job it is to publish events that other people can find.
+These guides are for the people running calendars on Pavillion — community organizers, venue staff, neighborhood associations, regional councils, anyone whose job it is to publish events that other people can find.
 
 Two ways to read this section:
 
 - **New to Pavillion?** Start with the [Quickstart](./quickstart). It takes you from a fresh login to a published calendar with one real event in about ten minutes. Everything else in this section is reference material you can come back to as you need it.
-- **Already running a calendar?** Browse the sidebar. Each guide answers a specific goal — running a recurring event, inviting an editor, importing from another calendar, sharing your public URL. Read the one you need.
+- **Already running a calendar?** Browse the sidebar. Each guide answers a specific goal — running a recurring event, inviting a collaborator, importing from another calendar, sharing your public URL. Read the one you need.
 
 ## What's in this section
 

--- a/docs/guides/calendar-owners/moderation.md
+++ b/docs/guides/calendar-owners/moderation.md
@@ -1,0 +1,12 @@
+# Handle reports and content moderation
+
+> Status: placeholder. This guide will be written after launch.
+
+When a public visitor reports an event on your calendar, that report lands somewhere you can act on it. This guide will cover the queue you'll see, the actions available to you, and the line between what a calendar owner handles and what gets escalated to the instance administrator.
+
+## Planned scope
+
+- What happens when a visitor reports an event on your calendar
+- The report queue
+- The actions available to you
+- The boundary between calendar-owner moderation and instance-administrator moderation

--- a/docs/guides/calendar-owners/multilingual.md
+++ b/docs/guides/calendar-owners/multilingual.md
@@ -1,0 +1,14 @@
+# Publish in multiple languages
+
+> Status: placeholder. This guide will be written after launch.
+
+Pavillion stores translatable content as a first-class concept rather than as an afterthought. If your community speaks more than one language — or if you want to reach beyond the language you started in — the system is built to support that. This guide will cover what's translatable, how to add a translation, and what visitors see when their language doesn't match any translation you've published.
+
+## Planned scope
+
+- Which fields are translatable
+- Adding a translation to an existing event
+- Fallback behavior when a visitor's language doesn't match any translation
+- The difference between a multilingual calendar (intended for several language communities) and a calendar that happens to have some translated events
+
+In the meantime, the language controls live alongside content fields in the editor.

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -1,0 +1,29 @@
+# Reuse venues with places
+
+> Status: stub. Full guide coming before launch.
+
+A place is a venue stored as its own object — an address, a name, a few details — that events reference rather than copy. Type the address once, attach it to ten events, and when the venue changes its name or street number, you change it once.
+
+## How places work
+
+The reference model: events point at places, they don't embed them.
+
+## Create a place
+
+The mechanics.
+
+## Attach a place to an event
+
+From inside the event editor.
+
+## Edit a place after the fact
+
+What happens to past events that already used the place. What happens to future events.
+
+## When not to use a place
+
+Online-only events. One-off venues you won't reuse. The cases where a place adds friction without adding value.
+
+## Naming places so they're recognizable later
+
+A small thing that pays off when an editor is picking from a long list six months from now.

--- a/docs/guides/calendar-owners/public-url.md
+++ b/docs/guides/calendar-owners/public-url.md
@@ -1,0 +1,21 @@
+# Share your public calendar URL
+
+> Status: stub. Full guide coming before launch.
+
+A calendar that nobody finds is a calendar that doesn't exist. Your calendar has two URLs that do different jobs: the editor URL, where you and your team go to manage events, and the public URL, where everyone else goes to see them. This guide is about the public one — what it shows, how to share it, and the federation handle that lives alongside it.
+
+## The two URLs your calendar has
+
+Why there are two, what each one is for, and which one to paste into a chat or an email.
+
+## Your public URL
+
+The shape: `/view/your-calendar-name`. Where to find it. What anonymous visitors see when they open it.
+
+## Your federation handle
+
+The other thing visitors and other calendar owners can use to find you — the form it takes, where it appears on the calendar, and what someone on a different Pavillion instance does with it.
+
+## Sharing the public URL
+
+The everyday case: pasting it into a chat, an email signature, a flyer.

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -35,7 +35,7 @@ Submit the form. You'll land on your new calendar's events management page. It's
 
 The two things you just entered are the bare minimum to create the calendar. Before publishing an event, fill in the rest of the basics:
 
-1. From your calendar's page, open **Manage Calendar**.
+1. From your calendar's page, open <Btn>Manage Calendar</Btn>.
 2. Add a **description**. One or two sentences: who this calendar is for and what kinds of events it lists. Visitors to your public page will read this. So will other calendar owners deciding whether to follow your calendar.
 3. The **primary language** is set to your account's language by default. If you only plan to publish in one language — leave it as is. If you'll publish in more than one, add the additional languages here too. The title and description fields then grow a small row of language tabs above them — one tab per language you've added — and clicking a tab swaps the field below to that language's text. You edit one language at a time.
 
@@ -51,7 +51,7 @@ Back on your calendar's page, look for the button to add an event (it lives near
 
 **Event details.** Give the event a title. Add a description — a short paragraph is fine, more if there's logistics worth spelling out. If accessibility info is relevant (wheelchair access, ASL interpretation, scent-free space), there's a dedicated field for it; visitors look for that information specifically and it shouldn't be buried in the description.
 
-**Location.** Click **Add location**. The location picker opens. You probably don't have any places saved yet, so choose **Create new place**, fill in the name and address, and confirm. The place is now reusable — for the next event you create at the same venue you will be able pick it from a list rather than re-typing the address.
+**Location.** Click <Btn>Add location</Btn>. The location picker opens. You probably don't have any places saved yet, so choose <Btn>Create new place</Btn>, fill in the name and address, and confirm. The place is now reusable — for the next event you create at the same venue you will be able pick it from a list rather than re-typing the address.
 
 ::: tip <Lightbulb /> A note on places.
 A "place" in Pavillion is its own thing — separate from the events that reference it. The address is stored once, on the place. Events point at the place. So when the venue changes its name or you correct a typo in the address, you fix it once and every event there is updated.
@@ -71,7 +71,7 @@ Categories are how visitors filter your public page (`Show only Sports events`) 
 
 **Date & time.** Set the start and end. For this first event, pick a date within the next week or two — the public page opens to a default two-week window, and a date much further out won't be visible there until the visitor changes the filter. (You can always add the real, far-out events afterwards; this is just so the page you're about to share has something on it.) Leave it as a single occurrence for now — no recurrence rules. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
 
-When the form is filled in, click **Save Changes** in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit, cancel, or delete it from the events list.
+When the form is filled in, click <Btn>Save Changes</Btn> in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit, cancel, or delete it from the events list.
 
 ## Step 5: See what visitors see
 
@@ -81,7 +81,7 @@ Open a new browser tab and go to `https://your-instance.example/view/your-handle
 
 What you're looking at is what anyone on the internet sees. No login required. Your event should be there, with the place, the date, the description, and the category you chose. Click into the event to see its detail page — that's the URL you'd share for a single event.
 
-If you don't see it, the most likely reason is the date filter. The public page opens to a default window — two weeks out by default — and an event further in the future is still there, just hidden until a visitor widens the range. The date control near the top of the page lets you (and visitors) jump forward. You can also change the calendar's default window from **Manage Calendar** if two weeks isn't right for your community's rhythm.
+If you don't see it, the most likely reason is the date filter. The public page opens to a default window — two weeks out by default — and an event further in the future is still there, just hidden until a visitor widens the range. The date control near the top of the page lets you (and visitors) jump forward. You can also change the calendar's default window from <Btn>Manage Calendar</Btn> if two weeks isn't right for your community's rhythm.
 
 Paste your calendar's URL into a chat with a friend. Have them open it. Ask whether the event makes sense to them as someone who's never seen it before. That feedback — from a fresh pair of eyes who is the audience, not the organizer — is more useful than any checklist.
 

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -10,13 +10,13 @@ A working calendar at a public URL, with one event on it, that you can paste int
 
 ## Before you start
 
-You need an account on a Pavillion instance. If you don't have one yet, that's an instance-administrator question — Pavillion accounts aren't self-serve. Whoever runs the instance you're joining (your local arts council, your neighborhood mesh, your housing co-op) is the person who issues accounts.
+You need an account on a Pavillion instance. Sign-up varies by instance: some accept open applications through the site, others run on invitation only — your local arts council, neighborhood mesh, or housing co-op decides which posture fits the community. Either way, signing up is the part where you provide an email address you control, confirm it through a link, and choose a password. By the time you're reading this, that's done and you have credentials in hand.
 
 Throughout this guide, "your instance" means the Pavillion server your account lives on. The URLs you see will use that instance's domain. We'll write `your-instance.example` as a stand-in.
 
 ## Step 1: Log in
 
-Go to `https://your-instance.example/` and sign in with the email and password you were given. The first thing you'll land on is your feed — the activity stream for any calendars you eventually follow. It will be empty for now. That's expected.
+Go to `https://your-instance.example/` and sign in with the email address and password you set up. The first thing you'll land on is your feed — the activity stream for any calendars you eventually follow. It will be empty for now. That's expected.
 
 You don't have a calendar yet. The next step is to make one.
 

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -1,49 +1,45 @@
 # Quickstart: from login to a published event
 
-This is the on-ramp. It takes you from "I just got an account on a Pavillion instance" to "I have a published calendar with one real event on it that I can share with a friend." It's linear and opinionated — no branching, no choices to make. About ten to fifteen minutes of reading and clicking.
+This is your on-ramp. It takes you from "I just got a Pavillion account" to "I have a published calendar with one real event on it that I can share with a friend."
 
-Everything else in the calendar-owner guides is reference material you can come back to. This page is sequential.
+A quick ten to fifteen minutes of reading and clicking will walk you through everything you need to get started. The rest of the guide is reference material you can come back to.
 
 ## What you'll have when you're done
 
-A working calendar at a public URL, with one event on it, that you can paste into a chat or an email and have a friend look at.
+When you finish this tutorial you'll have a working calendar at a public URL, with one event on it. You'll be able to share that link with a friend in a chat or an email for them to see.
 
 ## Before you start
 
-You need an account on a Pavillion instance. Sign-up varies by instance: some accept open applications through the site, others run on invitation only — your local arts council, neighborhood mesh, or housing co-op decides which posture fits the community. Either way, signing up is the part where you provide an email address you control, confirm it through a link, and choose a password. By the time you're reading this, that's done and you have credentials in hand.
+You need an account on a Pavillion *instance* — one community's installation of Pavillion. Your local arts council might run one, your chamber of commerce might run another, and your account lives on whichever you signed up for. This is your calendar's home. How this impacts using the guide here is small — URLs will show `your-instance.example` as a placeholder; just substitute the domain you actually signed up at in its place.
 
-Throughout this guide, "your instance" means the Pavillion server your account lives on. The URLs you see will use that instance's domain. We'll write `your-instance.example` as a stand-in.
+Sign-up itself varies by instance: some accept open applications through the site, others run on invitation only — the community running it decides which posture fits. By the time you're reading this, you've got your account and are ready to start building.
 
 ## Step 1: Log in
 
-Go to `https://your-instance.example/` and sign in with the email address and password you set up. The first thing you'll land on is your feed — the activity stream for any calendars you eventually follow. It will be empty for now. That's expected.
-
-You don't have a calendar yet. The next step is to make one.
+Go to `https://your-instance.example/` and sign in with the email address and password you set up. Because you don't have a calendar yet, Pavillion drops you straight into the new-calendar form — the first-run shortcut for the most obvious next step. (If you already had a calendar, you'd land on its page; if you had several, you'd land on a list of them.)
 
 ## Step 2: Create your calendar
 
-Open the calendars list (the calendar icon in the navigation) and choose **New calendar**.
-
-You'll be asked for two things:
+The form asks for two things:
 
 - **Calendar title** — the human-readable name. "Westside Community Garden Events," "Riverbend Folk Series," "Maplewood Mutual Aid Calendar." Whatever your community will recognize.
-- **URL handle** — the short, URL-safe slug that becomes part of your calendar's web address. Pavillion auto-fills this from the title (lowercased, hyphenated, trimmed), and you can edit it before submitting. The full handle takes the form `your-handle@your-instance.example` — the `@` shape matters because that's how other Pavillion calendars (on this instance or any other) will find and follow you.
+- **URL handle** — the short, URL-safe name that becomes part of your calendar's web address. Pavillion auto-fills this based on the title, and you can edit it before submitting. The full handle for your calendar takes the form `your-calendar-handle@your-instance.example` — the `@` shape matters because that's how other Pavillion calendars (on this instance or any other) will find and follow your calendar.
 
 > **A note on choosing a handle.** The handle is hard to change after the fact — once people have linked to it, bookmarked it, or pasted it into an email, changes break those links. Pick something short, durable, and tied to the community rather than to a moment in time. `riverbend-folk` ages better than `riverbend-2026-season`.
 
-Submit the form. You'll land on your new calendar's editor page. It's empty. We'll fix that.
+Submit the form. You'll land on your new calendar's events management page. It's empty. We'll fix that.
 
 ## Step 3: Round out your calendar's identity
 
 The two things you just entered are the bare minimum to create the calendar. Before publishing an event, fill in the rest of the basics:
 
-1. From your calendar's page, open **Settings**.
-2. Add a **description**. One or two sentences: who this calendar is for and what kinds of events it lists. Visitors to your public page will read this. So will other calendar owners deciding whether to follow you.
-3. The **primary language** is set to your account's language by default. Most calendars run in one language — leave it as is. If you'll publish in more than one, you can add additional languages here too; each translatable field (titles, descriptions) becomes a tabbed surface across those languages.
+1. From your calendar's page, open **Manage Calendar**.
+2. Add a **description**. One or two sentences: who this calendar is for and what kinds of events it lists. Visitors to your public page will read this. So will other calendar owners deciding whether to follow your calendar.
+3. The **primary language** is set to your account's language by default. Most calendars will run in one language — leave it as is. If you'll publish in more than one, add the additional languages here too. The title and description fields then grow a small row of language tabs above them — one tab per language you've added — and clicking a tab swaps the field below to that language's text. You edit one language at a time.
 
-Settings save as you go — there's no separate "save" button on this page. Move on when you're satisfied.
+Settings save as you go: text fields save when you click out of them, dropdowns save when you pick a new value, the default event image saves as soon as upload finishes. There's no separate "save" button for the basics. Move on when you're satisfied.
 
-> **A note on description.** Treat the description as something a stranger reads before deciding to follow your calendar. "Events organized by and for the Westside community garden — workdays, harvests, potlucks, and quarterly meetings" tells a visitor whether they're in the right place. "All events" tells them nothing.
+> **A note on calendar description.** Treat the description as something a stranger reads before deciding to follow your calendar. "Events organized by and for the Westside community garden — workdays, harvests, potlucks, and quarterly meetings" tells a visitor whether they're in the right place. "All events" tells them nothing.
 
 ## Step 4: Add your first event
 
@@ -51,7 +47,7 @@ Back on your calendar's page, look for the button to add an event (it lives near
 
 **Event details.** Give the event a title. Add a description — a short paragraph is fine, more if there's logistics worth spelling out. If accessibility info is relevant (wheelchair access, ASL interpretation, scent-free space), there's a dedicated field for it; visitors look for that information specifically and it shouldn't be buried in the description.
 
-**Location.** Click **Add location**. The location picker opens. You probably don't have any places saved yet, so choose **Create new place**, fill in the name and address, and confirm. The place is now reusable — the next event you create at the same venue will pick it from a list rather than re-typing the address.
+**Location.** Click **Add location**. The location picker opens. You probably don't have any places saved yet, so choose **Create new place**, fill in the name and address, and confirm. The place is now reusable — for the next event you create at the same venue you will be able pick it from a list rather than re-typing the address.
 
 > **A note on places.** A "place" in Pavillion is its own thing — separate from the events that reference it. The address is stored once, on the place. Events point at the place. So when the venue changes its name or you correct a typo in the address, you fix it once and every event there is updated.
 
@@ -59,23 +55,25 @@ Back on your calendar's page, look for the button to add an event (it lives near
 
 **Event image** (optional). Upload one if you have it. If you don't, skip — the calendar's default event image will fill in.
 
-**Categories.** Pick at least one. If your calendar is brand new, no categories exist yet — you'll need to create one. From the category section, add a category like "Community gathering" or "Workday" or whatever fits. You can add more later.
+**Categories.** Pick at least one. If your calendar is brand new, no categories exist yet — you'll need to create one. From the category section, add a category like "Community gathering" or "Music" or whatever fits. You can add more later.
 
-> **A note on categories.** Categories are how visitors filter your public page (`Show only Workdays`) and how your events get matched up when other calendars repost them. A small, durable vocabulary works better than a long list of one-off labels — "Concert" earns its keep over many events; "Tuesday night jazz quartet" doesn't.
+> **A note on categories.** Categories are how visitors filter your public page (`Show only Sports events`) and how your events get matched up when other calendars repost them. A small, durable vocabulary works better than a long list of one-off labels — "Concert" can help visitors find many events; "Tuesday night jazz quartet" won't.
 
 **Series.** Skip for this first event. A series is for grouping multiple distinct events under one named program (a summer concert series, a fall lecture series). One-off events don't need it.
 
-**Date & time.** Set the start and end. For your first event, leave it as a single occurrence — no recurrence rule. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
+**Date & time.** Set the start and end. For this first event, pick a date within the next week or two — the public page opens to a default two-week window, and a date much further out won't be visible there until the visitor changes the filter. (You can always add the real, far-out events afterwards; this is just so the page you're about to share has something on it.) Leave it as a single occurrence for now — no recurrence rules. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
 
-When the form is filled in, click **Save Changes** in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit or cancel it from the events list.
+When the form is filled in, click **Save Changes** in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit, cancel, or delete it from the events list.
 
 ## Step 5: See what visitors see
 
 Your event is live. Now look at your public page.
 
-Open a new browser tab and go to `https://your-instance.example/view/your-handle`, replacing `your-handle` with the URL handle you chose in Step 2. (You can also find this URL on the calendar page — there's a link to "view public page" or similar.)
+Open a new browser tab and go to `https://your-instance.example/view/your-handle`, replacing `your-handle` with the URL handle you chose in Step 2. (You can also find this URL on the calendar page — there's a link under the calendar's title.)
 
 What you're looking at is what anyone on the internet sees. No login required. Your event should be there, with the place, the date, the description, and the category you chose. Click into the event to see its detail page — that's the URL you'd share for a single event.
+
+If you don't see it, the most likely reason is the date filter. The public page opens to a default window — two weeks out by default — and an event further in the future is still there, just hidden until a visitor widens the range. The date control near the top of the page lets you (and visitors) jump forward. You can also change the calendar's default window from **Manage Calendar** if two weeks isn't right for your community's rhythm.
 
 Paste your calendar's URL into a chat with a friend. Have them open it. Ask whether the event makes sense to them as someone who's never seen it before. That feedback — from a fresh pair of eyes who is the audience, not the organizer — is more useful than any checklist.
 
@@ -88,4 +86,3 @@ You have a calendar. You have one event on it. You have a URL you can share. The
 - **More people.** If you're not running this alone, invite editors so others can publish too — the editors guide covers that.
 - **More reach.** Find other calendars in your community to follow, and decide whether to repost their events onto yours — the follow-and-repost guide covers that. If you're migrating from an existing calendar (Google Calendar, Nextcloud, a WordPress plugin, an existing Gancio or Mobilizon calendar), the ICS-import guide shows how to bring that history in.
 
-You don't have to do any of those today. The calendar you just made is enough to start with.

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -25,7 +25,9 @@ The form asks for two things:
 - **Calendar title** — the human-readable name. "Westside Community Garden Events," "Riverbend Folk Series," "Maplewood Mutual Aid Calendar." Whatever your community will recognize.
 - **URL handle** — the short, URL-safe name that becomes part of your calendar's web address. Pavillion auto-fills this based on the title, and you can edit it before submitting. The full handle for your calendar takes the form `your-calendar-handle@your-instance.example` — the `@` shape matters because that's how other Pavillion calendars (on this instance or any other) will find and follow your calendar.
 
-> **A note on choosing a handle.** The handle is hard to change after the fact — once people have linked to it, bookmarked it, or pasted it into an email, changes break those links. Pick something short, durable, and tied to the community rather than to a moment in time. `riverbend-folk` ages better than `riverbend-2026-season`.
+::: tip <Lightbulb /> A note on choosing a handle.
+The handle is hard to change after the fact — once people have linked to it, bookmarked it, or pasted it into an email, changes break those links. Pick something short, durable, and tied to the community rather than to a moment in time. `riverbend-folk` ages better than `riverbend-2026-season`.
+:::
 
 Submit the form. You'll land on your new calendar's events management page. It's empty. We'll fix that.
 
@@ -35,11 +37,13 @@ The two things you just entered are the bare minimum to create the calendar. Bef
 
 1. From your calendar's page, open **Manage Calendar**.
 2. Add a **description**. One or two sentences: who this calendar is for and what kinds of events it lists. Visitors to your public page will read this. So will other calendar owners deciding whether to follow your calendar.
-3. The **primary language** is set to your account's language by default. Most calendars will run in one language — leave it as is. If you'll publish in more than one, add the additional languages here too. The title and description fields then grow a small row of language tabs above them — one tab per language you've added — and clicking a tab swaps the field below to that language's text. You edit one language at a time.
+3. The **primary language** is set to your account's language by default. If you only plan to publish in one language — leave it as is. If you'll publish in more than one, add the additional languages here too. The title and description fields then grow a small row of language tabs above them — one tab per language you've added — and clicking a tab swaps the field below to that language's text. You edit one language at a time.
 
 Settings save as you go: text fields save when you click out of them, dropdowns save when you pick a new value, the default event image saves as soon as upload finishes. There's no separate "save" button for the basics. Move on when you're satisfied.
 
-> **A note on calendar description.** Treat the description as something a stranger reads before deciding to follow your calendar. "Events organized by and for the Westside community garden — workdays, harvests, potlucks, and quarterly meetings" tells a visitor whether they're in the right place. "All events" tells them nothing.
+::: tip <Lightbulb /> A note on calendar description.
+Treat the description as something a stranger reads before deciding to follow your calendar. "Events organized by and for the Westside community garden — workdays, harvests, potlucks, and quarterly meetings" tells a visitor whether they're in the right place. "All events" tells them nothing.
+:::
 
 ## Step 4: Add your first event
 
@@ -49,7 +53,9 @@ Back on your calendar's page, look for the button to add an event (it lives near
 
 **Location.** Click **Add location**. The location picker opens. You probably don't have any places saved yet, so choose **Create new place**, fill in the name and address, and confirm. The place is now reusable — for the next event you create at the same venue you will be able pick it from a list rather than re-typing the address.
 
-> **A note on places.** A "place" in Pavillion is its own thing — separate from the events that reference it. The address is stored once, on the place. Events point at the place. So when the venue changes its name or you correct a typo in the address, you fix it once and every event there is updated.
+::: tip <Lightbulb /> A note on places.
+A "place" in Pavillion is its own thing — separate from the events that reference it. The address is stored once, on the place. Events point at the place. So when the venue changes its name or you correct a typo in the address, you fix it once and every event there is updated.
+:::
 
 **External link** (optional). If the event has a registration page, ticket link, or external info page elsewhere, paste the URL here and pick the prompt that matches it ("More info," "Tickets," "RSVP"). Skip this if there's nothing external to link to.
 
@@ -57,7 +63,9 @@ Back on your calendar's page, look for the button to add an event (it lives near
 
 **Categories.** Pick at least one. If your calendar is brand new, no categories exist yet — you'll need to create one. From the category section, add a category like "Community gathering" or "Music" or whatever fits. You can add more later.
 
-> **A note on categories.** Categories are how visitors filter your public page (`Show only Sports events`) and how your events get matched up when other calendars repost them. A small, durable vocabulary works better than a long list of one-off labels — "Concert" can help visitors find many events; "Tuesday night jazz quartet" won't.
+::: tip <Lightbulb /> A note on categories
+Categories are how visitors filter your public page (`Show only Sports events`) and how your events get matched up when other calendars repost them. A small, durable vocabulary works better than a long list of one-off labels — "Concert" can help visitors find many events; "Tuesday night jazz quartet" won't.
+:::
 
 **Series.** Skip for this first event. A series is for grouping multiple distinct events under one named program (a summer concert series, a fall lecture series). One-off events don't need it.
 

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: from login to a published event
+
+> Status: stub. Full guide coming before launch.
+
+This is the on-ramp. It takes you from "I just got an account on a Pavillion instance" to "I have a published calendar with one real event on it that I can share with someone." It's linear and opinionated — no branching, no choices to make. About ten to fifteen minutes of reading and clicking.
+
+Everything else in the calendar-owner guides is reference material you can come back to. This page is sequential.
+
+## What you'll have when you're done
+
+A working calendar at a public URL, with one event on it, that you can paste into a chat or an email and have a friend look at.
+
+## Before you start
+
+What you need: an account on a Pavillion instance. If you don't have one yet, that's an instance-administrator question — Pavillion accounts aren't self-serve.
+
+## Step 1: Log in
+
+## Step 2: Create a calendar
+
+The four things you'll be asked for: a URL handle, a display name, a short description, and a primary language. A note on each.
+
+## Step 3: Publish your first event
+
+A single-occurrence event with a place and a category. The minimum viable shape.
+
+## Step 4: Get the public URL
+
+Where to find it, what visitors see when they open it.
+
+## What next
+
+Pointers into the rest of the guides — recurring events, inviting editors, following other calendars, importing existing events.

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -1,8 +1,6 @@
 # Quickstart: from login to a published event
 
-> Status: stub. Full guide coming before launch.
-
-This is the on-ramp. It takes you from "I just got an account on a Pavillion instance" to "I have a published calendar with one real event on it that I can share with someone." It's linear and opinionated — no branching, no choices to make. About ten to fifteen minutes of reading and clicking.
+This is the on-ramp. It takes you from "I just got an account on a Pavillion instance" to "I have a published calendar with one real event on it that I can share with a friend." It's linear and opinionated — no branching, no choices to make. About ten to fifteen minutes of reading and clicking.
 
 Everything else in the calendar-owner guides is reference material you can come back to. This page is sequential.
 
@@ -12,22 +10,82 @@ A working calendar at a public URL, with one event on it, that you can paste int
 
 ## Before you start
 
-What you need: an account on a Pavillion instance. If you don't have one yet, that's an instance-administrator question — Pavillion accounts aren't self-serve.
+You need an account on a Pavillion instance. If you don't have one yet, that's an instance-administrator question — Pavillion accounts aren't self-serve. Whoever runs the instance you're joining (your local arts council, your neighborhood mesh, your housing co-op) is the person who issues accounts.
+
+Throughout this guide, "your instance" means the Pavillion server your account lives on. The URLs you see will use that instance's domain. We'll write `your-instance.example` as a stand-in.
 
 ## Step 1: Log in
 
-## Step 2: Create a calendar
+Go to `https://your-instance.example/` and sign in with the email and password you were given. The first thing you'll land on is your feed — the activity stream for any calendars you eventually follow. It will be empty for now. That's expected.
 
-The four things you'll be asked for: a URL handle, a display name, a short description, and a primary language. A note on each.
+You don't have a calendar yet. The next step is to make one.
 
-## Step 3: Publish your first event
+## Step 2: Create your calendar
 
-A single-occurrence event with a place and a category. The minimum viable shape.
+Open the calendars list (the calendar icon in the navigation) and choose **New calendar**.
 
-## Step 4: Get the public URL
+You'll be asked for two things:
 
-Where to find it, what visitors see when they open it.
+- **Calendar title** — the human-readable name. "Westside Community Garden Events," "Riverbend Folk Series," "Maplewood Mutual Aid Calendar." Whatever your community will recognize.
+- **URL handle** — the short, URL-safe slug that becomes part of your calendar's web address. Pavillion auto-fills this from the title (lowercased, hyphenated, trimmed), and you can edit it before submitting. The full handle takes the form `your-handle@your-instance.example` — the `@` shape matters because that's how other Pavillion calendars (on this instance or any other) will find and follow you.
+
+> **A note on choosing a handle.** The handle is hard to change after the fact — once people have linked to it, bookmarked it, or pasted it into an email, changes break those links. Pick something short, durable, and tied to the community rather than to a moment in time. `riverbend-folk` ages better than `riverbend-2026-season`.
+
+Submit the form. You'll land on your new calendar's editor page. It's empty. We'll fix that.
+
+## Step 3: Round out your calendar's identity
+
+The two things you just entered are the bare minimum to create the calendar. Before publishing an event, fill in the rest of the basics:
+
+1. From your calendar's page, open **Settings**.
+2. Add a **description**. One or two sentences: who this calendar is for and what kinds of events it lists. Visitors to your public page will read this. So will other calendar owners deciding whether to follow you.
+3. The **primary language** is set to your account's language by default. Most calendars run in one language — leave it as is. If you'll publish in more than one, you can add additional languages here too; each translatable field (titles, descriptions) becomes a tabbed surface across those languages.
+
+Settings save as you go — there's no separate "save" button on this page. Move on when you're satisfied.
+
+> **A note on description.** Treat the description as something a stranger reads before deciding to follow your calendar. "Events organized by and for the Westside community garden — workdays, harvests, potlucks, and quarterly meetings" tells a visitor whether they're in the right place. "All events" tells them nothing.
+
+## Step 4: Add your first event
+
+Back on your calendar's page, look for the button to add an event (it lives near the events list). The event editor opens as a full-page form. We'll go top to bottom.
+
+**Event details.** Give the event a title. Add a description — a short paragraph is fine, more if there's logistics worth spelling out. If accessibility info is relevant (wheelchair access, ASL interpretation, scent-free space), there's a dedicated field for it; visitors look for that information specifically and it shouldn't be buried in the description.
+
+**Location.** Click **Add location**. The location picker opens. You probably don't have any places saved yet, so choose **Create new place**, fill in the name and address, and confirm. The place is now reusable — the next event you create at the same venue will pick it from a list rather than re-typing the address.
+
+> **A note on places.** A "place" in Pavillion is its own thing — separate from the events that reference it. The address is stored once, on the place. Events point at the place. So when the venue changes its name or you correct a typo in the address, you fix it once and every event there is updated.
+
+**External link** (optional). If the event has a registration page, ticket link, or external info page elsewhere, paste the URL here and pick the prompt that matches it ("More info," "Tickets," "RSVP"). Skip this if there's nothing external to link to.
+
+**Event image** (optional). Upload one if you have it. If you don't, skip — the calendar's default event image will fill in.
+
+**Categories.** Pick at least one. If your calendar is brand new, no categories exist yet — you'll need to create one. From the category section, add a category like "Community gathering" or "Workday" or whatever fits. You can add more later.
+
+> **A note on categories.** Categories are how visitors filter your public page (`Show only Workdays`) and how your events get matched up when other calendars repost them. A small, durable vocabulary works better than a long list of one-off labels — "Concert" earns its keep over many events; "Tuesday night jazz quartet" doesn't.
+
+**Series.** Skip for this first event. A series is for grouping multiple distinct events under one named program (a summer concert series, a fall lecture series). One-off events don't need it.
+
+**Date & time.** Set the start and end. For your first event, leave it as a single occurrence — no recurrence rule. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
+
+When the form is filled in, click **Save Changes** in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit or cancel it from the events list.
+
+## Step 5: See what visitors see
+
+Your event is live. Now look at your public page.
+
+Open a new browser tab and go to `https://your-instance.example/view/your-handle`, replacing `your-handle` with the URL handle you chose in Step 2. (You can also find this URL on the calendar page — there's a link to "view public page" or similar.)
+
+What you're looking at is what anyone on the internet sees. No login required. Your event should be there, with the place, the date, the description, and the category you chose. Click into the event to see its detail page — that's the URL you'd share for a single event.
+
+Paste your calendar's URL into a chat with a friend. Have them open it. Ask whether the event makes sense to them as someone who's never seen it before. That feedback — from a fresh pair of eyes who is the audience, not the organizer — is more useful than any checklist.
 
 ## What next
 
-Pointers into the rest of the guides — recurring events, inviting editors, following other calendars, importing existing events.
+You have a calendar. You have one event on it. You have a URL you can share. The rest of the calendar-owner guides cover what comes after:
+
+- **More events.** Add the rest of what's coming up. Events that repeat (weekly meetings, monthly meetups) — see the recurring-events guide. Series of distinct events under a program name — see the series guide.
+- **More structure.** A bigger event list benefits from a richer set of categories and a tidied-up list of places — those have their own guides.
+- **More people.** If you're not running this alone, invite editors so others can publish too — the editors guide covers that.
+- **More reach.** Find other calendars in your community to follow, and decide whether to repost their events onto yours — the follow-and-repost guide covers that. If you're migrating from an existing calendar (Google Calendar, Nextcloud, a WordPress plugin, an existing Gancio or Mobilizon calendar), the ICS-import guide shows how to bring that history in.
+
+You don't have to do any of those today. The calendar you just made is enough to start with.

--- a/docs/guides/calendar-owners/recurring-events.md
+++ b/docs/guides/calendar-owners/recurring-events.md
@@ -1,0 +1,33 @@
+# Run a recurring event
+
+> Status: stub. Full guide coming before launch.
+
+Most calendars have at least one event that repeats — a weekly meeting, a monthly meetup, a Tuesday-night open mic. This guide covers how to express those patterns in Pavillion, how to handle the inevitable exceptions ("we're skipping the week of Thanksgiving"), and how to tell when your event has outgrown recurrence and wants to be a series instead.
+
+## When recurrence is the right tool
+
+The same event, on a predictable schedule, with mostly the same details each time.
+
+## Set up a recurring event
+
+How recurrence rules work in Pavillion — the underlying shape is RRULE, but you'll see plain-language controls in the editor.
+
+## Override a single occurrence
+
+The most common use: one occurrence happens at a different time, in a different place, or with a different description. How to change just that one without disturbing the rest.
+
+## Cancel a single occurrence
+
+Different from overriding. The occurrence still appears on the calendar so people who were planning to attend can see it didn't happen — it just shows as cancelled.
+
+## End the recurrence
+
+When the recurring program is over, how to end it cleanly so future occurrences stop appearing without breaking the history.
+
+## When recurrence isn't the right tool
+
+A short decision aid for when the events you're planning vary too much for recurrence to feel honest. Pointer to series.
+
+## Common foot-guns
+
+The places organizers most often get tripped up — for instance, changing the start time of a recurring event in a way that breaks already-published occurrences.

--- a/docs/guides/calendar-owners/recurring-events.md
+++ b/docs/guides/calendar-owners/recurring-events.md
@@ -10,7 +10,7 @@ If the events you're planning vary in ways that matter — different topics, dif
 
 ## Set up a schedule
 
-Open the event editor — creating a new event or editing an existing one. Find the **Date & Time** section, where each event has at least one **Schedule 1** block with date, time, end date, end time, and timezone fields. Fill those in for the *first* occurrence of the event. Then click **Add recurrence** below the timezone field.
+Open the event editor — creating a new event or editing an existing one. Find the **Date & Time** section, where each event has at least one **Schedule 1** block with date, time, end date, end time, and timezone fields. Fill those in for the *first* occurrence of the event. Then click <Btn>Add recurrence</Btn> below the timezone field.
 
 A panel slides in titled **Recurrence**.
 
@@ -18,26 +18,26 @@ A panel slides in titled **Recurrence**.
 
 **Every [N] weeks/months/days/years.** Most events are "every 1" of the chosen unit — that's just *weekly*, *monthly*, etc. The number is there for the cases that aren't: "every 2 weeks" for biweekly, "every 3 months" for quarterly.
 
-**On.** For *Weekly* recurrence, a row of weekday pills — Sunday through Saturday. Click the days the event happens. (For a class that meets twice a week, click both days.) For *Monthly* recurrence, a grid of positional days — *1st Sunday*, *1st Monday*, all the way through *5th Saturday* — so you can pick "the 3rd Wednesday of the month" rather than a fixed calendar date. (If you want a fixed calendar date — "the 15th of every month" — leave this grid alone; the schedule's start date already encodes the day.)
+**On.** For *Weekly* recurrence, a row of weekday pills — Sunday through Saturday. Click the days the event happens. (For a class that meets twice a week, click both days.) For *Monthly* recurrence, a grid of positional days — *1st Sunday*, *1st Monday*, all the way through *5th Saturday* — so you can pick "the 3rd Wednesday of the month" rather than a fixed calendar date. (If you want a fixed calendar date — "the 15th of every month" — leave this grid alone; the schedule's start date already sets the day.)
 
 **Ends.** Three options:
-- **never** — the event repeats indefinitely. Pavillion only renders a horizon of upcoming occurrences for the public page, so an unbounded series doesn't flood anything.
+- **never** — the event repeats indefinitely.
 - **after [N] occurrences** — a finite count. Right for an eight-week course or a six-session series.
 - **on [date]** — a specific end date. Right for a program that runs through the end of a season.
 
-Click **Done** to close the panel. Back in the editor, the schedule now shows a plain-language summary: *Every Tuesday*, *Monthly*, *Yearly*. If something doesn't look right, the **Edit recurrence** button next to the summary reopens the panel.
+Click <Btn>Done</Btn> to close the panel. Back in the editor, the schedule now shows a plain-language summary: *Every Tuesday*, *Monthly*, *Yearly*. If something doesn't look right, the <Btn>Edit recurrence</Btn> button next to the summary reopens the panel.
 
-Save the event. The occurrences are generated from the schedule — you don't create them one by one.
+Save the event. Pavillion fills in the repeating dates from the schedule — you don't enter each one.
 
 ::: tip <Lightbulb /> A note on the start date.
-The schedule's **Date** field — the one outside the recurrence panel — is the *first* occurrence, not just a "starting from" reference. A weekly schedule with a start date of Tuesday January 7th will generate occurrences on January 7th, 14th, 21st, and so on. If your start date is on a Tuesday but you've only checked Monday in the recurrence panel, the first occurrence won't be until the *following* Monday, January 13th — the Tuesday is skipped. Easier to keep the start date and the weekday selection consistent.
+The schedule's **Date** field — the one outside the recurrence panel — is the *first* occurrence, not just a "starting from" reference. A weekly schedule with a start date of Tuesday January 7th will repeat on January 7th, 14th, 21st, and so on. If your start date is on a Tuesday but you've only checked Monday in the recurrence panel, the first occurrence won't be until the *following* Monday, January 13th — the Tuesday is skipped. Easier to keep the start date and the weekday selection consistent.
 :::
 
 ## Add a one-off exception
 
-Sometimes a recurring event has a one-off exception that doesn't fit the pattern — the weekly Tuesday meeting moves to Friday for one week because of a holiday, or a monthly board meeting adds an extra session before the AGM.
+Sometimes a recurring event has a one-off exception that doesn't fit the pattern — the weekly Tuesday meeting moves to Friday for one week because of a holiday, or a monthly board meeting adds an extra session before the annual meeting.
 
-In Pavillion, an event can have more than one schedule. Below the first schedule block, click **+ Add another schedule**. A second schedule appears — *Schedule 2*, with its own date, time, timezone, and recurrence button. Set the date and time for the one-off occurrence and leave its recurrence at *Never*. That's a single-occurrence schedule layered onto the recurring one.
+In Pavillion, an event can have more than one schedule. Below the first schedule block, click <Btn>+ Add another schedule</Btn>. A second schedule appears — *Schedule 2*, with its own date, time, timezone, and recurrence button. Set the date and time for the one-off occurrence and leave its recurrence at *Never*. That's a one-off date sitting alongside the recurring schedule.
 
 If the exception *replaces* a regular occurrence (the Tuesday is moved to Friday, not added on top of it), you'll also want to cancel the original Tuesday occurrence — see the next section.
 
@@ -47,16 +47,16 @@ Multiple schedules are also the way to express "the same meeting at two differen
 
 ## Cancel a single occurrence
 
-For a recurring event, the editor shows a **Manage cancellations** button below the schedule blocks. Click it to expand a **Cancellations** panel — a horizontal row of upcoming occurrence cards, each showing the occurrence date and time. Distant occurrences live further down the row; **Show more** appends the next batch, and **Jump to month** lets you skip ahead to a specific month.
+For a recurring event, the editor shows a <Btn>Manage cancellations</Btn> button below the schedule blocks. Click it to expand a **Cancellations** panel — a horizontal row of cards for the upcoming dates, each showing date and time. Later dates live further down the row; <Btn>Show more</Btn> appends the next batch, and <Btn>Jump to month</Btn> lets you skip ahead to a specific month.
 
-To cancel one occurrence, find its card and click **Cancel**. A confirmation modal opens — *Cancel this instance?* — with a **Hide from public** toggle and two buttons: *Cancel* (dismiss the modal) and *Cancel instance* (confirm).
+To cancel one occurrence, find its card and click <Btn>Cancel</Btn>. A confirmation modal opens — *Cancel this instance?* — with a **Hide from public** toggle and two buttons: <Btn>Cancel</Btn> (dismiss the modal) and <Btn>Cancel instance</Btn> (confirm).
 
 The toggle is the important choice:
 
 - **Off (the default): show as cancelled.** The occurrence stays on the calendar. Visitors and any calendar reposting from yours still see it, but it's marked **Cancelled**. This is the right choice for an event that *was* announced and that people might be planning to attend — cancelling-but-showing tells them the meeting they had on their calendar isn't happening.
 - **On: hide from public.** The occurrence is removed from the public page and from any calendar reposting from yours. This is the right choice for occurrences that haven't been visible long enough for anyone to be planning around them — for example, a brand-new recurring event where you want to skip an upcoming holiday week before the public page has had time to surface those occurrences.
 
-Confirm with **Cancel instance**. The card now shows a **Cancelled** or **Hidden** badge, and its button changes to **Restore**. If you change your mind, click **Restore** to bring the occurrence back; that's immediate, no confirmation needed.
+Confirm with <Btn>Cancel instance</Btn>. The card now shows a **Cancelled** or **Hidden** badge, and its button changes to <Btn>Restore</Btn>. If you change your mind, click <Btn>Restore</Btn> to bring the occurrence back; that's immediate, no confirmation needed.
 
 ::: tip <Lightbulb /> A note on cancelling for the wrong reason.
 Cancellation is for an occurrence that won't happen. If the event will happen but at a different time or place, you don't want a bare cancellation — you want a one-off exception (see above) *plus* a cancellation of the original occurrence. The pair tells visitors "the regular Tuesday is off, but we're meeting Friday instead." A bare cancellation just says "no meeting."
@@ -64,9 +64,9 @@ Cancellation is for an occurrence that won't happen. If the event will happen bu
 
 ## End the recurrence
 
-When a recurring program runs its course — the eight-week class wraps, the seasonal series ends — wind it down by setting an end on the schedule rather than deleting the event. Click **Edit recurrence** on the schedule. In the **ends** section, switch from *never* to either *after [N] occurrences* or *on [date]*. Click **Done** and save the event.
+When a recurring program runs its course — the eight-week class wraps, the seasonal series ends — wind it down by setting an end on the schedule rather than deleting the event. Click <Btn>Edit recurrence</Btn> on the schedule. In the **ends** section, switch from *never* to either *after [N] occurrences* or *on [date]*. Click <Btn>Done</Btn> and save the event.
 
-Past occurrences stay on the calendar as history. Future occurrences stop being generated. People who attended in the past — and any calendar that reposted from yours — see the same record they always did; nothing rewrites the past.
+Past occurrences stay on the calendar as history. No new dates appear after the end. People who attended in the past — and any calendar that reposted from yours — see the same record they always did; nothing rewrites the past.
 
 ::: tip <Lightbulb /> A note on shortening the end of a recurrence.
 If you set the end date earlier than what's already been published, occurrences past that new end date disappear from the public page and from reposting calendars. People who had those occurrences on their personal calendar may end up confused. If the recurrence is being shortened because plans changed, consider cancelling the affected occurrences with a "show as cancelled" instead — visitors get to see *that* the dates were dropped rather than have them quietly vanish.
@@ -78,9 +78,9 @@ A short decision aid: if the events you're planning share an *identity* — the 
 
 The quick test: would the title field be the same on every occurrence? If yes, recurrence. If you'd want to change the title — even slightly — for each occurrence, the recurrence editor will fight you, and a series is what you actually want.
 
-## Common foot-guns
+## Things that trip people up
 
-A short list of the places organizers most often get tripped up.
+A short list of the most common stumbles.
 
 **Changing the start time of an already-published recurring event.** If your Tuesday meeting was 7pm and you change the schedule's time to 8pm, *every* future occurrence shifts to 8pm — including ones that were already on the public page (and on visitors' personal calendars, if they added it). For a one-time time change, use a one-off exception schedule and cancel the original. For a permanent time change, accept that anyone who saved the old time has a stale entry, and announce the change visibly somewhere visitors will see it.
 
@@ -88,6 +88,6 @@ A short list of the places organizers most often get tripped up.
 
 **"Show as cancelled" on an event nobody was attending yet.** If you skip an occurrence on a brand-new recurring event before anyone's seen the public page, the **Cancelled** badge is just noise. Use **Hide from public** instead so the occurrence quietly drops out.
 
-**Setting an end date earlier than the start date.** If the schedule's end date is before its start date, no occurrences are generated and the event has no instances on the calendar. The editor allows this combination — it just means an empty schedule. Double-check both fields if a recurring event isn't appearing.
+**Setting an end date earlier than the start date.** If the schedule's end date is before its start date, the event won't show any dates on the calendar. The editor allows this combination — it just means an empty schedule. Double-check both fields if a recurring event isn't appearing.
 
-**Treating a series like a recurring event.** A monthly book club where the book changes each month is *not* a recurring event with the same title — visitors won't be able to tell the August meeting from the September one. That's a series.
+**Treating a series like a recurring event.** A weekly film screening where the film changes each week is *not* a recurring event with the same title — visitors won't be able to tell which film is playing on which date. That's a series.

--- a/docs/guides/calendar-owners/recurring-events.md
+++ b/docs/guides/calendar-owners/recurring-events.md
@@ -1,33 +1,93 @@
-# Run a recurring event
+# Post a recurring event
 
-> Status: stub. Full guide coming before launch.
-
-Most calendars have at least one event that repeats — a weekly meeting, a monthly meetup, a Tuesday-night open mic. This guide covers how to express those patterns in Pavillion, how to handle the inevitable exceptions ("we're skipping the week of Thanksgiving"), and how to tell when your event has outgrown recurrence and wants to be a series instead.
+Most calendars have at least one event that repeats — a weekly board meeting, a monthly meetup, a Tuesday-night open mic. This guide covers how to express those patterns in Pavillion, how to handle the inevitable exceptions ("we're skipping the week of Thanksgiving"), and how to tell when an event has outgrown recurrence and wants to be a series of distinct events instead.
 
 ## When recurrence is the right tool
 
-The same event, on a predictable schedule, with mostly the same details each time.
+Recurrence is for the same event happening on a predictable schedule, with mostly the same details each time: the board meeting on the third Wednesday at 7pm in the same room, the Tuesday-night open mic at the same coffee shop, the weekly community garden workday from 9 to noon.
 
-## Set up a recurring event
+If the events you're planning vary in ways that matter — different topics, different presenters, different titles — the right tool is probably a series, not recurrence. There's a short decision aid further down.
 
-How recurrence rules work in Pavillion — the underlying shape is RRULE, but you'll see plain-language controls in the editor.
+## Set up a schedule
 
-## Override a single occurrence
+Open the event editor — creating a new event or editing an existing one. Find the **Date & Time** section, where each event has at least one **Schedule 1** block with date, time, end date, end time, and timezone fields. Fill those in for the *first* occurrence of the event. Then click **Add recurrence** below the timezone field.
 
-The most common use: one occurrence happens at a different time, in a different place, or with a different description. How to change just that one without disturbing the rest.
+A panel slides in titled **Recurrence**.
+
+**Repeats.** A dropdown that starts at *Never*. Pick *Daily*, *Weekly*, *Monthly*, or *Yearly*. As soon as you do, the rest of the controls appear.
+
+**Every [N] weeks/months/days/years.** Most events are "every 1" of the chosen unit — that's just *weekly*, *monthly*, etc. The number is there for the cases that aren't: "every 2 weeks" for biweekly, "every 3 months" for quarterly.
+
+**On.** For *Weekly* recurrence, a row of weekday pills — Sunday through Saturday. Click the days the event happens. (For a class that meets twice a week, click both days.) For *Monthly* recurrence, a grid of positional days — *1st Sunday*, *1st Monday*, all the way through *5th Saturday* — so you can pick "the 3rd Wednesday of the month" rather than a fixed calendar date. (If you want a fixed calendar date — "the 15th of every month" — leave this grid alone; the schedule's start date already encodes the day.)
+
+**Ends.** Three options:
+- **never** — the event repeats indefinitely. Pavillion only renders a horizon of upcoming occurrences for the public page, so an unbounded series doesn't flood anything.
+- **after [N] occurrences** — a finite count. Right for an eight-week course or a six-session series.
+- **on [date]** — a specific end date. Right for a program that runs through the end of a season.
+
+Click **Done** to close the panel. Back in the editor, the schedule now shows a plain-language summary: *Every Tuesday*, *Monthly*, *Yearly*. If something doesn't look right, the **Edit recurrence** button next to the summary reopens the panel.
+
+Save the event. The occurrences are generated from the schedule — you don't create them one by one.
+
+::: tip <Lightbulb /> A note on the start date.
+The schedule's **Date** field — the one outside the recurrence panel — is the *first* occurrence, not just a "starting from" reference. A weekly schedule with a start date of Tuesday January 7th will generate occurrences on January 7th, 14th, 21st, and so on. If your start date is on a Tuesday but you've only checked Monday in the recurrence panel, the first occurrence won't be until the *following* Monday, January 13th — the Tuesday is skipped. Easier to keep the start date and the weekday selection consistent.
+:::
+
+## Add a one-off exception
+
+Sometimes a recurring event has a one-off exception that doesn't fit the pattern — the weekly Tuesday meeting moves to Friday for one week because of a holiday, or a monthly board meeting adds an extra session before the AGM.
+
+In Pavillion, an event can have more than one schedule. Below the first schedule block, click **+ Add another schedule**. A second schedule appears — *Schedule 2*, with its own date, time, timezone, and recurrence button. Set the date and time for the one-off occurrence and leave its recurrence at *Never*. That's a single-occurrence schedule layered onto the recurring one.
+
+If the exception *replaces* a regular occurrence (the Tuesday is moved to Friday, not added on top of it), you'll also want to cancel the original Tuesday occurrence — see the next section.
+
+::: tip <Lightbulb /> A note on multiple schedules.
+Multiple schedules are also the way to express "the same meeting at two different times each week" — a Monday morning and a Wednesday evening session, say. Add two schedules, each weekly, each with their own day and time. One event behind both rhythms.
+:::
 
 ## Cancel a single occurrence
 
-Different from overriding. The occurrence still appears on the calendar so people who were planning to attend can see it didn't happen — it just shows as cancelled.
+For a recurring event, the editor shows a **Manage cancellations** button below the schedule blocks. Click it to expand a **Cancellations** panel — a horizontal row of upcoming occurrence cards, each showing the occurrence date and time. Distant occurrences live further down the row; **Show more** appends the next batch, and **Jump to month** lets you skip ahead to a specific month.
+
+To cancel one occurrence, find its card and click **Cancel**. A confirmation modal opens — *Cancel this instance?* — with a **Hide from public** toggle and two buttons: *Cancel* (dismiss the modal) and *Cancel instance* (confirm).
+
+The toggle is the important choice:
+
+- **Off (the default): show as cancelled.** The occurrence stays on the calendar. Visitors and any calendar reposting from yours still see it, but it's marked **Cancelled**. This is the right choice for an event that *was* announced and that people might be planning to attend — cancelling-but-showing tells them the meeting they had on their calendar isn't happening.
+- **On: hide from public.** The occurrence is removed from the public page and from any calendar reposting from yours. This is the right choice for occurrences that haven't been visible long enough for anyone to be planning around them — for example, a brand-new recurring event where you want to skip an upcoming holiday week before the public page has had time to surface those occurrences.
+
+Confirm with **Cancel instance**. The card now shows a **Cancelled** or **Hidden** badge, and its button changes to **Restore**. If you change your mind, click **Restore** to bring the occurrence back; that's immediate, no confirmation needed.
+
+::: tip <Lightbulb /> A note on cancelling for the wrong reason.
+Cancellation is for an occurrence that won't happen. If the event will happen but at a different time or place, you don't want a bare cancellation — you want a one-off exception (see above) *plus* a cancellation of the original occurrence. The pair tells visitors "the regular Tuesday is off, but we're meeting Friday instead." A bare cancellation just says "no meeting."
+:::
 
 ## End the recurrence
 
-When the recurring program is over, how to end it cleanly so future occurrences stop appearing without breaking the history.
+When a recurring program runs its course — the eight-week class wraps, the seasonal series ends — wind it down by setting an end on the schedule rather than deleting the event. Click **Edit recurrence** on the schedule. In the **ends** section, switch from *never* to either *after [N] occurrences* or *on [date]*. Click **Done** and save the event.
+
+Past occurrences stay on the calendar as history. Future occurrences stop being generated. People who attended in the past — and any calendar that reposted from yours — see the same record they always did; nothing rewrites the past.
+
+::: tip <Lightbulb /> A note on shortening the end of a recurrence.
+If you set the end date earlier than what's already been published, occurrences past that new end date disappear from the public page and from reposting calendars. People who had those occurrences on their personal calendar may end up confused. If the recurrence is being shortened because plans changed, consider cancelling the affected occurrences with a "show as cancelled" instead — visitors get to see *that* the dates were dropped rather than have them quietly vanish.
+:::
 
 ## When recurrence isn't the right tool
 
-A short decision aid for when the events you're planning vary too much for recurrence to feel honest. Pointer to series.
+A short decision aid: if the events you're planning share an *identity* — the same name, the same place, the same time, the same audience — and differ mostly in *date*, recurrence fits. If they share a *program* but differ in their substance — different speakers, different topics, different titles — a series is the better tool. A "Fall Lecture Series" with a different speaker each Thursday isn't one recurring event; it's seven distinct events grouped under a series name.
+
+The quick test: would the title field be the same on every occurrence? If yes, recurrence. If you'd want to change the title — even slightly — for each occurrence, the recurrence editor will fight you, and a series is what you actually want.
 
 ## Common foot-guns
 
-The places organizers most often get tripped up — for instance, changing the start time of a recurring event in a way that breaks already-published occurrences.
+A short list of the places organizers most often get tripped up.
+
+**Changing the start time of an already-published recurring event.** If your Tuesday meeting was 7pm and you change the schedule's time to 8pm, *every* future occurrence shifts to 8pm — including ones that were already on the public page (and on visitors' personal calendars, if they added it). For a one-time time change, use a one-off exception schedule and cancel the original. For a permanent time change, accept that anyone who saved the old time has a stale entry, and announce the change visibly somewhere visitors will see it.
+
+**Picking a weekday that doesn't include the start date.** A weekly schedule that starts on a Tuesday but only checks Monday in the recurrence panel will skip the first Tuesday entirely — the first occurrence won't be until the following Monday. Either set the start date to a Monday, or add Tuesday to the weekday selection if you want the first Tuesday to count.
+
+**"Show as cancelled" on an event nobody was attending yet.** If you skip an occurrence on a brand-new recurring event before anyone's seen the public page, the **Cancelled** badge is just noise. Use **Hide from public** instead so the occurrence quietly drops out.
+
+**Setting an end date earlier than the start date.** If the schedule's end date is before its start date, no occurrences are generated and the event has no instances on the calendar. The editor allows this combination — it just means an empty schedule. Double-check both fields if a recurring event isn't appearing.
+
+**Treating a series like a recurring event.** A monthly book club where the book changes each month is *not* a recurring event with the same title — visitors won't be able to tell the August meeting from the September one. That's a series.

--- a/docs/guides/calendar-owners/series.md
+++ b/docs/guides/calendar-owners/series.md
@@ -1,0 +1,25 @@
+# Group related events into a series
+
+> Status: stub. Full guide coming before launch.
+
+A series is a named program made up of distinct events that share an identity — a "Summer Music Series" of concerts on different dates with different performers, a "Fall Lecture Series" with a different speaker each week. Series and recurring events are both about "this thing repeats," but they answer different questions, and choosing the right tool up front saves a lot of editing later.
+
+## When a series is the right tool
+
+A named program of varied events that share an identity. Different content each time, same umbrella.
+
+## When recurrence is the right tool instead
+
+The same event, repeating. Mostly identical details each occurrence.
+
+## Create a series
+
+The mechanics.
+
+## Add events to a series
+
+How a single event joins a series. How to remove one.
+
+## What a series looks like to visitors
+
+How the public calendar surfaces a series, and how visitors navigate from one event in the series to the others.

--- a/docs/guides/calendar-owners/when-to-create-a-calendar.md
+++ b/docs/guides/calendar-owners/when-to-create-a-calendar.md
@@ -1,0 +1,17 @@
+# Decide when to make a calendar (and when to follow one instead)
+
+> Status: placeholder. This guide will be written after launch.
+
+Before spinning up a calendar, the first question worth asking is whether you should. The neighborhood association already runs one. The music venue does too. The regional climate-action group has been at it for years. Sometimes the right move is to follow theirs and repost what fits — not to create a parallel calendar of your own.
+
+The same question comes up internally. Most calendar owners only need one calendar of their own; categories handle the subdivision between, say, workdays and concerts and quarterly meetings. A second calendar earns its keep when it's run by a different team, serves a different audience, or represents a different community altogether.
+
+This guide will cover both halves of that decision.
+
+## Planned scope
+
+- When to follow an existing calendar instead of creating one
+- The "don't run a calendar for an org you aren't part of" guideline, and why
+- When you genuinely do need multiple calendars of your own
+- Why categories usually do the work of "multiple calendars" for a single community
+- How to wind down or merge a calendar if you decide later you didn't need it


### PR DESCRIPTION
## Summary

Stands up the calendar-owners guide section in the VitePress docs site with the first two written guides and supporting tooling.

- **Quickstart** (`docs/guides/calendar-owners/quickstart.md`) — walks a new user from login to a published event with one shareable URL.
- **Post a recurring event** (`docs/guides/calendar-owners/recurring-events.md`) — covers schedule setup, exceptions, cancellations, ending recurrences, when to use a series instead, and common stumbles.
- **Section scaffold** (`docs/guides/calendar-owners/index.md` and the rest of the directory's placeholders) — sidebar structure for the remaining calendar-owner guides.
- **Tip-box styling** — lightbulb icon and blue accent for `::: tip` blocks in `docs/.vitepress/theme/`.
- **\`<Btn>\` pill component** — inline pill with a \`currentColor\` border for clickable button references in the docs, distinct from bolded form-field labels and section headers. Currently applied in the quickstart and recurring-events guides; ready to roll out across the rest of the section.

## Test plan

- [ ] \`npm run docs:dev\` and walk the quickstart and recurring-events guides end-to-end
- [ ] Verify \`<Btn>\` pills render correctly in light and dark modes
- [ ] Verify tip boxes show the lightbulb icon and blue accent
- [ ] \`npm run docs:build\` succeeds with no broken links or unresolved components