### PR TITLE
fix(calendar): scope event-detail categories to the display calendar

### DIFF
--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -270,8 +270,8 @@ export default class CalendarInterface {
     return this.eventService.listEvents(calendar, options);
   }
 
-  async getEventById(eventId: string): Promise<CalendarEvent> {
-    return this.eventService.getEventById(eventId);
+  async getEventById(eventId: string, displayCalendarId?: string): Promise<CalendarEvent> {
+    return this.eventService.getEventById(eventId, displayCalendarId);
   }
 
   async createEvent(account: Account, eventParams: Record<string, any>): Promise<CalendarEvent> {
@@ -418,8 +418,9 @@ export default class CalendarInterface {
   async findOrMaterializeInstanceWithDetails(
     eventId: string,
     startTime: DateTime,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance | null> {
-    return this.eventInstanceService.findOrMaterializeInstanceWithDetails(eventId, startTime);
+    return this.eventInstanceService.findOrMaterializeInstanceWithDetails(eventId, startTime, displayCalendarId);
   }
 
   /**

--- a/src/server/calendar/service/event_instance.ts
+++ b/src/server/calendar/service/event_instance.ts
@@ -524,9 +524,17 @@ export default class EventInstanceService {
    * Schedules are stripped at the public API boundary (see toPublicEventObject)
    * so they never reach the wire — populating them here is safe for both
    * internal consumers and the public detail page.
+   *
+   * @param displayCalendarId - Optional. When the caller knows the display
+   *   calendar (e.g. the public detail handler resolved it from a `?calendar=`
+   *   query param), pass its id so reposted events show that calendar's
+   *   category mappings. Under the single-producer model the row's
+   *   `calendar_id` is always the originating calendar, so without an explicit
+   *   override repost categories on the display calendar are filtered out.
    */
   private async hydrateInstanceEntity(
     eventInstance: EventInstanceEntity,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance> {
     const instance = eventInstance.toModel();
     const event = eventInstance.event;
@@ -542,17 +550,19 @@ export default class EventInstanceService {
       instance.event.location = event.location.toModel();
     }
 
-    // Populate categories via the category service, filtered to the display calendar
-    // so reposted events only show the display calendar's categories
+    // Populate categories via the category service, filtered to the display
+    // calendar so reposted events only show the display calendar's categories.
+    // Caller-supplied displayCalendarId wins; otherwise fall back to the row's
+    // calendar_id (the originating calendar under the single-producer model).
     instance.event.categories = await this.categoryService.getEventCategories(
       instance.event.id,
-      eventInstance.calendar_id,
+      displayCalendarId ?? eventInstance.calendar_id,
     );
 
     // Resolve source calendar information for reposted events
     const repostContext: RepostContext = {
       event: instance.event,
-      displayCalendarId: eventInstance.calendar_id,
+      displayCalendarId: displayCalendarId ?? eventInstance.calendar_id,
       eventCalendarId: eventInstance.event?.calendar_id ?? null,
       sourceCalendarUrlName: eventInstance.event?.calendar?.url_name,
     };
@@ -642,11 +652,16 @@ export default class EventInstanceService {
    *
    * @param eventId - The owning event ID
    * @param startTime - Occurrence start datetime (minute precision)
+   * @param displayCalendarId - Optional display calendar id (e.g. resolved from
+   *   a `?calendar=urlName` query param). Forwarded to hydration so reposted
+   *   events show category mappings on the display calendar rather than the
+   *   originating calendar.
    * @returns Hydrated CalendarEventInstance or null if not found / invalid
    */
   async findOrMaterializeInstanceWithDetails(
     eventId: string,
     startTime: DateTime,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance | null> {
     const startMs = startTime.toUTC().toMillis();
     const startDate = new Date(startMs);
@@ -670,7 +685,7 @@ export default class EventInstanceService {
       // Short-circuit: do not re-validate against the RRuleSet. Materialized
       // rows are authoritative; a subsequent schedule edit that would now
       // reject this date does not invalidate a pre-existing bookmark.
-      return this.hydrateInstanceEntity(cached);
+      return this.hydrateInstanceEntity(cached, displayCalendarId);
     }
 
     // 2. Load the event with BOTH schedules and the detail-page associations
@@ -721,7 +736,7 @@ export default class EventInstanceService {
       }
       // Shown cancellation: build a transient in-memory instance directly
       // from the already-loaded eventEntity. No second fetch, no persistence.
-      return this.buildTransientCancelledInstance(eventEntity, startTime);
+      return this.buildTransientCancelledInstance(eventEntity, startTime, displayCalendarId);
     }
 
     // 6. Materialization cap.
@@ -774,7 +789,7 @@ export default class EventInstanceService {
       }],
     });
     if (!persisted) return null;
-    return this.hydrateInstanceEntity(persisted);
+    return this.hydrateInstanceEntity(persisted, displayCalendarId);
   }
 
   /**
@@ -808,6 +823,7 @@ export default class EventInstanceService {
   private async buildTransientCancelledInstance(
     eventEntity: EventEntity,
     startTime: DateTime,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance> {
     const eventModel = eventEntity.toModel();
     const scheduleEntities = (eventEntity.getDataValue('schedules') ?? []) as EventScheduleEntity[];
@@ -817,7 +833,7 @@ export default class EventInstanceService {
     }
     eventModel.categories = await this.categoryService.getEventCategories(
       eventModel.id,
-      eventEntity.calendar_id,
+      displayCalendarId ?? eventEntity.calendar_id,
     );
 
     const endTime = this.computeOccurrenceEndTime(eventModel, startTime);
@@ -831,7 +847,7 @@ export default class EventInstanceService {
 
     const repostContext: RepostContext = {
       event: instance.event,
-      displayCalendarId: eventEntity.calendar_id,
+      displayCalendarId: displayCalendarId ?? eventEntity.calendar_id,
       eventCalendarId: eventEntity.calendar_id ?? null,
       sourceCalendarUrlName: eventEntity.calendar?.url_name,
     };

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1326,7 +1326,17 @@ class EventService {
     }
   }
 
-  async getEventById(eventId: string): Promise<CalendarEvent> {
+  /**
+   * Look up an event by id, eagerly loading content/location/schedules/media/series.
+   *
+   * @param eventId - The event id to fetch
+   * @param displayCalendarId - Optional display calendar id. When provided,
+   *   categories are filtered to assignments on that calendar so reposted
+   *   events display the reposting calendar's category mappings rather than
+   *   the originating calendar's. The public detail handler resolves this
+   *   from the `?calendar=urlName` query param.
+   */
+  async getEventById(eventId: string, displayCalendarId?: string): Promise<CalendarEvent> {
     // Validate eventId parameter
     if (!eventId || (typeof eventId === 'string' && eventId.trim() === '')) {
       throw new ValidationError('eventId is required');
@@ -1366,7 +1376,7 @@ class EventService {
       e.media = event.media.toModel();
     }
 
-    e.categories = await this.categoryService.getEventCategories(event.id);
+    e.categories = await this.categoryService.getEventCategories(event.id, displayCalendarId);
 
     return e;
   }

--- a/src/server/calendar/test/service/event_instance.test.ts
+++ b/src/server/calendar/test/service/event_instance.test.ts
@@ -1402,6 +1402,39 @@ describe('EventInstanceService.findOrMaterializeInstanceWithDetails', () => {
     expect(result!.start.toMillis()).toBe(MATCHING_START.toMillis());
   });
 
+  it('forwards an explicit displayCalendarId to getEventCategories so reposted events resolve display-calendar mappings', async () => {
+    const eventEntity = buildEventWithWeeklyMondaySchedule();
+    const cached = buildCachedInstanceEntity(eventEntity, MATCHING_START);
+    sandbox.stub(EventInstanceEntity, 'findOne').resolves(cached);
+
+    // Replace the no-arg stub with one we can inspect — the row's calendar_id
+    // is the originating calendar but the caller passes a different display
+    // calendar id (the repost target). The override must win.
+    (service['categoryService'].getEventCategories as sinon.SinonStub).restore();
+    const categoryStub = sandbox.stub(service['categoryService'], 'getEventCategories').resolves([]);
+
+    await service.findOrMaterializeInstanceWithDetails(EVENT_ID, MATCHING_START, 'display-cal-id');
+
+    expect(categoryStub.calledOnce).toBe(true);
+    const [, calendarIdArg] = categoryStub.firstCall.args;
+    expect(calendarIdArg).toBe('display-cal-id');
+  });
+
+  it('falls back to the row calendar_id when no displayCalendarId override is provided', async () => {
+    const eventEntity = buildEventWithWeeklyMondaySchedule();
+    const cached = buildCachedInstanceEntity(eventEntity, MATCHING_START);
+    sandbox.stub(EventInstanceEntity, 'findOne').resolves(cached);
+
+    (service['categoryService'].getEventCategories as sinon.SinonStub).restore();
+    const categoryStub = sandbox.stub(service['categoryService'], 'getEventCategories').resolves([]);
+
+    await service.findOrMaterializeInstanceWithDetails(EVENT_ID, MATCHING_START);
+
+    expect(categoryStub.calledOnce).toBe(true);
+    const [, calendarIdArg] = categoryStub.firstCall.args;
+    expect(calendarIdArg).toBe(CALENDAR_ID);
+  });
+
   it('short-circuits RRule validation on cache hit', async () => {
     // Even if the current schedule would reject the date, a pre-existing row
     // is authoritative: the RRule-check must not be invoked on the cache-hit

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -409,7 +409,13 @@ export default class CalendarRoutes {
 
   async getEvent(req: Request, res: Response) {
     const eventId = req.params.id;
-    const event = await this.service.getEventById(eventId);
+
+    // Optional `?calendar=<urlName>` scopes category mappings to the display
+    // calendar. Without this, reposted events would expose the originating
+    // calendar's categories instead of the calendar the visitor is viewing.
+    const displayCalendarId = await this.resolveDisplayCalendarId(req.query.calendar);
+
+    const event = await this.service.getEventById(eventId, displayCalendarId);
     if ( event ) {
       res.json(toPublicEventObject(event.toObject()));
     }
@@ -419,6 +425,20 @@ export default class CalendarRoutes {
         errorName: 'EventNotFoundError',
       });
     }
+  }
+
+  /**
+   * Resolve a `?calendar=<urlName>` query param to a calendar id, or undefined.
+   * Silently ignores unknown / malformed values so a bad query string never
+   * 404s the detail page; the handler simply falls back to the originating
+   * calendar's categories (the prior behavior).
+   */
+  private async resolveDisplayCalendarId(rawCalendar: unknown): Promise<string | undefined> {
+    if (typeof rawCalendar !== 'string') return undefined;
+    const urlName = rawCalendar.trim();
+    if (!urlName) return undefined;
+    const calendar = await this.service.getCalendarByName(urlName);
+    return calendar?.id;
   }
 
   async getEventInstance(req: Request, res: Response) {
@@ -448,7 +468,15 @@ export default class CalendarRoutes {
     }
 
     try {
-      const instance = await this.service.findOrMaterializeInstanceWithDetails(eventId, startTime);
+      // Optional `?calendar=<urlName>` scopes category mappings to the display
+      // calendar so reposted events show the reposting calendar's categories.
+      const displayCalendarId = await this.resolveDisplayCalendarId(req.query.calendar);
+
+      const instance = await this.service.findOrMaterializeInstanceWithDetails(
+        eventId,
+        startTime,
+        displayCalendarId,
+      );
       if (!instance) {
         res.status(404).json({
           "error": "instance not found",

--- a/src/server/public/interface/index.ts
+++ b/src/server/public/interface/index.ts
@@ -34,8 +34,8 @@ export default class PublicCalendarInterface {
     return this.publicCalendarService.listEventInstances(calendar);
   }
 
-  async getEventById(eventId: string): Promise<CalendarEvent> {
-    return this.calendarInterface.getEventById(eventId);
+  async getEventById(eventId: string, displayCalendarId?: string): Promise<CalendarEvent> {
+    return this.calendarInterface.getEventById(eventId, displayCalendarId);
   }
 
   /**
@@ -51,12 +51,17 @@ export default class PublicCalendarInterface {
    * Find or materialize an event instance by (eventId, startTime) for the
    * public detail page. Delegates to the calendar domain via its interface;
    * Public domain does not import calendar services directly.
+   *
+   * @param displayCalendarId - Optional display calendar id (resolved from a
+   *   `?calendar=urlName` query param by the handler). Forwarded so reposted
+   *   events show the display calendar's category mappings.
    */
   async findOrMaterializeInstanceWithDetails(
     eventId: string,
     startTime: DateTime,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance | null> {
-    return this.publicCalendarService.findOrMaterializeInstanceWithDetails(eventId, startTime);
+    return this.publicCalendarService.findOrMaterializeInstanceWithDetails(eventId, startTime, displayCalendarId);
   }
 
   async listCategoriesForCalendar(

--- a/src/server/public/service/calendar.ts
+++ b/src/server/public/service/calendar.ts
@@ -202,8 +202,9 @@ export default class PublicCalendarService {
   async findOrMaterializeInstanceWithDetails(
     eventId: string,
     startTime: DateTime,
+    displayCalendarId?: string,
   ): Promise<CalendarEventInstance | null> {
-    return this.calendarInterface.findOrMaterializeInstanceWithDetails(eventId, startTime);
+    return this.calendarInterface.findOrMaterializeInstanceWithDetails(eventId, startTime, displayCalendarId);
   }
 
   /**

--- a/src/server/public/test/events-api.test.ts
+++ b/src/server/public/test/events-api.test.ts
@@ -418,6 +418,42 @@ describe('Public API - toPublicEventObject shape contract', () => {
       });
       assertMediaProjection(response.body.media);
     });
+
+    it('forwards ?calendar=<urlName> as displayCalendarId so reposted-event categories scope to the display calendar', async () => {
+      const displayCalendar = new Calendar('display-cal-id', 'mitown');
+      const event = new CalendarEvent('event-1', 'source-cal-id');
+      event.schedules = [];
+
+      const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(displayCalendar);
+      const eventStub = apiSandbox.stub(publicInterface, 'getEventById').resolves(event);
+
+      router.get('/handler/:id', (req, res) => {
+        routes.getEvent(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler/event-1?calendar=mitown');
+
+      expect(response.status).toBe(200);
+      expect(calendarStub.calledOnceWith('mitown')).toBe(true);
+      expect(eventStub.calledOnceWith('event-1', 'display-cal-id')).toBe(true);
+    });
+
+    it('silently ignores an unknown ?calendar=<urlName> and falls back to default category scoping', async () => {
+      const event = new CalendarEvent('event-1', 'source-cal-id');
+      event.schedules = [];
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(null);
+      const eventStub = apiSandbox.stub(publicInterface, 'getEventById').resolves(event);
+
+      router.get('/handler/:id', (req, res) => {
+        routes.getEvent(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler/event-1?calendar=ghost');
+
+      expect(response.status).toBe(200);
+      expect(eventStub.calledOnceWith('event-1', undefined)).toBe(true);
+    });
   });
 
   describe('getEventInstance', () => {
@@ -537,6 +573,30 @@ describe('Public API - toPublicEventObject shape contract', () => {
       expect(eventIdArg).toBe(EVENT_UUID);
       // Slug 20260508-1800 = UTC 2026-05-08T18:00Z
       expect(startArg.toUTC().toISO()).toBe('2026-05-08T18:00:00.000Z');
+    });
+
+    it('forwards ?calendar=<urlName> as displayCalendarId for reposted-event category scoping', async () => {
+      const displayCalendar = new Calendar('display-cal-id', 'mitown');
+      const event = new CalendarEvent('event-1', 'source-cal-id');
+      event.schedules = [];
+      const instance = new CalendarEventInstance('inst-1', event, DateTime.utc(2026, 5, 8, 18, 0), null);
+
+      const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(displayCalendar);
+      const stub = apiSandbox.stub(publicInterface, 'findOrMaterializeInstanceWithDetails').resolves(instance);
+
+      router.get('/handler/:eventId/:startTime', (req, res) => {
+        routes.getEventInstance(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .get(`/handler/${EVENT_UUID}/${VALID_SLUG}?calendar=mitown`);
+
+      expect(response.status).toBe(200);
+      expect(calendarStub.calledOnceWith('mitown')).toBe(true);
+      expect(stub.calledOnce).toBe(true);
+      const [eventIdArg, _startArg, displayCalendarIdArg] = stub.firstCall.args;
+      expect(eventIdArg).toBe(EVENT_UUID);
+      expect(displayCalendarIdArg).toBe('display-cal-id');
     });
   });
 

--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -74,7 +74,7 @@ onBeforeMount(async () => {
       return;
     }
 
-    state.instance = await calendarService.loadEventInstance(eventId, parsedStartTime);
+    state.instance = await calendarService.loadEventInstance(eventId, parsedStartTime, state.calendar.urlName);
     if (!state.instance) {
       state.notFound = true;
       return;

--- a/src/site/components/event.vue
+++ b/src/site/components/event.vue
@@ -128,7 +128,7 @@ onBeforeMount(async () => {
     }
     else {
       // Load events for this calendar
-      state.event = await calendarService.loadEvent(eventId);
+      state.event = await calendarService.loadEvent(eventId, state.calendar.urlName);
       if (!state.event) {
         state.notFound = true;
         return;

--- a/src/site/service/calendar.ts
+++ b/src/site/service/calendar.ts
@@ -93,19 +93,28 @@ export default class CalendarService {
    * `/api/public/v1/events/:eventId/instances/:startTime`. The DateTime is
    * converted to UTC before formatting, so callers may pass a zoned value.
    *
+   * When `calendarUrlName` is supplied it is forwarded as `?calendar=<urlName>`
+   * so the backend scopes category mappings to that display calendar — needed
+   * for reposted events where the originating calendar's categories should be
+   * suppressed in favor of the reposting calendar's.
+   *
    * @param eventId - The parent event id (UUID)
    * @param startTime - The instance's start time; converted to UTC for the slug
+   * @param calendarUrlName - Optional display calendar URL name
    * @returns The loaded instance, or `null` if the backend returned 404
    */
   async loadEventInstance(
     eventId: string,
     startTime: DateTime,
+    calendarUrlName?: string,
   ): Promise<CalendarEventInstance | null> {
     try {
       const slug = formatInstanceSlug(startTime);
-      const instance = await ModelService.getModel(
-        `/api/public/v1/events/${eventId}/instances/${slug}`,
-      );
+      const path = `/api/public/v1/events/${eventId}/instances/${slug}`;
+      const url = calendarUrlName
+        ? `${path}?calendar=${encodeURIComponent(calendarUrlName)}`
+        : path;
+      const instance = await ModelService.getModel(url);
       if (instance) {
         const calendarEvent = CalendarEventInstance.fromObject(instance);
         this.eventStore.addEvent(calendarEvent);
@@ -120,9 +129,13 @@ export default class CalendarService {
   }
 
 
-  async loadEvent(eventId: string): Promise<CalendarEvent|null> {
+  async loadEvent(eventId: string, calendarUrlName?: string): Promise<CalendarEvent|null> {
     try {
-      const event = await ModelService.getModel(`/api/public/v1/events/${eventId}`);
+      const path = `/api/public/v1/events/${eventId}`;
+      const url = calendarUrlName
+        ? `${path}?calendar=${encodeURIComponent(calendarUrlName)}`
+        : path;
+      const event = await ModelService.getModel(url);
       if (event) {
         const calendarEvent = CalendarEvent.fromObject(event);
         return calendarEvent;

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -9,6 +9,7 @@ import { useWidgetStore } from '../stores/widgetStore';
 import NotFound from '@/site/components/not-found.vue';
 import EventDetailBody from '@/site/components/EventDetailBody.vue';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
+import type { EventCategory } from '@/common/model/event_category';
 
 const { t } = useTranslation('system');
 const route = useRoute();
@@ -35,6 +36,19 @@ const goBack = () => {
     params: { urlName: widgetStore.calendarUrlName! },
   });
 };
+
+/**
+ * Builds a widget-scoped category filter href that returns to the widget
+ * calendar list pre-filtered by the chosen category. Uses the resolved
+ * router URL so the iframe-aware base path is preserved.
+ */
+function categoryHrefBuilder(category: EventCategory): string {
+  return router.resolve({
+    name: 'widget-calendar',
+    params: { urlName: widgetStore.calendarUrlName! },
+    query: { categories: category.id },
+  }).href;
+}
 
 onBeforeMount(async () => {
   try {
@@ -66,6 +80,7 @@ onBeforeMount(async () => {
       const instance = await calendarService.loadEventInstance(
         eventId as string,
         parsedStartTime,
+        calendarId as string,
       );
       if (!instance) {
         state.notFound = true;
@@ -135,6 +150,7 @@ onBeforeMount(async () => {
         <EventDetailBody
           :instance="state.instance"
           :calendar="state.calendar"
+          :category-href-builder="categoryHrefBuilder"
         />
       </main>
     </div>

--- a/src/widget/test/event-detail-overlay.test.ts
+++ b/src/widget/test/event-detail-overlay.test.ts
@@ -236,7 +236,7 @@ describe('widget event-detail-overlay shell', () => {
     wrapper.unmount();
   });
 
-  it('passes the loaded instance and calendar to EventDetailBody, and omits categoryHrefBuilder', async () => {
+  it('passes the loaded instance, calendar, and a category href builder to EventDetailBody', async () => {
     const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
     const body = wrapper.findComponent({ name: 'EventDetailBody' });
@@ -244,8 +244,13 @@ describe('widget event-detail-overlay shell', () => {
     expect(body.props('instance')).toBeTruthy();
     expect((body.props('instance') as any).id).toBe('inst-1');
     expect((body.props('calendar') as any).urlName).toBe('test_calendar');
-    // Widget shell omits categoryHrefBuilder so categories render as <span>.
-    expect(body.props('categoryHrefBuilder')).toBeUndefined();
+    // Widget shell supplies a categoryHrefBuilder so categories render as
+    // clickable <a> badges that filter the widget calendar list.
+    const builder = body.props('categoryHrefBuilder') as ((c: { id: string }) => string) | undefined;
+    expect(typeof builder).toBe('function');
+    const href = builder!({ id: 'cat-123' } as any);
+    expect(href).toContain('/widget/test_calendar');
+    expect(href).toContain('categories=cat-123');
     wrapper.unmount();
   });
 });
@@ -301,10 +306,13 @@ describe('widget event-detail-overlay slug routing', () => {
     const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1/20260508-1800');
 
     expect(loadEventInstanceMock).toHaveBeenCalledTimes(1);
-    const [calledEventId, calledStartTime] = loadEventInstanceMock.mock.calls[0];
+    const [calledEventId, calledStartTime, calledCalendar] = loadEventInstanceMock.mock.calls[0];
     expect(calledEventId).toBe('evt-1');
     // parseInstanceSlug('20260508-1800') → 2026-05-08T18:00:00Z DateTime
     expect(calledStartTime.toISO()).toBe('2026-05-08T18:00:00.000Z');
+    // Calendar urlName forwarded so reposted-event categories scope to the
+    // display calendar via the backend's `?calendar=` query param.
+    expect(calledCalendar).toBe('test_calendar');
     // The fallback list-scan path must NOT run when the slug path is taken.
     expect(loadCalendarEventsMock).not.toHaveBeenCalled();
     wrapper.unmount();


### PR DESCRIPTION
## Summary

- Reposted events on the public detail page (`/view/:cal/events/:id` and `/view/:cal/events/:id/:slug`) returned `categories: []` because the detail handlers passed the row's `calendar_id` — always the originating calendar under the single-producer model — to `getEventCategories`, filtering out the reposting calendar's category mappings.
- Threads the display calendar through both detail endpoints via an optional `?calendar=<urlName>` query param. The site and widget detail shells forward the calendar URL name they already know.
- Widget overlay now supplies a `categoryHrefBuilder` so category badges render as clickable links into the filtered widget calendar list.

The categories were already laid out below the description in `EventDetailBody.vue`; the visible-on-mitown bug was strictly missing data on reposts. Repro URL: https://demo.pavillion.events/view/mitown/events/cc8be93e-edb9-423c-bb92-48ebb21ce7c3/20260507-2300 returned `categories: []` from `/api/public/v1/events/.../instances/...` even though the listing endpoint returned the same event with three mitown categories.

Closes pv-cfes

## Test plan

- [x] `npx vitest run src/server/public/test/events-api.test.ts src/server/calendar/test/service/event_instance.test.ts src/widget/test/event-detail-overlay.test.ts` (95 unit tests pass, including new coverage for query-param forwarding, service-layer override, and widget overlay clickable badges)
- [x] `npx vitest run --config vitest.integration.config.ts src/server/public/test/integration/event_instance_api.test.ts` (8 integration tests pass)
- [x] `npx eslint` on touched files — no new errors
- [ ] After deploy: visit the repro URL above and confirm categories appear below the description and link to `/view/mitown?categories=<id>`
- [ ] After deploy: visit a non-repost event detail and confirm categories still render
- [ ] After deploy: open the widget overlay and confirm clickable category badges navigate to the filtered widget list