### PR TITLE
docs: calendar-owners categories guide

### DIFF
--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -30,19 +30,17 @@ Once a category exists, it shows up in three places:
 - On your public calendar page, as a button in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
 - On the detail page of every event that uses it, as a clickable badge that takes the visitor back to the calendar filtered to similar events.
 
-To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single thing all along.
+To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single grouping after all.
 
 ## Designing the list
 
-A short, durable list works better than a long, descriptive one. Three reasons:
+A short, durable list works better than a long, descriptive one, for two reasons:
 
-**Visitors scan the filter row.** A list of six categories is a row people read in a glance. A list of thirty is a wall of text — and most filter rows on most pages get scrolled or wrapped, so the categories at the end might as well not be there.
+**Visitors scan the filter row.** A list of six categories is a row people read in a glance. A list of thirty is a wall of text — and most filter rows on most pages get scrolled, so the categories at the end might as well not be there.
 
-**Tagging shouldn't be a fresh decision every time.** Each event you publish, you pick its categories from your list. If the list is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") that pick becomes a small decision every time — and different editors will make those calls differently, so the same kind of event ends up under different labels. A coarser category ("Music") absorbs all three, makes the choice automatic, and keeps tagging consistent across the calendar.
+**Tagging shouldn't be a fresh decision every time.** Each event you publish, you pick its categories from your list. If the list is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") that pick becomes a small decision every time — and different editors will make those calls differently, so the same kind of event ends up under different labels. A coarser category ("Music") absorbs all four, makes the choice simple, and keeps tagging consistent across the calendar.
 
-**Other calendars are matching against your category names, not your event titles.** A specific event title can carry the detail. The category name is the bucket. Reach for the name that *most* events of that kind would still want to wear a year from now.
-
-A useful starting point is five to ten categories that cover the general shape of what you publish. *Music*, *Workshop*, *Community gathering*, *Volunteer*, *Talk*, *Family-friendly*, *Online* — you'll know your community's actual buckets better than any generic list. The point is the *count*, not the exact words.
+A useful starting point is five to ten categories that cover the general shape of what you publish. *Music*, *Workshop*, *Community gathering*, *Volunteer*, *Talk*, *Family-friendly*, *Online* — you'll know your community's actual buckets better than any generic list.
 
 ## When you're tempted to add a category
 
@@ -64,14 +62,14 @@ Renaming a category looks free from inside the editor — the change saves immed
 
 It is more of a deal than it looks, for two reasons.
 
-**Other calendars have rules wired up to your category names.** If another calendar is reposting your events onto theirs, they may have set up a rule that says "events from your-calendar tagged *Concert* go on our *Live Music* calendar." Renaming your *Concert* category to *Concerts & DJ Sets* breaks that rule until they notice and update it. Several reposting calendars means several broken rules. Your events still propagate (the underlying connection isn't broken), but they may land in the wrong category on the other end, or fall into a "needs review" pile that the other owner has to triage.
+**Other calendars have rules matching your category names.** If another calendar is reposting your events onto theirs, they may have set up a rule that says "events from your-calendar tagged *Concert* go on our *Live Music* category." Renaming your *Concert* category to *Concerts & DJ Sets* breaks that rule until they notice and update it. Several reposting calendars means several broken rules. Your events still propagate (the underlying connection isn't broken), but they may land in the wrong category on the other end, or fall into a "needs review" pile that the other owner has to triage.
 
-**Visitors and editors have built up muscle memory.** Regulars know your filter row. Co-editors know which category to pick for a given event. Renaming or splitting a category invalidates that knowledge — every editor relearns the list, every visitor wonders where *Music* went and why everything is now under *Sound*.
+**Visitors and editors have built up muscle memory.** Regulars know your filters. Co-editors know which category to pick for a given event. Renaming or splitting a category invalidates that knowledge — every editor relearns the list, every visitor wonders where *Music* went and why everything is now under *Sound*.
 
-Both of these argue for the same thing: pick category names that age well. Names tied to the kind of event ("Concert," "Workshop") age better than names tied to a moment ("Summer 2026 series"). Names that other communities would also recognize ("Volunteer day") age better than insider terminology ("Stewardship hours"). Names short enough to fit in a filter button on a phone screen age better than long ones that will get truncated.
+Pick category names that age well. Names tied to the kind of event ("Concert," "Workshop") age better than names tied to a moment ("Summer 2026 series"). Names that other communities would also recognize ("Volunteer day") age better than insider terminology ("Stewardship hours"). Names short enough to fit in a filter button on a phone screen age better than long ones that will get truncated.
 
 When you do need to change a name, the editor's pencil icon updates the label without disturbing the events on it. That's the right tool for a small fix — correcting a typo, adjusting capitalization, refining a translation. For bigger restructurings — collapsing two categories into one, splitting one into two — the merge and migrate tools in the category list are designed for exactly that work, and they'll handle the event reassignments in one move rather than one event at a time.
 
 ::: tip <Lightbulb /> A note on the first month.
-The category list you set up in the first weeks of a new calendar is a draft, not a commitment. Watch what kinds of events you actually publish for a month or two before treating the list as fixed. The categories you'll use most are usually obvious by then — and the ones you'll never use again are obvious too. A small cleanup in month two costs much less than a big restructuring in year two.
+The category list you set up in the first weeks of a new calendar is a draft, not a commitment. Watch what kinds of events you actually publish for a month or two before treating the list as fixed. The categories you'll use most are usually obvious by then — and the ones you'll never use again are obvious too.
 :::

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -31,7 +31,7 @@ Once a category exists, it shows up in two places:
 
 To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single thing all along.
 
-## Designing your vocabulary
+## Designing the list
 
 A short, durable list works better than a long, descriptive one. Three reasons:
 
@@ -43,39 +43,19 @@ A short, durable list works better than a long, descriptive one. Three reasons:
 
 A useful starting point is five to ten categories that cover the general shape of what you publish. *Music*, *Workshop*, *Community gathering*, *Volunteer*, *Talk*, *Family-friendly*, *Online* — you'll know your community's actual buckets better than any generic list. The point is the *count*, not the exact words.
 
-::: tip <Lightbulb /> A note on overlap.
-Events can carry more than one category. A workshop that's also a fundraiser doesn't need a *Workshop fundraisers* category — it can be tagged *Workshop* and *Fundraiser* both. When you find yourself wanting to combine two existing categories into a compound one, the answer is almost always "use both, separately."
-:::
+## When you're tempted to add a category
 
-## When to add a new category vs. extend an existing one
+A new event arrives that doesn't *quite* fit any existing category, and the impulse is to add a new one. Before you do, ask whether what you're trying to flag really is a category at all — most of the time the impulse is pointing at something that belongs in a different tool.
 
-Most calendars eventually face this judgment call: a new event arrives that doesn't *quite* fit any existing category. Something has to give.
+**Is this a detail of this one event?** The name of the band, the topic of the talk, the cuisine at the potluck — those are details of *this* event. They belong in the event's title or description, where they're searchable and where visitors actually read them. A category is for the *kind of thing* the event is, not for the specifics of what's happening at it.
 
-Three questions to ask, in order:
+**Is this a program of distinct events?** A summer concert series with a different artist each week, a fall lecture series with rotating speakers, a recurring book club where the topic changes each session — these are programs with several distinct events under them. The right tool is a series, which groups related events under one program name. Adding *Summer Concert Series* as a category just to find this year's events again creates a label that goes stale by definition.
 
-**Will this category have at least three or four events on it within the next year?** If yes, it's a real category. If no — if it's the one outdoor film screening you're hosting in August — don't make a category for it. Use an existing close-fit category and put the specifics in the event title and description. A category with one event on it does no work for visitors and drifts toward becoming dead weight.
+**Could the event carry two existing categories instead of one new one?** Events can carry more than one category. A workshop that's also a fundraiser doesn't need a *Workshop fundraisers* category — tag it *Workshop* and *Fundraiser* both. When you find yourself wanting to combine two existing categories into a compound one, the answer is usually to use them both, separately.
 
-**Will visitors filter for it?** *Concerts* is a category visitors filter for. *Tuesday-evening events* is not — visitors are not browsing your calendar by weekday. Categories that don't help a visitor find what they're looking for are using up filter-row space without earning it.
+If the event genuinely belongs in none of those, a new category may be the right move. One last practical check: will it have at least three or four events on it within the next year, and will visitors filter for it? A category with one event does no work for visitors and drifts toward becoming dead weight; a category nobody filters for ("Tuesday-evening events," "2026 season") uses up filter-row space without earning it.
 
-**Could the existing category absorb it without losing meaning?** If the new event is "a slightly different kind of workshop," and your *Workshop* category is broad enough to include it, the answer is to use *Workshop*. If it's a kind of thing that genuinely doesn't belong under any current label — a *Performance* in a calendar that previously only ran *Talks* and *Workshops* — that's when a new category earns its place.
-
-The bias should be toward fewer categories rather than more. It's easier to split a category later (one busy *Workshop* category becomes *Workshop* and *Class*) than to consolidate ten thin ones back down.
-
-## Why no free-form tags
-
-Pavillion doesn't have free-form tags — the kind of label where every event can have its own list of words and phrases attached. That's deliberate.
-
-Tags drift. *Live music*, *live-music*, *livemusic*, *concert*, *concerts*, and *gig* all describe the same thing, and on a tag-based system they all coexist as separate labels. Visitors filtering by *concerts* miss the events tagged *gig*. Search-by-tag becomes unreliable. Other calendars trying to repost your events get a different vocabulary on every event.
-
-Categories trade flexibility for shared meaning. The list is short, the names are stable, the same word means the same thing across every event on the calendar — and across the federated network when other calendars are deciding which of your events match theirs. That predictability is what makes filtering and matching work.
-
-If you find yourself reaching for a tag, there are usually two better tools:
-
-**Use the event title and description.** Specifics that apply to *this event* — the name of the band, the topic of the talk, the cuisine at the potluck — belong in the event itself. They're searchable in the description. They show up in the title where visitors actually read them. They don't need to live as a label.
-
-**Use a series.** A run of events that share an identity — a summer concert series, a fall lecture series, a recurring book club — is what a series is for. The series name groups related events on the public page without needing a category for each one.
-
-Between titles, descriptions, categories, and series, almost every reach-for-a-tag impulse turns out to belong somewhere else.
+The bias should be toward fewer categories rather than more. It's easier to split a busy *Workshop* category into *Workshop* and *Class* later than to consolidate ten thin ones back down.
 
 ## The cost of churning category names later
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -1,33 +1,33 @@
 # Organize events with categories
 
-Categories are the short list of buckets your events fall into — *Concert*, *Workshop*, *Community gathering*, *Volunteer day*. Visitors use them to filter your public page down to what they're looking for, and other calendars use them as the basis for matching when they repost your events alongside their own.
+Categories are the short list of buckets your events fall into — *Concert*, *Workshop*, *Community gathering*, *Volunteer days*. Visitors use them to filter your public page down to what they're looking for, and other calendars use them as the basis for matching when they repost your events alongside their own.
 
-The list is short on purpose. A small, durable category vocabulary is one of the highest-leverage decisions you'll make as a calendar owner — and one that's hard to undo well. This guide is about designing that vocabulary so it serves you over time.
+Your category list should be short. A small, durable category vocabulary is one of the highest-leverage decisions you'll make as a calendar owner. This guide is about designing that vocabulary so it serves you over time.
 
 ## What categories do
 
 Three jobs:
 
-**Filter the public page.** Visitors browsing your calendar see a row of category pills above the events. Clicking *Concerts* hides everything that isn't a concert. A casual visitor who came looking for something specific finds it faster; a regular who wants the full picture leaves the filter alone. Either way, categories are the main way visitors *narrow down* a busy calendar.
+**Filter the public page.** Visitors browsing your calendar see a row of category buttons above the events. Clicking *Concerts* hides everything that isn't a concert. Categories are the main way visitors *narrow down* a busy calendar.
 
-**Jump from one event to related events.** On every event's detail page, the categories it carries appear as clickable badges. A visitor reading about Tuesday's concert can click *Concert* and land back on the calendar filtered to every other concert you've published. It's the "more like this" path — different from the filter row in that the visitor enters from a specific event they were already interested in, not from the top of the calendar. This is where stable category names earn their keep: if last month's *Live Music* and this month's *Concerts* are technically the same kind of event under different labels, the jump from one to the other doesn't work.
+**Jump from one event to related events.** On every event's detail page, the categories it carries appear as clickable links. A visitor reading about Tuesday's concert can click *Concert* and land back on the calendar filtered to every other concert you've published. It's the "more like this" path. This is where consistent category names are valuable: if last month's *Live Music* and this month's *Concerts* are technically the same kind of event under different labels, the jump from one to the other doesn't work.
 
-**Give other calendars something to match against.** When another calendar reposts an event from yours, their categories rarely line up with yours one-to-one — your *Concerts* might be their *Live Music*, your *Workshops* might be their *Classes*. Category names are the signal each calendar uses to translate between vocabularies. Stable, recognizable category names mean other calendars can route your events to the right place on theirs without you (or them) doing it by hand every time.
+**Give other calendars something to match against.** When another calendar reposts an event from yours, their categories rarely line up with yours one-to-one — your *Concerts* might be their *Live Music*, your *Workshops* might be their *Classes*. Category names are the signal each calendar uses to translate between vocabularies. Stable, recognizable category names mean other organizers can route your events to the right place on their calendars without you (or them) doing it by hand every time.
 
-Categories don't appear in the event title or description. They're metadata — sorting, navigation, and matching information — not part of the event copy. They're also not strictly required; an event with no categories will still publish. But it won't show up when visitors filter, won't appear under "more like this" on a related event, and won't have anything for other calendars to match against — which is enough reason to tag every event.
+Categories aren't strictly required; an event with no categories will still publish. But it won't show up when visitors filter, won't appear under "more like this" on a related event, and won't have anything for other calendars to match against — which is enough reason to tag every event.
 
 ## Create a category
 
 Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Categories** tab. The first time you visit, the list is empty.
 
-Click <Btn>+ Add category</Btn>. A small editor opens with one field: a name. Type the category name — *Concert*, *Workshop*, *Volunteer day* — and click <Btn>Create</Btn>. The new category appears in the list with an event count of zero.
+Click <Btn>+ Add category</Btn>. A small editor opens with one field: a name. Type the category name — *Concert*, *Workshop*, *Volunteer days* — and click <Btn>Create</Btn>. The new category appears in the list with an event count of zero.
 
 If your calendar publishes in more than one language, the editor lets you provide the category name in each — click <Btn>+ Add language</Btn>, pick the language, and fill in the translation. A *Workshop* category in English becomes *Atelier* for visitors browsing the page in French. The category itself is one thing with multiple labels, not multiple categories.
 
 Once a category exists, it shows up in three places:
 
 - In the **Categories** section of the event editor, where you check the categories that apply to the event you're creating or editing.
-- On your public calendar page, as a pill in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
+- On your public calendar page, as a button in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
 - On the detail page of every event that uses it, as a clickable badge that takes the visitor back to the calendar filtered to similar events.
 
 To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single thing all along.
@@ -68,7 +68,7 @@ It is more of a deal than it looks, for two reasons.
 
 **Visitors and editors have built up muscle memory.** Regulars know your filter row. Co-editors know which category to pick for a given event. Renaming or splitting a category invalidates that knowledge — every editor relearns the list, every visitor wonders where *Music* went and why everything is now under *Sound*.
 
-Both of these argue for the same thing: pick category names that age well. Names tied to the kind of event ("Concert," "Workshop") age better than names tied to a moment ("Summer 2026 series"). Names that other communities would also recognize ("Volunteer day") age better than insider terminology ("Stewardship hours"). Names short enough to fit in a filter pill on a phone screen age better than long ones that will get truncated.
+Both of these argue for the same thing: pick category names that age well. Names tied to the kind of event ("Concert," "Workshop") age better than names tied to a moment ("Summer 2026 series"). Names that other communities would also recognize ("Volunteer day") age better than insider terminology ("Stewardship hours"). Names short enough to fit in a filter button on a phone screen age better than long ones that will get truncated.
 
 When you do need to change a name, the editor's pencil icon updates the label without disturbing the events on it. That's the right tool for a small fix — correcting a typo, adjusting capitalization, refining a translation. For bigger restructurings — collapsing two categories into one, splitting one into two — the merge and migrate tools in the category list are designed for exactly that work, and they'll handle the event reassignments in one move rather than one event at a time.
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -6,13 +6,15 @@ The list is short on purpose. A small, durable category vocabulary is one of the
 
 ## What categories do
 
-Two jobs:
+Three jobs:
 
 **Filter the public page.** Visitors browsing your calendar see a row of category pills above the events. Clicking *Concerts* hides everything that isn't a concert. A casual visitor who came looking for something specific finds it faster; a regular who wants the full picture leaves the filter alone. Either way, categories are the main way visitors *narrow down* a busy calendar.
 
+**Jump from one event to related events.** On every event's detail page, the categories it carries appear as clickable badges. A visitor reading about Tuesday's concert can click *Concert* and land back on the calendar filtered to every other concert you've published. It's the "more like this" path — different from the filter row in that the visitor enters from a specific event they were already interested in, not from the top of the calendar. This is where stable category names earn their keep: if last month's *Live Music* and this month's *Concerts* are technically the same kind of event under different labels, the jump from one to the other doesn't work.
+
 **Give other calendars something to match against.** When another calendar reposts an event from yours, their categories rarely line up with yours one-to-one — your *Concerts* might be their *Live Music*, your *Workshops* might be their *Classes*. Category names are the signal each calendar uses to translate between vocabularies. Stable, recognizable category names mean other calendars can route your events to the right place on theirs without you (or them) doing it by hand every time.
 
-Categories don't appear in the event title or description. They're metadata — sorting and matching information — not part of the event copy.
+Categories don't appear in the event title or description. They're metadata — sorting, navigation, and matching information — not part of the event copy.
 
 ## Create a category
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -38,7 +38,7 @@ A short, durable list works better than a long, descriptive one. Three reasons:
 
 **Visitors scan the filter row.** A list of six categories is a row people read in a glance. A list of thirty is a wall of text — and most filter rows on most pages get scrolled or wrapped, so the categories at the end might as well not be there.
 
-**Tagging shouldn't be a fresh decision every time.** Each event you publish, you pick its categories from your list. If the list is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") that pick becomes a small decision every time — and different editors will make those calls differently, so the same kind of event ends up under different labels. A coarser list ("Concerts," "Open Mic") makes the choice automatic and keeps tagging consistent across the calendar.
+**Tagging shouldn't be a fresh decision every time.** Each event you publish, you pick its categories from your list. If the list is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") that pick becomes a small decision every time — and different editors will make those calls differently, so the same kind of event ends up under different labels. A coarser category ("Music") absorbs all three, makes the choice automatic, and keeps tagging consistent across the calendar.
 
 **Other calendars are matching against your category names, not your event titles.** A specific event title can carry the detail. The category name is the bucket. Reach for the name that *most* events of that kind would still want to wear a year from now.
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -24,10 +24,11 @@ Click <Btn>+ Add category</Btn>. A small editor opens with one field: a name. Ty
 
 If your calendar publishes in more than one language, the editor lets you provide the category name in each — click <Btn>+ Add language</Btn>, pick the language, and fill in the translation. A *Workshop* category in English becomes *Atelier* for visitors browsing the page in French. The category itself is one thing with multiple labels, not multiple categories.
 
-Once a category exists, it shows up in two places:
+Once a category exists, it shows up in three places:
 
 - In the **Categories** section of the event editor, where you check the categories that apply to the event you're creating or editing.
 - On your public calendar page, as a pill in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
+- On the detail page of every event that uses it, as a clickable badge that takes the visitor back to the calendar filtered to similar events.
 
 To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single thing all along.
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -1,29 +1,94 @@
 # Organize events with categories
 
-> Status: stub. Full guide coming before launch.
+Categories are the short list of buckets your events fall into — *Concert*, *Workshop*, *Community gathering*, *Volunteer day*. Visitors use them to filter your public page down to what they're looking for, and other calendars use them as the basis for matching when they repost your events alongside their own.
 
-Categories are how visitors filter your calendar — and how other calendars decide which of your events match theirs when you're sharing across communities. A small, durable category vocabulary is one of the highest-leverage decisions you'll make as a calendar owner. This guide is about designing that vocabulary so it serves you over time.
+The list is short on purpose. A small, durable category vocabulary is one of the highest-leverage decisions you'll make as a calendar owner — and one that's hard to undo well. This guide is about designing that vocabulary so it serves you over time.
 
 ## What categories do
 
-Two jobs: filter UI for visitors browsing your public calendar, and the basis for matching when you share events with other calendars.
+Two jobs:
+
+**Filter the public page.** Visitors browsing your calendar see a row of category pills above the events. Clicking *Concerts* hides everything that isn't a concert. A casual visitor who came looking for something specific finds it faster; a regular who wants the full picture leaves the filter alone. Either way, categories are the main way visitors *narrow down* a busy calendar.
+
+**Give other calendars something to match against.** When another calendar reposts an event from yours, their categories rarely line up with yours one-to-one — your *Concerts* might be their *Live Music*, your *Workshops* might be their *Classes*. Category names are the signal each calendar uses to translate between vocabularies. Stable, recognizable category names mean other calendars can route your events to the right place on theirs without you (or them) doing it by hand every time.
+
+Categories don't appear in the event title or description. They're metadata — sorting and matching information — not part of the event copy.
 
 ## Create a category
 
-The mechanics, briefly.
+Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Categories** tab. The first time you visit, the list is empty.
+
+Click <Btn>+ Add category</Btn>. A small editor opens with one field: a name. Type the category name — *Concert*, *Workshop*, *Volunteer day* — and click <Btn>Create</Btn>. The new category appears in the list with an event count of zero.
+
+If your calendar publishes in more than one language, the editor lets you provide the category name in each — click <Btn>+ Add language</Btn>, pick the language, and fill in the translation. Visitors browsing the page in French see *Concert*; visitors browsing in English see whatever name you gave it in English. The category itself is one thing with multiple labels, not multiple categories.
+
+Once a category exists, it shows up in two places:
+
+- In the **Categories** section of the event editor, where you check the categories that apply to the event you're creating or editing.
+- On your public calendar page, as a pill in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
+
+To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single thing all along.
 
 ## Designing your vocabulary
 
-The harder, more important part. How to keep the list short, durable, and meaningful — and how to recognize when you're about to add a category you'll regret.
+A short, durable list works better than a long, descriptive one. Three reasons:
+
+**Visitors scan the filter row.** A list of six categories is a row people read in a glance. A list of thirty is a wall of text — and most filter rows on most pages get scrolled or wrapped, so the categories at the end might as well not be there.
+
+**Each event needs at least one category.** That's a rule the editor enforces. If your vocabulary is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") you'll spend more time deciding which one each event is than the visitor will spend reading them all. A coarser list ("Concerts," "Open Mic") makes the choice automatic.
+
+**Other calendars are matching against your category names, not your event titles.** A specific event title can carry the detail. The category name is the bucket. Reach for the name that *most* events of that kind would still want to wear a year from now.
+
+A useful starting point is five to ten categories that cover the general shape of what you publish. *Music*, *Workshop*, *Community gathering*, *Volunteer*, *Talk*, *Family-friendly*, *Online* — you'll know your community's actual buckets better than any generic list. The point is the *count*, not the exact words.
+
+::: tip <Lightbulb /> A note on overlap.
+Events can carry more than one category. A workshop that's also a fundraiser doesn't need a *Workshop fundraisers* category — it can be tagged *Workshop* and *Fundraiser* both. When you find yourself wanting to combine two existing categories into a compound one, the answer is almost always "use both, separately."
+:::
 
 ## When to add a new category vs. extend an existing one
 
-The judgment call most calendar owners eventually face.
+Most calendars eventually face this judgment call: a new event arrives that doesn't *quite* fit any existing category. Something has to give.
+
+Three questions to ask, in order:
+
+**Will this category have at least three or four events on it within the next year?** If yes, it's a real category. If no — if it's the one outdoor film screening you're hosting in August — don't make a category for it. Use an existing close-fit category and put the specifics in the event title and description. A category with one event on it does no work for visitors and drifts toward becoming dead weight.
+
+**Will visitors filter for it?** *Concerts* is a category visitors filter for. *Tuesday-evening events* is not — visitors are not browsing your calendar by weekday. Categories that don't help a visitor find what they're looking for are using up filter-row space without earning it.
+
+**Could the existing category absorb it without losing meaning?** If the new event is "a slightly different kind of workshop," and your *Workshop* category is broad enough to include it, the answer is to use *Workshop*. If it's a kind of thing that genuinely doesn't belong under any current label — a *Performance* in a calendar that previously only ran *Talks* and *Workshops* — that's when a new category earns its place.
+
+The bias should be toward fewer categories rather than more. It's easier to split a category later (one busy *Workshop* category becomes *Workshop* and *Class*) than to consolidate ten thin ones back down.
 
 ## Why no free-form tags
 
-Pavillion deliberately doesn't have tags. The reasons, and what to do when you'd reach for one.
+Pavillion doesn't have free-form tags — the kind of label where every event can have its own list of words and phrases attached. That's deliberate.
+
+Tags drift. *Live music*, *live-music*, *livemusic*, *concert*, *concerts*, and *gig* all describe the same thing, and on a tag-based system they all coexist as separate labels. Visitors filtering by *concerts* miss the events tagged *gig*. Search-by-tag becomes unreliable. Other calendars trying to repost your events get a different vocabulary on every event.
+
+Categories trade flexibility for shared meaning. The list is short, the names are stable, the same word means the same thing across every event on the calendar — and across the federated network when other calendars are deciding which of your events match theirs. That predictability is what makes filtering and matching work.
+
+If you find yourself reaching for a tag, there are usually two better tools:
+
+**Use the event title and description.** Specifics that apply to *this event* — the name of the band, the topic of the talk, the cuisine at the potluck — belong in the event itself. They're searchable in the description. They show up in the title where visitors actually read them. They don't need to live as a label.
+
+**Use a series.** A run of events that share an identity — a summer concert series, a fall lecture series, a recurring book club — is what a series is for. The series name groups related events on the public page without needing a category for each one.
+
+Between titles, descriptions, categories, and series, almost every reach-for-a-tag impulse turns out to belong somewhere else.
 
 ## The cost of churning category names later
 
-Why renaming a category isn't free, especially once other calendars are reposting your events.
+Renaming a category looks free from inside the editor — the change saves immediately, the events update, the public page reflects the new name on the next reload. It doesn't feel like a big deal.
+
+It is more of a deal than it looks, for two reasons.
+
+**Other calendars have rules wired up to your category names.** If another calendar is reposting your events onto theirs, they may have set up a rule that says "events from your-calendar tagged *Concert* go on our *Live Music* calendar." Renaming your *Concert* category to *Concerts & DJ Sets* breaks that rule until they notice and update it. Several reposting calendars means several broken rules. Your events still propagate (the underlying connection isn't broken), but they may land in the wrong category on the other end, or fall into a "needs review" pile that the other owner has to triage.
+
+**Visitors and editors have built up muscle memory.** Regulars know your filter row. Co-editors know which category to pick for a given event. Renaming or splitting a category invalidates that knowledge — every editor relearns the list, every visitor wonders where *Music* went and why everything is now under *Sound*.
+
+Both of these argue for the same thing: pick category names that age well. Names tied to the kind of event ("Concert," "Workshop") age better than names tied to a moment ("Summer 2026 series"). Names that other communities would also recognize ("Volunteer day") age better than insider terminology ("Stewardship hours"). Names short enough to fit in a filter pill on a phone screen age better than long ones that will get truncated.
+
+When you do need to change a name, the editor's pencil icon updates the label without disturbing the events on it. That's the right tool for a small fix — correcting a typo, adjusting capitalization, refining a translation. For bigger restructurings — collapsing two categories into one, splitting one into two — the merge and migrate tools in the category list are designed for exactly that work, and they'll handle the event reassignments in one move rather than one event at a time.
+
+::: tip <Lightbulb /> A note on the first month.
+The category list you set up in the first weeks of a new calendar is a draft, not a commitment. Watch what kinds of events you actually publish for a month or two before treating the list as fixed. The categories you'll use most are usually obvious by then — and the ones you'll never use again are obvious too. A small cleanup in month two costs much less than a big restructuring in year two.
+:::

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -22,7 +22,7 @@ Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Categorie
 
 Click <Btn>+ Add category</Btn>. A small editor opens with one field: a name. Type the category name — *Concert*, *Workshop*, *Volunteer day* — and click <Btn>Create</Btn>. The new category appears in the list with an event count of zero.
 
-If your calendar publishes in more than one language, the editor lets you provide the category name in each — click <Btn>+ Add language</Btn>, pick the language, and fill in the translation. Visitors browsing the page in French see *Concert*; visitors browsing in English see whatever name you gave it in English. The category itself is one thing with multiple labels, not multiple categories.
+If your calendar publishes in more than one language, the editor lets you provide the category name in each — click <Btn>+ Add language</Btn>, pick the language, and fill in the translation. A *Workshop* category in English becomes *Atelier* for visitors browsing the page in French. The category itself is one thing with multiple labels, not multiple categories.
 
 Once a category exists, it shows up in two places:
 

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -14,7 +14,7 @@ Three jobs:
 
 **Give other calendars something to match against.** When another calendar reposts an event from yours, their categories rarely line up with yours one-to-one — your *Concerts* might be their *Live Music*, your *Workshops* might be their *Classes*. Category names are the signal each calendar uses to translate between vocabularies. Stable, recognizable category names mean other calendars can route your events to the right place on theirs without you (or them) doing it by hand every time.
 
-Categories don't appear in the event title or description. They're metadata — sorting, navigation, and matching information — not part of the event copy.
+Categories don't appear in the event title or description. They're metadata — sorting, navigation, and matching information — not part of the event copy. They're also not strictly required; an event with no categories will still publish. But it won't show up when visitors filter, won't appear under "more like this" on a related event, and won't have anything for other calendars to match against — which is enough reason to tag every event.
 
 ## Create a category
 
@@ -37,7 +37,7 @@ A short, durable list works better than a long, descriptive one. Three reasons:
 
 **Visitors scan the filter row.** A list of six categories is a row people read in a glance. A list of thirty is a wall of text — and most filter rows on most pages get scrolled or wrapped, so the categories at the end might as well not be there.
 
-**Each event needs at least one category.** That's a rule the editor enforces. If your vocabulary is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") you'll spend more time deciding which one each event is than the visitor will spend reading them all. A coarser list ("Concerts," "Open Mic") makes the choice automatic.
+**Tagging shouldn't be a fresh decision every time.** Each event you publish, you pick its categories from your list. If the list is too granular ("Acoustic Folk Concert," "Indie Rock Concert," "Open Mic Night") that pick becomes a small decision every time — and different editors will make those calls differently, so the same kind of event ends up under different labels. A coarser list ("Concerts," "Open Mic") makes the choice automatic and keeps tagging consistent across the calendar.
 
 **Other calendars are matching against your category names, not your event titles.** A specific event title can carry the detail. The category name is the bucket. Reach for the name that *most* events of that kind would still want to wear a year from now.
 


### PR DESCRIPTION
## Summary

Adds the calendar-owners categories guide (pv-i2i0) and refines it through several rounds of editing. The final shape:

- **What categories do** — three concrete jobs: filtering the public page, jumping from one event to related events, and giving other calendars something to match against when reposting.
- **Create a category** — the editor flow, including translations and where the category surfaces (event editor, public filter row, event detail page).
- **Designing the list** — argues for a short, durable vocabulary on two grounds (visitor scanning and tagging consistency).
- **When you're tempted to add a category** — diagnostic questions for the "this doesn't quite fit" impulse, redirecting to event title/description, series, or multi-tagging.
- **The cost of churning category names later** — federation rules wired up to your category names break on rename; visitors and editors lose muscle memory; pick names that age well.

## Test plan

- [ ] Render the docs site locally and confirm the page renders without broken `<Btn>` / `<Lightbulb />` components or formatting glitches.
- [ ] Sanity-check internal cross-references (none introduced, but verify `/manage` and category-tab UX language matches the live UI).
- [ ] Read top-to-bottom for tone and flow.