### PR TITLE
fix(housekeeping): URL-encode credentials in pg-boss connection string

### DIFF
--- a/src/server/housekeeping/service/job-queue.ts
+++ b/src/server/housekeeping/service/job-queue.ts
@@ -59,11 +59,15 @@ export default class JobQueueService {
       return 'postgres://test:test@localhost:5432/test';
     }
 
-    const user = dbConfig.user || dbConfig.username || 'postgres';
-    const password = dbConfig.password || '';
+    // URL-encode credentials and database name so URL-special characters
+    // (e.g. @ : / ? # %) in a password don't produce a malformed connection
+    // string. pg-connection-string.parse() throws on invalid URLs, which
+    // crashes pg-boss start in worker mode.
+    const user = encodeURIComponent(dbConfig.user || dbConfig.username || 'postgres');
+    const password = encodeURIComponent(dbConfig.password || '');
     const host = dbConfig.host || 'localhost';
     const port = dbConfig.port || 5432;
-    const database = dbConfig.database || 'pavillion';
+    const database = encodeURIComponent(dbConfig.database || 'pavillion');
 
     return `postgres://${user}:${password}@${host}:${port}/${database}`;
   }

--- a/src/server/housekeeping/test/job-queue.test.ts
+++ b/src/server/housekeeping/test/job-queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { parse as parseConnectionString } from 'pg-connection-string';
 import JobQueueService from '@/server/housekeeping/service/job-queue';
 import PgBoss from 'pg-boss';
 
@@ -65,6 +66,28 @@ describe('JobQueueService', () => {
 
       expect(PgBoss.prototype.start).toHaveBeenCalledTimes(2);
       expect(PgBoss.prototype.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a connection string parseable by pg-connection-string when the password contains URL-special chars', async () => {
+      const tricky = new JobQueueService({
+        host: 'db',
+        port: 5432,
+        database: 'pavillion',
+        user: 'pavillion',
+        password: 'p@ss/word#1?two[three]',
+      });
+      await tricky.start();
+
+      const cs = (PgBoss as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as string;
+      expect(typeof cs).toBe('string');
+
+      // The whole point: this must not throw on a password full of URL-special chars.
+      const parsed = parseConnectionString(cs);
+      expect(parsed.user).toBe('pavillion');
+      expect(parsed.password).toBe('p@ss/word#1?two[three]');
+      expect(parsed.host).toBe('db');
+      expect(parsed.port).toBe('5432');
+      expect(parsed.database).toBe('pavillion');
     });
   });
 


### PR DESCRIPTION
## Motivation

The worker container has been crash-looping on instances whose `DB_PASSWORD` contains URL-special characters (`@ : / ? # % [ ]`). On startup, Sequelize connects fine, but `pg-boss` then throws:

```
TypeError: Cannot read properties of undefined (reading 'searchParams')
    at parse (/app/node_modules/pg-connection-string/index.js:39:30)
    at new ConnectionParameters (...)
    ...
    at PgBoss.start (/app/node_modules/pg-boss/src/index.js:119:30)
```

`JobQueueService.buildConnectionString` builds the connection URL via raw template-literal interpolation:

```ts
return `postgres://${user}:${password}@${host}:${port}/${database}`;
```

Any URL-special character in the password produces a malformed URL that `pg-connection-string` cannot parse, killing the worker before any job runs. Sequelize is unaffected because it passes credentials as separate fields to `pg`, never going through URL parsing.

This bug has likely silently disabled all background work on affected instances since the housekeeping feature shipped — backups, retention enforcement, IP cleanup, notifications cleanup, inbox cleanup, and disk monitoring all run from the worker.

## Approach

Wrap `user`, `password`, and `database` in `encodeURIComponent` before interpolation. `host` and `port` are config values in canonical form and don't need encoding.

This is the minimal surgical fix — no change to `pg-boss`'s API contract, no change to test mocking, no change to the SQLite-mode escape hatch.

## Validation

- New unit test in `src/server/housekeeping/test/job-queue.test.ts` constructs a `JobQueueService` with a deliberately tricky password (`p@ss/word#1?two[three]`) and asserts the resulting connection string round-trips through `pg-connection-string.parse()`, recovering the original password byte-for-byte.
- Reproduced the failure in a worker container before the fix using the same password — both `new URL(connectionString)` and `pg-connection-string.parse(connectionString)` failed with the exact errors seen in production logs.
- Local test runs:
  - lint: 0 errors
  - unit: 442 passed
  - integration: 561 passed (5 skipped)
  - housekeeping suite specifically: 104 passed across 11 files
  - build: passing
  - e2e: 131 passed; 2 pre-existing port-conflict failures unrelated to this change