### PR TITLE
docs: clarify rename-on-push convention in git-workflow skill

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Pavillion git and GitHub conventions for branches, commits, pull requests, and releases. Use when naming a branch, drafting a commit message, opening a pull request, or cutting a release.
+description: Pavillion git and GitHub conventions for branches, commits, pushes, pull requests, and releases. Use when naming a branch, drafting a commit message, pushing a branch to origin, opening a pull request, or cutting a release.
 ---
 
 # Git Workflow
@@ -17,6 +17,7 @@ GitHub artifacts must be self-contained for GitHub readers. Local-only reference
 |---|---|
 | Naming a branch | [branches.md](branches.md) |
 | Writing a commit | [commits.md](commits.md) |
+| Pushing a branch to origin | [pull-requests.md](pull-requests.md) (also see local-vs-remote in [branches.md](branches.md)) |
 | Opening a pull request | [pull-requests.md](pull-requests.md) |
 | Cutting a release | [releases.md](releases.md) |
 

--- a/.claude/skills/git-workflow/branches.md
+++ b/.claude/skills/git-workflow/branches.md
@@ -41,9 +41,24 @@ Total branch name ≤ 60 characters. If the kebab-title alone would push the bra
 
 Branch from `main` by default. If there is a reason to branch from somewhere else, prompt the user before branching.
 
+## Local vs. remote branch names
+
+The convention above applies to the **remote (`origin`) branch name** — the name GitHub readers see in the branch list, PR list, and merge-commit messages. Local branch names do not have to match.
+
+Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone — but when pushing, push to a properly-named remote ref:
+
+```bash
+git push -u origin HEAD:feat/widget-powered-by-footer
+```
+
+This sets the upstream so subsequent `git push` calls go to the same remote name. Verify with `git branch -vv` after the first push: the local branch should show `[origin/feat/widget-powered-by-footer]` as its upstream.
+
+If the local branch name already conforms (e.g. you created it manually with `git checkout -b feat/...`), `git push -u origin HEAD` is fine — no rename needed.
+
 ## Disallowed
 
-- Bead IDs or other local tracker IDs.
+- Bead IDs or other local tracker IDs in the **remote** name.
 - Suffix-style ID encoding (no `<title>-<id>`, no trailing identifiers).
-- Mixed case.
-- Underscores.
+- Mixed case in the remote name.
+- Underscores in the remote name.
+- Pushing a nonsense auto-generated branch name (from `superset.sh` or similar) straight to `origin` without renaming on push.

--- a/.claude/skills/git-workflow/pull-requests.md
+++ b/.claude/skills/git-workflow/pull-requests.md
@@ -46,6 +46,18 @@ In the PR body, place the reference wherever it reads naturally — top of Motiv
 - **Push to origin** only after build-guardian PASS (lint, unit, integration, build, e2e via build-guardian).
 - **Squash merge** on landing.
 
+## Pushing to origin
+
+Before the first push, verify the local branch name conforms to [branches.md](branches.md). If it does **not** (for example, an auto-generated name from `superset.sh` like `apple-father` or `abrupt-grapple`), push with an explicit remote ref so the GitHub branch follows the convention:
+
+```bash
+git push -u origin HEAD:<type>/<kebab-title>
+```
+
+The `-u` flag wires the local branch's upstream to the renamed remote, so future pushes (`git push`) go to the same ref without re-specifying it.
+
+If the local branch already conforms, `git push -u origin HEAD` is sufficient.
+
 ## Disallowed
 
 - Bead IDs or other local tracker references in title or body.


### PR DESCRIPTION
## Motivation

Tooling like `superset.sh` creates worktrees with auto-generated nonsense local branch names (e.g. `apple-father`, `abrupt-grapple`). When those branches got pushed straight to origin, the GitHub-visible branch name did not follow Pavillion's `<type>/<kebab-title>` convention, polluting the branch list and merge commit messages.

## Approach

Updated three files in `.claude/skills/git-workflow/`:

- `branches.md` — new "Local vs. remote branch names" section explaining that the convention applies to the `origin` ref, with the canonical `git push -u origin HEAD:<type>/<kebab-title>` rename-on-push command. Disallowed list updated to call out remote-name nonsense explicitly.
- `pull-requests.md` — new "Pushing to origin" subsection so the rename pattern sits next to the existing "Push to origin only after build-guardian PASS" workflow bullet.
- `SKILL.md` — extended the frontmatter `description` and reference table so the skill triggers on push tasks, not only on PR submission.

The orchestrator-internal `bead-branch-and-pr` skill needed no change: orchestrator runs already create properly-named local branches via `branchName()`, so the rename-on-push case does not apply there.

## Validation

Documentation-only change to a skill. Verified by reading back updated files. The skill triggered correctly when prompted to push and submit this PR — the agent invoked `git-workflow` and followed the new guidance to produce the renamed remote branch (`docs/git-workflow-rename-on-push`) from the auto-generated local branch (`apple-father`).