### PR TITLE
refactor(orchestrators): allow any branch as long as HEAD is at origin/main

### DIFF
--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -48,13 +48,6 @@ export interface PreflightFailure {
 export interface PreflightResult {
   ok: boolean;
   failures: PreflightFailure[];
-  /**
-   * Set when preflight detected an orphaned orchestrator branch (see
-   * tryRecoverOrphanBranch) and successfully returned the working tree to
-   * main. The Phase 0 runner uses this to emit a `preflight_recovered`
-   * event so the condition is visible in run logs.
-   */
-  recovered?: { orphanedBranch: string };
 }
 
 export interface BeadJson {
@@ -145,12 +138,16 @@ function run(
 // =============================================================================
 
 /**
- * Check that the working tree is clean and we are on the main branch.
+ * Check that the working tree is clean and HEAD is current with origin/main.
  *
- * Mirrors git-safe-to-start.sh logic:
  *   - must be inside a git work tree
- *   - current branch must be 'main' (or GIT_SAFE_MAIN_BRANCH override)
+ *   - HEAD commit must equal origin/<mainBranch> (any branch name is fine)
  *   - working tree must be clean (git status --porcelain is empty)
+ *
+ * The "current with main" model (rather than "on main") supports worktree-based
+ * workflows where each worktree's branch starts at origin/main and feature
+ * branches are cut from there. The env var `GIT_SAFE_MAIN_BRANCH` still
+ * configures the upstream branch name (default: `main`).
  */
 export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
@@ -162,15 +159,22 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
     return { ok: false, reason: 'not inside a git work tree' };
   }
 
-  // Check branch
-  const branchResult = run('git', ['rev-parse', '--abbrev-ref', 'HEAD'], spawn);
-  if (branchResult.exitCode !== 0) {
-    return { ok: false, reason: 'git rev-parse failed unexpectedly' };
+  // Check HEAD == origin/<mainBranch>
+  const headSha = run('git', ['rev-parse', 'HEAD'], spawn);
+  if (headSha.exitCode !== 0) {
+    return { ok: false, reason: 'git rev-parse HEAD failed unexpectedly' };
   }
-  if (branchResult.stdout !== mainBranch) {
+  const baseSha = run('git', ['rev-parse', `origin/${mainBranch}`], spawn);
+  if (baseSha.exitCode !== 0) {
     return {
       ok: false,
-      reason: `on '${branchResult.stdout}', expected '${mainBranch}'`,
+      reason: `could not resolve origin/${mainBranch}; check remote access`,
+    };
+  }
+  if (headSha.stdout !== baseSha.stdout) {
+    return {
+      ok: false,
+      reason: `HEAD is not at origin/${mainBranch} (HEAD=${headSha.stdout.slice(0, 7)}, origin/${mainBranch}=${baseSha.stdout.slice(0, 7)})`,
     };
   }
 
@@ -191,81 +195,20 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
 // =============================================================================
 
 /**
- * Orchestrator-generated branch pattern. Matches legacy branches that still
- * carry a `-pv-<beadId>` suffix from before pv-p85n stripped bead IDs out of
- * git artifacts. New `branchName()` output (`<type>/<kebab-title>`) will not
- * match — the orphan-recovery shortcut is intentionally legacy-only because
- * a no-suffix pattern is too loose to safely distinguish abandoned
- * orchestrator branches from real user work.
- *
- * A branch that matches this pattern still has to pass every other recovery
- * guard (clean tree, no commits ahead of main, no open PR) before preflight
- * will touch it.
- */
-const ORCHESTRATOR_BRANCH_PATTERN = /^(chore|feat|fix)\/[a-z0-9][a-z0-9-]*-pv-[a-z0-9-]+$/;
-
-/**
- * Decide whether the current non-main branch is a stale, abandoned
- * orchestrator branch that's safe to check out of automatically.
- *
- * Safe-to-recover requires ALL of:
- *   - branch name matches the orchestrator-generated pattern
- *   - working tree is clean (no uncommitted changes)
- *   - branch has no commits ahead of main
- *   - no open PR exists for the branch
- *
- * Any gh/git failure returns false — safer to halt than to guess.
- */
-function canRecoverOrphanBranch(
-  branch: string,
-  mainBranch: string,
-  spawn: SpawnFn,
-): boolean {
-  if (!ORCHESTRATOR_BRANCH_PATTERN.test(branch)) return false;
-
-  const status = run('git', ['status', '--porcelain'], spawn);
-  if (status.exitCode !== 0 || status.stdout.length > 0) return false;
-
-  const revList = run('git', ['rev-list', '--count', `${mainBranch}..${branch}`], spawn);
-  if (revList.exitCode !== 0) return false;
-  const ahead = parseInt(revList.stdout || '0', 10);
-  if (Number.isNaN(ahead) || ahead > 0) return false;
-
-  const prList = run(
-    'gh',
-    ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number'],
-    spawn,
-  );
-  if (prList.exitCode !== 0) return false;
-
-  try {
-    const prs = JSON.parse(prList.stdout || '[]');
-    if (Array.isArray(prs) && prs.length > 0) return false;
-  }
-  catch {
-    return false;
-  }
-
-  return true;
-}
-
-/**
  * Full preflight gate. Checks:
  *   - dirty_tree:     working tree has uncommitted changes
- *   - wrong_branch:   not on main (or GIT_SAFE_MAIN_BRANCH)
- *   - stale_main:     local main differs from origin/main
+ *   - behind_main:    HEAD is not at origin/<mainBranch> (or fetch failed)
  *   - empty_backlog:  no ready beads excluding needs-human beads
  *
- * Before reporting `wrong_branch`, preflight attempts to recover from an
- * orphaned orchestrator branch (see canRecoverOrphanBranch). Successful
- * recovery sets `result.recovered` and silences the `wrong_branch` failure.
+ * The branch name is not enforced: any branch is acceptable as long as HEAD
+ * is at origin/main. This supports worktree workflows where each worktree's
+ * branch starts at origin/main.
  */
 export function preflight(deps: SpawnDeps = {}): PreflightResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
   const mainBranch = process.env.PREFLIGHT_MAIN_BRANCH ?? 'main';
   const readyLimit = parseInt(process.env.PREFLIGHT_READY_LIMIT ?? '50', 10);
   const failures: PreflightFailure[] = [];
-  let recovered: { orphanedBranch: string } | undefined;
 
   // 1. Clean working tree
   const statusResult = run('git', ['status', '--porcelain'], spawn);
@@ -276,40 +219,27 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
     });
   }
 
-  // 2. On main branch — attempt orphan recovery first
-  const branchResult = run('git', ['branch', '--show-current'], spawn);
-  let currentBranch = branchResult.stdout;
-  if (currentBranch && currentBranch !== mainBranch) {
-    if (canRecoverOrphanBranch(currentBranch, mainBranch, spawn)) {
-      const checkout = run('git', ['checkout', mainBranch], spawn);
-      if (checkout.exitCode === 0) {
-        recovered = { orphanedBranch: currentBranch };
-        currentBranch = mainBranch;
-      }
-    }
-  }
-
-  if (currentBranch !== mainBranch) {
-    failures.push({
-      kind: 'wrong_branch',
-      reason: `expected to be on '${mainBranch}' but currently on '${currentBranch}'`,
-    });
-  }
-
-  // 3. Local main in sync with origin/main
+  // 2. HEAD is current with origin/<mainBranch>
   const fetchResult = run('git', ['fetch', 'origin', mainBranch], spawn, { timeout: 30_000 });
   if (fetchResult.exitCode !== 0) {
     failures.push({
-      kind: 'stale_main',
+      kind: 'behind_main',
       reason: `could not fetch origin/${mainBranch}; check network or remote`,
     });
   }
   else {
-    const diffResult = run('git', ['diff', `origin/${mainBranch}`, '--quiet'], spawn);
-    if (diffResult.exitCode !== 0) {
+    const headSha = run('git', ['rev-parse', 'HEAD'], spawn);
+    const baseSha = run('git', ['rev-parse', `origin/${mainBranch}`], spawn);
+    if (headSha.exitCode !== 0 || baseSha.exitCode !== 0) {
       failures.push({
-        kind: 'stale_main',
-        reason: `local ${mainBranch} differs from origin/${mainBranch}; pull or reset before /process-backlog`,
+        kind: 'behind_main',
+        reason: `could not resolve HEAD or origin/${mainBranch}`,
+      });
+    }
+    else if (headSha.stdout !== baseSha.stdout) {
+      failures.push({
+        kind: 'behind_main',
+        reason: `HEAD is not at origin/${mainBranch} (HEAD=${headSha.stdout.slice(0, 7)}, origin/${mainBranch}=${baseSha.stdout.slice(0, 7)}); pull, rebase, or check out a fresh branch from origin/${mainBranch}`,
       });
     }
   }
@@ -346,7 +276,6 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
   return {
     ok: failures.length === 0,
     failures,
-    ...(recovered ? { recovered } : {}),
   };
 }
 

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -142,17 +142,15 @@ export interface AdvisorTriageVerdict {
 export const PREFLIGHT_MESSAGES: Record<string, string> = {
   dirty_tree:
     'Working tree is dirty \u2014 commit or stash before re-running /process-backlog.',
-  wrong_branch:
-    'Not on main \u2014 return to main (or finish your current branch\u2019s PR) before re-running /process-backlog.',
-  stale_main:
-    'Local main is out of sync with origin/main \u2014 `git pull` (or fix remote access) before re-running /process-backlog.',
+  behind_main:
+    'HEAD is not at origin/main \u2014 pull, rebase, or check out a fresh branch from origin/main before re-running /process-backlog.',
   empty_backlog:
     'No ready beads available (or every ready bead is labelled `needs-human`) \u2014 shape or unlabel a bead before re-running /process-backlog.',
 };
 
 export const GIT_SAFE_MESSAGES: Record<number, string> = {
-  1: 'Not on main \u2014 return to main (or finish your current branch\u2019s PR) before re-running /process-backlog.',
-  2: 'Not on main \u2014 return to main (or finish your current branch\u2019s PR) before re-running /process-backlog.',
+  1: 'HEAD is not at origin/main \u2014 pull, rebase, or check out a fresh branch from origin/main before re-running /process-backlog.',
+  2: 'HEAD is not at origin/main \u2014 pull, rebase, or check out a fresh branch from origin/main before re-running /process-backlog.',
 };
 
 // =============================================================================
@@ -953,13 +951,6 @@ export async function preflight(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Ph
 
   // Step 1: Run preflight checks
   const preflightResult = runPreflightCheck({ spawnFn: deps.spawnFn });
-
-  if (preflightResult.recovered) {
-    ctx.logger.appendRunJson({
-      event: 'preflight_recovered',
-      orphanedBranch: preflightResult.recovered.orphanedBranch,
-    });
-  }
 
   // When an explicit bead is given, backlog emptiness is not a blocker:
   // the user may be picking up a partially-processed or non-ready bead.

--- a/.claude/orchestrators/process-backlog.ts
+++ b/.claude/orchestrators/process-backlog.ts
@@ -170,8 +170,7 @@ export type RunVerdict = 'completed' | 'transient_halt' | 'needs_human';
 const TRANSIENT_ERROR_PATTERNS = [
   /timed out/i,
   /timeout/i,
-  /wrong_branch/i,
-  /stale_main/i,
+  /behind_main/i,
 ];
 
 export function classifyVerdict(ctx: OrchestratorCtx): RunVerdict {

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -85,17 +85,18 @@ describe('Integration: leaf happy path', () => {
 
       // gitSafeToStart + preflight status checks
       if (a.includes('status --porcelain')) return { exitCode: 0, stdout: '', stderr: '' };
-      // gitSafeToStart branch check
+      // gitSafeToStart inside-repo check
       if (a.includes('rev-parse --is-inside-work-tree')) return { exitCode: 0, stdout: 'true', stderr: '' };
-      if (a.includes('rev-parse --abbrev-ref')) return { exitCode: 0, stdout: 'main', stderr: '' };
-      // preflight branch check
+      // preflight + gitSafeToStart "current with main" check: HEAD == origin/main
+      if (a.includes('rev-parse HEAD') || a.includes('rev-parse origin/')) {
+        return { exitCode: 0, stdout: 'abc1234567890abcdef', stderr: '' };
+      }
+      // branch phase: branch --show-current — main triggers checkout
       if (a.includes('branch --show-current')) {
-        // branch phase: first call → main (trigger checkout); second call in PR → feature branch
         return { exitCode: 0, stdout: 'main', stderr: '' };
       }
-      // preflight fetch/diff
+      // preflight fetch
       if (a.includes('fetch origin')) return { exitCode: 0, stdout: '', stderr: '' };
-      if (a.includes('diff')) return { exitCode: 0, stdout: '', stderr: '' };
       // branch phase: checkout
       if (a.includes('checkout')) return { exitCode: 0, stdout: '', stderr: '' };
       // PR phase: push

--- a/.claude/orchestrators/test/integration/safeguards.test.ts
+++ b/.claude/orchestrators/test/integration/safeguards.test.ts
@@ -48,36 +48,27 @@ function unshapedBeadText(): string {
  * Mount a full passing preflight on a ScriptRouter.
  *
  * Covers all git/bd calls made by:
- *   - runPreflightCheck(): git status, git branch, git fetch, git diff, bd ready, bd label list
- *   - gitSafeToStart():    git rev-parse (work tree), git rev-parse (branch), git status
+ *   - runPreflightCheck(): git status, git fetch, git rev-parse HEAD,
+ *                          git rev-parse origin/main, bd ready, bd label list
+ *   - gitSafeToStart():    git rev-parse (work tree), git rev-parse HEAD,
+ *                          git rev-parse origin/main, git status
  */
 function mountPassingPreflight(scripts: ScriptRouter, beadId = 'pv-test.1'): void {
-  let preflightCallCount = 0;
-  let gitSafeCallCount = 0;
-
   scripts.on('git', (args) => {
-    // Both preflight and gitSafeToStart call git. We distinguish by call order.
     const argStr = args.join(' ');
 
     if (argStr.includes('status --porcelain')) {
-      preflightCallCount++;
-      // First call: from runPreflightCheck; second: from gitSafeToStart
       return { exitCode: 0, stdout: '', stderr: '' };
-    }
-    if (argStr.includes('branch --show-current')) {
-      return { exitCode: 0, stdout: 'main', stderr: '' };
     }
     if (argStr.includes('fetch origin')) {
-      return { exitCode: 0, stdout: '', stderr: '' };
-    }
-    if (argStr.includes('diff')) {
       return { exitCode: 0, stdout: '', stderr: '' };
     }
     if (argStr.includes('rev-parse --is-inside-work-tree')) {
       return { exitCode: 0, stdout: 'true', stderr: '' };
     }
-    if (argStr.includes('rev-parse --abbrev-ref')) {
-      return { exitCode: 0, stdout: 'main', stderr: '' };
+    if (argStr.includes('rev-parse HEAD') || argStr.includes('rev-parse origin/')) {
+      // Both HEAD and origin/main return the same SHA → preflight/gitSafe pass
+      return { exitCode: 0, stdout: 'abc1234567890abcdef', stderr: '' };
     }
     return { exitCode: 0, stdout: '', stderr: '' };
   });

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -59,33 +59,58 @@ function seqSpawn(...results: SpawnSyncReturns<Buffer>[]) {
 // =============================================================================
 
 describe('gitSafeToStart', () => {
-  it('returns ok=true when inside repo, on main, clean tree', () => {
+  it('returns ok=true when inside repo, HEAD at origin/main, clean tree', () => {
     const spawn = seqSpawn(
-      fakeSpawn('true'),         // rev-parse --is-inside-work-tree
-      fakeSpawn('main'),         // rev-parse --abbrev-ref HEAD
-      fakeSpawn(''),             // git status --porcelain (empty = clean)
+      fakeSpawn('true'),                                            // rev-parse --is-inside-work-tree
+      fakeSpawn('abc1234567890abcdef1234567890abcdef123456'),       // rev-parse HEAD
+      fakeSpawn('abc1234567890abcdef1234567890abcdef123456'),       // rev-parse origin/main
+      fakeSpawn(''),                                                // git status --porcelain (clean)
     );
     const result = gitSafeToStart({ spawnFn: spawn as never });
     expect(result.ok).toBe(true);
     expect(result.reason).toBeUndefined();
   });
 
-  it('returns ok=false with reason when on wrong branch', () => {
+  it('returns ok=true on a non-main branch as long as HEAD == origin/main', () => {
     const spawn = seqSpawn(
-      fakeSpawn('true'),         // rev-parse --is-inside-work-tree
-      fakeSpawn('feat/my-work'), // wrong branch
-      fakeSpawn(''),             // status (won't be called but safe to stub)
+      fakeSpawn('true'),
+      fakeSpawn('def4567890abcdef1234567890abcdef12345678'),
+      fakeSpawn('def4567890abcdef1234567890abcdef12345678'),
+      fakeSpawn(''),
+    );
+    const result = gitSafeToStart({ spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok=false with reason when HEAD differs from origin/main', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('true'),
+      fakeSpawn('aaaaaaa1234567890abcdef1234567890abcdef1'),       // HEAD
+      fakeSpawn('bbbbbbb1234567890abcdef1234567890abcdef1'),       // origin/main differs
+      fakeSpawn(''),
     );
     const result = gitSafeToStart({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
-    expect(result.reason).toContain('feat/my-work');
+    expect(result.reason).toContain('origin/main');
+  });
+
+  it('returns ok=false when origin/main cannot be resolved', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('true'),
+      fakeSpawn('abc1234'),                                         // HEAD ok
+      fakeSpawn('', 'unknown ref', 128),                            // origin/main missing
+    );
+    const result = gitSafeToStart({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('origin/main');
   });
 
   it('returns ok=false when tree is dirty', () => {
     const spawn = seqSpawn(
       fakeSpawn('true'),
-      fakeSpawn('main'),
-      fakeSpawn(' M src/server/app.ts\n'), // dirty
+      fakeSpawn('abc1234'),
+      fakeSpawn('abc1234'),
+      fakeSpawn(' M src/server/app.ts\n'),                          // dirty
     );
     const result = gitSafeToStart({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
@@ -106,128 +131,79 @@ describe('gitSafeToStart', () => {
 
 describe('preflight', () => {
   it('returns ok=true when all checks pass', () => {
-    // Calls in order: git status, git branch --show-current, git fetch, git diff,
+    // Calls in order: git status, git fetch, git rev-parse HEAD, git rev-parse origin/main,
     // bd ready --json, bd label list (per bead)
     const beadsJson = JSON.stringify([
       { id: 'pv-abc1', priority: 1, created_at: '2026-01-01' },
     ]);
     const spawn = seqSpawn(
-      fakeSpawn(''),           // git status --porcelain (clean)
-      fakeSpawn('main'),       // git branch --show-current
-      fakeSpawn(''),           // git fetch origin main (success)
-      fakeSpawn('', '', 0),   // git diff origin/main --quiet (no diff)
-      fakeSpawn(beadsJson),   // bd ready --json
-      fakeSpawn('  - backlog'),  // bd label list pv-abc1 (no needs-human)
+      fakeSpawn(''),                  // git status --porcelain (clean)
+      fakeSpawn(''),                  // git fetch origin main (success)
+      fakeSpawn('abc1234'),           // git rev-parse HEAD
+      fakeSpawn('abc1234'),           // git rev-parse origin/main (matches)
+      fakeSpawn(beadsJson),           // bd ready --json
+      fakeSpawn('  - backlog'),       // bd label list pv-abc1 (no needs-human)
     );
     const result = preflight({ spawnFn: spawn as never });
     expect(result.ok).toBe(true);
     expect(result.failures).toHaveLength(0);
   });
 
-  it('reports dirty_tree and wrong_branch failures', () => {
+  it('passes when on a non-main branch as long as HEAD == origin/main', () => {
+    const beadsJson = JSON.stringify([
+      { id: 'pv-abc1', priority: 1, created_at: '2026-01-01' },
+    ]);
+    const spawn = seqSpawn(
+      fakeSpawn(''),                  // clean
+      fakeSpawn(''),                  // fetch ok
+      fakeSpawn('def5678'),           // HEAD
+      fakeSpawn('def5678'),           // origin/main matches
+      fakeSpawn(beadsJson),
+      fakeSpawn('  - other'),
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+  });
+
+  it('reports dirty_tree, behind_main, and empty_backlog failures together', () => {
     const spawn = seqSpawn(
       fakeSpawn(' M src/file.ts'),   // dirty
-      fakeSpawn('feat/branch'),       // wrong branch
-      fakeSpawn('', '', 1),           // fetch fails → stale_main
-      fakeSpawn('[]'),               // bd ready (empty → empty_backlog)
+      fakeSpawn('', '', 1),           // fetch fails → behind_main
+      fakeSpawn('[]'),                // bd ready (empty → empty_backlog)
     );
     const result = preflight({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     const kinds = result.failures.map(f => f.kind);
     expect(kinds).toContain('dirty_tree');
-    expect(kinds).toContain('wrong_branch');
-    expect(kinds).toContain('stale_main');
+    expect(kinds).toContain('behind_main');
     expect(kinds).toContain('empty_backlog');
+  });
+
+  it('reports behind_main when HEAD differs from origin/main', () => {
+    const spawn = seqSpawn(
+      fakeSpawn(''),                  // clean
+      fakeSpawn(''),                  // fetch ok
+      fakeSpawn('aaaaaaa'),           // HEAD
+      fakeSpawn('bbbbbbb'),           // origin/main differs
+      fakeSpawn('[]'),                // bd ready (empty → empty_backlog too)
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    const kinds = result.failures.map(f => f.kind);
+    expect(kinds).toContain('behind_main');
   });
 
   it('reports empty_backlog when all ready beads have needs-human label', () => {
     const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
     const spawn = seqSpawn(
-      fakeSpawn(''),              // clean tree
-      fakeSpawn('main'),          // on main
-      fakeSpawn(''),              // fetch ok
-      fakeSpawn('', '', 0),      // no diff
-      fakeSpawn(beadsJson),       // bd ready
-      fakeSpawn('  - needs-human'),  // label list: has needs-human
+      fakeSpawn(''),                  // clean tree
+      fakeSpawn(''),                  // fetch ok
+      fakeSpawn('abc1234'),           // HEAD
+      fakeSpawn('abc1234'),           // origin/main matches
+      fakeSpawn(beadsJson),           // bd ready
+      fakeSpawn('  - needs-human'),   // label list: has needs-human
     );
     const result = preflight({ spawnFn: spawn as never });
     expect(result.failures.map(f => f.kind)).toContain('empty_backlog');
-  });
-
-  // ---------------------------------------------------------------------------
-  // Orphan branch recovery
-  // ---------------------------------------------------------------------------
-
-  it('recovers from an orphaned orchestrator branch and continues preflight', () => {
-    // Branch matches pattern, tree clean, no commits ahead, no open PR →
-    // checkout main and proceed without reporting wrong_branch.
-    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
-    const spawn = seqSpawn(
-      fakeSpawn(''),                           // git status (clean)
-      fakeSpawn('chore/some-title-pv-abc'),    // git branch --show-current
-      // canRecoverOrphanBranch:
-      fakeSpawn(''),                           // git status (clean)
-      fakeSpawn('0'),                          // git rev-list --count main..branch
-      fakeSpawn('[]'),                         // gh pr list (no open PR)
-      fakeSpawn('', '', 0),                    // git checkout main (success)
-      // Resume preflight:
-      fakeSpawn('', '', 0),                    // git fetch origin main
-      fakeSpawn('', '', 0),                    // git diff (no diff)
-      fakeSpawn(beadsJson),                    // bd ready
-      fakeSpawn('  - other'),                  // bd label list pv-x1
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.ok).toBe(true);
-    expect(result.recovered).toEqual({ orphanedBranch: 'chore/some-title-pv-abc' });
-    expect(result.failures.map(f => f.kind)).not.toContain('wrong_branch');
-  });
-
-  it('does not recover when branch has commits ahead of main', () => {
-    const spawn = seqSpawn(
-      fakeSpawn(''),                              // git status (clean)
-      fakeSpawn('feat/wip-pv-xyz'),               // git branch
-      // canRecoverOrphanBranch:
-      fakeSpawn(''),                              // git status (clean)
-      fakeSpawn('3'),                             // git rev-list: 3 commits ahead → refuse
-      // No checkout; proceed with wrong_branch failure:
-      fakeSpawn('', '', 0),                       // git fetch
-      fakeSpawn('', '', 0),                       // git diff
-      fakeSpawn('[]'),                            // bd ready (empty)
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.recovered).toBeUndefined();
-    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
-  });
-
-  it('does not recover when branch has an open PR', () => {
-    const spawn = seqSpawn(
-      fakeSpawn(''),                              // git status
-      fakeSpawn('fix/bug-pv-pqr'),                // git branch
-      fakeSpawn(''),                              // git status (recovery check)
-      fakeSpawn('0'),                             // no commits ahead
-      fakeSpawn('[{"number":101}]'),              // gh pr list: open PR exists → refuse
-      fakeSpawn('', '', 0),                       // git fetch
-      fakeSpawn('', '', 0),                       // git diff
-      fakeSpawn('[]'),                            // bd ready
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.recovered).toBeUndefined();
-    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
-  });
-
-  it('does not recover non-orchestrator-looking branch names', () => {
-    // Branch doesn't match pattern → skip recovery entirely, report wrong_branch.
-    const spawn = seqSpawn(
-      fakeSpawn(''),                              // git status
-      fakeSpawn('my-local-experiment'),           // git branch — no type prefix
-      // canRecoverOrphanBranch returns false on pattern mismatch — no extra calls
-      fakeSpawn('', '', 0),                       // git fetch
-      fakeSpawn('', '', 0),                       // git diff
-      fakeSpawn('[]'),                            // bd ready
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.recovered).toBeUndefined();
-    expect(result.failures.map(f => f.kind)).toContain('wrong_branch');
   });
 });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -115,43 +115,45 @@ function beadTextExecuting(): string {
 }
 
 // =============================================================================
-// Canonical seqSpawn sequences for gitSafeToStart() (3 git calls)
+// Canonical seqSpawn sequences for gitSafeToStart() (4 git calls)
 // =============================================================================
 
-/** 3 spawn calls that satisfy gitSafeToStart() successfully */
+/** 4 spawn calls that satisfy gitSafeToStart() successfully */
 function gitSafeOkSpawns(): SpawnSyncReturns<Buffer>[] {
   return [
-    fakeSpawn('true', '', 0),   // git rev-parse --is-inside-work-tree
-    fakeSpawn('main', '', 0),   // git rev-parse --abbrev-ref HEAD
-    fakeSpawn('', '', 0),       // git status --porcelain (clean)
+    fakeSpawn('true', '', 0),       // git rev-parse --is-inside-work-tree
+    fakeSpawn('abc1234', '', 0),    // git rev-parse HEAD
+    fakeSpawn('abc1234', '', 0),    // git rev-parse origin/main (matches HEAD)
+    fakeSpawn('', '', 0),           // git status --porcelain (clean)
   ];
 }
 
-/** 3 spawn calls that make gitSafeToStart() fail on dirty tree */
+/** 4 spawn calls that make gitSafeToStart() fail on dirty tree */
 function gitSafeDirtySpawns(): SpawnSyncReturns<Buffer>[] {
   return [
     fakeSpawn('true', '', 0),        // git rev-parse --is-inside-work-tree
-    fakeSpawn('main', '', 0),        // git rev-parse --abbrev-ref HEAD
+    fakeSpawn('abc1234', '', 0),     // git rev-parse HEAD
+    fakeSpawn('abc1234', '', 0),     // git rev-parse origin/main
     fakeSpawn('M somefile', '', 0),  // git status --porcelain (dirty)
   ];
 }
 
 // =============================================================================
 // Canonical seqSpawn sequences for preflight() / runPreflightCheck() (6 calls)
-// then gitSafeToStart() (3 calls) = 9 total for full success
+// then gitSafeToStart() (4 calls) = 10 total for full success
 // =============================================================================
 
 /**
- * 9 spawn calls for a fully passing preflight() (runPreflightCheck + gitSafeToStart).
+ * 10 spawn calls for a fully passing preflight() (runPreflightCheck + gitSafeToStart).
  * Bead id used for label check is passed in.
  */
 function preflightPassingSpawns(beadId = 'pv-abc-1'): SpawnSyncReturns<Buffer>[] {
   return [
     // runPreflightCheck:
     fakeSpawn('', '', 0),                                  // git status --porcelain (clean)
-    fakeSpawn('main', '', 0),                              // git branch --show-current
     fakeSpawn('', '', 0),                                  // git fetch origin main
-    fakeSpawn('', '', 0),                                  // git diff origin/main --quiet
+    fakeSpawn('abc1234', '', 0),                           // git rev-parse HEAD
+    fakeSpawn('abc1234', '', 0),                           // git rev-parse origin/main (matches)
     fakeSpawn(JSON.stringify([{ id: beadId }]), '', 0),    // bd ready --limit=50 --json
     fakeSpawn('- other-label', '', 0),                     // bd label list <id>
     // gitSafeToStart:
@@ -234,15 +236,13 @@ describe('preflight', () => {
     const spawn = seqSpawn(
       // runPreflightCheck passes:
       fakeSpawn('', '', 0),                                      // git status --porcelain (clean)
-      fakeSpawn('main', '', 0),                                  // git branch --show-current
       fakeSpawn('', '', 0),                                      // git fetch origin main
-      fakeSpawn('', '', 0),                                      // git diff origin/main --quiet
+      fakeSpawn('abc1234', '', 0),                               // git rev-parse HEAD
+      fakeSpawn('abc1234', '', 0),                               // git rev-parse origin/main (matches)
       fakeSpawn(JSON.stringify([{ id: 'pv-abc-1' }]), '', 0),   // bd ready --limit=50 --json
       fakeSpawn('- other-label', '', 0),                         // bd label list
       // gitSafeToStart fails:
-      fakeSpawn('true', '', 0),    // git rev-parse --is-inside-work-tree
-      fakeSpawn('main', '', 0),    // git rev-parse --abbrev-ref HEAD
-      fakeSpawn('M file', '', 0),  // git status --porcelain (dirty)
+      ...gitSafeDirtySpawns(),
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -254,9 +254,9 @@ describe('preflight', () => {
   it('should halt when backlog is empty (automatic selection mode)', async () => {
     const spawn = seqSpawn(
       fakeSpawn('', '', 0),        // git status --porcelain (clean)
-      fakeSpawn('main', '', 0),    // git branch --show-current
       fakeSpawn('', '', 0),        // git fetch origin main
-      fakeSpawn('', '', 0),        // git diff origin/main --quiet
+      fakeSpawn('abc1234', '', 0), // git rev-parse HEAD
+      fakeSpawn('abc1234', '', 0), // git rev-parse origin/main (matches)
       fakeSpawn('[]', '', 0),      // bd ready: empty array
     );
 
@@ -272,9 +272,9 @@ describe('preflight', () => {
     const spawn = seqSpawn(
       // runPreflightCheck (empty_backlog is the only failure):
       fakeSpawn('', '', 0),        // git status --porcelain (clean)
-      fakeSpawn('main', '', 0),    // git branch --show-current
       fakeSpawn('', '', 0),        // git fetch origin main
-      fakeSpawn('', '', 0),        // git diff origin/main --quiet
+      fakeSpawn('abc1234', '', 0), // git rev-parse HEAD
+      fakeSpawn('abc1234', '', 0), // git rev-parse origin/main (matches)
       fakeSpawn('[]', '', 0),      // bd ready: empty array
       // gitSafeToStart passes:
       ...gitSafeOkSpawns(),
@@ -1064,10 +1064,11 @@ describe('branch', () => {
   beforeEach(() => vi.restoreAllMocks());
 
   it('should halt when git-safe-to-start fails', async () => {
-    // gitSafeToStart: 3 calls (work tree ok, main ok, dirty)
+    // gitSafeToStart: 4 calls (work tree ok, HEAD, origin/main, dirty)
     const spawn = seqSpawn(
       fakeSpawn('true', '', 0),       // git rev-parse --is-inside-work-tree
-      fakeSpawn('main', '', 0),       // git rev-parse --abbrev-ref HEAD
+      fakeSpawn('abc1234', '', 0),    // git rev-parse HEAD
+      fakeSpawn('abc1234', '', 0),    // git rev-parse origin/main
       fakeSpawn('M dirty', '', 0),    // git status --porcelain (dirty)
     );
 
@@ -1080,9 +1081,10 @@ describe('branch', () => {
   it('should create branch and route epic to Epic phase', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'epic', title: 'My Epic Feature' }]);
     const spawn = seqSpawn(
-      // gitSafeToStart (3 calls):
+      // gitSafeToStart (4 calls):
       fakeSpawn('true', '', 0),            // git rev-parse --is-inside-work-tree
-      fakeSpawn('main', '', 0),            // git rev-parse --abbrev-ref HEAD
+      fakeSpawn('abc1234', '', 0),         // git rev-parse HEAD
+      fakeSpawn('abc1234', '', 0),         // git rev-parse origin/main
       fakeSpawn('', '', 0),                // git status --porcelain (clean)
       // bd show --json (for title + issueType):
       fakeSpawn(bdShowJson, '', 0),
@@ -1102,7 +1104,8 @@ describe('branch', () => {
     const spawn = seqSpawn(
       // gitSafeToStart:
       fakeSpawn('true', '', 0),
-      fakeSpawn('main', '', 0),
+      fakeSpawn('abc1234', '', 0),
+      fakeSpawn('abc1234', '', 0),
       fakeSpawn('', '', 0),
       // bd show --json:
       fakeSpawn(bdShowJson, '', 0),
@@ -1124,7 +1127,8 @@ describe('branch', () => {
     const spawn = seqSpawn(
       // gitSafeToStart:
       fakeSpawn('true', '', 0),
-      fakeSpawn('main', '', 0),
+      fakeSpawn('abc1234', '', 0),
+      fakeSpawn('abc1234', '', 0),
       fakeSpawn('', '', 0),
       // bd show --json:
       fakeSpawn(bdShowJson, '', 0),
@@ -1136,8 +1140,8 @@ describe('branch', () => {
     const result = await branch(makeCtx(), { spawnFn: spawn });
 
     expect(result.next).toBe(PhaseName.Leaf);
-    // 5 spawn calls total (no checkout)
-    expect(spawn).toHaveBeenCalledTimes(5);
+    // 6 spawn calls total (no checkout)
+    expect(spawn).toHaveBeenCalledTimes(6);
   });
 });
 
@@ -1146,9 +1150,9 @@ describe('branch', () => {
 // =============================================================================
 
 describe('message constants', () => {
-  it('should have exactly 4 preflight message kinds', () => {
+  it('should have exactly 3 preflight message kinds', () => {
     expect(Object.keys(PREFLIGHT_MESSAGES)).toEqual([
-      'dirty_tree', 'wrong_branch', 'stale_main', 'empty_backlog',
+      'dirty_tree', 'behind_main', 'empty_backlog',
     ]);
   });
 

--- a/.claude/orchestrators/test/unit/pipeline.test.ts
+++ b/.claude/orchestrators/test/unit/pipeline.test.ts
@@ -335,11 +335,11 @@ describe('classifyVerdict', () => {
     expect(classifyVerdict(ctx)).toBe('transient_halt');
   });
 
-  it('returns transient_halt when preflight halts on wrong_branch', () => {
+  it('returns transient_halt when preflight halts on behind_main', () => {
     const ctx = makeCtx({
       phaseHistory: [
         { phase: PhaseName.Preflight, ok: false, durationMs: 300,
-          error: 'wrong_branch: expected main but on feat/x' },
+          error: 'behind_main: HEAD is not at origin/main' },
       ] as PhaseResult[],
     });
     expect(classifyVerdict(ctx)).toBe('transient_halt');


### PR DESCRIPTION
## Summary

- Replace orchestrator preflight's "must be on main" check with "HEAD == origin/main" — branch name is no longer enforced.
- Unblocks worktree-based workflows where each worktree's branch is created from origin/main and is not literally named `main`.
- Drops the orphan-recovery shortcut (which existed only to switch back to main) and collapses `wrong_branch` + `stale_main` failure kinds into a single `behind_main` kind.

## Why

Running `/process-backlog` from a worktree that branched off origin/main (the project's actual workflow per the worktree list) failed at preflight because the branch name wasn't `main`. The check was conflating "branch name" with "starting state." HEAD-equality with origin/main captures the real intent: start every bead from a clean copy of origin/main, regardless of which branch name the worktree uses.

Strict equality (not ancestry) is intentional. The branch phase does `git checkout -b <bead-branch>` from current HEAD, so any extra commits on the worktree branch would leak into the bead's PR.

## Files changed

- `.claude/orchestrators/lib/helpers.ts` — preflight + gitSafeToStart now compare HEAD SHA to origin/<mainBranch> SHA
- `.claude/orchestrators/lib/phases.ts` — message constants and preflight runner updated
- `.claude/orchestrators/process-backlog.ts` — `TRANSIENT_ERROR_PATTERNS` matches `behind_main`
- 5 test files — spawn sequences updated to match new call pattern

## Test plan

- [x] All 289 orchestrator tests pass (`npx vitest run --config <orchestrator-config>` — needed to be run via a custom config since the project's vitest.config.ts only includes `src/**`).
- [ ] After merge, a fresh worktree at origin/main can run `/process-backlog --bead-id <id>` without env overrides.