### PR TITLE
refactor(client): use DEFAULT_LANGUAGE_CODE constant in editors (pv-m22j)

### DIFF
--- a/src/client/components/common/language-picker.vue
+++ b/src/client/components/common/language-picker.vue
@@ -120,7 +120,7 @@
   <Sheet :title="t('select_language')" @close="closeModal">
     <div
       class="language-picker-body"
-      :dir="iso6391.getDir(defaultLanguage) == 'rtl' ? 'rtl' : ''"
+      :dir="iso6391.getDir(DEFAULT_LANGUAGE_CODE) == 'rtl' ? 'rtl' : ''"
     >
       <!-- Search -->
       <div class="search-section">
@@ -175,6 +175,7 @@
 import { reactive, computed } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import iso6391 from 'iso-639-1-dir';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import Sheet from '@/client/components/common/Sheet.vue';
 
 const emit = defineEmits(['close', 'select']);
@@ -182,8 +183,6 @@ const emit = defineEmits(['close', 'select']);
 const { t } = useTranslation('system', {
   keyPrefix: 'language_picker',
 });
-
-const defaultLanguage = 'en';
 
 const props = defineProps({
   languages: Array,

--- a/src/client/components/logged_in/calendar-content/category-editor.vue
+++ b/src/client/components/logged_in/calendar-content/category-editor.vue
@@ -89,6 +89,7 @@ import { reactive, ref, nextTick, onMounted, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { X } from 'lucide-vue-next';
 import iso6391 from 'iso-639-1-dir';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventCategoryContent } from '@/common/model/event_category_content';
 import { DuplicateCategoryNameError } from '@/common/exceptions/category';
 import CategoryService from '@/client/service/category';
@@ -110,13 +111,12 @@ const { t } = useTranslation('categories', {
 });
 
 const categoryService = new CategoryService();
-const defaultLanguage = 'en';
 let allLanguages = iso6391.getAllCodes();
-allLanguages.unshift(defaultLanguage);
+allLanguages.unshift(DEFAULT_LANGUAGE_CODE);
 let availableLanguages = ref([...new Set(allLanguages)]);
 
 const state = reactive({
-  currentLanguage: defaultLanguage,
+  currentLanguage: DEFAULT_LANGUAGE_CODE,
   showLanguagePicker: false,
   isSaving: false,
   error: '',

--- a/src/client/components/logged_in/calendar-content/series-editor.vue
+++ b/src/client/components/logged_in/calendar-content/series-editor.vue
@@ -3,6 +3,7 @@ import { reactive, ref, computed, nextTick, onMounted, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { ArrowLeft } from 'lucide-vue-next';
 import iso6391 from 'iso-639-1-dir';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventSeriesContent } from '@/common/model/event_series_content';
 import { DuplicateSeriesNameError, SeriesUrlNameAlreadyExistsError, InvalidSeriesUrlNameError } from '@/common/exceptions/series';
 import SeriesService from '@/client/service/series';
@@ -29,13 +30,12 @@ const { t: tEditor } = useTranslation('series', {
 });
 
 const seriesService = new SeriesService();
-const defaultLanguage = 'en';
 let allLanguages = iso6391.getAllCodes();
-allLanguages.unshift(defaultLanguage);
+allLanguages.unshift(DEFAULT_LANGUAGE_CODE);
 let availableLanguages = ref([...new Set(allLanguages)]);
 
 const state = reactive({
-  currentLanguage: defaultLanguage,
+  currentLanguage: DEFAULT_LANGUAGE_CODE,
   showLanguagePicker: false,
   isSaving: false,
   error: '',

--- a/src/client/components/logged_in/calendar-management/settings.vue
+++ b/src/client/components/logged_in/calendar-management/settings.vue
@@ -223,6 +223,7 @@
 import { reactive, ref, computed, onMounted } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import iso6391 from 'iso-639-1-dir';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { CalendarContent } from '@/common/model/calendar';
 import CalendarService from '@/client/service/calendar';
 import FundingService from '@/client/service/funding';
@@ -254,9 +255,8 @@ const fundingService = new FundingService();
 // Instance name for extended features description
 const instanceName = ref('this instance');
 
-const defaultLanguage = 'en';
 let allLanguages = iso6391.getAllCodes();
-allLanguages.unshift(defaultLanguage);
+allLanguages.unshift(DEFAULT_LANGUAGE_CODE);
 const availableLanguages = ref([...new Set(allLanguages)]);
 
 // Local calendar clone for translatable content editing
@@ -269,7 +269,7 @@ const state = reactive({
   isSaving: false,
   error: '',
   success: '',
-  currentLanguage: defaultLanguage,
+  currentLanguage: DEFAULT_LANGUAGE_CODE,
   showLanguagePicker: false,
   defaultDateRange: '2weeks',
   defaultEventImage: null,

--- a/src/client/components/logged_in/calendar/category-selector.vue
+++ b/src/client/components/logged_in/calendar/category-selector.vue
@@ -66,6 +66,7 @@
 import { reactive, computed, onMounted, ref, nextTick, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import i18next from 'i18next';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventCategory } from '@/common/model/event_category';
 import { EventCategoryContent } from '@/common/model/event_category_content';
 import CategoryService from '@/client/service/category';
@@ -107,13 +108,12 @@ const state = reactive({
 
 /**
  * Construct a fresh EventCategory scoped to the current calendar and open
- * the CategoryEditor modal in create mode. The 'en' default matches
- * category-editor.vue's internal defaultLanguage constant — if either
- * changes, both must change in lock-step.
+ * the CategoryEditor modal in create mode. Uses DEFAULT_LANGUAGE_CODE so
+ * the seeded content matches the editor's initial language tab.
  */
 function openCreateCategory() {
   const fresh = new EventCategory('', props.calendarId);
-  fresh.addContent(new EventCategoryContent('en', ''));
+  fresh.addContent(new EventCategoryContent(DEFAULT_LANGUAGE_CODE, ''));
   state.newCategory = fresh;
   state.showCategoryEditor = true;
 }

--- a/src/client/components/logged_in/calendar/edit-place.vue
+++ b/src/client/components/logged_in/calendar/edit-place.vue
@@ -946,6 +946,7 @@ import EditSpace from '@/client/components/logged_in/calendar/edit-space.vue';
 import LocationService from '@/client/service/location';
 import CalendarService from '@/client/service/calendar';
 import { useToast } from '@/client/composables/useToast';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventLocation, EventLocationSpace, validateLocationHierarchy } from '@/common/model/location';
 import iso6391 from 'iso-639-1-dir';
 
@@ -1283,9 +1284,8 @@ const formData = reactive({
 const accessibilityInfo = reactive<Record<string, string>>({});
 
 // Language management
-const defaultLanguage = 'en';
-const languages = ref<string[]>([defaultLanguage]);
-const currentLanguage = ref(defaultLanguage);
+const languages = ref<string[]>([DEFAULT_LANGUAGE_CODE]);
+const currentLanguage = ref(DEFAULT_LANGUAGE_CODE);
 const showLanguagePicker = ref(false);
 const accessibilityLangTabs = ref<InstanceType<typeof LanguageTabSelector> | null>(null);
 

--- a/src/client/components/logged_in/calendar/edit-space.vue
+++ b/src/client/components/logged_in/calendar/edit-space.vue
@@ -18,6 +18,7 @@ import { ref, reactive, computed, onBeforeMount, watch, nextTick } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import LanguageTabSelector from '@/client/components/common/language-tab-selector.vue';
 import languagePicker from '@/client/components/common/language-picker.vue';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventLocationSpace, EventLocationSpaceContent } from '@/common/model/location';
 import iso6391 from 'iso-639-1-dir';
 
@@ -53,9 +54,8 @@ const nameByLang = reactive<Record<string, string>>({});
 const accessibilityByLang = reactive<Record<string, string>>({});
 
 // Language tab management.
-const defaultLanguage = 'en';
-const languages = ref<string[]>([defaultLanguage]);
-const currentLanguage = ref(defaultLanguage);
+const languages = ref<string[]>([DEFAULT_LANGUAGE_CODE]);
+const currentLanguage = ref(DEFAULT_LANGUAGE_CODE);
 const showLanguagePicker = ref(false);
 const langTabs = ref<InstanceType<typeof LanguageTabSelector> | null>(null);
 
@@ -151,8 +151,8 @@ function handleCancel() {
  */
 onBeforeMount(() => {
   // Always seed the default language so the form has at least one tab.
-  if (!(defaultLanguage in nameByLang)) nameByLang[defaultLanguage] = '';
-  if (!(defaultLanguage in accessibilityByLang)) accessibilityByLang[defaultLanguage] = '';
+  if (!(DEFAULT_LANGUAGE_CODE in nameByLang)) nameByLang[DEFAULT_LANGUAGE_CODE] = '';
+  if (!(DEFAULT_LANGUAGE_CODE in accessibilityByLang)) accessibilityByLang[DEFAULT_LANGUAGE_CODE] = '';
 
   const source = props.space ?? null;
   if (!source) {

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -1217,6 +1217,7 @@ import LocationDisplayCard from '@/client/components/common/location-display-car
 import LocationPickerModal from '@/client/components/common/location-picker-modal.vue';
 import CreateLocationForm from '@/client/components/common/create-location-form.vue';
 import { ValidationError } from '@/common/exceptions';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import iso6391 from 'iso-639-1-dir';
 
 // Composables
@@ -1247,9 +1248,6 @@ const { t: tCancellations } = useTranslation('event_editor', {
   keyPrefix: 'cancellations',
 });
 
-// Initialize composables
-const defaultLanguage = 'en';
-
 // Event editor composable
 const {
   state: editorState,
@@ -1261,7 +1259,7 @@ const {
   initializeEvent,
   saveEvent,
   pageTitle,
-} = useEventEditor(defaultLanguage);
+} = useEventEditor(DEFAULT_LANGUAGE_CODE);
 
 // Location management composable
 const {

--- a/src/client/composables/useLanguageManagement.ts
+++ b/src/client/composables/useLanguageManagement.ts
@@ -1,5 +1,6 @@
 import { ref, Ref } from 'vue';
 import iso6391 from 'iso-639-1-dir';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { CalendarEvent } from '@/common/model/events';
 
 export interface LanguageManagement {
@@ -24,17 +25,15 @@ export interface LanguageManagement {
  * - Language picker modal state
  */
 export function useLanguageManagement(): LanguageManagement {
-  const defaultLanguage = 'en';
-
   // Active languages for the current event
-  const languages = ref<string[]>([defaultLanguage]);
+  const languages = ref<string[]>([DEFAULT_LANGUAGE_CODE]);
 
   // All available languages (default + all ISO 639-1 codes)
   const allLanguages = iso6391.getAllCodes();
-  const availableLanguages = ref<string[]>([...new Set([defaultLanguage, ...allLanguages])]);
+  const availableLanguages = ref<string[]>([...new Set([DEFAULT_LANGUAGE_CODE, ...allLanguages])]);
 
   // Current language selection
-  const currentLanguage = ref<string>(defaultLanguage);
+  const currentLanguage = ref<string>(DEFAULT_LANGUAGE_CODE);
 
   // Language picker modal state
   const showLanguagePicker = ref<boolean>(false);
@@ -68,7 +67,7 @@ export function useLanguageManagement(): LanguageManagement {
   const initializeLanguages = (event: CalendarEvent): void => {
     if (event) {
       const eventLanguages = event.getLanguages();
-      eventLanguages.unshift(defaultLanguage);
+      eventLanguages.unshift(DEFAULT_LANGUAGE_CODE);
       languages.value = [...new Set(eventLanguages)];
     }
   };


### PR DESCRIPTION
## Summary
- Replace 8 hardcoded `const defaultLanguage = 'en'` literals in `src/client/` with imports of `DEFAULT_LANGUAGE_CODE` from `@/common/i18n/languages` — the canonical constant already exported alongside `AVAILABLE_LANGUAGES` and `isValidLanguageCode`.
- Bonus: fix `category-selector.vue`, which had a stale inline `'en'` literal plus a comment documenting the lock-step coupling that the centralized constant retires.
- No behavior change; pure mechanical refactor surfaced during PR #283 review.

Closes pv-m22j.

## Test plan
- [x] `npm run lint` clean (0 errors, 277 pre-existing warnings)
- [x] Unit tests: 7747/7747 pass
- [x] Integration tests: 585/585 pass (5 skipped)
- [x] Frontend + widget SDK build succeeds
- [x] `grep "defaultLanguage = 'en'" src/client/` returns no matches
- [x] Architecture-auditor: PASS