### PR TITLE
docs: write and refine the calendar-owner places guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,7 +41,7 @@ export default defineConfig({
           items: [
             { text: 'Post a recurring event', link: '/guides/calendar-owners/recurring-events' },
             { text: 'Organize events with categories', link: '/guides/calendar-owners/categories' },
-            { text: 'Reuse venues with places', link: '/guides/calendar-owners/places' },
+            { text: 'Manage event locations', link: '/guides/calendar-owners/places' },
             { text: 'Group related events into a series', link: '/guides/calendar-owners/series' },
             { text: "Customize your calendar's identity", link: '/guides/calendar-owners/identity' },
             { text: 'Publish in multiple languages', link: '/guides/calendar-owners/multilingual' },

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -1,29 +1,80 @@
 # Reuse venues with places
 
-> Status: stub. Full guide coming before launch.
+A *place* in Pavillion is a venue stored as its own object — an address, a name, a few details — that events reference rather than copy. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
 
-A place is a venue stored as its own object — an address, a name, a few details — that events reference rather than copy. Type the address once, attach it to ten events, and when the venue changes its name or street number, you change it once.
+This guide covers what places are, how to create them, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, one-off venues — so you don't end up with a list of places you'll never reuse.
 
 ## How places work
 
-The reference model: events point at places, they don't embed them.
+Places are separate from events. An event has a *reference* to a place, not a copy of it. This is the single fact that explains everything else in this guide.
+
+The day-to-day consequence is small but valuable. When the community center on Main Street renames itself, you don't go event by event correcting the venue name. You open the place once, fix the name, save. The event lists, the event detail pages, the public calendar — all of it shows the new name on the next page load.
+
+The other consequence is that places are reusable. Every event you publish at the same venue picks the place from a list rather than retyping the address. Over a year of running a calendar, a small set of recurring venues accounts for most of your events; saving them as places turns each new event's location field from a typing exercise into a one-click pick.
+
+A place belongs to a calendar. If you run more than one calendar, each calendar has its own list of places — they aren't shared. That's usually what you want, since the venues a community garden uses are different from the venues a folk concert series uses.
 
 ## Create a place
 
-The mechanics.
+You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes save the same kind of object — pick whichever fits the moment.
+
+**From the Places tab.** Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Places** tab. The first time you visit, the list is empty. Click <Btn>+ Add place</Btn>. The place editor opens as a full page with two sections:
+
+- **Basic information.** A name (required), street address, city, state or province, postal code. The name is the only required field — you could save a place with just a name if that's all you have, though for most venues the address fields are what makes the place useful.
+- **Accessibility information.** A free-text field for things like wheelchair access, ASL interpretation, scent-free policy, parking notes — anything a visitor specifically needs to know about getting into and around the venue. If your calendar publishes in more than one language, this field shows a row of language tabs so you can write the accessibility note once per language.
+
+Click <Btn>Save</Btn>. The place is now in your list and available to attach to events.
+
+**From inside the event editor.** While editing an event, click <Btn>Add location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create new place</Btn>, fill in the same fields, and confirm. The place is saved to the calendar (it persists past this event) and is attached to the event you're editing.
+
+Either way, the place is now reusable from any future event on this calendar.
 
 ## Attach a place to an event
 
-From inside the event editor.
+In the event editor, find the **Location** section and click <Btn>Add location</Btn>. The location picker opens with your saved places listed alphabetically.
+
+There's a search box at the top of the picker. It searches across every field — name, address, city, state, postal code — so you can find a place by typing any of those, not just the name. *"Main"* will match a venue called *Main Street Hall* and a venue at *200 Main Street*, both.
+
+Click a place to select it. The picker closes and the chosen venue appears in the event's Location section. To swap it for a different one, click <Btn>Change location</Btn> and pick again. To remove the location entirely (for an online-only event you originally tagged with a place), open the picker and use the <Btn>Remove</Btn> option.
+
+Saving the event saves the reference to the place. The event doesn't store its own copy of the address — it remembers *which place* it points at, and reads the address from the place at display time.
 
 ## Edit a place after the fact
 
-What happens to past events that already used the place. What happens to future events.
+Open <Btn>Manage Calendar</Btn>, find the **Places** tab, click the pencil icon on the place you want to edit, change what needs changing, save.
+
+The change is reflected everywhere immediately. Every event currently attached to that place — past, present, future — will display the updated information on its detail page the next time the page loads. Past events aren't frozen; they show the venue's current state, not the state it was in on the day the event happened.
+
+This is intentional, and it's the right behavior most of the time. If you correct a typo in the address, you want every event there to be correct. If the venue changes its name, you want every listing to reflect that. The reference model is what makes this clean — a copy-and-paste model would have left ten events stuck on the old typo.
+
+::: tip <Lightbulb /> A note on past events.
+Because past events show the venue's current state, the archive of your calendar is a record of *what happened*, not *what the listing said at the time*. If you want a permanent snapshot of the original address — say, for an event ticket stub or a community history project — copy that detail somewhere outside Pavillion (the event description, an external doc) before the venue changes. This is rarely worth doing, but worth knowing.
+:::
+
+Deleting a place behaves a little differently from editing. The delete dialog tells you how many events currently use the place; if you proceed, the place is removed from your list and every affected event keeps existing but loses its location. The events don't disappear — they just no longer have a venue attached. You can attach a different place (or a new one) to any of them by editing the event.
 
 ## When not to use a place
 
-Online-only events. One-off venues you won't reuse. The cases where a place adds friction without adding value.
+A place earns its keep through reuse. Creating one for a venue you'll list once and never again adds friction without saving any.
+
+**Online-only events.** If the event is a video call, a livestream, or otherwise has no physical location, leave the location field empty and put the join link in the **External link** field. There's no venue to reuse and no address to update.
+
+**One-off venues you won't return to.** A pop-up at a borrowed location, a guest lecture in someone's living room, a single visiting artist's studio open day. If you're confident this is the only event you'll ever publish at that location, the cost of creating a place for it (a list entry to scroll past forever) outweighs the benefit (zero reuse). Put the address in the event description instead, or — if you want it more visible — in the accessibility field if it's part of the access notes.
+
+**Venues you're still figuring out.** If the booking isn't confirmed, or the address might change before the event happens, hold off on creating a place. You can attach one (or create one inline from the event editor) once the venue is settled.
+
+The bias should be toward fewer places, not more. A list of thirty places where you actually only use six creates exactly the friction the place system is supposed to remove — every new event you publish, you scroll past twenty-four near-irrelevant entries to find the one you want. Treat a place as a small commitment to reuse, and your list stays useful.
 
 ## Naming places so they're recognizable later
 
-A small thing that pays off when an editor is picking from a long list six months from now.
+The place's name is the first thing you see in the picker, so the way you name a place determines whether picking the right one feels obvious or feels like guessing.
+
+**Use the venue's actual name when there is one.** *Riverbend Community Center* is a name your editors will recognize next month and next year. *Main location* or *That coffee shop* won't be — and a co-editor who joins six months from now won't have any idea what those refer to.
+
+**Add a disambiguator when the name alone isn't enough.** If your community has two venues both called *The Hall*, name them *The Hall (Riverbend)* and *The Hall (Westside)*, or include the street so the picker shows them apart at a glance. The search will match either way, but the visible label is what makes the choice quick.
+
+**Avoid names that age badly.** *New downtown space* stops being new. *Temporary venue* implies a successor that may or may not arrive. *Bob's place* breaks when Bob moves. Names tied to the venue itself age better than names tied to the moment.
+
+**Don't put the address into the name.** The address has its own fields and is searchable. *123 Main Street Concert Hall* is harder to scan than *Main Street Concert Hall* with *123 Main Street* underneath it. Reserve the name for the human label; let the address be the address.
+
+A small habit pays off here. When you create a place, ask yourself whether a co-editor — or you, six months from now, picking quickly from a list of fifteen — will recognize this name without having to read its address. If the answer is no, rename it before you save.

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -2,7 +2,7 @@
 
 A *place* in Pavillion is a venue you save once and reuse — an address, a name, a few details. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
 
-A place can be flat — just an address — or it can have **Rooms & Spaces** inside it: named sub-locations like *Sterling Room*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in distinguishably different sub-areas, the rooms live as part of the place, and an event can attach to either the whole venue or a specific room within it.
+A place can be flat — just an address — or it can have rooms and spaces inside it: named sub-locations like *Sterling Room*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in distinguishably different sub-areas, the rooms live as part of the place, and an event can attach to either the whole venue or a specific room within it.
 
 This guide covers what places are, how rooms and spaces fit, how to create both, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, one-off venues — so you don't end up with a list of places you'll never reuse.
 

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -2,7 +2,9 @@
 
 A *place* in Pavillion is a venue stored as its own object — an address, a name, a few details — that events reference rather than copy. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
 
-This guide covers what places are, how to create them, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, one-off venues — so you don't end up with a list of places you'll never reuse.
+A place can be flat — just an address — or it can have **Rooms & Spaces** inside it: named sub-locations like *Sterling Room*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in distinguishably different sub-areas, the rooms live as part of the place, and an event can attach to either the whole venue or a specific room within it.
+
+This guide covers what places are, how rooms and spaces fit, how to create both, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, one-off venues — so you don't end up with a list of places you'll never reuse.
 
 ## How places work
 
@@ -14,30 +16,42 @@ The other consequence is that places are reusable. Every event you publish at th
 
 A place belongs to a calendar. If you run more than one calendar, each calendar has its own list of places — they aren't shared. That's usually what you want, since the venues a community garden uses are different from the venues a folk concert series uses.
 
+**Rooms and spaces are part of the place.** A place that has internal structure — a library with three meeting rooms, a community center with a hall and an art studio — can name those rooms inside its own record. The place holds the address; each room holds a name and any room-specific accessibility notes. When you attach a location to an event, the picker shows the venue itself *and* each named room as separate options. Picking *Riverbend Community Center* attaches the whole venue; picking *Riverbend Community Center — Art Studio* attaches the studio specifically. Every event keeps the same reference behavior: change the room's name once and every event in it updates.
+
 ## Create a place
 
 You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes save the same kind of object — pick whichever fits the moment.
 
-**From the Places tab.** Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Places** tab. The first time you visit, the list is empty. Click <Btn>+ Add place</Btn>. The place editor opens as a full page with two sections:
+**From the Places tab.** Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Places** tab. The first time you visit, the list is empty. Click <Btn>Add Place</Btn>. The place editor opens as a full page with three sections:
 
 - **Basic information.** A name (required), street address, city, state or province, postal code. The name is the only required field — you could save a place with just a name if that's all you have, though for most venues the address fields are what makes the place useful.
-- **Accessibility information.** A free-text field for things like wheelchair access, ASL interpretation, scent-free policy, parking notes — anything a visitor specifically needs to know about getting into and around the venue. If your calendar publishes in more than one language, this field shows a row of language tabs so you can write the accessibility note once per language.
+- **Accessibility information.** A free-text field for things that apply to the *whole venue* — wheelchair access at the main entrance, ASL interpretation policy, scent-free notes, parking notes — anything a visitor specifically needs to know about getting into and around the building. If your calendar publishes in more than one language, this field shows a row of language tabs so you can write the accessibility note once per language.
+- **Rooms & Spaces.** Optional. If the venue has named sub-locations, list them here. Click <Btn>Add room or space</Btn> to add one inline; give it a name (required, translatable per language) and any room-specific accessibility notes (also translatable). Save the place and the rooms save with it as one operation.
 
-Click <Btn>Save</Btn>. The place is now in your list and available to attach to events.
+Click <Btn>Save</Btn>. The place — and any rooms you added — are now in your list and available to attach to events.
 
-**From inside the event editor.** While editing an event, click <Btn>Add location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create new place</Btn>, fill in the same fields, and confirm. The place is saved to the calendar (it persists past this event) and is attached to the event you're editing.
+**From inside the event editor.** While editing an event, click <Btn>Add Location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create New</Btn>, fill in the basic information and accessibility notes, and confirm. The place is saved to the calendar (it persists past this event) and is attached to the event you're editing.
 
-Either way, the place is now reusable from any future event on this calendar.
+The inline form is the express lane — it covers the venue itself but not its rooms. If the place needs rooms or spaces, save it inline first and then open it from the **Places** tab to add the rooms; or create it from the **Places** tab to begin with. Either way, the place is now reusable from any future event on this calendar.
 
-## Attach a place to an event
+::: tip <Lightbulb /> Don't pre-create rooms.
+You don't need a room for every cubby a venue has. Add rooms when you're publishing a *second* event that needs to be told apart from the first one at the same venue — that's the moment the room name starts earning its keep. Until then, the whole-venue place handles it cleanly.
+:::
 
-In the event editor, find the **Location** section and click <Btn>Add location</Btn>. The location picker opens with your saved places listed alphabetically.
+## Attach a place — or a specific room — to an event
 
-There's a search box at the top of the picker. It searches across every field — name, address, city, state, postal code — so you can find a place by typing any of those, not just the name. *"Main"* will match a venue called *Main Street Hall* and a venue at *200 Main Street*, both.
+In the event editor, find the **Location** section and click <Btn>Add Location</Btn>. The location picker opens with your saved locations listed alphabetically.
 
-Click a place to select it. The picker closes and the chosen venue appears in the event's Location section. To swap it for a different one, click <Btn>Change location</Btn> and pick again. To remove the location entirely (for an online-only event you originally tagged with a place), open the picker and use the <Btn>Remove</Btn> option.
+What the list looks like depends on whether your places have rooms:
 
-Saving the event saves the reference to the place. The event doesn't store its own copy of the address — it remembers *which place* it points at, and reads the address from the place at display time.
+- **A place with no rooms** appears as a single entry. Picking it attaches the venue.
+- **A place with one or more rooms** appears as multiple entries: one for the whole venue (suffixed *(whole venue)*) and one for each room (with a door icon, indented). Picking the whole-venue entry says "this event uses the building broadly"; picking a room entry says "this event happens in this specific room."
+
+There's a search box at the top of the picker. It searches across the rendered name and the address — so *Sterling* matches *Multnomah County Library — Sterling Room*, *Main* matches a venue called *Main Street Hall* and a venue at *200 Main Street*, both. Typing a room name finds it whether or not you can see its parent place at that moment.
+
+Click an entry to select it. The picker closes and the chosen location appears in the event's Location section: the place's name (or *Place — Room Name* if you picked a specific room), with the address underneath. To swap it, click <Btn>Change</Btn> and pick again. To remove the location entirely (for an online-only event you originally tagged with a place), open the picker and use <Btn>Remove location</Btn>.
+
+Saving the event saves the reference. The event doesn't store its own copy of the address — it remembers *which place, and optionally which room* it points at, and reads the address and name from the place at display time.
 
 ## Edit a place after the fact
 
@@ -47,11 +61,25 @@ The change is reflected everywhere immediately. Every event currently attached t
 
 This is intentional, and it's the right behavior most of the time. If you correct a typo in the address, you want every event there to be correct. If the venue changes its name, you want every listing to reflect that. The reference model is what makes this clean — a copy-and-paste model would have left ten events stuck on the old typo.
 
+The same applies to rooms. Rename *Conference Room A* to *Sterling Room* in the place editor, save, and every event attached to that room shows the new name on next load. Edit a room's accessibility notes and the same propagation happens.
+
 ::: tip <Lightbulb /> A note on past events.
 Because past events show the venue's current state, the archive of your calendar is a record of *what happened*, not *what the listing said at the time*. If you want a permanent snapshot of the original address — say, for an event ticket stub or a community history project — copy that detail somewhere outside Pavillion (the event description, an external doc) before the venue changes. This is rarely worth doing, but worth knowing.
 :::
 
-Deleting a place behaves a little differently from editing. The delete dialog tells you how many events currently use the place; if you proceed, the place is removed from your list and every affected event keeps existing but loses its location. The events don't disappear — they just no longer have a venue attached. You can attach a different place (or a new one) to any of them by editing the event.
+**Deleting a room.** When you remove a room from a place, the editor checks how many events are using it. If none, the room just goes. If some events use it, you get a small dialog asking where those events should go: onto the whole venue (the default and usually right answer), or onto a different room of your choosing. The events don't disappear and they don't lose their place — they just stop pointing at the room you removed.
+
+**Deleting a whole place.** The delete dialog tells you how many events currently use the place; if you proceed, the place is removed from your list and every affected event keeps existing but loses its location entirely. The events don't disappear — they just no longer have a venue attached. You can attach a different place (or a new one) to any of them by editing the event.
+
+## When to use a room or space
+
+A place earns its keep through reuse, and a room earns its keep through *distinguishing*. The rule of thumb: add a room only when the same venue hosts events in sub-areas that visitors care about telling apart.
+
+**Yes:** a public library where events happen in three different rooms, each with its own size, layout, and accessibility profile. A community center with a main hall, a gym, and an art studio that get used in parallel. A school where different events happen in the auditorium, the cafeteria, and specific classrooms.
+
+**No:** a venue with a single usable space, even if you reuse it constantly. A coffeeshop with a tiny back room you've used once. A venue where the room is mentioned in the event description anyway and visitors don't navigate by it. In these cases the whole-venue place does the same job with less ceremony.
+
+If you're not sure, default to no room. A flat place is always cleaner; you can add rooms later, when a real reason shows up.
 
 ## When not to use a place
 
@@ -65,7 +93,7 @@ A place earns its keep through reuse. Creating one for a venue you'll list once 
 
 The bias should be toward fewer places, not more. A list of thirty places where you actually only use six creates exactly the friction the place system is supposed to remove — every new event you publish, you scroll past twenty-four near-irrelevant entries to find the one you want. Treat a place as a small commitment to reuse, and your list stays useful.
 
-## Naming places so they're recognizable later
+## Naming places and rooms so they're recognizable later
 
 The place's name is the first thing you see in the picker, so the way you name a place determines whether picking the right one feels obvious or feels like guessing.
 
@@ -77,4 +105,10 @@ The place's name is the first thing you see in the picker, so the way you name a
 
 **Don't put the address into the name.** The address has its own fields and is searchable. *123 Main Street Concert Hall* is harder to scan than *Main Street Concert Hall* with *123 Main Street* underneath it. Reserve the name for the human label; let the address be the address.
 
-A small habit pays off here. When you create a place, ask yourself whether a co-editor — or you, six months from now, picking quickly from a list of fifteen — will recognize this name without having to read its address. If the answer is no, rename it before you save.
+**Room names sit inside their parent.** A room is always shown next to its place — *Multnomah County Library — Sterling Room*, never *Sterling Room* by itself — so the room name doesn't need to identify the building. *Sterling Room* is enough; you don't need *Library Sterling Room*. Use whatever the venue itself calls the room: library staff already say *Sterling Room*, so that's the right name.
+
+**Disambiguate within the parent, not across the calendar.** Two rooms in the same venue both called *Studio* become *Studio (front)* and *Studio (back)*, or *North Studio* and *South Studio*. Two rooms in *different* places can share a name without any trouble — the parent place name keeps them apart in the picker.
+
+**Avoid generic room labels.** *Big room*, *Room 1*, *The other one* will be confusing the moment your list grows past two. If the venue has a real name for the room, use it; if it doesn't, pick a stable descriptor (*Front Hall*, *Upstairs Studio*) rather than a positional one.
+
+A small habit pays off here. When you create a place or a room, ask yourself whether a co-editor — or you, six months from now, picking quickly from a list of fifteen — will recognize this name without having to read its address. If the answer is no, rename it before you save.

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -1,6 +1,6 @@
 # Reuse venues with places
 
-A *place* in Pavillion is a venue stored as its own object — an address, a name, a few details — that events reference rather than copy. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
+A *place* in Pavillion is a venue you save once and reuse — an address, a name, a few details. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
 
 A place can be flat — just an address — or it can have **Rooms & Spaces** inside it: named sub-locations like *Sterling Room*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in distinguishably different sub-areas, the rooms live as part of the place, and an event can attach to either the whole venue or a specific room within it.
 
@@ -8,7 +8,7 @@ This guide covers what places are, how rooms and spaces fit, how to create both,
 
 ## How places work
 
-Places are separate from events. An event has a *reference* to a place, not a copy of it. This is the single fact that explains everything else in this guide.
+A place lives on its own, not inside any one event. When you attach it to an event, the event doesn't take a copy of the address — it just remembers which place it's at and reads the details from there. This is the single fact that explains everything else in this guide.
 
 The day-to-day consequence is small but valuable. When the community center on Main Street renames itself, you don't go event by event correcting the venue name. You open the place once, fix the name, save. The event lists, the event detail pages, the public calendar — all of it shows the new name on the next page load.
 
@@ -16,23 +16,23 @@ The other consequence is that places are reusable. Every event you publish at th
 
 A place belongs to a calendar. If you run more than one calendar, each calendar has its own list of places — they aren't shared. That's usually what you want, since the venues a community garden uses are different from the venues a folk concert series uses.
 
-**Rooms and spaces are part of the place.** A place that has internal structure — a library with three meeting rooms, a community center with a hall and an art studio — can name those rooms inside its own record. The place holds the address; each room holds a name and any room-specific accessibility notes. When you attach a location to an event, the picker shows the venue itself *and* each named room as separate options. Picking *Riverbend Community Center* attaches the whole venue; picking *Riverbend Community Center — Art Studio* attaches the studio specifically. Every event keeps the same reference behavior: change the room's name once and every event in it updates.
+**Rooms and spaces are part of the place.** A place with internal structure — a library with three meeting rooms, a community center with a hall and an art studio — can name those rooms inside the place itself. The place holds the address; each room carries its own name and any room-specific accessibility notes. When you attach a location to an event, the picker shows the venue itself *and* each named room as separate options. Picking *Riverbend Community Center* attaches the whole venue; picking *Riverbend Community Center — Art Studio* attaches the studio specifically. Rooms work the same way places do — change a room's name once and every event using that room updates.
 
 ## Create a place
 
-You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes save the same kind of object — pick whichever fits the moment.
+You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes save the same place — pick whichever fits the moment.
 
 **From the Places tab.** Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Places** tab. The first time you visit, the list is empty. Click <Btn>Add Place</Btn>. The place editor opens as a full page with three sections:
 
 - **Basic information.** A name (required), street address, city, state or province, postal code. The name is the only required field — you could save a place with just a name if that's all you have, though for most venues the address fields are what makes the place useful.
 - **Accessibility information.** A free-text field for things that apply to the *whole venue* — wheelchair access at the main entrance, ASL interpretation policy, scent-free notes, parking notes — anything a visitor specifically needs to know about getting into and around the building. If your calendar publishes in more than one language, this field shows a row of language tabs so you can write the accessibility note once per language.
-- **Rooms & Spaces.** Optional. If the venue has named sub-locations, list them here. Click <Btn>Add room or space</Btn> to add one inline; give it a name (required, translatable per language) and any room-specific accessibility notes (also translatable). Save the place and the rooms save with it as one operation.
+- **Rooms & Spaces.** Optional. If the venue has named sub-locations, list them here. Click <Btn>Add room or space</Btn> to add one to the list; give it a name (required, translatable per language) and any room-specific accessibility notes (also translatable). Saving the place saves the rooms along with it — one save covers both.
 
 Click <Btn>Save</Btn>. The place — and any rooms you added — are now in your list and available to attach to events.
 
-**From inside the event editor.** While editing an event, click <Btn>Add Location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create New</Btn>, fill in the basic information and accessibility notes, and confirm. The place is saved to the calendar (it persists past this event) and is attached to the event you're editing.
+**From inside the event editor.** While editing an event, click <Btn>Add Location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create New</Btn>, fill in the basic information and accessibility notes, and confirm. The place is saved to the calendar (it sticks around for future events) and is attached to the event you're editing.
 
-The inline form is the express lane — it covers the venue itself but not its rooms. If the place needs rooms or spaces, save it inline first and then open it from the **Places** tab to add the rooms; or create it from the **Places** tab to begin with. Either way, the place is now reusable from any future event on this calendar.
+The on-the-fly form is the express lane — it covers the venue itself but not its rooms. If the place needs rooms or spaces, save the basics first and then open the place from the **Places** tab to add the rooms; or create it from the **Places** tab to begin with. Either way, the place is now reusable from any future event on this calendar.
 
 ::: tip <Lightbulb /> Don't pre-create rooms.
 You don't need a room for every cubby a venue has. Add rooms when you're publishing a *second* event that needs to be told apart from the first one at the same venue — that's the moment the room name starts earning its keep. Until then, the whole-venue place handles it cleanly.
@@ -47,11 +47,11 @@ What the list looks like depends on whether your places have rooms:
 - **A place with no rooms** appears as a single entry. Picking it attaches the venue.
 - **A place with one or more rooms** appears as multiple entries: one for the whole venue (suffixed *(whole venue)*) and one for each room (with a door icon, indented). Picking the whole-venue entry says "this event uses the building broadly"; picking a room entry says "this event happens in this specific room."
 
-There's a search box at the top of the picker. It searches across the rendered name and the address — so *Sterling* matches *Multnomah County Library — Sterling Room*, *Main* matches a venue called *Main Street Hall* and a venue at *200 Main Street*, both. Typing a room name finds it whether or not you can see its parent place at that moment.
+There's a search box at the top of the picker. It searches across each entry's name and address — so *Sterling* matches *Multnomah County Library — Sterling Room*, *Main* matches a venue called *Main Street Hall* and a venue at *200 Main Street*, both. Typing a room name finds it whether or not you can see its parent place at that moment.
 
 Click an entry to select it. The picker closes and the chosen location appears in the event's Location section: the place's name (or *Place — Room Name* if you picked a specific room), with the address underneath. To swap it, click <Btn>Change</Btn> and pick again. To remove the location entirely (for an online-only event you originally tagged with a place), open the picker and use <Btn>Remove location</Btn>.
 
-Saving the event saves the reference. The event doesn't store its own copy of the address — it remembers *which place, and optionally which room* it points at, and reads the address and name from the place at display time.
+The event doesn't keep its own copy of the address. It remembers *which place — and which room, if you picked one* — and reads the details from there every time the event page loads.
 
 ## Edit a place after the fact
 
@@ -59,15 +59,15 @@ Open <Btn>Manage Calendar</Btn>, find the **Places** tab, click the pencil icon 
 
 The change is reflected everywhere immediately. Every event currently attached to that place — past, present, future — will display the updated information on its detail page the next time the page loads. Past events aren't frozen; they show the venue's current state, not the state it was in on the day the event happened.
 
-This is intentional, and it's the right behavior most of the time. If you correct a typo in the address, you want every event there to be correct. If the venue changes its name, you want every listing to reflect that. The reference model is what makes this clean — a copy-and-paste model would have left ten events stuck on the old typo.
+This is intentional, and it's the right behavior most of the time. If you correct a typo in the address, you want every event there to be correct. If the venue changes its name, you want every listing to reflect that. That's the whole point of places — if every event kept its own copy of the address, fixing a typo would mean editing ten events one at a time.
 
-The same applies to rooms. Rename *Conference Room A* to *Sterling Room* in the place editor, save, and every event attached to that room shows the new name on next load. Edit a room's accessibility notes and the same propagation happens.
+The same applies to rooms. Rename *Conference Room A* to *Sterling Room* in the place editor, save, and every event attached to that room shows the new name on next load. Edit a room's accessibility notes and they update everywhere too.
 
 ::: tip <Lightbulb /> A note on past events.
 Because past events show the venue's current state, the archive of your calendar is a record of *what happened*, not *what the listing said at the time*. If you want a permanent snapshot of the original address — say, for an event ticket stub or a community history project — copy that detail somewhere outside Pavillion (the event description, an external doc) before the venue changes. This is rarely worth doing, but worth knowing.
 :::
 
-**Deleting a room.** When you remove a room from a place, the editor checks how many events are using it. If none, the room just goes. If some events use it, you get a small dialog asking where those events should go: onto the whole venue (the default and usually right answer), or onto a different room of your choosing. The events don't disappear and they don't lose their place — they just stop pointing at the room you removed.
+**Deleting a room.** When you remove a room from a place, the editor checks how many events are using it. If none, the room just goes. If some events use it, you get a small dialog asking where those events should go: onto the whole venue (the default and usually right answer), or onto a different room of your choosing. The events don't disappear and they don't lose their place — they just stop being attached to the room you removed.
 
 **Deleting a whole place.** The delete dialog tells you how many events currently use the place; if you proceed, the place is removed from your list and every affected event keeps existing but loses its location entirely. The events don't disappear — they just no longer have a venue attached. You can attach a different place (or a new one) to any of them by editing the event.
 
@@ -79,7 +79,7 @@ A place earns its keep through reuse, and a room earns its keep through *disting
 
 **No:** a venue with a single usable space, even if you reuse it constantly. A coffeeshop with a tiny back room you've used once. A venue where the room is mentioned in the event description anyway and visitors don't navigate by it. In these cases the whole-venue place does the same job with less ceremony.
 
-If you're not sure, default to no room. A flat place is always cleaner; you can add rooms later, when a real reason shows up.
+If you're not sure, leave the rooms off. A simple place is always cleaner; you can add rooms later, when a real reason shows up.
 
 ## When not to use a place
 
@@ -89,9 +89,9 @@ A place earns its keep through reuse. Creating one for a venue you'll list once 
 
 **One-off venues you won't return to.** A pop-up at a borrowed location, a guest lecture in someone's living room, a single visiting artist's studio open day. If you're confident this is the only event you'll ever publish at that location, the cost of creating a place for it (a list entry to scroll past forever) outweighs the benefit (zero reuse). Put the address in the event description instead, or — if you want it more visible — in the accessibility field if it's part of the access notes.
 
-**Venues you're still figuring out.** If the booking isn't confirmed, or the address might change before the event happens, hold off on creating a place. You can attach one (or create one inline from the event editor) once the venue is settled.
+**Venues you're still figuring out.** If the booking isn't confirmed, or the address might change before the event happens, hold off on creating a place. You can attach one (or create one on the fly from the event editor) once the venue is settled.
 
-The bias should be toward fewer places, not more. A list of thirty places where you actually only use six creates exactly the friction the place system is supposed to remove — every new event you publish, you scroll past twenty-four near-irrelevant entries to find the one you want. Treat a place as a small commitment to reuse, and your list stays useful.
+The bias should be toward fewer places, not more. A list of thirty places where you actually only use six creates exactly the friction places are supposed to remove — every new event you publish, you scroll past twenty-four near-irrelevant entries to find the one you want. Treat a place as a small commitment to reuse, and your list stays useful.
 
 ## Naming places and rooms so they're recognizable later
 

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -1,18 +1,20 @@
-# Reuse venues with places
+# Manage event locations
 
-A *place* in Pavillion is a venue you save once and reuse — an address, a name, a few details. Type the venue's address once, attach it to ten events at that venue, and when the venue changes its name or you spot a typo in the address, you fix it once and every event there is updated.
+A *place* in Pavillion is an event location you save once and reuse — an address, a name, a few details. Create the venue once and you can link it to ten different events. Then, when the venue changes its name or you spot a typo in the address, you can fix it once and every event there is updated. (You'll manage them on the **Places** tab on your calendar page, alongside Events, Categories, and Series.)
 
-A place can be flat — just an address — or it can have rooms and spaces inside it: named sub-locations like *Sterling Room*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in distinguishably different sub-areas, the rooms live as part of the place, and an event can attach to either the whole venue or a specific room within it.
+A place can be flat — just an address — or it can have rooms and spaces inside it: named sub-locations like *Main Hall*, *Children's Story Corner*, *the gym*, *the back studio*. When a venue hosts events in specific sub-areas, an event can attach to either the whole venue or a specific room within it.
 
-This guide covers what places are, how rooms and spaces fit, how to create both, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, one-off venues — so you don't end up with a list of places you'll never reuse.
+This guide covers what places are, how rooms and spaces fit, how to create both, how to attach them to events, and what changes when you edit one. It also covers the cases where a place is the wrong tool — online events, venues that aren't settled yet.
 
 ## How places work
 
-A place lives on its own, not inside any one event. When you attach it to an event, the event doesn't take a copy of the address — it just remembers which place it's at and reads the details from there. This is the single fact that explains everything else in this guide.
+A place lives on its own, not inside any one event. When you attach it to an event, the event doesn't take a copy of the address — it just remembers which place it's at and reads the details from there. The place's name, address, and accessibility notes appear in their own dedicated spots on the event's public page, rather than a sentence buried in the event description.
 
-The day-to-day consequence is small but valuable. When the community center on Main Street renames itself, you don't go event by event correcting the venue name. You open the place once, fix the name, save. The event lists, the event detail pages, the public calendar — all of it shows the new name on the next page load.
+That structure pays off three ways:
 
-The other consequence is that places are reusable. Every event you publish at the same venue picks the place from a list rather than retyping the address. Over a year of running a calendar, a small set of recurring venues accounts for most of your events; saving them as places turns each new event's location field from a typing exercise into a one-click pick.
+- **Edit once, propagate everywhere.** When a venue renames itself, you fix the place — not every event that uses it. The lists, detail pages, and public calendar all show the new name on the next page load.
+- **Reusable across events.** Recurring venues become one-click picks instead of address retyping. Over a year of running a calendar, a small set of places covers most of your events.
+- **Free directions link.** If the place has a street address, the public event page renders it as a tap-to-open link — one-tap navigation on a phone, a map in a new tab on desktop. Just fill the address in and it happens automatically.
 
 A place belongs to a calendar. If you run more than one calendar, each calendar has its own list of places — they aren't shared. That's usually what you want, since the venues a community garden uses are different from the venues a folk concert series uses.
 
@@ -20,13 +22,13 @@ A place belongs to a calendar. If you run more than one calendar, each calendar 
 
 ## Create a place
 
-You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes save the same place — pick whichever fits the moment.
+You can create a place two ways: ahead of time from the calendar's **Places** tab, or on the fly from inside the event editor. Both routes do the same thing — pick whichever fits the moment.
 
-**From the Places tab.** Open <Btn>Manage Calendar</Btn> from your calendar page and find the **Places** tab. The first time you visit, the list is empty. Click <Btn>Add Place</Btn>. The place editor opens as a full page with three sections:
+**From the Places tab.** On your calendar page, switch to the **Places** tab (alongside Events, Categories, and Series). The first time you visit, the list is empty. Click <Btn>Add Place</Btn>. The place editor opens as a full page with three sections:
 
 - **Basic information.** A name (required), street address, city, state or province, postal code. The name is the only required field — you could save a place with just a name if that's all you have, though for most venues the address fields are what makes the place useful.
 - **Accessibility information.** A free-text field for things that apply to the *whole venue* — wheelchair access at the main entrance, ASL interpretation policy, scent-free notes, parking notes — anything a visitor specifically needs to know about getting into and around the building. If your calendar publishes in more than one language, this field shows a row of language tabs so you can write the accessibility note once per language.
-- **Rooms & Spaces.** Optional. If the venue has named sub-locations, list them here. Click <Btn>Add room or space</Btn> to add one to the list; give it a name (required, translatable per language) and any room-specific accessibility notes (also translatable). Saving the place saves the rooms along with it — one save covers both.
+- **Rooms & Spaces.** Optional. If the venue has named sub-locations, list them here. Click <Btn>Add room or space</Btn> to add one to the list; give it a name (required, translatable per language) and any room-specific accessibility notes (also translatable). Saving the place saves the rooms along with it.
 
 Click <Btn>Save</Btn>. The place — and any rooms you added — are now in your list and available to attach to events.
 
@@ -34,8 +36,8 @@ Click <Btn>Save</Btn>. The place — and any rooms you added — are now in your
 
 The on-the-fly form is the express lane — it covers the venue itself but not its rooms. If the place needs rooms or spaces, save the basics first and then open the place from the **Places** tab to add the rooms; or create it from the **Places** tab to begin with. Either way, the place is now reusable from any future event on this calendar.
 
-::: tip <Lightbulb /> Don't pre-create rooms.
-You don't need a room for every cubby a venue has. Add rooms when you're publishing a *second* event that needs to be told apart from the first one at the same venue — that's the moment the room name starts earning its keep. Until then, the whole-venue place handles it cleanly.
+::: tip <Lightbulb /> Just create the room you need right now.
+Specific rooms help attendees find the right door — but you don't have to map out every space in a venue while you're in the middle of creating an event. Add the room this event happens in, save, and move on. The next time you publish an event at the same venue, add that room then. The list fills in as you actually use it.
 :::
 
 ## Attach a place — or a specific room — to an event
@@ -55,7 +57,7 @@ The event doesn't keep its own copy of the address. It remembers *which place �
 
 ## Edit a place after the fact
 
-Open <Btn>Manage Calendar</Btn>, find the **Places** tab, click the pencil icon on the place you want to edit, change what needs changing, save.
+On your calendar page, switch to the **Places** tab, click the pencil icon on the place you want to edit, change what needs changing, save.
 
 The change is reflected everywhere immediately. Every event currently attached to that place — past, present, future — will display the updated information on its detail page the next time the page loads. Past events aren't frozen; they show the venue's current state, not the state it was in on the day the event happened.
 
@@ -83,15 +85,11 @@ If you're not sure, leave the rooms off. A simple place is always cleaner; you c
 
 ## When not to use a place
 
-A place earns its keep through reuse. Creating one for a venue you'll list once and never again adds friction without saving any.
+Most venues belong in your places list, even ones you'll only use once — the public listing is easier to use that way. The exceptions are events without a physical location and venues you can't yet commit to.
 
 **Online-only events.** If the event is a video call, a livestream, or otherwise has no physical location, leave the location field empty and put the join link in the **External link** field. There's no venue to reuse and no address to update.
 
-**One-off venues you won't return to.** A pop-up at a borrowed location, a guest lecture in someone's living room, a single visiting artist's studio open day. If you're confident this is the only event you'll ever publish at that location, the cost of creating a place for it (a list entry to scroll past forever) outweighs the benefit (zero reuse). Put the address in the event description instead, or — if you want it more visible — in the accessibility field if it's part of the access notes.
-
 **Venues you're still figuring out.** If the booking isn't confirmed, or the address might change before the event happens, hold off on creating a place. You can attach one (or create one on the fly from the event editor) once the venue is settled.
-
-The bias should be toward fewer places, not more. A list of thirty places where you actually only use six creates exactly the friction places are supposed to remove — every new event you publish, you scroll past twenty-four near-irrelevant entries to find the one you want. Treat a place as a small commitment to reuse, and your list stays useful.
 
 ## Naming places and rooms so they're recognizable later
 


### PR DESCRIPTION
## Summary

- Replaces the stub at `docs/guides/calendar-owners/places.md` with the full Reuse-venues-with-places / Manage-event-locations guide (originally pv-oqjj), then iterates on it across several commits to settle on title, structure, voice, and benefit framing.
- Final shape: titled **Manage event locations** (matching side nav), with "How places work" presenting the three concrete payoffs as a bullet list — edit-once propagation, reuse across events, and the tap-to-open directions link the public event page renders whenever a place has a street address.
- Tone passes that drop programmery vocabulary, lowercase *rooms and spaces* in prose, and reframe the room-creation tip from "don't pre-create rooms" to "just create the room you need right now" (specific rooms help attendees; calendar owners shouldn't feel pressured to map every space mid-event-creation).
- Trims **When not to use a place**: a saved place is now the default even for one-off venues, since the public listing reads better with a place attached. Online-only events and not-yet-confirmed venues remain as the two genuine exceptions.

## Test plan

- [ ] `npm run docs:build` succeeds
- [ ] Side-nav entry under *Calendar Owner Guides* reads "Manage event locations" and links to the right page
- [ ] Page H1 reads "Manage event locations"
- [ ] "How places work" renders the three payoffs as a bulleted list with bold ledes
- [ ] "Just create the room you need right now" tip box renders inside the `:::tip` block
- [ ] No broken `<Btn>` / `<Lightbulb />` shortcodes