### PR TITLE
refactor(location-picker): use native button + ul/li semantics

### DIFF
--- a/src/client/components/common/location-picker-modal.vue
+++ b/src/client/components/common/location-picker-modal.vue
@@ -229,55 +229,53 @@ defineExpose({ close, sheetRef });
 
       <!-- Location List -->
       <div class="location-list-container">
-        <div v-if="hasLocations && filteredEntries.length > 0" class="location-list">
-          <div
-            v-for="entry in filteredEntries"
-            :key="entry.key"
-            class="location-item"
-            :class="{
-              selected: isSelected(entry),
-              'is-space-entry': entry.isSpaceEntry,
-            }"
-            role="button"
-            tabindex="0"
-            :aria-label="entry.ariaLabel"
-            @click="handleEntryClick(entry)"
-            @keydown.enter="handleEntryClick(entry)"
-            @keydown.space.prevent="handleEntryClick(entry)"
-          >
-            <DoorOpen v-if="entry.isSpaceEntry" :size="20" class="location-icon" />
-            <MapPin v-else :size="20" class="location-icon" />
-            <div class="location-info">
-              <div class="location-name">
-                <template v-if="entry.isWholeVenue">
-                  <span>{{ entry.placeName }}</span>
-                  {{ ' ' }}
-                  <span class="whole-venue-suffix">
-                    {{ tPlaces('picker.whole_venue_suffix') }}
-                  </span>
-                </template>
-                <template v-else-if="entry.isSpaceEntry">
-                  {{ entry.spaceName }}
-                </template>
-                <template v-else>
-                  {{ entry.displayName }}
-                </template>
+        <ul v-if="hasLocations && filteredEntries.length > 0" role="list" class="location-list">
+          <li v-for="entry in filteredEntries" :key="entry.key">
+            <button
+              type="button"
+              class="location-item"
+              :class="{
+                selected: isSelected(entry),
+                'is-space-entry': entry.isSpaceEntry,
+              }"
+              :aria-label="entry.ariaLabel"
+              :aria-pressed="isSelected(entry)"
+              @click="handleEntryClick(entry)"
+            >
+              <DoorOpen v-if="entry.isSpaceEntry" :size="20" class="location-icon" />
+              <MapPin v-else :size="20" class="location-icon" />
+              <div class="location-info">
+                <div class="location-name">
+                  <template v-if="entry.isWholeVenue">
+                    <span>{{ entry.placeName }}</span>
+                    {{ ' ' }}
+                    <span class="whole-venue-suffix">
+                      {{ tPlaces('picker.whole_venue_suffix') }}
+                    </span>
+                  </template>
+                  <template v-else-if="entry.isSpaceEntry">
+                    {{ entry.spaceName }}
+                  </template>
+                  <template v-else>
+                    {{ entry.displayName }}
+                  </template>
+                </div>
+                <!--
+                  Space entries: show parent Place name (de-emphasized) so the row
+                  is self-describing when search filters out the parent. Other
+                  entries: show address.
+                -->
+                <div v-if="entry.isSpaceEntry" class="location-parent-name">
+                  {{ entry.placeName }}
+                </div>
+                <div v-else-if="entry.address" class="location-address">
+                  {{ entry.address }}
+                </div>
               </div>
-              <!--
-                Space entries: show parent Place name (de-emphasized) so the row
-                is self-describing when search filters out the parent. Other
-                entries: show address.
-              -->
-              <div v-if="entry.isSpaceEntry" class="location-parent-name">
-                {{ entry.placeName }}
-              </div>
-              <div v-else-if="entry.address" class="location-address">
-                {{ entry.address }}
-              </div>
-            </div>
-            <Check v-if="isSelected(entry)" :size="20" class="checkmark" />
-          </div>
-        </div>
+              <Check v-if="isSelected(entry)" :size="20" class="checkmark" />
+            </button>
+          </li>
+        </ul>
 
         <div v-else-if="!hasLocations" class="empty-state">
           <MapPin :size="48" class="empty-icon" />
@@ -353,9 +351,14 @@ defineExpose({ close, sheetRef });
   padding: 1rem;
   border-radius: 0.5rem;
   border: 1px solid var(--pav-color-stone-200);
-  background: white;
+  background: var(--pav-surface-card);
   cursor: pointer;
   transition: all 0.15s ease;
+  // Native button delta over the global button:not([role="tab"]) reset:
+  // entries are full-width rows with leading-aligned content, not the
+  // centered inline-flex shape the global rule sets up.
+  text-align: start;
+  width: 100%;
 
   // Indent and shrink Space entries so they read as children of the Place
   // entry above. Margin (not padding) moves the box itself; a subtle
@@ -388,7 +391,6 @@ defineExpose({ close, sheetRef });
   }
 
   @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-700);
     border-color: var(--pav-color-stone-600);
 
     &:hover {

--- a/src/client/test/components/location-picker-modal.test.ts
+++ b/src/client/test/components/location-picker-modal.test.ts
@@ -138,6 +138,89 @@ describe('LocationPickerModal', () => {
       expect(items[2].find('.checkmark').exists()).toBe(false);
     });
 
+    it('renders entries as native <button type="button"> with no role/tabindex overrides', () => {
+      // Accessibility regression guard: each picker entry must be a native
+      // <button>, not a div-as-button. The global button:not([role="tab"]) reset
+      // and the .location-item width/text-align delta reproduce the prior
+      // visuals; native semantics ensure AT virtual-cursor activation,
+      // forced-colors mode styling, and built-in Enter/Space activation.
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: mockLocations,
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const items = wrapper.findAll('.location-item');
+      expect(items.length).toBeGreaterThan(0);
+
+      // Element + type
+      expect(items[0].element.tagName).toBe('BUTTON');
+      expect(items[0].attributes('type')).toBe('button');
+
+      // Negative regression: no leftover ARIA/keyboard plumbing
+      expect(items[0].attributes('role')).not.toBe('button');
+      expect(items[0].attributes('tabindex')).toBeUndefined();
+    });
+
+    it('wraps entries in <ul role="list"> with one <li> per entry', () => {
+      // Explicit role="list" is a deliberate Safari/VoiceOver workaround:
+      // when CSS removes default markers (via _reset.scss), Safari strips
+      // list semantics. role="list" restores them.
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: mockLocations,
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const list = wrapper.find('ul.location-list');
+      expect(list.exists()).toBe(true);
+      expect(list.attributes('role')).toBe('list');
+      expect(list.findAll('li')).toHaveLength(mockLocations.length);
+    });
+
+    it('exposes aria-pressed on selected and unselected entries', () => {
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: mockLocations,
+        selectedLocationId: 'loc-2',
+        selectedSpaceId: null,
+      },
+      });
+
+      const items = wrapper.findAll('.location-item');
+      expect(items[0].attributes('aria-pressed')).toBe('false');
+      expect(items[1].attributes('aria-pressed')).toBe('true');
+      expect(items[2].attributes('aria-pressed')).toBe('false');
+    });
+
+    it('activates via the native button without manual @keydown handlers (no onkeydown attribute, click fires once)', async () => {
+      // Single keyboard-activation invariant. The prior div-as-button shim
+      // had explicit @keydown.enter / @keydown.space.prevent handlers; those
+      // are gone, and a native <button type="button"> converts Enter and
+      // Space into click events at the browser level. We assert (a) no
+      // leftover onkeydown attribute on the rendered element and (b) a click
+      // — which is what Enter/Space dispatch on a real button — emits the
+      // selection exactly once. Testing Enter and Space separately would
+      // over-test JSDOM rather than component logic (per testing-advisor).
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: mockLocations,
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const item = wrapper.findAll('.location-item')[0];
+      expect(item.attributes('onkeydown')).toBeUndefined();
+
+      await item.trigger('click');
+
+      const events = wrapper.emitted('location-selected');
+      expect(events).toBeTruthy();
+      expect(events?.length).toBe(1);
+      expect(events?.[0]).toEqual([{ placeId: 'loc-1', spaceId: null }]);
+    });
+
     it('should render footer buttons', () => {
       const wrapper = mount(LocationPickerModal, {
         props: {


### PR DESCRIPTION
## Motivation

`location-picker-modal.vue` rendered each picker entry as `<div role="button" tabindex="0">` with manual `@keydown.enter` and `@keydown.space.prevent` handlers. WCAG SC 4.1.2 prefers a native `<button type="button">`: correct implicit semantics for free, AT virtual cursor activation, and forced-colors mode picks up the styling. Surfaced by an accessibility audit during the previous epic-completion sweep.

## Approach

- Replace `<div class="location-list">` with `<ul role="list" class="location-list">`. The explicit `role="list"` is a deliberate Safari/VoiceOver workaround — Safari strips list semantics from `<ul>`s whose CSS removes default markers (which `_reset.scss` does globally).
- Replace each `<div class="location-item" role="button" tabindex="0">` with `<li><button type="button" class="location-item" :aria-pressed="isSelected(entry)">`. Drop the manual `@keydown` handlers — native buttons activate on Enter and Space without help.
- Defer to the global `button:not([role="tab"])` reset in `_buttons.scss` and the `_reset.scss` defaults instead of duplicating them. The only scoped delta is `text-align: start; width: 100%` for the full-width row layout, mirroring the `widget-config.vue` view-mode-card precedent.
- Replace the hardcoded `background: white` on `.location-item` with `var(--pav-surface-card)` and drop the matching dark-mode `@media` background override now that the token covers both modes.
- Keep the `class="location-item"` on the new `<button>` so existing test selectors and SCSS continue to work without churn.

The sister pattern in `src/site/components/category-pill-selector.vue` is intentionally out of scope; it will follow in a separate PR.

## Validation

- New component-tier assertions in `src/client/test/components/location-picker-modal.test.ts`:
  - Native `<button type="button">` with negative regression checks on `role` and `tabindex`.
  - `<ul role="list">` wrapper with one `<li>` per entry.
  - `aria-pressed` reflects selection state for both selected and unselected entries.
  - Single keyboard-activation test asserts no `onkeydown` attribute and that activation emits `location-selected` once with the correct payload. A separate Space test was deliberately omitted — that path is browser-guaranteed once the element is a `<button>` and would over-test JSDOM rather than component logic.
- `npm run lint` clean (0 errors).
- Targeted vitest run `src/client/test/components/location-picker-modal.test.ts` — all tests pass.