### PR TITLE
feat(calendar): inline rooms + add-space from event-editor picker

### DIFF
--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -35,7 +35,7 @@ Click <Btn>Save</Btn>. The place — and any rooms you added — are now in your
 **From inside the event editor.** While editing an event, click <Btn>Add Location</Btn> in the **Location** section. A picker opens showing every place this calendar already has. If the venue isn't in the list, click <Btn>Create New</Btn>, fill in the basic information, accessibility notes, and any rooms you need, and confirm. What happens next depends on whether you added rooms:
 
 - **No rooms.** The new place is attached to the event right away, with the whole venue selected. You're done.
-- **One or more rooms.** The picker re-opens with the search pre-filled with the new place's name and the whole-venue entry pre-selected. Click a room to refine the choice, or close the picker to keep the whole venue. Either way the place is saved to the calendar and reusable from future events.
+- **One or more rooms.** The picker re-opens. Click a room to refine the choice, or close the picker to use the whole venue. Either way the place is saved to the calendar and reusable from future events.
 
 The on-the-fly form is the express lane — it covers the venue and any rooms or spaces you need to add. The place is now reusable from any future event on this calendar.
 

--- a/src/client/components/common/add-space-sheet.vue
+++ b/src/client/components/common/add-space-sheet.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+/**
+ * Add-space sheet — opens from the per-Place add-space action in the location
+ * picker. Wraps SpacesEditor (with the per-row delete affordance hidden) over
+ * a working buffer cloned from the target Place. Save persists the snapshot
+ * via LocationService.updateLocation; cancel walks away without writing.
+ *
+ * Component split rationale (parent epic pv-s6s3 design): edit-place's full
+ * editor stays on its dedicated route; this sheet is a focused inline flow
+ * for the common "I just need to add one room" case from the event editor.
+ * Removal is intentionally out of scope here — the editor's per-row delete
+ * needs the eventCount-aware reassign branch which lives on the full
+ * edit-place screen.
+ */
+import { ref, nextTick, watch } from 'vue';
+import { useTranslation } from 'i18next-vue';
+import Sheet from '@/client/components/common/Sheet.vue';
+import PillButton from '@/client/components/common/pill-button.vue';
+import SpacesEditor from '@/client/components/logged_in/calendar/SpacesEditor.vue';
+import LocationService from '@/client/service/location';
+import { cloneLocationForBuffer } from '@/client/composables/location-helpers';
+import { EventLocation, EventLocationSpace } from '@/common/model/location';
+import { ValidationError } from '@/common/exceptions';
+
+const props = defineProps<{
+  place: EventLocation;
+  calendarId: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'saved', updatedPlace: EventLocation): void;
+  (e: 'cancelled'): void;
+  (e: 'close'): void;
+}>();
+
+const { t } = useTranslation('calendars', { keyPrefix: 'places.add_space' });
+
+const locationService = new LocationService();
+
+/**
+ * Working buffer of Spaces. Cloned from `props.place.spaces` so SpacesEditor
+ * mutations (add / inline edit) never reach back into the parent's
+ * availableLocations array. On save we re-clone from `props.place` so the
+ * full Place state (name, address, content, etc.) goes to the server PUT.
+ */
+const buffer = ref<EventLocationSpace[]>(cloneLocationForBuffer(props.place).spaces);
+
+const submissionError = ref('');
+const isSaving = ref(false);
+const submissionErrorEl = ref<HTMLElement | null>(null);
+
+watch(submissionError, async (newVal) => {
+  if (newVal) {
+    await nextTick();
+    submissionErrorEl.value?.focus();
+  }
+});
+
+async function handleSave() {
+  submissionError.value = '';
+  isSaving.value = true;
+
+  // Build a snapshot from the original Place plus the working buffer's spaces.
+  // The clone preserves all fields (name, address, content, etc.) so the
+  // server PUT operates on the full Place state.
+  const snapshot = cloneLocationForBuffer(props.place);
+  snapshot.spaces = buffer.value;
+
+  try {
+    const updated = await locationService.updateLocation(props.calendarId, snapshot);
+    emit('saved', updated);
+  }
+  catch (error: unknown) {
+    if (error instanceof ValidationError) {
+      submissionError.value = error.message;
+    }
+    else {
+      submissionError.value = (error as Error)?.message || t('error_saving');
+    }
+  }
+  finally {
+    isSaving.value = false;
+  }
+}
+
+function handleCancel() {
+  emit('cancelled');
+  emit('close');
+}
+</script>
+
+<template>
+  <Sheet
+    :title="t('title', { name: props.place.name })"
+    @close="handleCancel"
+  >
+    <div class="add-space-body">
+      <SpacesEditor
+        :spaces="buffer"
+        :hide-remove="true"
+        @update:spaces="buffer = $event"
+      />
+
+      <div
+        v-if="submissionError"
+        ref="submissionErrorEl"
+        class="alert alert--error"
+        role="alert"
+        tabindex="-1"
+      >
+        {{ submissionError }}
+      </div>
+
+      <footer class="modal-actions">
+        <PillButton
+          variant="ghost"
+          size="sm"
+          :disabled="isSaving"
+          @click="handleCancel"
+        >
+          {{ t('cancel_button') }}
+        </PillButton>
+        <PillButton
+          variant="primary"
+          size="sm"
+          :disabled="isSaving"
+          @click="handleSave"
+        >
+          {{ t('save_button') }}
+        </PillButton>
+      </footer>
+    </div>
+  </Sheet>
+</template>
+
+<style scoped lang="scss">
+.add-space-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pav-space-lg);
+  min-height: 0;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--pav-space-sm);
+  padding-top: var(--pav-space-md);
+  border-top: var(--pav-border-width-1) solid var(--pav-border-primary);
+}
+</style>

--- a/src/client/components/common/icons/door-plus.vue
+++ b/src/client/components/common/icons/door-plus.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+/**
+ * DoorPlus Icon
+ *
+ * Custom Lucide-style icon used by the location picker's per-Place
+ * "add space" action. Composes Lucide's closed-door silhouette with a
+ * Lucide-style "+" badge replacing the lock badge from DoorClosedLocked.
+ *
+ * Door paths are inlined (not imported from lucide-vue-next) so the
+ * inline-end badge can be precisely placed. The default attribute set
+ * mirrors lucide-vue-next so this icon sits next to existing Lucide
+ * icons (DoorOpen, MapPin, Plus, etc.) without visual drift.
+ *
+ * Decorative by default (aria-hidden); the calling button supplies the
+ * accessible label.
+ */
+
+withDefaults(defineProps<{
+  size?: number;
+}>(), {
+  size: 24,
+});
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <!-- Closed-door silhouette (lucide DoorClosedLocked door paths) -->
+    <path d="M18 9V6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v14" />
+    <path d="M2 20h8" />
+    <path d="M10 12h.01" />
+    <!-- Plus badge in the inline-end corner where the lock would sit -->
+    <path d="M15 18h6" />
+    <path d="M18 15v6" />
+  </svg>
+</template>

--- a/src/client/components/common/location-picker-modal.vue
+++ b/src/client/components/common/location-picker-modal.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { Search, MapPin, DoorOpen, Check } from 'lucide-vue-next';
+import DoorPlus from '@/client/components/common/icons/door-plus.vue';
 import PillButton from '@/client/components/common/pill-button.vue';
 import Sheet from '@/client/components/common/Sheet.vue';
 import { useLocalizedContent } from '@/client/composables/useLocalizedContent';
@@ -50,6 +51,8 @@ const { t: tPlaces } = useTranslation('calendars', { keyPrefix: 'places' });
  * Emits:
  * @emits location-selected - User picked an entry.
  *   @param {{ placeId: string, spaceId: string | null }} selection
+ * @emits add-space - User clicked the per-Place "add space" action button.
+ *   @param {{ placeId: string }} payload
  * @emits create-new
  * @emits remove-location
  * @emits close
@@ -79,6 +82,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   (e: 'location-selected', selection: { placeId: string; spaceId: string | null }): void;
+  (e: 'add-space', payload: { placeId: string }): void;
   (e: 'create-new'): void;
   (e: 'remove-location'): void;
   (e: 'close'): void;
@@ -212,6 +216,10 @@ const handleEntryClick = (entry: PickerEntry) => {
   emit('location-selected', { placeId: entry.placeId, spaceId: entry.spaceId });
 };
 
+const handleAddSpace = (entry: PickerEntry) => {
+  emit('add-space', { placeId: entry.placeId });
+};
+
 const handleCreateNew = () => {
   emit('create-new');
 };
@@ -253,49 +261,66 @@ defineExpose({ close, sheetRef });
       <div class="location-list-container">
         <ul v-if="hasLocations && filteredEntries.length > 0" role="list" class="location-list">
           <li v-for="entry in filteredEntries" :key="entry.key">
-            <button
-              type="button"
-              class="location-item"
-              :class="{
-                selected: isSelected(entry),
-                'is-space-entry': entry.isSpaceEntry,
-              }"
-              :aria-label="entry.ariaLabel"
-              :aria-pressed="isSelected(entry)"
-              @click="handleEntryClick(entry)"
-            >
-              <DoorOpen v-if="entry.isSpaceEntry" :size="20" class="location-icon" />
-              <MapPin v-else :size="20" class="location-icon" />
-              <div class="location-info">
-                <div class="location-name">
-                  <template v-if="entry.isWholeVenue">
-                    <span>{{ entry.placeName }}</span>
-                    {{ ' ' }}
-                    <span class="whole-venue-suffix">
-                      {{ tPlaces('picker.whole_venue_suffix') }}
-                    </span>
-                  </template>
-                  <template v-else-if="entry.isSpaceEntry">
-                    {{ entry.spaceName }}
-                  </template>
-                  <template v-else>
-                    {{ entry.displayName }}
-                  </template>
+            <div class="location-row">
+              <button
+                type="button"
+                class="location-item"
+                :class="{
+                  selected: isSelected(entry),
+                  'is-space-entry': entry.isSpaceEntry,
+                }"
+                :aria-label="entry.ariaLabel"
+                :aria-pressed="isSelected(entry)"
+                @click="handleEntryClick(entry)"
+              >
+                <DoorOpen v-if="entry.isSpaceEntry" :size="20" class="location-icon" />
+                <MapPin v-else :size="20" class="location-icon" />
+                <div class="location-info">
+                  <div class="location-name">
+                    <template v-if="entry.isWholeVenue">
+                      <span>{{ entry.placeName }}</span>
+                      {{ ' ' }}
+                      <span class="whole-venue-suffix">
+                        {{ tPlaces('picker.whole_venue_suffix') }}
+                      </span>
+                    </template>
+                    <template v-else-if="entry.isSpaceEntry">
+                      {{ entry.spaceName }}
+                    </template>
+                    <template v-else>
+                      {{ entry.displayName }}
+                    </template>
+                  </div>
+                  <!--
+                    Space entries: show parent Place name (de-emphasized) so the row
+                    is self-describing when search filters out the parent. Other
+                    entries: show address.
+                  -->
+                  <div v-if="entry.isSpaceEntry" class="location-parent-name">
+                    {{ entry.placeName }}
+                  </div>
+                  <div v-else-if="entry.address" class="location-address">
+                    {{ entry.address }}
+                  </div>
                 </div>
-                <!--
-                  Space entries: show parent Place name (de-emphasized) so the row
-                  is self-describing when search filters out the parent. Other
-                  entries: show address.
-                -->
-                <div v-if="entry.isSpaceEntry" class="location-parent-name">
-                  {{ entry.placeName }}
-                </div>
-                <div v-else-if="entry.address" class="location-address">
-                  {{ entry.address }}
-                </div>
-              </div>
-              <Check v-if="isSelected(entry)" :size="20" class="checkmark" />
-            </button>
+                <Check v-if="isSelected(entry)" :size="20" class="checkmark" />
+              </button>
+              <!--
+                Per-Place "add space" affordance. Renders as a sibling of the
+                select-button so AT users can tab to it independently and so it
+                does not nest interactives. Hidden on Space sub-rows — those
+                cannot host their own Spaces.
+              -->
+              <button
+                v-if="!entry.isSpaceEntry"
+                type="button"
+                class="picker-add-space-button"
+                :aria-label="t('add_space_aria', { name: entry.placeName })"
+                @click="handleAddSpace(entry)"
+              >
+                <DoorPlus :size="20" />
+              </button>
+            </div>
           </li>
         </ul>
 
@@ -366,6 +391,18 @@ defineExpose({ close, sheetRef });
   gap: 0.5rem;
 }
 
+// Row wrapper: hosts the select-button and the optional sibling
+// picker-add-space-button so they read as visually distinct slots without
+// nesting interactives. align-items: stretch lets the action button match
+// the select-button's hover/selected box height; min-width: 0 on the
+// select button (below) keeps the info column ellipsizable before the
+// action gets squashed.
+.location-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
 .location-item {
   display: flex;
   align-items: center;
@@ -380,7 +417,11 @@ defineExpose({ close, sheetRef });
   // entries are full-width rows with leading-aligned content, not the
   // centered inline-flex shape the global rule sets up.
   text-align: start;
-  width: 100%;
+  // flex 1 so the select-button consumes the row's free width; min-width 0
+  // lets the inner .location-info ellipsize before the sibling add-space
+  // action gets squeezed.
+  flex: 1;
+  min-width: 0;
 
   // Indent and shrink Space entries so they read as children of the Place
   // entry above. Margin (not padding) moves the box itself; a subtle
@@ -470,6 +511,56 @@ defineExpose({ close, sheetRef });
   .checkmark {
     flex-shrink: 0;
     color: var(--pav-color-orange-500);
+  }
+}
+
+// Per-Place "add space" sibling action. Sits at the row's true trailing
+// edge (outside the select-button) so it cannot nest inside the select
+// affordance and gets its own tab stop. Hit area is at least 44x44 CSS px
+// per WCAG 2.5.5; padding is tuned to wrap the 20px DoorPlus icon.
+//
+// Class is namespaced (`picker-add-space-button`) to avoid colliding with
+// SpacesEditor's `.add-space-button` when both components render in the
+// same test wrapper — `wrapper.find('.add-space-button')` would otherwise
+// match ambiguously.
+.picker-add-space-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-inline-size: 44px;
+  min-block-size: 44px;
+  padding: 0.625rem; // (44 - 20) / 2 / 16 ≈ 0.75rem visual; tighter so the
+  // icon centers without dwarfing the hit area.
+  border-radius: 0.5rem;
+  border: 1px solid var(--pav-color-stone-200);
+  background: var(--pav-surface-card);
+  color: var(--pav-color-stone-600);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: var(--pav-color-stone-50);
+    border-color: var(--pav-color-stone-300);
+    color: var(--pav-color-stone-900);
+  }
+
+  // Match the existing orange ring on .location-item so the two siblings
+  // read as a coherent affordance set under keyboard focus.
+  &:focus-visible {
+    outline: 2px solid var(--pav-color-orange-500);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    border-color: var(--pav-color-stone-600);
+    color: var(--pav-color-stone-400);
+
+    &:hover {
+      background: var(--pav-color-stone-600);
+      border-color: var(--pav-color-stone-500);
+      color: var(--pav-color-stone-100);
+    }
   }
 }
 

--- a/src/client/components/logged_in/calendar/SpacesEditor.vue
+++ b/src/client/components/logged_in/calendar/SpacesEditor.vue
@@ -170,6 +170,7 @@
               <Pencil :size="20" :stroke-width="2" aria-hidden="true" />
             </button>
             <button
+              v-if="!hideRemove"
               type="button"
               class="icon-button icon-button--danger delete-space-button"
               :aria-label="t('space.delete_space_button', { name: spaceDisplayName(space) })"
@@ -238,9 +239,22 @@ import { Pencil, Plus, Trash2 } from 'lucide-vue-next';
 import EditSpace from '@/client/components/logged_in/calendar/edit-space.vue';
 import { EventLocationSpace } from '@/common/model/location';
 
-const props = defineProps<{
-  spaces: EventLocationSpace[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    spaces: EventLocationSpace[];
+    /**
+     * When true, the per-row delete button is not rendered. The component
+     * still emits `remove-space` programmatically if a parent calls it, but
+     * the editor's own UI offers no removal affordance — used by consumers
+     * (like the add-space sheet) where deletion is handled in a dedicated
+     * full place editor and would be out of scope here.
+     */
+    hideRemove?: boolean;
+  }>(),
+  {
+    hideRemove: false,
+  },
+);
 
 const emit = defineEmits<{
   (e: 'update:spaces', value: EventLocationSpace[]): void;

--- a/src/client/components/logged_in/calendar/edit-place.vue
+++ b/src/client/components/logged_in/calendar/edit-place.vue
@@ -757,6 +757,7 @@ import LocationService from '@/client/service/location';
 import CalendarService from '@/client/service/calendar';
 import { useToast } from '@/client/composables/useToast';
 import { useLanguageManagement } from '@/client/composables/useLanguageManagement';
+import { cloneLocationForBuffer } from '@/client/composables/location-helpers';
 import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import { EventLocation, EventLocationSpace, validateLocationHierarchy } from '@/common/model/location';
 import iso6391 from 'iso-639-1-dir';
@@ -832,32 +833,6 @@ const pendingReassigns = reactive<Map<string, string>>(new Map());
 
 // Ref into the reassign dialog's cancel button — used by focus-management code.
 const reassignCancelRef = ref<HTMLElement | null>(null);
-
-/**
- * Clone an EventLocation into a detached working buffer. `EventLocation.toObject`
- * intentionally omits `eventCount` (read-only, never round-tripped into writes),
- * so the JSON-shaped clone loses it. Reattach it onto matching Space rows so the
- * delete dialog branch logic — which keys off `space.eventCount` — survives the
- * staging-buffer hand-off.
- */
-function cloneLocationForBuffer(source: EventLocation): EventLocation {
-  const clone = EventLocation.fromObject(source.toObject());
-  // Patch eventCount back onto each Space whose id matches a source row.
-  if (source.spaces && source.spaces.length > 0) {
-    const eventCountById = new Map<string, number>();
-    for (const sourceSpace of source.spaces) {
-      if (sourceSpace.id && typeof sourceSpace.eventCount === 'number') {
-        eventCountById.set(sourceSpace.id, sourceSpace.eventCount);
-      }
-    }
-    for (const cloneSpace of clone.spaces) {
-      if (cloneSpace.id && eventCountById.has(cloneSpace.id)) {
-        cloneSpace.eventCount = eventCountById.get(cloneSpace.id);
-      }
-    }
-  }
-  return clone;
-}
 
 /**
  * Helpers retained for the eventCount-aware reassign dialog (which still

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -1069,6 +1069,7 @@ button {
     @location-selected="handleLocationSelected"
     @create-new="createNewLocation"
     @remove-location="handleRemoveLocation"
+    @add-space="handleAddSpace"
     @close="showLocationPicker = false"
   />
 
@@ -1081,6 +1082,15 @@ button {
     @create-location="handleLocationCreated"
     @back-to-search="backToSearch"
     @close="showCreateLocationForm = false"
+  />
+
+  <!-- Add Space Sheet -->
+  <AddSpaceSheet
+    v-if="showAddSpace && addSpaceTargetPlace && editorState.event"
+    :place="addSpaceTargetPlace"
+    :calendar-id="editorState.event.calendarId"
+    @saved="saveAddSpace"
+    @cancelled="cancelAddSpace"
   />
 
   <!-- Unsaved Changes Confirmation Dialog -->
@@ -1130,6 +1140,7 @@ import LanguageTabSelector from '@/client/components/common/language-tab-selecto
 import LocationDisplayCard from '@/client/components/common/location-display-card.vue';
 import LocationPickerModal from '@/client/components/common/location-picker-modal.vue';
 import CreateLocationForm from '@/client/components/common/create-location-form.vue';
+import AddSpaceSheet from '@/client/components/common/add-space-sheet.vue';
 import { ValidationError } from '@/common/exceptions';
 import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import iso6391 from 'iso-639-1-dir';
@@ -1180,6 +1191,8 @@ const {
   availableLocations,
   showLocationPicker,
   showCreateLocationForm,
+  showAddSpace,
+  addSpaceTargetPlaceId,
   locationFieldErrors,
   locationSubmissionError,
   initialSearch: locationInitialSearch,
@@ -1190,7 +1203,19 @@ const {
   createLocation,
   removeLocation,
   backToSearch,
+  openAddSpace,
+  saveAddSpace,
+  cancelAddSpace,
 } = useLocationManagement();
+
+/**
+ * Resolved Place for the add-space sheet. Looks up the target placeId in
+ * availableLocations; returns null if the target is unset or the place
+ * is no longer present (defensive — should not happen in practice).
+ */
+const addSpaceTargetPlace = computed(() =>
+  availableLocations.value.find(loc => loc.id === addSpaceTargetPlaceId.value) ?? null,
+);
 
 // Unsaved changes composable
 const {
@@ -1425,6 +1450,15 @@ const handleRemoveLocation = () => {
   if (editorState.event) {
     removeLocation(editorState.event);
   }
+};
+
+/**
+ * Handle the picker's per-Place "add space" action — hands off to the
+ * composable, which closes the picker and opens the add-space sheet for
+ * the target Place.
+ */
+const handleAddSpace = ({ placeId }) => {
+  openAddSpace(placeId);
 };
 
 /**

--- a/src/client/composables/location-helpers.ts
+++ b/src/client/composables/location-helpers.ts
@@ -1,0 +1,33 @@
+import { EventLocation } from '@/common/model/location';
+
+/**
+ * Clone an EventLocation into a detached working buffer.
+ *
+ * `EventLocation.toObject` intentionally omits `eventCount` (read-only, never
+ * round-tripped into writes), so the JSON-shaped clone loses it. This helper
+ * reattaches `eventCount` onto matching Space rows so any consumer that keys
+ * UI behavior off `space.eventCount` (e.g. the delete-reassign branch in
+ * edit-place) survives the staging-buffer hand-off.
+ *
+ * Lifted from edit-place.vue when the add-space sheet became a second
+ * consumer (pv-s6s3.4) — the staged buffer pattern is shared, so the helper
+ * lives here to avoid drift.
+ */
+export function cloneLocationForBuffer(source: EventLocation): EventLocation {
+  const clone = EventLocation.fromObject(source.toObject());
+  // Patch eventCount back onto each Space whose id matches a source row.
+  if (source.spaces && source.spaces.length > 0) {
+    const eventCountById = new Map<string, number>();
+    for (const sourceSpace of source.spaces) {
+      if (sourceSpace.id && typeof sourceSpace.eventCount === 'number') {
+        eventCountById.set(sourceSpace.id, sourceSpace.eventCount);
+      }
+    }
+    for (const cloneSpace of clone.spaces) {
+      if (cloneSpace.id && eventCountById.has(cloneSpace.id)) {
+        cloneSpace.eventCount = eventCountById.get(cloneSpace.id);
+      }
+    }
+  }
+  return clone;
+}

--- a/src/client/composables/useLocationManagement.ts
+++ b/src/client/composables/useLocationManagement.ts
@@ -17,6 +17,8 @@ export function useLocationManagement() {
   const availableLocations = ref<EventLocation[]>([]);
   const showLocationPicker = ref(false);
   const showCreateLocationForm = ref(false);
+  const showAddSpace = ref(false);
+  const addSpaceTargetPlaceId = ref<string | null>(null);
   const locationFieldErrors = ref<Record<string, string>>({});
   const locationSubmissionError = ref('');
   // Seed value for the picker's search field. Set transiently when re-opening
@@ -220,10 +222,70 @@ export function useLocationManagement() {
     showLocationPicker.value = true;
   };
 
+  /**
+   * Open the add-space sheet for an existing Place. Mirrors the
+   * createNewLocation pattern: closes the picker and opens the add-space
+   * sheet, with the target placeId captured for the sheet to operate on.
+   *
+   * @param placeId - ID of the Place to add a Space to
+   */
+  const openAddSpace = (placeId: string): void => {
+    showLocationPicker.value = false;
+    addSpaceTargetPlaceId.value = placeId;
+    showAddSpace.value = true;
+    initialSearch.value = '';
+  };
+
+  /**
+   * Persist the result of the add-space sheet. The sheet has already called
+   * LocationService.updateLocation; this handler swaps the updated Place
+   * into availableLocations (find by id; push if missing), closes the
+   * sheet, and re-opens the picker seeded with the Place name so the user
+   * lands back where they were and can see the new Space sub-row.
+   *
+   * Mirrors the post-create reopen flow in createLocation. The picker's
+   * `initialSearch` watch only reseeds on empty -> non-empty transitions,
+   * so we explicitly clear before setting to satisfy the watcher.
+   *
+   * @param updatedPlace - The Place returned from the update call,
+   *                       carrying the new Space inline on `spaces[]`.
+   */
+  const saveAddSpace = (updatedPlace: EventLocation): void => {
+    const idx = availableLocations.value.findIndex(loc => loc.id === updatedPlace.id);
+    if (idx >= 0) {
+      availableLocations.value[idx] = updatedPlace;
+    }
+    else {
+      availableLocations.value.push(updatedPlace);
+    }
+
+    showAddSpace.value = false;
+    addSpaceTargetPlaceId.value = null;
+
+    // Force a transition empty -> non-empty so the picker's initialSearch
+    // watcher reseeds the search input.
+    initialSearch.value = '';
+    initialSearch.value = updatedPlace.name;
+    showLocationPicker.value = true;
+  };
+
+  /**
+   * Cancel the add-space sheet. Closes the sheet and re-opens the picker
+   * with no search seed. Mirrors the backToSearch pattern.
+   */
+  const cancelAddSpace = (): void => {
+    showAddSpace.value = false;
+    addSpaceTargetPlaceId.value = null;
+    initialSearch.value = '';
+    showLocationPicker.value = true;
+  };
+
   return {
     availableLocations,
     showLocationPicker,
     showCreateLocationForm,
+    showAddSpace,
+    addSpaceTargetPlaceId,
     locationFieldErrors,
     locationSubmissionError,
     initialSearch,
@@ -235,5 +297,8 @@ export function useLocationManagement() {
     clearLocationErrors,
     removeLocation,
     backToSearch,
+    openAddSpace,
+    saveAddSpace,
+    cancelAddSpace,
   };
 }

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -400,6 +400,12 @@
         "picker": {
             "whole_venue_suffix": "(whole venue)"
         },
+        "add_space": {
+            "title": "Add a space to {{name}}",
+            "save_button": "Save",
+            "cancel_button": "Cancel",
+            "error_saving": "Could not save the space. Please try again."
+        },
         "space": {
             "section_title": "Rooms & Spaces",
             "add_button": "Add room or space",

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -67,7 +67,8 @@
     "empty_help": "Create your first location to get started",
     "no_results": "No locations match your search",
     "remove_button": "Remove location",
-    "create_new_button": "Create New"
+    "create_new_button": "Create New",
+    "add_space_aria": "Add space to {{name}}"
   },
   "create_location": {
     "title": "Create Location",

--- a/src/client/locales/es/calendars.json
+++ b/src/client/locales/es/calendars.json
@@ -400,6 +400,12 @@
         "picker": {
             "whole_venue_suffix": "(lugar completo)"
         },
+        "add_space": {
+            "title": "Añadir un espacio a {{name}}",
+            "save_button": "Guardar",
+            "cancel_button": "Cancelar",
+            "error_saving": "No se pudo guardar el espacio. Inténtalo de nuevo."
+        },
         "space": {
             "section_title": "Salas y espacios",
             "add_button": "Añadir sala o espacio",

--- a/src/client/locales/es/event_editor.json
+++ b/src/client/locales/es/event_editor.json
@@ -67,7 +67,8 @@
     "empty_help": "Crea tu primera ubicación para comenzar",
     "no_results": "Ninguna ubicación coincide con tu búsqueda",
     "remove_button": "Eliminar ubicación",
-    "create_new_button": "Crear nueva"
+    "create_new_button": "Crear nueva",
+    "add_space_aria": "Añadir espacio a {{name}}"
   },
   "create_location": {
     "title": "Crear ubicación",

--- a/src/client/locales/fr/calendars.json
+++ b/src/client/locales/fr/calendars.json
@@ -400,6 +400,12 @@
         "picker": {
             "whole_venue_suffix": "(lieu entier)"
         },
+        "add_space": {
+            "title": "Ajouter un espace à {{name}}",
+            "save_button": "Enregistrer",
+            "cancel_button": "Annuler",
+            "error_saving": "Impossible d'enregistrer l'espace. Veuillez réessayer."
+        },
         "space": {
             "section_title": "Salles et espaces",
             "add_button": "Ajouter une salle ou un espace",

--- a/src/client/locales/fr/event_editor.json
+++ b/src/client/locales/fr/event_editor.json
@@ -67,7 +67,8 @@
     "empty_help": "Créez votre premier lieu pour commencer",
     "no_results": "Aucun lieu ne correspond à votre recherche",
     "remove_button": "Supprimer le lieu",
-    "create_new_button": "Créer un nouveau"
+    "create_new_button": "Créer un nouveau",
+    "add_space_aria": "Ajouter un espace à {{name}}"
   },
   "create_location": {
     "title": "Créer un lieu",

--- a/src/client/test/components/add-space-sheet.test.ts
+++ b/src/client/test/components/add-space-sheet.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import i18next from 'i18next';
+import I18NextVue from 'i18next-vue';
+import AddSpaceSheet from '@/client/components/common/add-space-sheet.vue';
+import PillButton from '@/client/components/common/pill-button.vue';
+import {
+  EventLocation,
+  EventLocationSpace,
+  EventLocationSpaceContent,
+} from '@/common/model/location';
+import { ValidationError } from '@/common/exceptions';
+import enSystem from '@/client/locales/en/system.json';
+import enCalendars from '@/client/locales/en/calendars.json';
+
+// Mock LocationService — only updateLocation is exercised by this sheet.
+const mockUpdateLocation = vi.fn();
+
+vi.mock('@/client/service/location', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    updateLocation: mockUpdateLocation,
+  })),
+}));
+
+const SheetStub = {
+  props: ['title'],
+  template: `
+    <dialog role="dialog" aria-modal="true">
+      <h2>{{ title }}</h2>
+      <slot/>
+    </dialog>
+  `,
+  emits: ['close'],
+  setup() {
+    return { open: () => {}, close: () => {} };
+  },
+};
+
+/**
+ * Stub for the SpacesEditor child. Mirrors the real component's contract:
+ *   - props: `spaces` (the working buffer), `hideRemove` (forwarded boolean)
+ *   - emits: `update:spaces` (add/edit) and `remove-space` (delete request)
+ *
+ * The stub records the most recent `hideRemove` prop so tests can assert that
+ * the sheet wires the prop through. Clicking `.stub-add-space` stages a new
+ * EventLocationSpace carrying a fresh `clientId`, mirroring SpacesEditor's
+ * create-mode behavior.
+ */
+const SpacesEditorStub = {
+  name: 'SpacesEditor',
+  props: ['spaces', 'hideRemove'],
+  emits: ['update:spaces', 'remove-space'],
+  methods: {
+    addStagedSpace(this: { spaces: EventLocationSpace[]; $emit: (event: string, ...args: any[]) => void }) {
+      const staged = new EventLocationSpace(undefined, undefined);
+      staged.clientId = `client-${Math.random().toString(36).slice(2, 10)}`;
+      staged.addContent(new EventLocationSpaceContent('en', 'Staged Room', ''));
+      this.$emit('update:spaces', [...(this.spaces ?? []), staged]);
+    },
+  },
+  template: `
+    <div class="spaces-editor-stub" :data-hide-remove="hideRemove ? 'true' : 'false'">
+      <button type="button" class="stub-add-space" @click="addStagedSpace">Add</button>
+      <ul>
+        <li v-for="s in spaces" :key="s.id || s.clientId">{{ s.content('en')?.name }}</li>
+      </ul>
+    </div>
+  `,
+};
+
+function makePlace(id: string, name: string, spaces: EventLocationSpace[] = []): EventLocation {
+  const place = new EventLocation(id, name);
+  place.spaces = spaces;
+  return place;
+}
+
+describe('AddSpaceSheet', () => {
+  beforeEach(async () => {
+    mockUpdateLocation.mockReset();
+    await i18next.init({
+      lng: 'en',
+      resources: {
+        en: {
+          system: enSystem,
+          calendars: enCalendars,
+        },
+      },
+    });
+  });
+
+  function mountWithI18n(options: any = {}) {
+    return mount(AddSpaceSheet, {
+      ...options,
+      global: {
+        plugins: [[I18NextVue, { i18next }]],
+        components: options.global?.components,
+        stubs: {
+          Sheet: SheetStub,
+          SpacesEditor: SpacesEditorStub,
+          ...(options.global?.stubs ?? {}),
+        },
+      },
+    });
+  }
+
+  describe('rendering', () => {
+    it('should render with the place name interpolated into the title', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+      });
+
+      expect(wrapper.find('[role="dialog"]').exists()).toBe(true);
+      expect(wrapper.find('h2').text()).toBe('Add a space to Community Center');
+    });
+
+    it('should render SpacesEditor with hide-remove enabled', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+      });
+
+      const editor = wrapper.find('.spaces-editor-stub');
+      expect(editor.exists()).toBe(true);
+      expect(editor.attributes('data-hide-remove')).toBe('true');
+    });
+
+    it('should render Save and Cancel buttons', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+        global: {
+          components: { PillButton },
+        },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      expect(buttons.length).toBe(2);
+
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      const cancelButton = buttons.find(b => b.text() === 'Cancel');
+
+      expect(saveButton).toBeDefined();
+      expect(saveButton?.props('variant')).toBe('primary');
+      expect(cancelButton).toBeDefined();
+      expect(cancelButton?.props('variant')).toBe('ghost');
+    });
+  });
+
+  describe('buffer initialization', () => {
+    it('mounts with an empty spaces buffer when the place has no spaces', () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Empty Place'),
+          calendarId: 'calendar-123',
+        },
+      });
+
+      // No <li> rendered for an empty buffer.
+      expect(wrapper.findAll('.spaces-editor-stub li').length).toBe(0);
+    });
+
+    it('does not mutate the prop place when buffer changes', async () => {
+      const place = makePlace('place-1', 'Empty Place');
+      const wrapper = mountWithI18n({
+        props: { place, calendarId: 'calendar-123' },
+      });
+
+      await wrapper.find('.stub-add-space').trigger('click');
+      await flushPromises();
+
+      // Buffer in the editor reflects the staged add.
+      expect(wrapper.findAll('.spaces-editor-stub li').length).toBe(1);
+      // Original prop unchanged.
+      expect(place.spaces.length).toBe(0);
+    });
+  });
+
+  describe('save path', () => {
+    it('calls LocationService.updateLocation once with the merged spaces[]', async () => {
+      const place = makePlace('place-1', 'Community Center');
+      mockUpdateLocation.mockImplementation((_calendarId, location: EventLocation) => {
+        // Echo back the saved place; copy spaces with `clientId` echo per
+        // the atomic Place + Spaces wire contract.
+        const saved = makePlace(location.id, location.name);
+        saved.spaces = (location.spaces ?? []).map((s, i) => {
+          const echoed = new EventLocationSpace(s.id || `server-${i}`, saved.id);
+          if (s.clientId) echoed.clientId = s.clientId;
+          return echoed;
+        });
+        return Promise.resolve(saved);
+      });
+
+      const wrapper = mountWithI18n({
+        props: { place, calendarId: 'calendar-123' },
+        global: { components: { PillButton } },
+      });
+
+      // Stage a new space via the SpacesEditor stub.
+      await wrapper.find('.stub-add-space').trigger('click');
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      await saveButton?.vm.$emit('click');
+      await flushPromises();
+
+      expect(mockUpdateLocation).toHaveBeenCalledTimes(1);
+      const [calledCalendarId, calledLocation] = mockUpdateLocation.mock.calls[0];
+      expect(calledCalendarId).toBe('calendar-123');
+      expect(calledLocation).toBeInstanceOf(EventLocation);
+      expect(calledLocation.id).toBe('place-1');
+      expect(calledLocation.name).toBe('Community Center');
+      expect(calledLocation.spaces).toHaveLength(1);
+      expect(calledLocation.spaces[0].clientId).toBeTruthy();
+    });
+
+    it('emits saved with the response from the service', async () => {
+      const place = makePlace('place-1', 'Community Center');
+      const savedPlace = makePlace('place-1', 'Community Center', [
+        new EventLocationSpace('space-new', 'place-1'),
+      ]);
+      mockUpdateLocation.mockResolvedValue(savedPlace);
+
+      const wrapper = mountWithI18n({
+        props: { place, calendarId: 'calendar-123' },
+        global: { components: { PillButton } },
+      });
+
+      await wrapper.find('.stub-add-space').trigger('click');
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      await saveButton?.vm.$emit('click');
+      await flushPromises();
+
+      const savedEmits = wrapper.emitted('saved');
+      expect(savedEmits).toBeTruthy();
+      expect(savedEmits?.length).toBe(1);
+      expect(savedEmits?.[0][0]).toBe(savedPlace);
+    });
+
+    it('does not emit cancelled or close on a successful save', async () => {
+      const place = makePlace('place-1', 'Community Center');
+      mockUpdateLocation.mockResolvedValue(makePlace('place-1', 'Community Center'));
+
+      const wrapper = mountWithI18n({
+        props: { place, calendarId: 'calendar-123' },
+        global: { components: { PillButton } },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      await saveButton?.vm.$emit('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('cancelled')).toBeFalsy();
+      expect(wrapper.emitted('close')).toBeFalsy();
+    });
+  });
+
+  describe('cancel path', () => {
+    it('emits cancelled and close without calling the service', async () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+        global: { components: { PillButton } },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const cancelButton = buttons.find(b => b.text() === 'Cancel');
+      await cancelButton?.vm.$emit('click');
+      await flushPromises();
+
+      expect(mockUpdateLocation).not.toHaveBeenCalled();
+      expect(wrapper.emitted('cancelled')).toBeTruthy();
+      expect(wrapper.emitted('close')).toBeTruthy();
+    });
+
+    it('does not emit saved on cancel', async () => {
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+        global: { components: { PillButton } },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const cancelButton = buttons.find(b => b.text() === 'Cancel');
+      await cancelButton?.vm.$emit('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('saved')).toBeFalsy();
+    });
+  });
+
+  describe('error handling', () => {
+    it('surfaces ValidationError messages via the alert region', async () => {
+      mockUpdateLocation.mockRejectedValue(
+        new ValidationError(['Name too long'], { name: ['Name too long'] }),
+      );
+
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+        global: { components: { PillButton } },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      await saveButton?.vm.$emit('click');
+      await flushPromises();
+
+      const alert = wrapper.find('[role="alert"]');
+      expect(alert.exists()).toBe(true);
+      expect(alert.text()).toContain('Name too long');
+
+      // Saved should NOT be emitted on validation failure.
+      expect(wrapper.emitted('saved')).toBeFalsy();
+    });
+
+    it('surfaces non-validation errors via the alert region', async () => {
+      mockUpdateLocation.mockRejectedValue(new Error('Server error'));
+
+      const wrapper = mountWithI18n({
+        props: {
+          place: makePlace('place-1', 'Community Center'),
+          calendarId: 'calendar-123',
+        },
+        global: { components: { PillButton } },
+      });
+
+      const buttons = wrapper.findAllComponents(PillButton);
+      const saveButton = buttons.find(b => b.text() === 'Save');
+      await saveButton?.vm.$emit('click');
+      await flushPromises();
+
+      const alert = wrapper.find('[role="alert"]');
+      expect(alert.exists()).toBe(true);
+      expect(wrapper.emitted('saved')).toBeFalsy();
+    });
+  });
+});

--- a/src/client/test/components/calendar/SpacesEditor.test.ts
+++ b/src/client/test/components/calendar/SpacesEditor.test.ts
@@ -80,7 +80,7 @@ const EditSpaceStub = {
 };
 
 const mountSpacesEditor = async (
-  props: { spaces: EventLocationSpace[] },
+  props: { spaces: EventLocationSpace[]; hideRemove?: boolean },
 ) => {
   const router: Router = createRouter({
     history: createMemoryHistory(),
@@ -309,6 +309,64 @@ describe('SpacesEditor', () => {
       expect(
         wrapper.find('.space-item .space-info__new-affordance').exists(),
       ).toBe(false);
+    });
+  });
+
+  describe('hideRemove prop', () => {
+    it('hides per-row delete buttons when hideRemove is true', async () => {
+      const a = createMockSpace('space-1', 'place-1', [
+        { language: 'en', name: 'Pacific Room' },
+      ]);
+      const b = createMockSpace('space-2', 'place-1', [
+        { language: 'en', name: 'Atlantic Room' },
+      ]);
+      const wrapper = await mountSpacesEditor({
+        spaces: [a, b],
+        hideRemove: true,
+      });
+
+      // No delete buttons rendered anywhere in the list.
+      expect(wrapper.findAll('.delete-space-button')).toHaveLength(0);
+
+      // Edit buttons are still present on every row — add-space-sheet
+      // still needs the rename affordance.
+      expect(wrapper.findAll('.edit-space-button')).toHaveLength(2);
+    });
+
+    it('still allows adding a new space when hideRemove is true', async () => {
+      const wrapper = await mountSpacesEditor({
+        spaces: [],
+        hideRemove: true,
+      });
+
+      // Add affordance is unaffected by hideRemove.
+      expect(wrapper.find('.add-space-button').exists()).toBe(true);
+
+      nextStagedSpaceName = 'Pacific Room';
+      await wrapper.find('.add-space-button').trigger('click');
+      await flushPromises();
+      await wrapper.find('.space-editor .btn-save').trigger('click');
+      await flushPromises();
+
+      const emissions = wrapper.emitted('update:spaces');
+      expect(emissions).toBeTruthy();
+      const last = emissions!.at(-1)![0] as EventLocationSpace[];
+      expect(last).toHaveLength(1);
+      expect(last[0].content('en').name).toBe('Pacific Room');
+      expect(last[0].clientId).toBeTruthy();
+
+      // Critically: the editor's own UI never fires remove-space when
+      // hideRemove is on (no delete button to click).
+      expect(wrapper.emitted('remove-space')).toBeFalsy();
+    });
+
+    it('renders delete buttons by default (hideRemove omitted)', async () => {
+      const a = createMockSpace('space-1', 'place-1', [
+        { language: 'en', name: 'Pacific Room' },
+      ]);
+      const wrapper = await mountSpacesEditor({ spaces: [a] });
+
+      expect(wrapper.findAll('.delete-space-button')).toHaveLength(1);
     });
   });
 

--- a/src/client/test/components/common/icons/door-plus.test.ts
+++ b/src/client/test/components/common/icons/door-plus.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import DoorPlus from '@/client/components/common/icons/door-plus.vue';
+
+describe('DoorPlus icon', () => {
+  it('renders an inline svg with lucide-vue-next default attributes', () => {
+    const wrapper = mount(DoorPlus);
+    const svg = wrapper.find('svg');
+
+    expect(svg.exists()).toBe(true);
+    expect(svg.attributes('viewBox')).toBe('0 0 24 24');
+    expect(svg.attributes('fill')).toBe('none');
+    expect(svg.attributes('stroke')).toBe('currentColor');
+    expect(svg.attributes('stroke-width')).toBe('2');
+    expect(svg.attributes('stroke-linecap')).toBe('round');
+    expect(svg.attributes('stroke-linejoin')).toBe('round');
+  });
+
+  it('defaults width and height to 24', () => {
+    const wrapper = mount(DoorPlus);
+    const svg = wrapper.find('svg');
+
+    expect(svg.attributes('width')).toBe('24');
+    expect(svg.attributes('height')).toBe('24');
+  });
+
+  it('applies the size prop to width and height', () => {
+    const wrapper = mount(DoorPlus, { props: { size: 18 } });
+    const svg = wrapper.find('svg');
+
+    expect(svg.attributes('width')).toBe('18');
+    expect(svg.attributes('height')).toBe('18');
+  });
+
+  it('is decorative by default (aria-hidden="true")', () => {
+    const wrapper = mount(DoorPlus);
+    expect(wrapper.find('svg').attributes('aria-hidden')).toBe('true');
+  });
+
+  it('renders both door silhouette paths and a plus glyph', () => {
+    const wrapper = mount(DoorPlus);
+    const paths = wrapper.findAll('svg path');
+
+    // At minimum: door body + door base + door handle dot + 2 plus strokes = 5 paths
+    expect(paths.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/src/client/test/components/location-picker-modal.test.ts
+++ b/src/client/test/components/location-picker-modal.test.ts
@@ -467,6 +467,115 @@ describe('LocationPickerModal', () => {
     });
   });
 
+  describe('add-space action button', () => {
+    const conventionCenter = new EventLocation('place-cc', 'Convention Center', '100 Main St', 'Portland', 'OR', '97201');
+
+    it('renders add-space action on Space-less Place header rows (place:placeId)', () => {
+      // Space-less Place: a single header row that needs the add-space affordance
+      // so the user can split a flat Place into Place + Spaces.
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [conventionCenter],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const rows = wrapper.findAll('li');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].find('.picker-add-space-button').exists()).toBe(true);
+    });
+
+    it('renders add-space action on the whole-venue header row (place:placeId:whole)', () => {
+      // Multi-Space Place: only the whole-venue header row gets the action;
+      // the Space sub-rows below it must NOT carry it (separate test).
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [placeWithSpaces(conventionCenter, [makeSpace('space-pacific', 'place-cc', 'Pacific Room')])],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const rows = wrapper.findAll('li');
+      expect(rows).toHaveLength(2);
+      // Row 0 is the whole-venue header.
+      expect(rows[0].find('.picker-add-space-button').exists()).toBe(true);
+    });
+
+    it('does NOT render add-space action on Space sub-rows (space:spaceId)', () => {
+      // Space sub-rows cannot host their own Spaces; the action button is
+      // strictly a Place-header affordance.
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [placeWithSpaces(conventionCenter, [
+          makeSpace('space-pacific', 'place-cc', 'Pacific Room'),
+          makeSpace('space-council', 'place-cc', 'Council Chambers'),
+        ])],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const rows = wrapper.findAll('li');
+      expect(rows).toHaveLength(3);
+      // Row 0 = whole-venue header (has action).
+      expect(rows[0].find('.picker-add-space-button').exists()).toBe(true);
+      // Rows 1 & 2 = Space sub-rows (no action).
+      expect(rows[1].find('.picker-add-space-button').exists()).toBe(false);
+      expect(rows[2].find('.picker-add-space-button').exists()).toBe(false);
+    });
+
+    it('clicking add-space emits {placeId} and does NOT emit location-selected', async () => {
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [placeWithSpaces(conventionCenter, [makeSpace('space-pacific', 'place-cc', 'Pacific Room')])],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const wholeVenueRow = wrapper.findAll('li')[0];
+      await wholeVenueRow.find('.picker-add-space-button').trigger('click');
+
+      expect(wrapper.emitted('add-space')).toBeTruthy();
+      expect(wrapper.emitted('add-space')?.[0]).toEqual([{ placeId: 'place-cc' }]);
+      // Independent action: the parent select stays untouched.
+      expect(wrapper.emitted('location-selected')).toBeFalsy();
+    });
+
+    it('aria-label uses the interpolated place name (source of truth, not title)', () => {
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [conventionCenter],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const action = wrapper.find('.picker-add-space-button');
+      expect(action.exists()).toBe(true);
+      expect(action.attributes('aria-label')).toBe('Add space to Convention Center');
+    });
+
+    it('action button is a sibling of (not nested inside) the select-button', () => {
+      // Nested interactives are an a11y bug (button-in-button is invalid HTML
+      // and AT-hostile). Both buttons must be direct children of .location-row.
+      const wrapper = mount(LocationPickerModal, { ...SHEET_GLOBAL, props: {
+        locations: [conventionCenter],
+        selectedLocationId: null,
+        selectedSpaceId: null,
+      },
+      });
+
+      const row = wrapper.find('.location-row');
+      expect(row.exists()).toBe(true);
+      // Both buttons live as direct children of the row wrapper.
+      const directChildren = Array.from(row.element.children);
+      const selectButton = directChildren.find((el) => el.classList.contains('location-item'));
+      const actionButton = directChildren.find((el) => el.classList.contains('picker-add-space-button'));
+      expect(selectButton).toBeDefined();
+      expect(actionButton).toBeDefined();
+      // Negative regression: the action button must NOT be inside the select-button.
+      expect(selectButton?.contains(actionButton ?? null)).toBe(false);
+    });
+  });
+
   describe('initialSearch prop', () => {
     const conventionCenter = new EventLocation('place-cc', 'Convention Center', '100 Main St', 'Portland', 'OR', '97201');
 

--- a/src/client/test/composables/useLocationManagement.test.ts
+++ b/src/client/test/composables/useLocationManagement.test.ts
@@ -365,6 +365,145 @@ describe('useLocationManagement', () => {
     });
   });
 
+  describe('openAddSpace', () => {
+    it('should close the picker, capture the target placeId, open the add-space sheet, and clear initialSearch', () => {
+      const {
+        openAddSpace,
+        showLocationPicker,
+        showAddSpace,
+        addSpaceTargetPlaceId,
+        initialSearch,
+      } = useLocationManagement();
+
+      // Simulate state where the picker is open and seeded.
+      showLocationPicker.value = true;
+      initialSearch.value = 'Convention Center';
+
+      openAddSpace('place-cc');
+
+      expect(showLocationPicker.value).toBe(false);
+      expect(addSpaceTargetPlaceId.value).toBe('place-cc');
+      expect(showAddSpace.value).toBe(true);
+      expect(initialSearch.value).toBe('');
+    });
+  });
+
+  describe('saveAddSpace', () => {
+    it('should replace the matching place in availableLocations, close the sheet, and re-open the picker seeded with the place name', () => {
+      const {
+        saveAddSpace,
+        availableLocations,
+        showLocationPicker,
+        showAddSpace,
+        addSpaceTargetPlaceId,
+        initialSearch,
+      } = useLocationManagement();
+
+      // Seed an existing Place; we'll replace it with an updated copy.
+      const existing = new EventLocation('place-cc', 'Convention Center', '500 Center Way');
+      availableLocations.value = [existing];
+
+      // Simulate the add-space sheet being open over the picker.
+      showAddSpace.value = true;
+      addSpaceTargetPlaceId.value = 'place-cc';
+
+      // Updated Place returned from LocationService.updateLocation, carrying
+      // the new Space inline on spaces[].
+      const updatedPlace = new EventLocation('place-cc', 'Convention Center', '500 Center Way');
+      const newSpace = new EventLocationSpace('space-pacific', 'place-cc');
+      newSpace.addContent(new EventLocationSpaceContent('en', 'Pacific Room', ''));
+      updatedPlace.spaces = [newSpace];
+
+      saveAddSpace(updatedPlace);
+
+      // Place was replaced (not duplicated). `availableLocations` is a Vue
+      // ref so its members are read through the reactive proxy — assert
+      // deep equality and confirm the new Space rode along inline.
+      expect(availableLocations.value).toHaveLength(1);
+      expect(availableLocations.value[0]).toEqual(updatedPlace);
+      expect(availableLocations.value[0].spaces).toHaveLength(1);
+      expect(availableLocations.value[0].spaces[0].id).toBe('space-pacific');
+
+      // Sheet closed, target cleared.
+      expect(showAddSpace.value).toBe(false);
+      expect(addSpaceTargetPlaceId.value).toBeNull();
+
+      // Picker re-opened seeded with the Place name.
+      expect(showLocationPicker.value).toBe(true);
+      expect(initialSearch.value).toBe('Convention Center');
+    });
+
+    it('should push the place when not already present in availableLocations', () => {
+      const { saveAddSpace, availableLocations } = useLocationManagement();
+
+      // Start with no places.
+      availableLocations.value = [];
+
+      const updatedPlace = new EventLocation('place-new', 'New Venue');
+      const newSpace = new EventLocationSpace('space-a', 'place-new');
+      newSpace.addContent(new EventLocationSpaceContent('en', 'Room A', ''));
+      updatedPlace.spaces = [newSpace];
+
+      saveAddSpace(updatedPlace);
+
+      expect(availableLocations.value).toHaveLength(1);
+      expect(availableLocations.value[0]).toEqual(updatedPlace);
+      expect(availableLocations.value[0].id).toBe('place-new');
+    });
+
+    it('should make no service calls', () => {
+      const getLocationsSpy = vi.spyOn(LocationService.prototype, 'getLocations');
+      const createLocationSpy = vi.spyOn(LocationService.prototype, 'createLocation');
+
+      const { saveAddSpace, availableLocations } = useLocationManagement();
+
+      const existing = new EventLocation('place-cc', 'Convention Center');
+      availableLocations.value = [existing];
+
+      const updatedPlace = new EventLocation('place-cc', 'Convention Center');
+      saveAddSpace(updatedPlace);
+
+      expect(getLocationsSpy).not.toHaveBeenCalled();
+      expect(createLocationSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelAddSpace', () => {
+    it('should close the sheet, clear the target, and re-open the picker without a search seed', () => {
+      const {
+        cancelAddSpace,
+        showLocationPicker,
+        showAddSpace,
+        addSpaceTargetPlaceId,
+        initialSearch,
+      } = useLocationManagement();
+
+      // Simulate the add-space sheet being open.
+      showAddSpace.value = true;
+      addSpaceTargetPlaceId.value = 'place-cc';
+      initialSearch.value = 'leftover';
+
+      cancelAddSpace();
+
+      expect(showAddSpace.value).toBe(false);
+      expect(addSpaceTargetPlaceId.value).toBeNull();
+      expect(showLocationPicker.value).toBe(true);
+      expect(initialSearch.value).toBe('');
+    });
+
+    it('should make no service calls', () => {
+      const getLocationsSpy = vi.spyOn(LocationService.prototype, 'getLocations');
+      const createLocationSpy = vi.spyOn(LocationService.prototype, 'createLocation');
+
+      const { cancelAddSpace } = useLocationManagement();
+
+      cancelAddSpace();
+
+      expect(getLocationsSpy).not.toHaveBeenCalled();
+      expect(createLocationSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('modal state transitions', () => {
     it('should transition from picker to create form and back', () => {
       const {

--- a/src/client/test/edit_event.vue.test.ts
+++ b/src/client/test/edit_event.vue.test.ts
@@ -39,6 +39,7 @@ const locationServiceMocks = {
   getLocations: vi.fn().mockResolvedValue([]),
   createLocation: vi.fn().mockResolvedValue({}),
   getLocationById: vi.fn().mockResolvedValue({}),
+  updateLocation: vi.fn().mockResolvedValue({}),
 };
 
 // Mock LocationService
@@ -238,6 +239,7 @@ describe('Location Integration', () => {
     locationServiceMocks.getLocations.mockResolvedValue([]);
     locationServiceMocks.createLocation.mockResolvedValue({});
     locationServiceMocks.getLocationById.mockResolvedValue({});
+    locationServiceMocks.updateLocation.mockResolvedValue({});
   });
 
   afterEach(async () => {
@@ -768,6 +770,177 @@ describe('Location Integration', () => {
       expect(freshPicker.exists()).toBe(true);
       // initialSearch must be empty on the fresh open — no stale seed.
       expect(freshPicker.props('initialSearch')).toBe('');
+    });
+  });
+
+  // pv-s6s3.8: Add-space sheet flow from the picker — clicking the per-Place
+  // add-space action opens AddSpaceSheet over the picker, saving a new Space
+  // calls LocationService.updateLocation with the merged spaces[] and then
+  // re-opens the picker seeded with the place name.
+  describe('Add-space flow from picker', () => {
+    /**
+     * Seed an EventLocation with one existing Space so the picker has a
+     * well-formed parent row that exposes the per-Place add-space action.
+     */
+    const buildExistingPlace = (
+      placeId: string,
+      placeName: string,
+      spaceId: string,
+      spaceName: string,
+    ) => {
+      const place = new EventLocation(placeId, placeName, '200 Main St', 'Portland', 'OR', '97201');
+      const space = new EventLocationSpace(spaceId, placeId);
+      space.addContent(new EventLocationSpaceContent('en', spaceName, ''));
+      place.spaces = [space];
+      return place;
+    };
+
+    it('add-space happy path: picker -> sheet -> save -> picker re-opens with new space sub-row', async () => {
+      const calendar = new Calendar('testCalendarId', 'testName');
+      calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+      const existingPlace = buildExistingPlace('place-1', 'Civic Hall', 'space-existing', 'Foyer');
+      locationServiceMocks.getLocations.mockResolvedValue([existingPlace]);
+
+      // Synthetic updateLocation response: a copy of the place with the
+      // newly-staged Space appended (server-issued id, clientId echoed).
+      locationServiceMocks.updateLocation.mockImplementationOnce(
+        async (_calendarId: string, snapshot: EventLocation) => {
+          const updated = new EventLocation(
+            snapshot.id, snapshot.name, snapshot.address, snapshot.city,
+            snapshot.state, snapshot.postalCode, snapshot.country,
+          );
+          updated.spaces = (snapshot.spaces ?? []).map((s, i) => {
+            const persisted = new EventLocationSpace(s.id || `server-space-${i}`, updated.id);
+            if (s.clientId) persisted.clientId = s.clientId;
+            // Carry the staged content forward so the picker can render the
+            // new sub-row by name.
+            for (const lang of s.getLanguages()) {
+              const c = s.content(lang);
+              persisted.addContent(
+                new EventLocationSpaceContent(lang, c.name, c.accessibilityInfo ?? ''),
+              );
+            }
+            return persisted;
+          });
+          return updated;
+        },
+      );
+
+      const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+      currentWrapper = wrapper;
+
+      // Open the picker.
+      const locationCard = wrapper.findComponent({ name: 'LocationDisplayCard' });
+      await locationCard.vm.$emit('add-location');
+      await nextTick();
+      await flushPromises();
+
+      const pickerModal = wrapper.findComponent({ name: 'LocationPickerModal' });
+      expect(pickerModal.exists()).toBe(true);
+
+      // Click the per-Place add-space action.
+      await pickerModal.vm.$emit('add-space', { placeId: 'place-1' });
+      await nextTick();
+      await flushPromises();
+
+      // Sheet visible, picker hidden.
+      const addSpaceSheet = wrapper.findComponent({ name: 'AddSpaceSheet' });
+      expect(addSpaceSheet.exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'LocationPickerModal' }).exists()).toBe(false);
+
+      // Sheet received the resolved Place + calendarId.
+      expect(addSpaceSheet.props('place').id).toBe('place-1');
+      expect(addSpaceSheet.props('calendarId')).toBe('testCalendarId');
+
+      // Stage a new Space via the real SpacesEditor's update:spaces emit
+      // (skipping the inline EditSpace UI keeps this test focused on the
+      // sheet wiring rather than the per-row form).
+      const spacesEditor = wrapper.findComponent({ name: 'SpacesEditor' });
+      expect(spacesEditor.exists()).toBe(true);
+      const stagedSpace = new EventLocationSpace(undefined, 'place-1');
+      stagedSpace.clientId = 'client-staged-1';
+      stagedSpace.addContent(new EventLocationSpaceContent('en', 'Atrium', ''));
+      const currentBuffer = spacesEditor.props('spaces') as EventLocationSpace[];
+      await spacesEditor.vm.$emit('update:spaces', [...currentBuffer, stagedSpace]);
+      await nextTick();
+      await flushPromises();
+
+      // Click Save — find the primary PillButton in the sheet's footer.
+      const sheetButtons = addSpaceSheet.findAllComponents({ name: 'PillButton' });
+      const saveButton = sheetButtons.find(b => b.props('variant') === 'primary');
+      expect(saveButton).toBeDefined();
+      await saveButton!.trigger('click');
+      await nextTick();
+      await flushPromises();
+
+      // updateLocation called once with the merged spaces[].
+      expect(locationServiceMocks.updateLocation).toHaveBeenCalledTimes(1);
+      const [calledCalendarId, calledSnapshot] = locationServiceMocks.updateLocation.mock.calls[0];
+      expect(calledCalendarId).toBe('testCalendarId');
+      expect(calledSnapshot).toBeInstanceOf(EventLocation);
+      expect(calledSnapshot.id).toBe('place-1');
+      expect(calledSnapshot.name).toBe('Civic Hall');
+      // The merged buffer carries both the existing Space and the staged one.
+      expect(calledSnapshot.spaces).toHaveLength(2);
+      expect(calledSnapshot.spaces.map((s: EventLocationSpace) => s.clientId ?? null))
+        .toContain('client-staged-1');
+
+      // Sheet closes; picker re-opens seeded with the place name.
+      expect(wrapper.findComponent({ name: 'AddSpaceSheet' }).exists()).toBe(false);
+      const reopenedPicker = wrapper.findComponent({ name: 'LocationPickerModal' });
+      expect(reopenedPicker.exists()).toBe(true);
+      expect(reopenedPicker.props('initialSearch')).toBe('Civic Hall');
+
+      // The new Space appears as a sub-row under the place — the picker's
+      // `locations` prop carries the updated Place with both spaces.
+      const places = reopenedPicker.props('locations') as EventLocation[];
+      const updatedRow = places.find(p => p.id === 'place-1');
+      expect(updatedRow).toBeDefined();
+      expect(updatedRow?.spaces).toHaveLength(2);
+      expect(updatedRow?.spaces.some(s => (s.content('en')?.name ?? '') === 'Atrium')).toBe(true);
+    });
+
+    it('add-space cancel path: clicking Cancel in the sheet returns to the picker without a service call', async () => {
+      const calendar = new Calendar('testCalendarId', 'testName');
+      calendar.addContent({ language: 'en', name: 'Test Calendar', description: '' });
+
+      const existingPlace = buildExistingPlace('place-2', 'Library Annex', 'space-foyer', 'Lobby');
+      locationServiceMocks.getLocations.mockResolvedValue([existingPlace]);
+
+      const { wrapper } = await mountedEditorOnRoute('/event', [calendar]);
+      currentWrapper = wrapper;
+
+      // Open picker -> click add-space.
+      const locationCard = wrapper.findComponent({ name: 'LocationDisplayCard' });
+      await locationCard.vm.$emit('add-location');
+      await nextTick();
+      await flushPromises();
+
+      const pickerModal = wrapper.findComponent({ name: 'LocationPickerModal' });
+      await pickerModal.vm.$emit('add-space', { placeId: 'place-2' });
+      await nextTick();
+      await flushPromises();
+
+      const addSpaceSheet = wrapper.findComponent({ name: 'AddSpaceSheet' });
+      expect(addSpaceSheet.exists()).toBe(true);
+
+      // Click Cancel — find the ghost PillButton in the sheet's footer.
+      const sheetButtons = addSpaceSheet.findAllComponents({ name: 'PillButton' });
+      const cancelButton = sheetButtons.find(b => b.props('variant') === 'ghost');
+      expect(cancelButton).toBeDefined();
+      await cancelButton!.trigger('click');
+      await nextTick();
+      await flushPromises();
+
+      // Sheet closed; picker re-opened with no search seed.
+      expect(wrapper.findComponent({ name: 'AddSpaceSheet' }).exists()).toBe(false);
+      const reopenedPicker = wrapper.findComponent({ name: 'LocationPickerModal' });
+      expect(reopenedPicker.exists()).toBe(true);
+      expect(reopenedPicker.props('initialSearch')).toBe('');
+
+      // No service call was made.
+      expect(locationServiceMocks.updateLocation).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- New per-Place "add space" action in the event-editor location picker (pv-s6s3): custom DoorPlus icon, ≥44×44 hit area, dedicated tab stop, translated aria-label. On activation it opens an `AddSpaceSheet` wrapping `SpacesEditor` with the delete control hidden.
- On save, the sheet calls `LocationService.updateLocation` and re-opens the picker seeded with the place name; the new Space appears as a sub-row, immediately pickable.
- Lifts `cloneLocationForBuffer` to a shared composable so `edit-place.vue` and the new sheet share one staged-buffer pattern.
- en/es/fr translations for `places.add_space.*` and `location_picker.add_space_aria`.
- Tightens places-guide copy.
- Frontend-only — reuses the existing atomic Place + Spaces save path. No backend, schema, or federation changes.

(The earlier inline-rooms (pv-3f2x) and picker-reopen (pv-24jz) arcs that were originally part of this branch shipped separately via #292.)

## Test plan

- [ ] `npm run lint` passes (0 errors)
- [ ] `npm test` passes (unit + integration)
- [ ] Manual: select an existing Place in the picker → click the door+plus action → add a Space in the sheet → Save → picker re-opens with the new Space as a sub-row → pick it
- [ ] Manual: open Add Space sheet → Cancel → picker re-opens with no search seed and no server write
- [ ] Manual: keyboard-only — Tab into picker, Tab between select-button and picker-add-space-button on a Place row, Enter to activate
- [ ] Manual: verify es and fr locales show translated copy in both the picker action's aria-label and the Add Space sheet