### PR TITLE
docs: voice pass on calendar-owner guides + documentation-playbook skill

### DIFF
--- a/.claude/skills/documentation-playbook/SKILL.md
+++ b/.claude/skills/documentation-playbook/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: Documentation Playbook
+description: Voice and structure standards for Pavillion user-facing documentation. Use this skill when writing or revising guides in docs/guides/, when evaluating documentation drafts for tone and scope, or when checking that new docs land in the same voice as the marketing site at pavillion.social.
+---
+
+# Documentation Playbook
+
+This Skill provides voice and structure standards for the Pavillion user-facing documentation in `docs/guides/`. Use it when writing a new guide, revising an existing one, or evaluating a draft.
+
+Pavillion documentation has a dual purpose: **teach the software well enough that someone can use it, AND help the reader become a better calendar owner, organizer, or administrator.** Voice and structure decisions follow from that dual purpose.
+
+## Reference Sources
+
+| Source | What it gives you |
+|--------|-------------------|
+| [./principles.md](./principles.md) | The substantive standards: voice principles, patterns, anti-patterns, length and scope rules, pre-publish checklist |
+| `docs/guides/calendar-owners/categories.md` and `places.md` | The most-developed exemplars of the voice in practice — verbatim quotes in `principles.md` are excerpted from these |
+| https://pavillion.social/ | The marketing-site voice these guides extend into reference material |
+
+## Routing Guide
+
+| If you are... | Read these sections of principles.md |
+|---------------|--------------------------------------|
+| Writing a new guide from scratch | All sections |
+| Adding a section to an existing guide | Voice principles + Patterns we use + Things we avoid |
+| Reviewing a draft | Things we avoid + Checklist |
+| Deciding whether a topic deserves a full guide or a stub | Notes on length and scope |
+| Calibrating tone before writing the first sentence | Voice principles + Continuity with the marketing site |
+
+## Instructions
+
+1. Read [./principles.md](./principles.md) for the standards.
+2. Skim at least one developed exemplar (`docs/guides/calendar-owners/categories.md` or `places.md`) to see the voice in practice — the verbatim quotes in `principles.md` come from these.
+3. Apply the voice principles when drafting; apply the anti-patterns and checklist when reviewing the result.
+4. When the dual-purpose layer (organizer judgment alongside mechanics) doesn't fit naturally for a topic, prefer omitting it over forcing it. Not every guide needs to read like `categories.md`.
+5. A stub that telegraphs planned scope (`> Status: stub. Full guide coming before launch.` followed by bulleted scope) is better than a thin half-guide.
+
+## Related Skills
+
+This skill covers user-facing documentation in `docs/guides/`. It does not cover:
+
+- **Code comments** — see `global-commenting`
+- **Commit messages** — see `git-workflow`
+- **Beads issue descriptions** — see beads workflow skills
+- **Design docs / specs** — see `architecture-playbook`, `complexity-playbook`
+
+If a doc is for end users (calendar owners, instance administrators, contributing developers reading guides about how to contribute), this skill applies. If it's a code artifact or an internal planning document, it doesn't.

--- a/.claude/skills/documentation-playbook/principles.md
+++ b/.claude/skills/documentation-playbook/principles.md
@@ -1,0 +1,205 @@
+# Documentation Voice and Structure Principles
+
+> Version: 1.0.0
+> Last Updated: 2026-05-10
+
+This file covers voice, structure, and scope standards for Pavillion user-facing documentation in `docs/guides/`. These standards extend the marketing-site voice (pavillion.social) into reference material — same reader, same values, more depth.
+
+## Who the guides are for
+
+The marketing site names the audience directly: "a nonprofit, a local business, a church, a neighborhood group." Inside the guides, the framing matches — these are people doing real organizing work in their actual communities, not generic users moving through a wizard.
+
+From `docs/guides/calendar-owners/index.md`:
+
+> These guides are for the people running calendars on Pavillion — community organizers, venue staff, neighborhood associations, regional councils, anyone whose job it is to publish events that other people can find.
+
+**Apply this:** Specificity matters. "Users" is a category that doesn't exist in the world. "The neighborhood association down the street" does. Name the reader before the second paragraph of any guide.
+
+## What the guides are trying to do
+
+Two things at once, in this order:
+
+**1. Teach the software well enough that someone can do the thing.** Without this, none of the rest matters. A calendar owner who can't find the cancel button isn't going to benefit from advice about cancellation etiquette.
+
+**2. Help the reader become a better calendar owner, organizer, or administrator.** The dual-purpose layer. Naming conventions that age, decision aids about which tool fits what, "when not to" framings, troubleshooting wisdom, the social rules of a federated network. This is what distinguishes a Pavillion guide from a feature manual.
+
+The second goal lives *inside* the first, anchored to specific moments of action. **Don't write a sermon called "How to be a good calendar owner" and link to it from each topic.** The advice shows up at the point the reader is actually making the decision — when they're naming a category, choosing between recurrence and a series, deciding whether to repost an event from a neighbor.
+
+## Voice principles
+
+### Address the reader directly
+
+Second person, present tense. "Your calendar," "your community." Match the marketing site's "you put real work into your events" register.
+
+> A calendar that nobody finds is a calendar that doesn't exist.
+
+> Most calendars worth running aren't run by one person.
+
+### Lead with the conclusion, then explain
+
+The reader is usually scanning to solve a specific problem. The conclusion goes first; the explanation supports it.
+
+> Almost always the right call is to cancel — that leaves an audit trail, tells anyone who was planning to attend that the event isn't happening, and propagates correctly to any calendar that's reposting from yours. Deletion is for a smaller, more specific set of cases.
+
+### Be concrete
+
+Specific examples beat abstract principles. "Riverbend-folk ages better than riverbend-2026-season" lands. "Choose timeless names" doesn't.
+
+> *Riverbend Community Center* is a name your editors will recognize next month and next year. *Main location* or *That coffee shop* won't be — and a co-editor who joins six months from now won't have any idea what those refer to.
+
+### Be honest about limits
+
+Pavillion does some things, doesn't do others, has rough edges. Pretending otherwise undermines trust and wastes the reader's time.
+
+> Past events show the venue's current state, not the state it was in on the day the event happened.
+
+> If you want a permanent snapshot of the original address ... copy that detail somewhere outside Pavillion (the event description, an external doc) before the venue changes. This is rarely worth doing, but worth knowing.
+
+### Name things in the reader's vocabulary
+
+Federation isn't ActivityPub. It's *follow*, *share*, *repost*. The protocol is internal vocabulary; the reader doesn't need it to use the feature.
+
+> The mechanism underneath is ActivityPub federation, but you don't have to think in those terms. Most of the time the right words are *follow*, *share*, *connect*, and *repost*.
+
+> Pavillion uses ActivityPub the way email uses SMTP — you don't need to know the protocol to send a message.
+
+The same rule applies to internal Pavillion vocabulary that doesn't match what the reader thinks about. The codebase says "funding plan" instead of "subscription" because the latter means a different thing in a federated system; the guides should make that boundary visible without requiring the reader to learn the why.
+
+### Don't preach
+
+The reader is an adult organizing real events. Hectoring them about ethics or best practices reads as condescension. State the practical reason, let them decide.
+
+> Pick something short, durable, and tied to the community rather than to a moment in time.
+
+Not: "It's important to choose names responsibly." The first sentence is advice; the second is a lecture.
+
+### Use warmth without slickness
+
+Conversational and confident, not breezy or branded. The marketing site's "ready to give your community a calendar it deserves?" works there because it's the close. Inside the guides, warmth shows up as treating the reader like a colleague: "you'll know your community's actual buckets better than any generic list."
+
+## Patterns we use
+
+### `::: tip <Lightbulb /> A note on X.` callouts
+
+The vehicle for advice that sits beside instructions. Use these for:
+
+- Naming conventions ("a note on URL names")
+- Forward-looking warnings ("a note on shortening the end of a recurrence")
+- Scope clarifications ("a note on the first month")
+- Acknowledging an edge case the prose doesn't fit
+
+**Don't use them for instructions.** The body of the doc is for instructions; the callout is for the *aside*.
+
+### "Things that trip people up" sections
+
+A short list of failure modes that aren't obvious from reading the rest of the guide. Place at the end of a topic. Keep each item to a sentence or two.
+
+This section earns its keep when the items are *non-obvious*. If every item is a recap of something explained earlier, cut the section or trim it. Examples of items that work:
+
+> **Changing the start time of an already-published recurring event.** If your Tuesday meeting was 7pm and you change the schedule's time to 8pm, *every* future occurrence shifts to 8pm — including ones that were already on the public page.
+
+> **Picking a weekday that doesn't include the start date.** A weekly schedule that starts on a Tuesday but only checks Monday in the recurrence panel will skip the first Tuesday entirely.
+
+### Decision aids
+
+When two features could solve the same problem, the guide should name the choice and give a quick test. Don't make the reader infer it.
+
+> The quick test: would the title field be the same on every occurrence? If yes, recurrence. If you'd want to change the title — even slightly — for each occurrence, the recurrence editor will fight you, and a series is what you actually want.
+
+### "When to use" and "When not to use" framings
+
+A guide that only documents the affordance is incomplete. Most features have a no-go region — events without a place, categories that don't earn a row in the filter, rooms that don't differentiate. Name both regions.
+
+> **No:** a venue with a single usable space, even if you reuse it constantly. A coffeeshop with a tiny back room you've used once.
+
+### Concrete example pairs
+
+When teaching a judgment call, give one example of "yes" and one of "no" so the contrast does the work.
+
+> *Riverbend Community Center* — yes. *Main location* — no.
+
+> *Concert*, *Workshop*, *Volunteer days* — yes. *Acoustic Folk Concert*, *Indie Rock Concert*, *Open Mic Night* — too granular.
+
+## Things we avoid
+
+### Marketing fluff inside reference material
+
+The marketing site sells the platform. The guides help someone use it. A guide that opens with "Pavillion empowers communities to..." is wasting the reader's first paragraph. Open with the topic.
+
+### Documenting the screen at button-label depth
+
+UI guidance is appropriate. UI walk-throughs that name every button, panel, and dialog title overshoot. Document the principle and the consequential choice; let the reader read the screen for the rest.
+
+Compare:
+
+> A confirmation modal opens — *Cancel this instance?* — with a **Hide from public** toggle and two buttons: <Btn>Cancel</Btn> (dismiss the modal) and <Btn>Cancel instance</Btn> (confirm).
+
+vs.
+
+> The confirmation that opens has one decision worth thinking about — a **Hide from public** toggle:
+
+The second still tells the reader what to look for. It doesn't pretend the buttons need names.
+
+### Saying the same thing twice
+
+The decision aid for series-vs-recurrence used to appear three times across two files. Once is enough; cross-link the rest. If you find yourself restating something already covered, link instead.
+
+### Hypothetical hedging
+
+"You might want to consider..." "Some users may prefer..." These are hedges that protect the writer at the cost of the reader. Take a position. If the answer truly depends, say what it depends on.
+
+### Jargon-first explanations
+
+ActivityPub, federation primitives, OAuth, ICS — these are real words and they appear in the guides where the reader needs them. They don't appear in the *first sentence of a topic*, where the reader is still orienting.
+
+### Process for its own sake
+
+Steps that don't change the outcome ("first, plan your category vocabulary by writing it on paper before opening the editor") read as filler. If a step exists, it should be load-bearing — skipping it should produce a worse result, and the guide should be willing to say what that result is.
+
+## Continuity with the marketing site
+
+The guides should read like the same project wrote them, with the register adjusted for the form. Common ground:
+
+- **Specific reader.** Marketing names "a nonprofit, a local business, a church, a neighborhood group." Guides name "community organizers, venue staff, neighborhood associations." Same person.
+- **Anti-extractive framing.** Marketing: "isn't a product." Guides treat federation as something the reader controls, not something done to them.
+- **Effort respected.** Marketing: "you put real work into your events." Guides assume competence and seriousness.
+- **Practical outcomes.** Marketing: "more people see your events, with less standing in the way." Guides: "a calendar that nobody finds is a calendar that doesn't exist."
+
+Where they differ:
+
+- **Marketing closes with a CTA.** Guides close with "what next" links and an honest read on what the doc didn't cover.
+- **Marketing speaks at the platform level.** Guides speak at the calendar level — the work the individual reader is doing.
+- **Marketing can be aspirational.** Guides have to be true. If a feature has a foot-gun, name it.
+
+## Notes on length and scope
+
+A guide is the right length when its sections each earn their space. Long isn't bad; padded is bad.
+
+**Reasonable signs a guide is over-budget:**
+
+- The same idea appears in more than one section.
+- A "Things that trip people up" list mostly recaps content from the body.
+- The UI walkthrough names buttons the user can read off the screen.
+- A subsection explains an internal mechanism (e.g. "the event reads from the place") when the reader only needs the consequence ("edits propagate").
+
+**Reasonable signs a guide is under-developed:**
+
+- Affordances are documented but no-go regions aren't.
+- The reader has to infer which feature solves their problem.
+- Naming, taxonomy, and other "design the right list" decisions get no advice.
+- Federation and multi-calendar interactions aren't named at all.
+
+A stub that telegraphs the planned scope of a guide-to-be-written is better than a thin half-guide that pretends to be complete. Use the placeholder pattern (`> Status: stub. Full guide coming before launch.`) and bullet the planned scope so a reader can see what's missing.
+
+## Pre-publish checklist
+
+Before claiming a guide is ready, run through these:
+
+- [ ] Does the first paragraph name the reader and the topic?
+- [ ] Does each major section answer a specific question the reader would actually ask?
+- [ ] Is every UI walk-through earning its detail, or is the reader going to figure that out from the screen?
+- [ ] Are decision points called out explicitly, with a quick test?
+- [ ] Is there at least one piece of organizer-judgment advice, anchored to a specific decision?
+- [ ] Are the no-go regions named, not just the affordances?
+- [ ] Did you cross-link rather than restate content from another guide?
+- [ ] Could a co-editor six months from now use this guide to settle an argument?

--- a/.claude/skills/standards-routing/index.yml
+++ b/.claude/skills/standards-routing/index.yml
@@ -169,6 +169,11 @@ architecture:
     description: Conceptual integrity, decision adherence, narrative coherence, responsibility clarity, federation model alignment, product direction
     skill: architecture-playbook
 
+documentation:
+  voice-and-structure:
+    description: Voice, structure, and scope standards for user-facing guides in docs/guides/; pre-publish checklist; continuity with the marketing site at pavillion.social
+    skill: documentation-playbook
+
 testing:
   test-tiers:
     description: Which test type to use (unit, integration, e2e), testing boundaries, tier selection rules

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -30,7 +30,7 @@ Once a category exists, it shows up in three places:
 - On your public calendar page, as a button in the filter row — but only once at least one event uses it. Empty categories don't clutter the filter.
 - On the detail page of every event that uses it, as a clickable badge that takes the visitor back to the calendar filtered to similar events.
 
-To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. There's also a multi-select on the list itself for merging two or more categories into one when you decide they were a single grouping after all.
+To rename or retranslate a category, click the pencil icon on its row in the list. To delete one, click the trash icon — the dialog asks whether to remove the category from its events (the events stay, they just lose that category) or migrate those events to a different category in one move. (For collapsing several categories into one or splitting one into two, see *The cost of churning category names later* below.)
 
 ## Designing the list
 

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -8,11 +8,9 @@ This guide covers what places are, how rooms and spaces fit, how to create both,
 
 ## How places work
 
-A place lives on its own, not inside any one event. When you attach it to an event, the event doesn't take a copy of the address — it just remembers which place it's at and reads the details from there. The place's name, address, and accessibility notes appear in their own dedicated spots on the event's public page, rather than a sentence buried in the event description.
+A place lives on its own, separate from any one event. Its name, address, and accessibility notes appear in their own dedicated spots on the event's public page, rather than buried in a sentence in the description. That arrangement pays off three ways:
 
-That structure pays off three ways:
-
-- **Edit once, propagate everywhere.** When a venue renames itself, you fix the place — not every event that uses it. The lists, detail pages, and public calendar all show the new name on the next page load.
+- **Edit once, propagate everywhere.** When a venue renames itself or you fix a typo in the address, you change the place once and every event there updates on the next page load — no editing each event.
 - **Reusable across events.** Recurring venues become one-click picks instead of address retyping. Over a year of running a calendar, a small set of places covers most of your events.
 - **Free directions link.** If the place has a street address, the public event page renders it as a tap-to-open link — one-tap navigation on a phone, a map in a new tab on desktop. Just fill the address in and it happens automatically.
 
@@ -72,7 +70,7 @@ The same applies to rooms. Rename *Conference Room A* to *Sterling Room* in the 
 Because past events show the venue's current state, the archive of your calendar is a record of *what happened*, not *what the listing said at the time*. If you want a permanent snapshot of the original address — say, for an event ticket stub or a community history project — copy that detail somewhere outside Pavillion (the event description, an external doc) before the venue changes. This is rarely worth doing, but worth knowing.
 :::
 
-**Deleting a room.** When you remove a room from a place, the editor checks how many events are using it. If none, the room just goes. If some events use it, you get a small dialog asking where those events should go: onto the whole venue (the default and usually right answer), or onto a different room of your choosing. The events don't disappear and they don't lose their place — they just stop being attached to the room you removed.
+**Deleting a room.** If events are using the room, the editor asks where to move them — onto the whole venue (usually the right answer) or onto a different room. The events don't disappear and don't lose their place; they just stop being attached to that specific room.
 
 **Deleting a whole place.** The delete dialog tells you how many events currently use the place; if you proceed, the place is removed from your list and every affected event keeps existing but loses its location entirely. The events don't disappear — they just no longer have a venue attached. You can attach a different place (or a new one) to any of them by editing the event.
 

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -69,7 +69,7 @@ Categories are how visitors filter your public page (`Show only Sports events`) 
 
 **Series.** Skip for this first event. A series is for grouping multiple distinct events under one named program (a summer concert series, a fall lecture series). One-off events don't need it.
 
-**Date & time.** Set the start and end. For this first event, pick a date within the next week or two — the public page opens to a default two-week window, and a date much further out won't be visible there until the visitor changes the filter. (You can always add the real, far-out events afterwards; this is just so the page you're about to share has something on it.) Leave it as a single occurrence for now — no recurrence rules. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
+**Date & time.** Set the start and end. For this first event, pick a date within the next week or two so it shows up immediately on the public page you're about to share — you can always add further-out events afterwards. Leave it as a single occurrence for now — no recurrence rules. If your event repeats on a schedule, recurrence handles that, but it's easier to learn the editor on a one-off first.
 
 When the form is filled in, click <Btn>Save Changes</Btn> in the page header. The event is now published — Pavillion doesn't have a draft state. If you change your mind, you can edit, cancel, or delete it from the events list.
 

--- a/docs/guides/calendar-owners/recurring-events.md
+++ b/docs/guides/calendar-owners/recurring-events.md
@@ -49,9 +49,7 @@ Multiple schedules are also the way to express "the same meeting at two differen
 
 For a recurring event, the editor shows a <Btn>Manage cancellations</Btn> button below the schedule blocks. Click it to expand a **Cancellations** panel — a horizontal row of cards for the upcoming dates, each showing date and time. Later dates live further down the row; <Btn>Show more</Btn> appends the next batch, and <Btn>Jump to month</Btn> lets you skip ahead to a specific month.
 
-To cancel one occurrence, find its card and click <Btn>Cancel</Btn>. A confirmation modal opens — *Cancel this instance?* — with a **Hide from public** toggle and two buttons: <Btn>Cancel</Btn> (dismiss the modal) and <Btn>Cancel instance</Btn> (confirm).
-
-The toggle is the important choice:
+To cancel one occurrence, find its card and click <Btn>Cancel</Btn>. The confirmation that opens has one decision worth thinking about — a **Hide from public** toggle:
 
 - **Off (the default): show as cancelled.** The occurrence stays on the calendar. Visitors and any calendar reposting from yours still see it, but it's marked **Cancelled**. This is the right choice for an event that *was* announced and that people might be planning to attend — cancelling-but-showing tells them the meeting they had on their calendar isn't happening.
 - **On: hide from public.** The occurrence is removed from the public page and from any calendar reposting from yours. This is the right choice for occurrences that haven't been visible long enough for anyone to be planning around them — for example, a brand-new recurring event where you want to skip an upcoming holiday week before the public page has had time to surface those occurrences.
@@ -89,5 +87,3 @@ A short list of the most common stumbles.
 **"Show as cancelled" on an event nobody was attending yet.** If you skip an occurrence on a brand-new recurring event before anyone's seen the public page, the **Cancelled** badge is just noise. Use **Hide from public** instead so the occurrence quietly drops out.
 
 **Setting an end date earlier than the start date.** If the schedule's end date is before its start date, the event won't show any dates on the calendar. The editor allows this combination — it just means an empty schedule. Double-check both fields if a recurring event isn't appearing.
-
-**Treating a series like a recurring event.** A weekly film screening where the film changes each week is *not* a recurring event with the same title — visitors won't be able to tell which film is playing on which date. That's a series.

--- a/docs/guides/calendar-owners/series.md
+++ b/docs/guides/calendar-owners/series.md
@@ -72,14 +72,6 @@ There is no top-level series listing on your calendar's home page; series surfac
 
 ## Things that trip people up
 
-A short list of the most common stumbles.
-
-**Treating a series like a recurring event.** A weekly film screening where the film changes each week is *not* a recurring event with the same title — visitors won't be able to tell which film is playing on which date, and the event editor will fight you when you try to give each occurrence a distinct name. That's a series of distinct events.
-
-**Treating a recurring event like a series.** The reverse: making a series for the third-Wednesday board meeting that happens every month with the same name and the same agenda template. That's one recurring event, not twelve identical series entries — the recurrence panel exists exactly for this case.
-
 **A series with no events on it.** A series that hasn't been assigned to any events doesn't show up to visitors anywhere. If a series you created isn't appearing on the public side, check whether at least one event has been assigned to it.
 
-**Trying to put one event in two series.** An event can carry one series affiliation, not several. If you want a single event to surface under two programs, the second affiliation should be a category, not a second series.
-
-**Renaming the URL to fix a typo.** The URL name can't be edited after creation by design — changing it would break links visitors and other calendars have saved. If the URL name is genuinely wrong, the only fix is to delete the series, recreate it with the correct slug, and reassign the events. The display name and description are freely editable; the slug is the one that's permanent.
+**A typo in the URL.** The URL slug can't be edited after creation — changing it would break links visitors and other calendars have saved. If the slug is genuinely wrong, the only fix is to delete the series, recreate it with the correct slug, and reassign the events. (The display name and description are freely editable; only the slug is permanent.)


### PR DESCRIPTION
## Motivation

The calendar-owner guides in `docs/guides/calendar-owners/` are taking shape as documentation that does dual duty — teaching the software AND helping readers become better calendar owners (naming conventions that age, decision aids about which feature fits, no-go regions, federation etiquette). The voice that's emerging in the developed guides (`categories.md`, `places.md`, `recurring-events.md`, `series.md`, `quickstart.md`) is distinct, and worth (a) tightening where it had drifted into restatement and screen-narration, and (b) capturing as a standard so future docs land in the same world.

## Approach

Two related passes:

**Trim pass on existing guides.** Five files, +7/-21. Cuts where the same idea was being delivered twice or where the UI walk-through described what the user can read off the screen:

- `places.md` — collapsed two-paragraph "How places work" intro into one; trimmed "Deleting a room" from a four-sentence dialog walkthrough to one sentence on the principle.
- `recurring-events.md` — removed modal button-label walkthrough on cancel-occurrence (kept the consequential toggle); deleted the third repetition of the series-vs-recurrence decision aid.
- `series.md` — trimmed "Things that trip people up" from five recap items to two genuinely diagnostic ones (empty series invisible, slug not editable). The series-vs-recurrence direction stays in the body where the decision aid lives.
- `quickstart.md` — removed Step 4 explanation of the date-filter mechanism; kept the more useful version in Step 5's troubleshooting moment.
- `categories.md` — pulled the multi-select-merge mention out of "Create a category" (where users aren't restructuring yet) and pointed forward to the existing "Cost of churning" section.

**New `documentation-playbook` skill.** `.claude/skills/documentation-playbook/` follows the existing playbook pattern (`SKILL.md` entry + `principles.md` content file). Captures voice principles, structural patterns (`::: tip` callouts, "Things that trip people up", decision aids, "when to / when not to" framings, concrete example pairs), anti-patterns (marketing fluff, button-label-depth UI, restatement, hypothetical hedging, jargon-first explanations, process for its own sake), length-and-scope rules, and a pre-publish checklist. Cross-references the marketing voice at pavillion.social so future docs extend that voice into reference material. Verbatim quotes throughout are excerpted from the developed guides so writers have models to imitate.

Registered in `.claude/skills/standards-routing/index.yml` under a new top-level `documentation:` section so agents discovering relevant standards via `standards-routing` will find it.

## Validation

Documentation-only changes — no source code, no tests, no build artifacts touched. The full build-guardian (lint/unit/integration/build/e2e) would not exercise anything that changed. Verified instead:

- `git diff --stat` shows only `.md` and `.yml` files
- Skill registers correctly: `documentation-playbook` appeared in the available-skills list with the expected description after the file was written
- Verified by reading back: `SKILL.md` (47 lines) + `principles.md` (205 lines) follow the same shape as `architecture-playbook` (the closest analog among the existing playbook skills)
- Cross-references check out: `principles.md` quotes from `categories.md` and `places.md` match the current text of those files (post-trim)