### PR TITLE
feat(activitypub): Note companion activity for Mastodon rendering

### DIFF
--- a/src/server/activitypub/api/v1/server.ts
+++ b/src/server/activitypub/api/v1/server.ts
@@ -225,6 +225,10 @@ export default class ActivityPubServerRoutes {
         }
         throw error;
       }
+      if (!event) {
+        res.status(404).send('Event not found');
+        return;
+      }
 
       const { NoteObject } = await import('@/server/activitypub/model/object/note');
       const noteObject = new NoteObject(calendar, event);

--- a/src/server/activitypub/api/v1/server.ts
+++ b/src/server/activitypub/api/v1/server.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, Application, RequestHandler } from 'express';
 import config from 'config';
 
+import ExpressHelper from '@/server/common/helper/express';
 import CreateActivity from '@/server/activitypub/model/action/create';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import DeleteActivity from '@/server/activitypub/model/action/delete';
@@ -11,6 +12,7 @@ import UndoActivity from '@/server/activitypub/model/action/undo';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import { logError } from '@/server/common/helper/error-logger';
 import CalendarInterface from '@/server/calendar/interface';
+import { EventNotFoundError } from '@/common/exceptions/calendar';
 import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('activitypub');
@@ -54,6 +56,7 @@ export default class ActivityPubServerRoutes {
     // Calendar (Group) actor endpoints
     router.get('/calendars/:urlname', this.getCalendarActor.bind(this));
     router.get('/calendars/:urlname/events/:eventid', this.getEvent.bind(this));
+    router.get('/calendars/:urlname/events/:eventid/note', this.getNote.bind(this));
     router.get('/calendars/:urlname/series', this.getSeriesCollection.bind(this));
     router.get('/calendars/:urlname/series/:seriesid', this.getSeries.bind(this));
     router.get('/calendars/:urlname/outbox', this.readOutbox.bind(this));
@@ -181,6 +184,56 @@ export default class ActivityPubServerRoutes {
     }
     catch (error) {
       logError(error, `Error fetching event ${req.params.eventid}`);
+      res.status(500).send('Internal server error');
+    }
+  }
+
+  /**
+   * Get a calendar event rendered as an ActivityStreams Note for Mastodon-class
+   * consumers. Mirrors `getEvent`'s posture: unauthenticated, 404 on missing
+   * calendar or missing event. The `:eventid` path param is UUID-validated to
+   * avoid wasting a DB query (and to satisfy security-playbook path-param
+   * validation).
+   *
+   * @param urlname - calendar URL name
+   * @param eventid - event UUID
+   * @returns Note object as ActivityPub JSON-LD
+   */
+  async getNote(req: Request, res: Response): Promise<void> {
+    const { urlname, eventid } = req.params;
+
+    if (!ExpressHelper.isValidUUID(eventid)) {
+      res.status(400).send('Invalid event id');
+      return;
+    }
+
+    try {
+      const calendar = await this.calendarService.getCalendarByName(urlname);
+      if (!calendar) {
+        res.status(404).send('Calendar not found');
+        return;
+      }
+
+      let event;
+      try {
+        event = await this.calendarService.getEventById(eventid);
+      }
+      catch (error) {
+        if (error instanceof EventNotFoundError) {
+          res.status(404).send('Event not found');
+          return;
+        }
+        throw error;
+      }
+
+      const { NoteObject } = await import('@/server/activitypub/model/object/note');
+      const noteObject = new NoteObject(calendar, event);
+
+      res.setHeader('Content-Type', 'application/activity+json');
+      res.json(noteObject.toActivityPubObject());
+    }
+    catch (error) {
+      logError(error, `Error fetching note for event ${req.params.eventid}`);
       res.status(500).send('Internal server error');
     }
   }

--- a/src/server/activitypub/events/index.ts
+++ b/src/server/activitypub/events/index.ts
@@ -16,6 +16,7 @@ import UpdateActivity from '../model/action/update';
 import DeleteActivity from '../model/action/delete';
 import AnnounceActivity from '../model/action/announce';
 import { EventObject } from '../model/object/event';
+import { NoteObject } from '../model/object/note';
 import { ActivityPubOutboxMessageEntity, ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import UserActorService from '../service/user_actor';
@@ -99,6 +100,17 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
       payload.calendar,
       new AnnounceActivity(actorUrl, eventUrl).addressPublic(`${actorUrl}/followers`),
     );
+
+    // Paired Create(Note) emission for Mastodon-class peers that ignore
+    // Event-typed activities on profile timelines. The Note wraps the same
+    // canonical event so the activity renders in Mastodon profile feeds.
+    await this.service.addToOutbox(
+      payload.calendar,
+      new CreateActivity(
+        actorUrl,
+        new NoteObject(payload.calendar, payload.event),
+      ).addressPublic(`${actorUrl}/followers`),
+    );
   }
 
   /**
@@ -121,6 +133,16 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
         new EventObject(payload.calendar, payload.event),
       ).addressPublic(`${actorUrl}/followers`),
     );
+
+    // Paired Update(Note) emission so Mastodon-class peers see edits reflected
+    // in profile timelines alongside the Pavillion-native Update(Event).
+    await this.service.addToOutbox(
+      payload.calendar,
+      new UpdateActivity(
+        actorUrl,
+        new NoteObject(payload.calendar, payload.event),
+      ).addressPublic(`${actorUrl}/followers`),
+    );
   }
 
   private async handleEventDeleted(payload: ActivityPubEventDeletedPayload): Promise<void> {
@@ -130,6 +152,17 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
       new DeleteActivity(
         actorUrl,
         EventObject.eventUrl(payload.calendar, payload.event),
+      ).addressPublic(`${actorUrl}/followers`),
+    );
+
+    // Paired Delete(Note) emission. Uses the Note IRI string form because
+    // DeleteActivity takes the object URL directly, mirroring the Event
+    // Delete shape.
+    await this.service.addToOutbox(
+      payload.calendar,
+      new DeleteActivity(
+        actorUrl,
+        NoteObject.noteUrl(payload.calendar, payload.event),
       ).addressPublic(`${actorUrl}/followers`),
     );
   }

--- a/src/server/activitypub/model/object/note.ts
+++ b/src/server/activitypub/model/object/note.ts
@@ -1,0 +1,230 @@
+import config from 'config';
+import he from 'he';
+import { DateTime } from 'luxon';
+
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent } from '@/common/model/events';
+import { ActivityPubObject, ActivityPubActor } from '@/server/activitypub/model/base';
+import { EventObject } from '@/server/activitypub/model/object/event';
+
+/**
+ * Sanitizes an untrusted href value from a federated peer. Returns a parsed
+ * http(s) URL string or null for any anomaly (non-string, empty/whitespace,
+ * too long, malformed, or non-http(s) scheme).
+ *
+ * Mirrors the helper in `event.ts` — duplicated here rather than re-exported
+ * to keep `event.ts`'s helper private to that module. The two implementations
+ * MUST stay in sync; both are the authoritative barrier against malicious
+ * peers injecting javascript:, data:, ftp:, or other dangerous URL schemes.
+ */
+function sanitizeExternalUrlHref(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed.length > 2048) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+}
+
+/**
+ * Wraps a CalendarEvent as an ActivityStreams `Note` for Mastodon-class
+ * consumers that ignore `type: 'Event'` activities on profile timelines.
+ *
+ * The Note is a thin presentation surface: a short HTML paragraph containing
+ * the event title (linked to its canonical URL), the start time, and the
+ * location (when present). Pavillion-aware peers continue to use the
+ * companion `EventObject` activity; the Note exists purely so Mastodon
+ * timelines render Pavillion posts at all.
+ *
+ * No `fromActivityPubObject` is implemented — Pavillion never ingests remote
+ * Notes (they are minted on-the-wire by each instance to wrap its own canonical
+ * Event). No `pavillion:*` extensions are emitted: this is an interop-only
+ * rendering, not a Pavillion-to-Pavillion wire format.
+ */
+class NoteObject extends ActivityPubObject {
+  type: string = 'Note';
+  attributedTo: string;
+
+  private readonly _calendar: Calendar;
+  private readonly _event: CalendarEvent;
+  private readonly _urlOverride: string | undefined;
+
+  /**
+   * Builds the canonical Note IRI for an event. Always anchored on the
+   * configured instance domain (NEVER `req.host` — host-header spoofing risk
+   * per security-playbook). The path is the event's canonical AP route with
+   * a `/note` suffix so the Note IRI is dereferenceable independently of the
+   * Event IRI.
+   */
+  static noteUrl(calendar: Calendar, event: CalendarEvent | string): string {
+    const id = typeof event === 'string'
+      ? event
+      : event.id;
+
+    return id.match('^https?:\/\/')
+      ? `${id}/note`
+      : 'https://' + config.get('domain') + '/calendars/' + calendar.urlName + '/events/' + id + '/note';
+  }
+
+  constructor(calendar: Calendar, event: CalendarEvent, options?: { urlOverride?: string }) {
+    super();
+    this._calendar = calendar;
+    this._event = event;
+    this._urlOverride = options?.urlOverride;
+    this.id = NoteObject.noteUrl(calendar, event);
+
+    // attributedTo is the calendar's actor URL — never an account IRI
+    // (privacy-playbook federation rule).
+    this.attributedTo = ActivityPubActor.actorUrl(calendar);
+  }
+
+  /**
+   * Serializes this event as an AS `Note` suitable for Mastodon-class
+   * consumers. The wire shape is intentionally minimal:
+   *
+   *   - `content` / `contentMap`: a short HTML paragraph with the title
+   *     (linked), start time, and location.
+   *   - `name` / `nameMap`: the bare event title.
+   *
+   * `name`/`nameMap` and `content`/`contentMap` use the same primary-language
+   * selection rule and 2+-language gate as `EventObject`. Title and location
+   * are HTML-escaped before interpolation (security-playbook template-injection
+   * rule) — the only HTML produced by Pavillion is the wrapper `<p>` and the
+   * anchor.
+   */
+  toActivityPubObject(): Record<string, any> {
+    const domain = config.get('domain');
+    const event = this._event;
+    const calendar = this._calendar;
+
+    // Determine primary language: prefer 'en' if event has en content with a
+    // name, otherwise use the first language with a non-empty name. Mirrors
+    // EventObject's primary-language pick.
+    const primaryLanguage = event._content['en']?.name
+      ? 'en'
+      : Object.keys(event._content).find(l => event._content[l]?.name) || 'en';
+
+    const primaryContent = event._content[primaryLanguage];
+    let name = primaryContent?.name || 'Untitled Event';
+    if (name === 'Untitled Event') {
+      for (const lang of Object.keys(event._content)) {
+        const c = event._content[lang];
+        if (c.name && c.name.trim().length > 0) {
+          name = c.name;
+          break;
+        }
+      }
+    }
+
+    // Resolve the canonical event URL the Note's anchor links to. For
+    // locally-owned events this is the event's own page; for re-shares the
+    // caller passes `urlOverride` set to the remote canonical IRI, which is
+    // validated through `sanitizeExternalUrlHref` so a malicious or malformed
+    // override never lands in the anchor href. A failed override silently
+    // omits `url` and the anchor's href falls back to the local event page.
+    let resolvedUrl: string | null = null;
+    if (this._urlOverride !== undefined) {
+      resolvedUrl = sanitizeExternalUrlHref(this._urlOverride);
+    }
+    else {
+      resolvedUrl = EventObject.eventUrl(calendar, event);
+    }
+
+    // Anchor href falls back to the local event URL when override validation
+    // fails so the content HTML still renders a working link.
+    const anchorHref = resolvedUrl ?? EventObject.eventUrl(calendar, event);
+
+    const formattedStartTime = this._formatStartTime(event);
+
+    const buildContent = (title: string, location: string | null): string => {
+      const escapedTitle = he.encode(title);
+      const escapedHref = he.encode(anchorHref);
+      const locationSegment = location && location.trim().length > 0
+        ? ` · ${he.encode(location)}`
+        : '';
+      return `<p><a href="${escapedHref}">${escapedTitle}</a> · ${formattedStartTime}${locationSegment}</p>`;
+    };
+
+    const locationName = event.location?.name ?? null;
+
+    const result: Record<string, any> = {
+      type: this.type,
+      id: this.id,
+      attributedTo: this.attributedTo,
+      name: he.encode(name),
+      content: buildContent(name, locationName),
+      to: ['https://www.w3.org/ns/activitystreams#Public'],
+      cc: [`https://${domain}/calendars/${calendar.urlName}/followers`],
+    };
+
+    // published: when the event was originally created (AS 2.0 vocabulary)
+    if (event.createdAt) {
+      result.published = event.createdAt.toISOString();
+    }
+
+    // url: canonical event page (Mobilizon parity). Omitted entirely when an
+    // override was supplied but failed validation — the anchor href still
+    // falls back to the local event page above so the Note remains useful.
+    if (resolvedUrl !== null) {
+      result.url = resolvedUrl;
+    }
+
+    // nameMap/contentMap: only when 2+ languages have content (mirrors
+    // EventObject's gate). The map values are per-language renderings of the
+    // same content shape.
+    const contentLanguages = Object.keys(event._content).filter(
+      lang => event._content[lang] && !event._content[lang].isEmpty(),
+    );
+    if (contentLanguages.length >= 2) {
+      const nameMap: Record<string, string> = {};
+      const contentMap: Record<string, string> = {};
+
+      for (const lang of contentLanguages) {
+        const c = event._content[lang];
+        if (c.name) {
+          nameMap[lang] = he.encode(c.name);
+          contentMap[lang] = buildContent(c.name, locationName);
+        }
+      }
+
+      if (Object.keys(nameMap).length > 0) {
+        result.nameMap = nameMap;
+      }
+      if (Object.keys(contentMap).length > 0) {
+        result.contentMap = contentMap;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolves a human-readable start-time string for the Note content. Uses
+   * ISO 8601 so the rendered surface is locale-independent and unambiguous —
+   * Mastodon clients render Note content verbatim, so the wire string is what
+   * the user sees. Falls back to the event's date field, then to current time
+   * (matching EventObject's defensive posture).
+   */
+  private _formatStartTime(event: CalendarEvent): string {
+    const firstSchedule = event.schedules[0];
+    if (firstSchedule?.startDate) {
+      return firstSchedule.startDate.toISO()!;
+    }
+
+    if (event.date) {
+      const parsed = DateTime.fromISO(String(event.date), { zone: 'utc' });
+      if (parsed.isValid) {
+        return parsed.toISO()!;
+      }
+    }
+
+    return DateTime.utc().toISO()!;
+  }
+}
+
+export { NoteObject };

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -19,6 +19,7 @@ import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
 import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
 import RemoteCalendarService from "@/server/activitypub/service/remote_calendar";
 import { EventObject } from "@/server/activitypub/model/object/event";
+import { NoteObject } from "@/server/activitypub/model/object/note";
 import { ActivityPubActor } from "@/server/activitypub/model/base";
 import CalendarInterface from "@/server/calendar/interface";
 import ModerationInterface from "@/server/moderation/interface";
@@ -931,6 +932,24 @@ class ProcessInboxService {
     // Add to outbox
     await addToOutbox(this.eventBus, calendar, announceActivity);
 
+    // Paired Create(Note) emission for Mastodon-class peers that ignore
+    // Announce(Event) on profile timelines. The Note is attributed to the
+    // reposting calendar (this calendar's actor URL) and carries the remote
+    // event's canonical IRI as `urlOverride`; NoteObject runs that override
+    // through `sanitizeExternalUrlHref` so a malicious or malformed scheme
+    // falls back to omitting `url` rather than landing in the wire payload.
+    // Both emissions live below the DEC-008 dismissal gate above, so a
+    // dismissed event suppresses both Announce(Event) and Create(Note)
+    // together.
+    const event = await this.calendarInterface.getEventById(eventObject.event_id);
+    if (event) {
+      const noteActivity = new CreateActivity(
+        localActorUrl,
+        new NoteObject(calendar, event, { urlOverride: eventApId }),
+      ).addressPublic(`${localActorUrl}/followers`);
+      await addToOutbox(this.eventBus, calendar, noteActivity);
+    }
+
     // Apply category mappings from stored AP payload (failure-safe)
     // remoteCalendar.id is the CalendarActorEntity UUID used as the source actor key
     try {
@@ -947,7 +966,13 @@ class ProcessInboxService {
 
     // Emit eventReposted so downstream handlers (e.g. event instance building)
     // can process the newly auto-reposted event on the reposter's calendar.
-    const event = await this.calendarInterface.getEventById(eventObject.event_id);
+    // Note: Update(Event) / Delete(Event) cascades for SharedEventEntity-bound
+    // events do not exist as distinct inbox emission sites — `processUpdateEvent`
+    // emits `eventUpdated` with `calendar: null` (which the outbox handler
+    // returns from early), and `processDeleteEvent` makes no bus emission.
+    // The paired Note Update/Delete propagation for locally-owned events lives
+    // in the outbox event handlers (handleEventUpdated/handleEventDeleted) and
+    // is covered by sibling pv-l35p.2.
     if (event) {
       this.eventBus.emit('eventReposted', { event, calendar });
     }

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -663,6 +663,15 @@ class ProcessInboxService {
       return null;
     }
 
+    // Pavillion never ingests remote Notes — they are interop-only, minted on
+    // the wire to wrap a peer's canonical Event for Mastodon-class consumers
+    // (see note.ts). Parsing a Note payload through EventObject.fromActivityPubObject
+    // produces a phantom event that, in mutual auto-repost setups, cascades back
+    // to the source and trips federation rate-limits.
+    if ((message.object as any).type === 'Note') {
+      return null;
+    }
+
     const apObjectId = message.object.id;
     const actorUri = message.actor;
 
@@ -1271,6 +1280,13 @@ class ProcessInboxService {
       return null;
     }
 
+    // See processCreateEvent: Pavillion never ingests remote Notes. An Update
+    // of a Note must short-circuit so it cannot find a stale EventObjectEntity
+    // (from any pre-fix Create(Note) ingest) and mutate it.
+    if ((message.object as any).type === 'Note') {
+      return null;
+    }
+
     const apObjectId = message.object.id;
     const actorUri = message.actor;
 
@@ -1468,6 +1484,17 @@ class ProcessInboxService {
     const objectValue = message.object as any;
     const apObjectId = typeof objectValue === 'string' ? objectValue : objectValue.id;
     const actorUri = message.actor;
+
+    // See processCreateEvent: Pavillion never ingests remote Notes. A Delete
+    // targeting a Note IRI — string form ending in `/note` or a Tombstone
+    // whose `formerType` is `Note` — must short-circuit so it cannot resolve
+    // and remove a phantom event.
+    const targetsNote = (typeof apObjectId === 'string' && apObjectId.endsWith('/note'))
+      || (typeof objectValue === 'object' && objectValue !== null
+        && (objectValue.formerType === 'Note' || objectValue.type === 'Note'));
+    if (targetsNote) {
+      return;
+    }
 
     // Look up the local event by its AP ID
     let apObject = await EventObjectEntity.findOne({

--- a/src/server/activitypub/test/api/get-endpoints.test.ts
+++ b/src/server/activitypub/test/api/get-endpoints.test.ts
@@ -165,6 +165,20 @@ describe('GET /calendars/:urlname/events/:eventid/note', () => {
     expect(res.send.calledWith('Event not found')).toBe(true);
   });
 
+  it('should return 404 when getEventById resolves to null', async () => {
+    sandbox.stub(calendarAPI, 'getCalendarByName').resolves(new Calendar('cal-id', 'mycal'));
+    sandbox.stub(calendarAPI, 'getEventById').resolves(null as any);
+
+    const req = { params: { urlname: 'mycal', eventid: validEventId } };
+    const res = { status: sinon.stub(), send: sinon.stub(), setHeader: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    await routes.getNote(req as any, res as any);
+
+    expect(res.status.calledWith(404)).toBe(true);
+    expect(res.send.calledWith('Event not found')).toBe(true);
+  });
+
   it('should return a properly serialized ActivityPub Note object', async () => {
     const calendar = new Calendar('cal-id', 'mycal');
     const event = new CalendarEvent(validEventId, 'cal-id');

--- a/src/server/activitypub/test/api/get-endpoints.test.ts
+++ b/src/server/activitypub/test/api/get-endpoints.test.ts
@@ -10,6 +10,7 @@ import { EventSeriesContent } from '@/common/model/event_series_content';
 import ActivityPubServerRoutes from '@/server/activitypub/api/v1/server';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import CalendarInterface from '@/server/calendar/interface';
+import { EventNotFoundError } from '@/common/exceptions/calendar';
 
 describe('GET /calendars/:urlname/events/:eventid', () => {
   let routes: ActivityPubServerRoutes;
@@ -106,6 +107,87 @@ describe('GET /calendars/:urlname/events/:eventid', () => {
     expect(result.nameMap.fr).toBe('Titre Francais');
     expect(result.summaryMap).toBeDefined();
     expect(result.contentMap).toBeDefined();
+  });
+});
+
+describe('GET /calendars/:urlname/events/:eventid/note', () => {
+  let routes: ActivityPubServerRoutes;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+  let calendarAPI: CalendarInterface;
+
+  const validEventId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    const eventBus = new EventEmitter();
+    const activityPubInterface = new ActivityPubInterface(eventBus);
+    calendarAPI = new CalendarInterface(eventBus);
+    routes = new ActivityPubServerRoutes(activityPubInterface, calendarAPI);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return 400 when eventid is not a valid UUID', async () => {
+    const req = { params: { urlname: 'mycal', eventid: 'not-a-uuid' } };
+    const res = { status: sinon.stub(), send: sinon.stub(), setHeader: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    await routes.getNote(req as any, res as any);
+
+    expect(res.status.calledWith(400)).toBe(true);
+  });
+
+  it('should return 404 when calendar not found', async () => {
+    sandbox.stub(calendarAPI, 'getCalendarByName').resolves(null);
+
+    const req = { params: { urlname: 'nonexistent', eventid: validEventId } };
+    const res = { status: sinon.stub(), send: sinon.stub(), setHeader: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    await routes.getNote(req as any, res as any);
+
+    expect(res.status.calledWith(404)).toBe(true);
+    expect(res.send.calledWith('Calendar not found')).toBe(true);
+  });
+
+  it('should return 404 when event not found', async () => {
+    sandbox.stub(calendarAPI, 'getCalendarByName').resolves(new Calendar('cal-id', 'mycal'));
+    sandbox.stub(calendarAPI, 'getEventById').rejects(new EventNotFoundError(validEventId));
+
+    const req = { params: { urlname: 'mycal', eventid: validEventId } };
+    const res = { status: sinon.stub(), send: sinon.stub(), setHeader: sinon.stub(), json: sinon.stub() };
+    res.status.returns(res);
+
+    await routes.getNote(req as any, res as any);
+
+    expect(res.status.calledWith(404)).toBe(true);
+    expect(res.send.calledWith('Event not found')).toBe(true);
+  });
+
+  it('should return a properly serialized ActivityPub Note object', async () => {
+    const calendar = new Calendar('cal-id', 'mycal');
+    const event = new CalendarEvent(validEventId, 'cal-id');
+    event.addContent(new CalendarEventContent('en', 'Test Event', 'A description'));
+    const startDt = DateTime.fromISO('2026-04-15T09:00:00.000Z');
+    event.schedules = [new CalendarEventSchedule('s1', startDt)];
+
+    sandbox.stub(calendarAPI, 'getCalendarByName').resolves(calendar);
+    sandbox.stub(calendarAPI, 'getEventById').resolves(event);
+
+    const req = { params: { urlname: 'mycal', eventid: validEventId } };
+    const res = { setHeader: sinon.stub(), json: sinon.stub() };
+
+    await routes.getNote(req as any, res as any);
+
+    expect(res.setHeader.calledWith('Content-Type', 'application/activity+json')).toBe(true);
+    expect(res.json.calledOnce).toBe(true);
+
+    const result = res.json.firstCall.args[0];
+    expect(result.type).toBe('Note');
+    expect(result.id).toMatch(/\/note$/);
+    expect(result.id).toContain(`/calendars/mycal/events/${validEventId}/note`);
+    expect(result.attributedTo).toContain('/calendars/mycal');
   });
 });
 

--- a/src/server/activitypub/test/events.test.ts
+++ b/src/server/activitypub/test/events.test.ts
@@ -10,6 +10,7 @@ import { ActivityPubInboxMessageEntity, ActivityPubOutboxMessageEntity } from '@
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import { ActivityPubActor } from '@/server/activitypub/model/base';
 import { EventObject } from '@/server/activitypub/model/object/event';
+import { NoteObject } from '@/server/activitypub/model/object/note';
 import { Calendar } from '@/common/model/calendar';
 import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { EventLocation, EventLocationContent, EventLocationSpace, EventLocationSpaceContent } from '@/common/model/location';
@@ -173,7 +174,7 @@ describe('handleEventUpdated guard', () => {
     expect(addToOutboxStub.called).toBe(false);
   });
 
-  it('should broadcast update when payload.calendar is present (local event update)', async () => {
+  it('should broadcast paired Update(Event) + Update(Note) when payload.calendar is present (local event update)', async () => {
     const calendar = Calendar.fromObject({ id: 'local-calendar-id', urlName: 'my_calendar' });
     const event = CalendarEvent.fromObject({ id: 'local-event-id' });
 
@@ -189,18 +190,32 @@ describe('handleEventUpdated guard', () => {
     await new Promise(resolve => setTimeout(resolve, 100));
 
     expect(actorUrlStub.calledOnce).toBe(true);
-    expect(addToOutboxStub.calledOnce).toBe(true);
+    // Paired emission: Update(Event) + Update(Note) so Mastodon-class peers see
+    // the edit on profile timelines alongside the Pavillion-native Update(Event).
+    expect(addToOutboxStub.calledTwice).toBe(true);
 
-    const outboxCall = addToOutboxStub.getCall(0);
-    expect(outboxCall.args[0]).toBe(calendar);
-    const update = outboxCall.args[1];
-    expect(update.type).toBe('Update');
+    const eventCall = addToOutboxStub.getCall(0);
+    expect(eventCall.args[0]).toBe(calendar);
+    const updateEvent = eventCall.args[1];
+    expect(updateEvent.type).toBe('Update');
+    expect(updateEvent.object.type).toBe('Event');
     // Update activities must be addressed publicly so AP consumers (Mastodon
     // included) treat them as visible profile timeline activity rather than
     // private/addressless updates.
-    expect(update.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
-    expect(update.cc).toEqual(['https://example.com/calendars/my_calendar/followers']);
-    expect(update.published).toBeInstanceOf(Date);
+    expect(updateEvent.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(updateEvent.cc).toEqual(['https://example.com/calendars/my_calendar/followers']);
+    expect(updateEvent.published).toBeInstanceOf(Date);
+
+    const noteCall = addToOutboxStub.getCall(1);
+    // Attribution invariant: the same calendar argument flows to both calls so
+    // outbox dispatcher attribution remains consistent across the pair.
+    expect(noteCall.args[0]).toBe(calendar);
+    const updateNote = noteCall.args[1];
+    expect(updateNote.type).toBe('Update');
+    expect(updateNote.object.type).toBe('Note');
+    expect(updateNote.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(updateNote.cc).toEqual(['https://example.com/calendars/my_calendar/followers']);
+    expect(updateNote.published).toBeInstanceOf(Date);
   });
 });
 
@@ -224,7 +239,7 @@ describe('handleEventCreated', () => {
     await teardownActivityPubSchema();
   });
 
-  it('creates an EventObjectEntity for the local event before dispatching Announce', async () => {
+  it('creates an EventObjectEntity for the local event before dispatching paired Announce(Event) + Create(Note)', async () => {
     const calendar = Calendar.fromObject({ id: uuidv4(), urlName: 'my_calendar' });
     const event = CalendarEvent.fromObject({ id: uuidv4() });
     const actorUrl = ActivityPubActor.actorUrl(calendar);
@@ -240,16 +255,34 @@ describe('handleEventCreated', () => {
     const eventObject = await EventObjectEntity.findOne({ where: { event_id: event.id } });
     expect(eventObject, 'EventObjectEntity must exist for local event').not.toBeNull();
     expect(eventObject!.attributed_to).toBe(actorUrl);
-    expect(addToOutboxStub.calledOnce).toBe(true);
+    // Paired emission: Announce(Event) first, Create(Note) second, both with
+    // public addressing so Mastodon-class peers render the Note while
+    // Pavillion-aware peers consume the Event.
+    expect(addToOutboxStub.calledTwice).toBe(true);
 
     // Announce envelope must be addressed publicly with followers in cc and a
     // populated published timestamp — without these, Mastodon ignores the
     // activity in profile timelines and HTTP delivery loses audience info.
-    const announce = addToOutboxStub.getCall(0).args[1];
+    const announceCall = addToOutboxStub.getCall(0);
+    expect(announceCall.args[0]).toBe(calendar);
+    const announce = announceCall.args[1];
     expect(announce.type).toBe('Announce');
     expect(announce.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
     expect(announce.cc).toEqual([`${actorUrl}/followers`]);
     expect(announce.published).toBeInstanceOf(Date);
+
+    // Paired Create(Note) emission with matching public addressing. The Note
+    // wraps the same canonical event so Mastodon-class peers render it on
+    // profile timelines.
+    const createCall = addToOutboxStub.getCall(1);
+    // Attribution invariant: the same calendar argument flows to both calls.
+    expect(createCall.args[0]).toBe(calendar);
+    const create = createCall.args[1];
+    expect(create.type).toBe('Create');
+    expect(create.object.type).toBe('Note');
+    expect(create.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(create.cc).toEqual([`${actorUrl}/followers`]);
+    expect(create.published).toBeInstanceOf(Date);
   });
 
   it('logs a warning but does not overwrite EventObjectEntity when a pre-existing row has mismatched attributed_to', async () => {
@@ -294,10 +327,10 @@ describe('handleEventCreated', () => {
 
     // Secondary assertion: despite the integrity signal, the event is still
     // dispatched to the outbox. This is the documented behavior — the warn is
-    // a signal, not a hard stop.
+    // a signal, not a hard stop. Both legs of the paired emission run.
     expect(
-      addToOutboxStub.calledOnce,
-      'addToOutbox must still be called so the event reaches federation',
+      addToOutboxStub.calledTwice,
+      'addToOutbox must still be called for both legs of the pair so the event reaches federation',
     ).toBe(true);
   });
 
@@ -326,6 +359,64 @@ describe('handleEventCreated', () => {
     expect(eventObject, 'no EventObjectEntity row for remote-origin event').toBeNull();
   });
 
+});
+
+describe('handleEventDeleted', () => {
+  let service: ActivityPubInterface;
+  let handlers: ActivityPubEventHandlers;
+  let eventBus: EventEmitter;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    eventBus = new EventEmitter();
+    service = new ActivityPubInterface(eventBus);
+    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    handlers.install(eventBus);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should broadcast paired Delete(Event) + Delete(Note) with public addressing and the same calendar arg', async () => {
+    const calendar = Calendar.fromObject({ id: uuidv4(), urlName: 'my_calendar' });
+    const event = CalendarEvent.fromObject({ id: uuidv4() });
+    const actorUrl = ActivityPubActor.actorUrl(calendar);
+
+    sandbox.stub(service, 'actorUrl').resolves(actorUrl);
+    const addToOutboxStub = sandbox.stub(service, 'addToOutbox').resolves();
+
+    // Invoke the private handler directly so the paired emission is asserted
+    // deterministically without racing setImmediate hops.
+    await (handlers as any)['handleEventDeleted']({ calendar, event });
+
+    // Paired emission: Delete(Event) first, Delete(Note) second.
+    expect(addToOutboxStub.calledTwice).toBe(true);
+
+    const eventCall = addToOutboxStub.getCall(0);
+    expect(eventCall.args[0]).toBe(calendar);
+    const deleteEvent = eventCall.args[1];
+    expect(deleteEvent.type).toBe('Delete');
+    // Delete activities carry the object URL as a string (not an embedded
+    // object), so we assert the canonical Event IRI form.
+    expect(deleteEvent.object).toBe(EventObject.eventUrl(calendar, event));
+    expect(deleteEvent.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(deleteEvent.cc).toEqual([`${actorUrl}/followers`]);
+    expect(deleteEvent.published).toBeInstanceOf(Date);
+
+    const noteCall = addToOutboxStub.getCall(1);
+    // Attribution invariant: the same calendar argument flows to both calls.
+    expect(noteCall.args[0]).toBe(calendar);
+    const deleteNote = noteCall.args[1];
+    expect(deleteNote.type).toBe('Delete');
+    // The Delete(Note) carries the Note IRI string form, NOT a Note object —
+    // mirroring the Event Delete shape.
+    expect(deleteNote.object).toBe(NoteObject.noteUrl(calendar, event));
+    expect(typeof deleteNote.object).toBe('string');
+    expect(deleteNote.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(deleteNote.cc).toEqual([`${actorUrl}/followers`]);
+    expect(deleteNote.published).toBeInstanceOf(Date);
+  });
 });
 
 describe('AP serialize → parse round-trip (Place + Space + multilingual content)', () => {

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -9,7 +9,9 @@ import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor'
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import FollowActivity from '@/server/activitypub/model/action/follow';
 import AnnounceActivity from '@/server/activitypub/model/action/announce';
+import CreateActivity from '@/server/activitypub/model/action/create';
 import UpdateActivity from '@/server/activitypub/model/action/update';
+import DeleteActivity from '@/server/activitypub/model/action/delete';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
 import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { CalendarEntity } from '@/server/calendar/entity/calendar';
@@ -1507,5 +1509,172 @@ describe('ProcessInboxService - processShareEvent SSRF Protection', () => {
 
     // addRemoteEvent must NOT have been called — SSRF protection blocked the fetch
     expect(addRemoteEventSpy.called).toBe(false);
+  });
+});
+
+/**
+ * Pavillion's outbox emits a paired Create(Note)/Update(Note)/Delete(Note)
+ * alongside every Announce(Event)/Update(Event)/Delete(Event) so Mastodon-class
+ * peers render the post on profile timelines. Notes are interop-only — the
+ * note.ts comment is explicit: "Pavillion never ingests remote Notes."
+ *
+ * Before this guard, the inbox dispatcher routed every Create/Update to
+ * processCreateEvent/processUpdateEvent without inspecting object.type and
+ * every Delete to processDeleteEvent without inspecting the target IRI.
+ * A Create(Note) would therefore be parsed as a Create(Event), creating a
+ * phantom EventEntity attributed to the source actor with the Note IRI as
+ * eventSourceUrl. In mutual auto-repost setups (federation Scenario 5) the
+ * phantom passed the loop-prevention guard and cascaded back to the source,
+ * tripping rate-limits and crowding the real Announce(Event) out of the
+ * test timeout window.
+ */
+describe('ProcessInboxService - Note-wrapped activities are skipped', () => {
+  let sandbox: sinon.SinonSandbox;
+  let inboxService: ProcessInboxService;
+  let eventBus: EventEmitter;
+  let testCalendar: Calendar;
+  let calendarInterface: CalendarInterface;
+
+  const remoteActorUri = 'https://remote.instance/calendars/source-calendar';
+  const eventApId = 'https://remote.instance/calendars/source-calendar/events/abc';
+  const noteApId = `${eventApId}/note`;
+
+  beforeEach(async () => {
+    await setupActivityPubSchema();
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    inboxService = new ProcessInboxService(eventBus, calendarInterface);
+
+    testCalendar = new Calendar('note-skip-calendar-id', 'note-skip-calendar');
+    testCalendar.addContent('en', new CalendarContent('en'));
+    testCalendar.content('en').title = 'Note Skip Test Calendar';
+
+    await CalendarEntity.create({
+      id: testCalendar.id,
+      url_name: testCalendar.urlName,
+      account_id: uuidv4(),
+      languages: 'en',
+    });
+
+    sandbox.stub(console, 'log');
+    sandbox.stub(console, 'warn');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+  });
+
+  it('processCreateEvent skips Note-typed objects without creating an EventObjectEntity or calling addRemoteEvent', async () => {
+    const addRemoteEventSpy = sandbox.stub(calendarInterface, 'addRemoteEvent');
+    const ownsObjectSpy = sandbox.stub(inboxService as any, 'actorOwnsObject');
+
+    const createNote = new CreateActivity(remoteActorUri, {
+      id: noteApId,
+      type: 'Note',
+      attributedTo: remoteActorUri,
+      name: 'Untrusted Note',
+      content: '<p>arbitrary</p>',
+    } as any);
+
+    const result = await inboxService['processCreateEvent'](testCalendar, createNote);
+
+    expect(result).toBeNull();
+    expect(addRemoteEventSpy.called).toBe(false);
+    // Short-circuit must happen before remote ownership verification: the
+    // helper would otherwise dereference the Note IRI over HTTP.
+    expect(ownsObjectSpy.called).toBe(false);
+
+    const persistedPhantom = await EventObjectEntity.findOne({
+      where: { ap_id: noteApId },
+    });
+    expect(persistedPhantom).toBeNull();
+  });
+
+  it('processUpdateEvent skips Note-typed objects even when a stale EventObjectEntity exists at the Note IRI', async () => {
+    // Seed the kind of phantom row a pre-fix Create(Note) would have minted.
+    // Without the Note-type guard, processUpdateEvent would find this row,
+    // load its event, and forward the Note payload to updateRemoteEvent.
+    const phantomEventId = uuidv4();
+    await EventObjectEntity.create({
+      event_id: phantomEventId,
+      ap_id: noteApId,
+      attributed_to: remoteActorUri,
+    });
+    sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(phantomEventId, null));
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+
+    const updateSpy = sandbox.stub(calendarInterface, 'updateRemoteEvent');
+
+    const updateNote = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: remoteActorUri,
+      object: {
+        id: noteApId,
+        type: 'Note',
+        attributedTo: remoteActorUri,
+        name: 'Untrusted Note',
+        content: '<p>arbitrary</p>',
+      },
+    });
+
+    const result = await inboxService.processUpdateEvent(testCalendar, updateNote!);
+
+    expect(result).toBeNull();
+    expect(updateSpy.called).toBe(false);
+  });
+
+  it('processDeleteEvent skips Note IRIs (object string ending in /note) even when an EventObjectEntity exists at that IRI', async () => {
+    // Seed the kind of phantom row a pre-fix Create(Note) would have minted.
+    // Without the Note IRI guard, processDeleteEvent would resolve this row,
+    // verify ownership, and call deleteRemoteEvent — destroying a phantom
+    // event the system never should have had in the first place.
+    const phantomEventId = uuidv4();
+    await EventObjectEntity.create({
+      event_id: phantomEventId,
+      ap_id: noteApId,
+      attributed_to: remoteActorUri,
+    });
+    sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(phantomEventId, null));
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    // Stub ownership verification to true so the test cannot pass for the
+    // wrong reason (i.e. the real fetcher failing on an unreachable IRI).
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const deleteEventSpy = sandbox.stub(calendarInterface, 'deleteRemoteEvent');
+
+    const deleteNote = new DeleteActivity(remoteActorUri, noteApId);
+    await inboxService.processDeleteEvent(testCalendar, deleteNote);
+
+    expect(deleteEventSpy.called).toBe(false);
+  });
+
+  it('processDeleteEvent skips Tombstone objects whose formerType is Note', async () => {
+    const phantomEventId = uuidv4();
+    await EventObjectEntity.create({
+      event_id: phantomEventId,
+      ap_id: noteApId,
+      attributed_to: remoteActorUri,
+    });
+    sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(phantomEventId, null));
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const deleteEventSpy = sandbox.stub(calendarInterface, 'deleteRemoteEvent');
+
+    const deleteTombstone = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: remoteActorUri,
+      object: {
+        id: noteApId,
+        type: 'Tombstone',
+        formerType: 'Note',
+      },
+    });
+
+    await inboxService.processDeleteEvent(testCalendar, deleteTombstone!);
+
+    expect(deleteEventSpy.called).toBe(false);
   });
 });

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -11,7 +11,7 @@ import FollowActivity from '@/server/activitypub/model/action/follow';
 import AnnounceActivity from '@/server/activitypub/model/action/announce';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
-import { CalendarEvent } from '@/common/model/events';
+import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { CalendarEntity } from '@/server/calendar/entity/calendar';
 import { EventEmitter } from 'events';
 import CalendarInterface from '@/server/calendar/interface';
@@ -870,6 +870,229 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
     });
     expect(dismissalsB).toBe(0);
   });
+});
+
+describe('ProcessInboxService - checkAndPerformAutoRepost paired Note emission', () => {
+  let sandbox: sinon.SinonSandbox;
+  let inboxService: ProcessInboxService;
+  let eventBus: EventEmitter;
+  let testCalendar: Calendar;
+  let calendarInterface: CalendarInterface;
+
+  const sourceActorUri = 'https://remote.instance/calendars/source-calendar';
+
+  beforeEach(async () => {
+    await setupActivityPubSchema();
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    inboxService = new ProcessInboxService(eventBus, calendarInterface);
+
+    testCalendar = new Calendar('test-calendar-id', 'test-calendar');
+    testCalendar.addContent('en', new CalendarContent('en'));
+    testCalendar.content('en').title = 'Test Calendar';
+
+    await CalendarEntity.create({
+      id: testCalendar.id,
+      url_name: testCalendar.urlName,
+      account_id: uuidv4(),
+      languages: 'en',
+    });
+
+    // Other test files may leave `PRAGMA foreign_keys = ON` on the shared
+    // SQLite connection. The auto-repost path persists rows referencing
+    // EventEntity which setupActivityPubSchema() does not sync.
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    sandbox.stub(console, 'log');
+    sandbox.stub(console, 'warn');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = ON');
+  });
+
+  async function seedAutoRepostPrerequisites(eventId: string, eventApId: string) {
+    const remoteCalendarActorId = uuidv4();
+    await CalendarActorEntity.create({
+      id: remoteCalendarActorId,
+      actor_type: 'remote',
+      actor_uri: sourceActorUri,
+      remote_display_name: null,
+      remote_domain: 'remote.instance',
+      calendar_id: null,
+      private_key: null,
+    });
+
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: testCalendar.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: sourceActorUri,
+    });
+  }
+
+  function buildReconstitutedEvent(eventId: string): CalendarEvent {
+    // Mirrors the shape the inbox cascade hands to NoteObject: a CalendarEvent
+    // with at least one language of content so the Note serialization produces
+    // a non-empty `name`/`content` payload.
+    const event = new CalendarEvent(eventId, null);
+    event.addContent(new CalendarEventContent('en', 'Reposted Event', ''));
+    return event;
+  }
+
+  it('emits paired Announce(Event) + Create(Note) on cascade, with Note attributed to the reposting calendar', async () => {
+    // Arrange
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedAutoRepostPrerequisites(eventId, eventApId);
+
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+
+    // Capture activities at outbox-enqueue time so assertions see the
+    // in-memory `NoteObject` instance (with its serialization methods
+    // intact) rather than the JSON-stringified shape from the DB row.
+    const enqueuedActivities: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueuedActivities.push(activity));
+
+    // Act
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+
+    // Assert — paired Announce(Event) and Create(Note) in order.
+    const announces = enqueuedActivities.filter(a => a.type === 'Announce');
+    const creates = enqueuedActivities.filter(a => a.type === 'Create');
+    expect(announces.length).toBe(1);
+    expect(creates.length).toBe(1);
+
+    // Announce wraps the remote event IRI directly (string object form).
+    expect(announces[0].object).toBe(eventApId);
+    expect(announces[0].to).toContain('https://www.w3.org/ns/activitystreams#Public');
+
+    // Create wraps a NoteObject attributed to the reposting calendar's actor
+    // URL. The remote canonical IRI is carried via `urlOverride` and surfaces
+    // in the AS payload as `url` after `toActivityPubObject()` runs it through
+    // sanitizeExternalUrlHref.
+    const createActivity = creates[0];
+    expect(createActivity.object.type).toBe('Note');
+    expect(createActivity.object.attributedTo).toContain('/calendars/test-calendar');
+    expect(createActivity.to).toContain('https://www.w3.org/ns/activitystreams#Public');
+    expect(createActivity.cc[0]).toContain('/calendars/test-calendar/followers');
+
+    // Serialize the Note via its toActivityPubObject() to verify the
+    // post-sanitization `url` field — that path is what the wire payload
+    // hits via ActivityPubActivity.toObject() at delivery time.
+    const apForm = createActivity.object.toActivityPubObject();
+    expect(apForm.url).toBe(eventApId);
+  });
+
+  it('suppresses both Announce(Event) and Create(Note) when a DEC-008 dismissal exists', async () => {
+    // Arrange
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedAutoRepostPrerequisites(eventId, eventApId);
+
+    // Sticky dismissal for this (event_id, calendar_id) pair — gate must
+    // suppress BOTH paired activities together.
+    await RepostDismissalEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: testCalendar.id,
+    });
+
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueuedActivities: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueuedActivities.push(activity));
+
+    // Act
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+
+    // Assert — neither Event nor Note activity should reach the outbox.
+    expect(enqueuedActivities.filter(a => a.type === 'Announce').length).toBe(0);
+    expect(enqueuedActivities.filter(a => a.type === 'Create').length).toBe(0);
+  });
+
+  it('emits the Note with `url` omitted when the remote canonical IRI uses an invalid scheme', async () => {
+    // Arrange — remote canonical IRI uses a javascript: scheme. NoteObject
+    // must validate via sanitizeExternalUrlHref and drop the `url` field
+    // rather than propagating a dangerous href to Mastodon followers.
+    const eventId = uuidv4();
+    const eventApId = 'javascript:alert(1)';
+
+    // Seed prerequisites manually because seedAutoRepostPrerequisites stores
+    // attributed_to keyed off sourceActorUri but the EventObjectEntity needs
+    // the malformed ap_id as the lookup key for checkAndPerformAutoRepost.
+    const remoteCalendarActorId = uuidv4();
+    await CalendarActorEntity.create({
+      id: remoteCalendarActorId,
+      actor_type: 'remote',
+      actor_uri: sourceActorUri,
+      remote_display_name: null,
+      remote_domain: 'remote.instance',
+      calendar_id: null,
+      private_key: null,
+    });
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: testCalendar.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: sourceActorUri,
+    });
+
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueuedActivities: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueuedActivities.push(activity));
+
+    // Act
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+
+    // Assert — paired Create(Note) still emitted, but the AP-serialized
+    // payload omits `url` because sanitizeExternalUrlHref rejects the
+    // javascript: scheme. The Note itself MUST still be emitted so
+    // Mastodon followers still see a post for the re-shared event.
+    const creates = enqueuedActivities.filter(a => a.type === 'Create');
+    expect(creates.length).toBe(1);
+    const note = creates[0].object;
+    expect(note.type).toBe('Note');
+    const apForm = note.toActivityPubObject();
+    expect(apForm.url).toBeUndefined();
+  });
+
+  // GAP DOCUMENTATION: Update(Event) and Delete(Event) cascades for
+  // SharedEventEntity-bound events do not exist as distinct inbox emission
+  // sites. `processUpdateEvent` emits `eventUpdated` with calendar: null
+  // (which the outbox handler returns from early — loop prevention) and
+  // `processDeleteEvent` makes no bus emission at all. Paired Note Update /
+  // Delete propagation for locally-owned events lives in the outbox event
+  // handlers (handleEventUpdated / handleEventDeleted) and is covered by
+  // sibling pv-l35p.2.
 });
 
 describe('ProcessInboxService - processUpdateEvent', () => {

--- a/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
+++ b/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
@@ -53,6 +53,8 @@ import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import CalendarActorService from '@/server/activitypub/service/calendar_actor';
 import { ActivityPubActor } from '@/server/activitypub/model/base';
+import { EventObject } from '@/server/activitypub/model/object/event';
+import { NoteObject } from '@/server/activitypub/model/object/note';
 import {
   FollowingCalendarEntity,
   FollowerCalendarEntity,
@@ -311,12 +313,18 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     // The outbox Announce row is written immediately after SharedEvent in
     // checkAndPerformAutoRepost but through a separate await chain; poll
     // for it to ensure the addToOutbox call has resolved before we assert.
+    // We fetch ALL of B's outbox messages and filter in JS by activity type
+    // so that future paired activity additions (e.g., Create(Note) from
+    // pv-l35p) cannot silently affect this assertion: the filter pins the
+    // assertion to the specific `Announce` activity type that this
+    // regression gate cares about.
     await waitFor(
       async () => {
         const messages = await ActivityPubOutboxMessageEntity.findAll({
-          where: { calendar_id: calendarB.id, type: 'Announce' },
+          where: { calendar_id: calendarB.id },
         });
-        return messages.length > 0 ? messages : null;
+        const announces = messages.filter(m => m.type === 'Announce');
+        return announces.length > 0 ? announces : null;
       },
       { maxWaitMs: 2000, label: 'ActivityPubOutboxMessageEntity Announce for B' },
     );
@@ -326,18 +334,19 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     // intermediate local calendars but never queued Announce activities in
     // their outboxes, so remote followers of those intermediate calendars
     // silently missed the event. The unified dispatcher fixes this.
-    const bOutboxMessages = await ActivityPubOutboxMessageEntity.findAll({
-      where: { calendar_id: calendarB.id, type: 'Announce' },
+    const bAllOutboxMessages = await ActivityPubOutboxMessageEntity.findAll({
+      where: { calendar_id: calendarB.id },
     });
+    const bAnnounceMessages = bAllOutboxMessages.filter(m => m.type === 'Announce');
     expect(
-      bOutboxMessages.length,
+      bAnnounceMessages.length,
       'B must queue an Announce in its outbox so D (remote) receives it',
     ).toBeGreaterThan(0);
 
     // Assertion 3: the queued Announce's recipient list must include D's actor URI.
     const outboxService = (apInterface as any).outboxService;
     const { default: AnnounceActivity } = await import('@/server/activitypub/model/action/announce');
-    const parsedActivity = AnnounceActivity.fromObject(bOutboxMessages[0].message);
+    const parsedActivity = AnnounceActivity.fromObject(bAnnounceMessages[0].message);
     expect(parsedActivity, 'outbox Announce must parse cleanly').not.toBeNull();
     const recipients = await outboxService.getRecipients(calendarB, parsedActivity!.object);
     expect(
@@ -365,6 +374,100 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
       deliveredToD,
       'axios.post must be called with D inbox_url so the event actually reaches D',
     ).toBe(true);
+  });
+
+  it('emits paired Announce(Event) + Create(Note) rows in A outbox with matching public addressing', async () => {
+    // pv-l35p paired-emission contract: handleEventCreated queues an
+    // Announce(Event) (Pavillion-native consumers) AND a Create(Note)
+    // (Mastodon-class peer rendering). Both must address the public
+    // collection with followers in cc, otherwise Mastodon drops them
+    // from profile timelines. We fetch ALL of A's outbox messages and
+    // filter by activity type + wrapped object type in JS so the
+    // assertion stays valid as more paired activity types are added.
+    const event = await calendarInterface.createEvent(accountA, {
+      calendarId: calendarA.id,
+      content: { en: { name: 'paired emission', description: 'Event + Note paired emission' } },
+      start_date: '2026-05-08',
+      start_time: '18:00',
+      end_date: '2026-05-08',
+      end_time: '20:00',
+    });
+
+    const actorUrlA = await apInterface.actorUrl(calendarA);
+    const eventUrl = EventObject.eventUrl(calendarA, event);
+    const noteUrl = NoteObject.noteUrl(calendarA, event);
+    const publicCollection = 'https://www.w3.org/ns/activitystreams#Public';
+    const followersCollection = `${actorUrlA}/followers`;
+
+    // Poll until both the Announce(Event) and the Create(Note) are queued.
+    // handleEventCreated awaits the two addToOutbox calls sequentially, so
+    // observing the second row guarantees the first is also present. Each
+    // filter is scoped to this event's specific Event/Note IRI so prior
+    // tests in this file (which also create events on A) cannot accidentally
+    // satisfy the assertion.
+    await waitFor(
+      async () => {
+        const messages = await ActivityPubOutboxMessageEntity.findAll({
+          where: { calendar_id: calendarA.id },
+        });
+        const announceEvent = messages.find(
+          m => m.type === 'Announce' && (m.message as any)?.object === eventUrl,
+        );
+        const createNote = messages.find(
+          m => m.type === 'Create' && (m.message as any)?.object?.type === 'Note' && (m.message as any)?.object?.id === noteUrl,
+        );
+        return announceEvent && createNote ? { announceEvent, createNote } : null;
+      },
+      { maxWaitMs: 2000, label: 'paired Announce(Event) + Create(Note) rows in A outbox' },
+    );
+
+    const aOutboxMessages = await ActivityPubOutboxMessageEntity.findAll({
+      where: { calendar_id: calendarA.id },
+    });
+
+    // Type-specific filter for the Announce(Event) row. The Announce wraps
+    // an IRI string (not a nested object), so we identify it by the
+    // matching canonical event URL. Filtering in JS (rather than a
+    // SQL `type:` clause) is deliberate: it documents at the call site
+    // that future paired activity additions cannot silently bump this
+    // count, because the assertion is pinned to a single activity type
+    // wrapping a specific object IRI.
+    const announceEventRows = aOutboxMessages.filter(
+      m => m.type === 'Announce' && (m.message as any)?.object === eventUrl,
+    );
+    expect(
+      announceEventRows.length,
+      'A must queue exactly one Announce(Event) for this event',
+    ).toBe(1);
+
+    // Type-specific filter for the Create(Note) row. The Create wraps a
+    // full Note object, so we identify it by the wrapped object's type
+    // AND its canonical Note IRI (event-scoped, so prior tests on A
+    // don't satisfy this assertion).
+    const createNoteRows = aOutboxMessages.filter(
+      m => m.type === 'Create' && (m.message as any)?.object?.type === 'Note' && (m.message as any)?.object?.id === noteUrl,
+    );
+    expect(
+      createNoteRows.length,
+      'A must queue exactly one Create(Note) paired with the Announce(Event)',
+    ).toBe(1);
+
+    // Both rows must be addressed publicly with followers in cc — without
+    // this, Mastodon ignores the activities in profile timelines and HTTP
+    // delivery loses audience info. This is the addressing invariant the
+    // paired-emission contract relies on.
+    const announceMessage = announceEventRows[0].message as any;
+    expect(announceMessage.to).toEqual([publicCollection]);
+    expect(announceMessage.cc).toEqual([followersCollection]);
+
+    const createMessage = createNoteRows[0].message as any;
+    expect(createMessage.to).toEqual([publicCollection]);
+    expect(createMessage.cc).toEqual([followersCollection]);
+
+    // The wrapped Note must point back to the same canonical event so
+    // Mastodon-class peers render a post that links to the Pavillion event
+    // and Pavillion-aware peers can correlate the two activities.
+    expect(createMessage.object.attributedTo).toBe(actorUrlA);
   });
 
   it('single-hop: B auto-reposts A event when B follows A with originals enabled', async () => {
@@ -660,7 +763,6 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     // (event_id, calendar_id) constraint on SharedEventEntity must keep the
     // row count at exactly one on B regardless of how many Announces A emits.
     const actorUrl = await apInterface.actorUrl(calendarA);
-    const { EventObject } = await import('@/server/activitypub/model/object/event');
     const eventUrl = EventObject.eventUrl(calendarA, event);
     const { default: AnnounceActivity } = await import('@/server/activitypub/model/action/announce');
     await apInterface.addToOutbox(calendarA, new AnnounceActivity(actorUrl, eventUrl));

--- a/src/server/activitypub/test/model/object/note.test.ts
+++ b/src/server/activitypub/test/model/object/note.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect } from 'vitest';
+import config from 'config';
+import he from 'he';
+import { DateTime } from 'luxon';
+
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent, CalendarEventContent, CalendarEventSchedule } from '@/common/model/events';
+import { EventLocation } from '@/common/model/location';
+import { NoteObject } from '@/server/activitypub/model/object/note';
+
+const domain = config.get<string>('domain');
+
+describe('NoteObject', () => {
+
+  describe('static noteUrl', () => {
+
+    it('produces /calendars/{urlName}/events/{event.id}/note', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+
+      const url = NoteObject.noteUrl(calendar, event);
+
+      expect(url).toBe(`https://${domain}/calendars/mycal/events/event-uuid/note`);
+    });
+
+    it('accepts a string event id', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+
+      const url = NoteObject.noteUrl(calendar, 'some-event-id');
+
+      expect(url).toBe(`https://${domain}/calendars/mycal/events/some-event-id/note`);
+    });
+
+  });
+
+  describe('AP id and attributedTo', () => {
+
+    it('sets id to the canonical note URL', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+
+      const note = new NoteObject(calendar, event);
+
+      expect(note.id).toBe(`https://${domain}/calendars/mycal/events/event-uuid/note`);
+    });
+
+    it('sets attributedTo to the calendar actor URL, never an account IRI', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+
+      const note = new NoteObject(calendar, event);
+
+      expect(note.attributedTo).toBe(`https://${domain}/calendars/mycal`);
+      // Defense against future regressions: must not include the
+      // /accounts/ or /users/ path that account IRIs use elsewhere.
+      expect(note.attributedTo).not.toContain('/accounts/');
+      expect(note.attributedTo).not.toContain('/users/');
+    });
+
+  });
+
+  describe('toActivityPubObject() — single-language event with location', () => {
+
+    it('emits name, content with title/time/location, and addressing without nameMap/contentMap', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Coffee Meetup', ''));
+      const startDt = DateTime.fromISO('2026-06-15T18:30:00.000Z');
+      const schedule = new CalendarEventSchedule('s1', startDt);
+      event.schedules = [schedule];
+      event.location = new EventLocation('loc-uuid', 'Riverside Park');
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      expect(result.type).toBe('Note');
+      expect(result.id).toBe(`https://${domain}/calendars/mycal/events/event-uuid/note`);
+      expect(result.attributedTo).toBe(`https://${domain}/calendars/mycal`);
+      expect(result.name).toBe('Coffee Meetup');
+      // Content: contains anchor + title, the schedule's ISO start time
+      // (preserves offset via Luxon), and location segment.
+      expect(result.content).toContain('<a href=');
+      expect(result.content).toContain('Coffee Meetup');
+      expect(result.content).toContain(startDt.toISO()!);
+      expect(result.content).toContain(' · Riverside Park');
+      // Addressing
+      expect(result.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+      expect(result.cc).toEqual([`https://${domain}/calendars/mycal/followers`]);
+      // Single-language: no nameMap/contentMap
+      expect(result).not.toHaveProperty('nameMap');
+      expect(result).not.toHaveProperty('contentMap');
+    });
+
+    it('omits the location segment when the event has no location', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Online Workshop', ''));
+      const startDt = DateTime.fromISO('2026-07-01T15:00:00.000Z');
+      event.schedules = [new CalendarEventSchedule('s1', startDt)];
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      expect(result.content).toContain('Online Workshop');
+      expect(result.content).toContain(startDt.toISO()!);
+      // The location separator " · " appears once (between title and time),
+      // not twice (no trailing location segment).
+      expect((result.content.match(/ · /g) ?? []).length).toBe(1);
+    });
+
+  });
+
+  describe('toActivityPubObject() — multilingual event', () => {
+
+    it('emits nameMap and contentMap with per-language renderings; primary content stays in primary language', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'English Title', 'English desc'));
+      event.addContent(new CalendarEventContent('es', 'Spanish Title', 'Spanish desc'));
+      const startDt = DateTime.fromISO('2026-06-15T18:30:00.000Z');
+      event.schedules = [new CalendarEventSchedule('s1', startDt)];
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      // Primary content: English (per 'en' preference rule)
+      expect(result.name).toBe('English Title');
+      expect(result.content).toContain('English Title');
+
+      // Multilingual maps present and cover both languages
+      expect(result.nameMap).toEqual({
+        en: 'English Title',
+        es: 'Spanish Title',
+      });
+      expect(result.contentMap).toHaveProperty('en');
+      expect(result.contentMap).toHaveProperty('es');
+      expect(result.contentMap.en).toContain('English Title');
+      expect(result.contentMap.es).toContain('Spanish Title');
+    });
+
+    it('falls back to first non-en language when en has no name', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('es', 'Solo Espanol', ''));
+      event.addContent(new CalendarEventContent('fr', 'Aussi Francais', ''));
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      // Primary picks the first language with a name (es here).
+      // Names are ASCII so he.encode is identity.
+      expect(['Solo Espanol', 'Aussi Francais']).toContain(result.name);
+    });
+
+  });
+
+  describe('toActivityPubObject() — minimal data', () => {
+
+    it('degrades gracefully when the event has no content, no schedules, and no location', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      expect(result.type).toBe('Note');
+      expect(result.id).toBe(`https://${domain}/calendars/mycal/events/event-uuid/note`);
+      expect(result.attributedTo).toBe(`https://${domain}/calendars/mycal`);
+      // Falls back to the default title and still emits content
+      expect(result.name).toBe('Untitled Event');
+      expect(typeof result.content).toBe('string');
+      expect(result.content).toContain('Untitled Event');
+    });
+
+    it('omits published when the event has no createdAt', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Hello', ''));
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      expect(result).not.toHaveProperty('published');
+    });
+
+    it('emits published as ISO when createdAt is set', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Hello', ''));
+      event.createdAt = new Date('2026-03-01T12:00:00.000Z');
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      expect(result.published).toBe('2026-03-01T12:00:00.000Z');
+    });
+
+  });
+
+  describe('HTML escaping', () => {
+
+    it('entity-encodes a hostile title in both name and content', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      const hostile = '</a><script>alert(1)</script>';
+      event.addContent(new CalendarEventContent('en', hostile, ''));
+      event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-06-15T18:30:00.000Z'))];
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      // name: fully encoded — the raw tag fragment must not appear
+      expect(result.name).not.toContain('<script>');
+      expect(result.name).not.toContain('</a>');
+      expect(result.name).toBe(he.encode(hostile));
+
+      // content: the only `<a>` / `</a>` / `<p>` tags allowed are the ones
+      // Pavillion itself wrote into the template. The hostile title's tags
+      // must be entity-encoded.
+      expect(result.content).not.toContain('<script>');
+      expect(result.content).toContain('&#x3C;script&#x3E;');
+      // The injected </a> tag must be encoded, not literal. There is exactly
+      // one literal </a> in the result (the wrapper anchor's closing tag).
+      expect((result.content.match(/<\/a>/g) ?? []).length).toBe(1);
+    });
+
+    it('entity-encodes a hostile location name in content', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Safe Title', ''));
+      event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-06-15T18:30:00.000Z'))];
+      event.location = new EventLocation('loc-uuid', '<img src=x onerror=alert(1)>');
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      // Tag delimiters MUST be entity-encoded so no new HTML element opens.
+      // The literal `onerror=` token remains visible inside the encoded text
+      // (it is benign without `<`/`>`), but no `<img` tag can fire.
+      expect(result.content).not.toContain('<img');
+      expect(result.content).toContain(he.encode('<img src=x onerror=alert(1)>'));
+    });
+
+  });
+
+  describe('urlOverride option', () => {
+
+    it('uses urlOverride for both the url field and the content anchor href', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Reposted Event', ''));
+      event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-06-15T18:30:00.000Z'))];
+
+      const remoteIri = 'https://remote.instance/events/abc-123';
+      const note = new NoteObject(calendar, event, { urlOverride: remoteIri });
+      const result = note.toActivityPubObject();
+
+      expect(result.url).toBe(remoteIri);
+      // Anchor href in content is the override too (HTML-encoded inside the
+      // href attribute — `he.encode` is identity for plain http(s) IRIs).
+      expect(result.content).toContain(`<a href="${remoteIri}">`);
+      // The Pavillion-local event page IRI must NOT appear in the content
+      // when an override is in effect.
+      expect(result.content).not.toContain(`https://${domain}/calendars/mycal/events/event-uuid"`);
+    });
+
+    it('omits url and falls back to local event page in the anchor when override has an invalid scheme', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Reposted Event', ''));
+      event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-06-15T18:30:00.000Z'))];
+
+      const note = new NoteObject(calendar, event, { urlOverride: 'javascript:alert(1)' });
+      const result = note.toActivityPubObject();
+
+      // url is omitted when override validation fails
+      expect(result).not.toHaveProperty('url');
+      // Note still serializes with a working local anchor href
+      expect(result.type).toBe('Note');
+      expect(result.content).toContain(`<a href="https://${domain}/calendars/mycal/events/event-uuid">`);
+    });
+
+    it('omits url when override is a non-http(s) URL', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Reposted Event', ''));
+
+      const note = new NoteObject(calendar, event, { urlOverride: 'data:text/html,<script>alert(1)</script>' });
+      const result = note.toActivityPubObject();
+
+      expect(result).not.toHaveProperty('url');
+    });
+
+  });
+
+  describe('no fromActivityPubObject', () => {
+
+    it('does not expose a fromActivityPubObject method', () => {
+      // Pavillion never ingests remote Notes — they are minted on-the-wire by
+      // each instance to wrap its own canonical Event.
+      expect((NoteObject as any).fromActivityPubObject).toBeUndefined();
+    });
+
+  });
+
+  describe('no pavillion:* extensions', () => {
+
+    it('does not emit any pavillion:* keys', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', 'Test', ''));
+
+      const note = new NoteObject(calendar, event);
+      const result = note.toActivityPubObject();
+
+      const pavillionKeys = Object.keys(result).filter(k => k.startsWith('pavillion:'));
+      expect(pavillionKeys).toEqual([]);
+    });
+
+  });
+
+});

--- a/src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts
+++ b/src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts
@@ -113,11 +113,18 @@ describe('Place+Spaces atomic save: federation regression', () => {
     eventBus.emit('eventUpdated', { calendar, event });
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    // Assert — exactly one outbox enqueue happened, and it carried an Update
-    // (NOT something Place-shaped). Architectural Decision 6 forbids Place-
-    // level AP activities; this assertion is the load-bearing guard.
-    expect(addToOutboxStub.calledOnce, 'exactly one Update enqueued for the event').toBe(true);
-    const [calendarArg, activity] = addToOutboxStub.getCall(0).args;
+    // Assert — paired Update(Event) + Update(Note) enqueued for the event.
+    // The first call carries the Pavillion-native Update(Event) (which is the
+    // subject of this regression — NOT something Place-shaped — Architectural
+    // Decision 6 forbids Place-level AP activities). The second call carries
+    // the paired Update(Note) for Mastodon-class peers; it does not affect
+    // the Place/Space wire shape this test pins.
+    expect(addToOutboxStub.calledTwice, 'paired Update(Event) + Update(Note) enqueued').toBe(true);
+    const eventCall = addToOutboxStub.getCalls().find(
+      call => (call.args[1] as any)?.object?.type === 'Event',
+    );
+    expect(eventCall, 'Update(Event) leg present in outbox calls').toBeDefined();
+    const [calendarArg, activity] = eventCall!.args;
     expect(calendarArg).toBe(calendar);
     expect(activity).toBeInstanceOf(UpdateActivity);
     expect((activity as UpdateActivity).type).toBe('Update');
@@ -194,8 +201,14 @@ describe('Place+Spaces atomic save: federation regression', () => {
     eventBus.emit('eventUpdated', { calendar, event });
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    expect(addToOutboxStub.calledOnce).toBe(true);
-    const activity = addToOutboxStub.getCall(0).args[1];
+    // Paired Update(Event) + Update(Note) emission — filter to the Event leg,
+    // which is the one carrying the pavillion:place wire shape this test pins.
+    expect(addToOutboxStub.calledTwice).toBe(true);
+    const eventCall = addToOutboxStub.getCalls().find(
+      call => (call.args[1] as any)?.object?.type === 'Event',
+    );
+    expect(eventCall, 'Update(Event) leg present in outbox calls').toBeDefined();
+    const activity = eventCall!.args[1];
     const emittedAp = (activity as any).object.toActivityPubObject();
 
     expect(emittedAp['pavillion:place']).toBeDefined();

--- a/src/server/calendar/test/integration/create_event.test.ts
+++ b/src/server/calendar/test/integration/create_event.test.ts
@@ -96,14 +96,18 @@ describe('Event API', () => {
     });
     let entity = await EventEntity.findOne({ where: { id: response.body.id } });
 
-    // Poll for the outbox message to be processed (ARM CI runners need more time)
+    // Poll for the outbox message to be processed (ARM CI runners need more time).
+    // Event creation now emits paired Announce(Event) + Create(Note) so we
+    // filter by activity type instead of ordering — protects against future
+    // activity additions and removes order-dependence.
     let message: ActivityPubOutboxMessageEntity | null = null;
     for (let i = 0; i < 20; i++) {
       await new Promise(resolve => setTimeout(resolve, 100));
-      message = await ActivityPubOutboxMessageEntity.findOne({
+      const messages = await ActivityPubOutboxMessageEntity.findAll({
         where: { calendar_id: calendar.id },
-        order: [['message_time', 'DESC']],
+        order: [['message_time', 'ASC']],
       });
+      message = messages.find(m => (m.message as any)?.type === 'Announce') ?? null;
       if (message?.processed_time) break;
     }
 
@@ -122,6 +126,9 @@ describe('Event API', () => {
       expect(messageObj.object, "has an appropriate event URL").toContain(entity.id);
       expect(message.processed_time,"message in the outbox was processed").not.toBe(null);
     }
-    expect(postStub.calledOnce,"post to remote inbox").toBe(true);
+    // Paired emission: Announce(Event) + Create(Note) both post to follower
+    // inboxes. The remote-post contract under test is "the event reached
+    // federation" — assert at least one post (the Announce leg) happened.
+    expect(postStub.called,"post to remote inbox").toBe(true);
   });
 });


### PR DESCRIPTION
## Motivation

Pavillion publishes calendar events as ActivityPub `Announce(Event)` activities. Mastodon's profile timeline only renders activities whose wrapped object is type `Note` or `Article` — `Event` objects are silently dropped. The result was that Mastodon followers of a Pavillion calendar saw the actor profile but an empty post list. PeerTube and Mobilizon hit the same wall; Mobilizon's solution is to emit a `Create(Note)` companion activity per event with a short content summary and a permalink back to the canonical event URL. AP-native consumers (Mobilizon, Gancio) keep consuming the rich `Event` activity; Mastodon-class consumers render the Note.

## Approach

Introduces a `NoteObject` ActivityStreams wire model and emits paired Note activities alongside every outbound Event activity. The Note is interop-only: no `pavillion:*` extensions, no inbound `fromActivityPubObject`, no new domain concept. AP IRI shape parallels existing `EventObject` (`/calendars/{cal}/events/{event}/note`).

- **NoteObject model** mirrors `EventObject` pattern: HTML-escaped title and location via `he.encode()`; `attributedTo` is the calendar actor URL (never an account IRI); per-locale `nameMap`/`contentMap` only when 2+ languages present; `urlOverride` constructor option for re-share canonical IRIs, validated through `sanitizeExternalUrlHref` (rejects non-http(s) schemes; falls back to local event page on rejection).
- **Outbox handlers** emit paired `Create(Note)` / `Update(Note)` / `Delete(Note)` after each existing `Announce(Event)` / `Update(Event)` / `Delete(Event)`. Both calls receive the same calendar argument (attribution invariant) and both carry public addressing (`to: [Public]`, `cc: [followers]`).
- **Inbox auto-repost cascade** emits paired `Create(Note)` for re-shared events, attributed to the reposting calendar. The dismissal gate now suppresses both Event and Note activities together.
- **GET /calendars/:urlname/events/:eventid/note** route serves the Note as `application/activity+json` (unauthenticated public; UUID-validated path param; 404 via `EventNotFoundError`).
- **Integration test refactor** replaces total-row count assertions with type-specific JS filters. Future paired-activity additions cannot silently break unrelated counts. Two pre-existing tests (`place-spaces-atomic-save-federation`, `create_event`) updated to expect doubled emission count.

**Documented structural gap (not a bug):** Inbox-originated `Update(Event)` and `Delete(Event)` on re-shared events do not cascade paired Note activities. `processUpdateEvent` emits `eventUpdated` with `calendar: null` (loop prevention; the outbox handler early-returns) and `processDeleteEvent` makes no bus emission. Locally-owned event Update/Delete is correctly handled via the outbox handlers above. Inline comments in `inbox.ts` and `inbox.test.ts` document the rationale.

## Validation

- Lint: 0 errors
- Unit tests: 7,840 / 7,840 passing
- Integration tests: 586 / 591 passing (5 intentional skips)
- Frontend + widget-sdk build: successful
- E2E: 3 pre-existing failures unrelated to this change (port-3100 contention in admin-calendars; cascade timeout in calendar-validation; missing federation cert in import-sources)
- Architecture audit (cumulative zoom-out): PASS WITH WARNINGS (2 LOW, non-blocking: shared sanitizer extraction, GET /note dynamic import — both deferred to follow-up)
- Per-area audits across consistency, security, privacy, complexity, testing: all PASS or PASS WITH WARNINGS after one targeted retry on the GET /note 404 path (now maps `EventNotFoundError` → 404) and one targeted retry on collateral test regressions

## Test plan

- [ ] Confirm CI lint, unit, and integration suites pass
- [ ] Verify a federated Mastodon test account following a Pavillion calendar sees event posts on the profile timeline after a local event is created
- [ ] Verify Mastodon timeline post is edited in place when the event is updated
- [ ] Verify Mastodon timeline post is removed when the event is deleted
- [ ] Verify re-shared remote events appear on the reposting calendar's Mastodon timeline attributed to the reposting calendar
- [ ] Verify unpost (dismissal) suppresses both Event and Note from the reposting calendar's outbox
- [ ] Spot-check `GET /calendars/{urlName}/events/{uuid}/note` returns valid `application/activity+json` for an existing event and 404 for a missing one