### PR TITLE
fix(public): strip internal FKs from public event API (pv-3vso)

### DIFF
--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -5,6 +5,8 @@ import { EventNotFoundError } from '@/common/exceptions/calendar';
 import { logError } from '@/server/common/helper/error-logger';
 import { CalendarEventSchedule } from '@/common/model/events';
 import CalendarEventInstance from '@/common/model/event_instance';
+import { EventSeries } from '@/common/model/event_series';
+import { EventCategory } from '@/common/model/event_category';
 import { getRecurrenceSummary } from '@/common/utils/recurrence-text';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
 import { publicEventInstanceByIp } from '@/server/common/middleware/rate-limiters';
@@ -27,35 +29,87 @@ function stripDefaultEventImage(calendarObj: Record<string, any>): Record<string
 }
 
 /**
- * Shapes a raw event object (from CalendarEvent.toObject()) for public consumption.
+ * Shapes a raw EventSeries object for public consumption via an explicit
+ * allow-list. Accepts either a model instance (and calls `.toObject()`
+ * internally) or an already-serialized plain object — this mirrors the
+ * shape of `toPublicInstanceObject` below and lets `toPublicEventObject`
+ * pass nested series shapes through transparently.
  *
- * Responsibilities:
- *   - Removes `schedules[]` so internal recurrence-row details (including
- *     hideFromPublic and isException cancellation metadata) cannot leak.
- *   - Removes the legacy English-only `recurrenceText` field if present.
- *   - Adds `isRecurring: boolean`, derived from whether the event has any
- *     non-exclusion schedule with a frequency.
- *   - Adds `recurrenceSummary: { key, params } | null` so the presentation
- *     layer can render a localized recurrence phrase.
- *   - Projects `media` to `{ id, mimeType }` only — internal fields such as
- *     calendarId, sha256, originalFilename, fileSize, and status are removed.
- *   - Projects `space` to `{ content }` only — the internal `id` (an AP
- *     identity hint used for inbound dedup) and `placeId` (an internal FK)
- *     have no Tier 1 anonymous-public use case and are stripped here.
- *     Authenticated calendar-editor APIs may still expose the full shape;
- *     this projection is strictly the public surface.
- *   - Projects `location` to address-display fields plus `content` only.
- *     Drops `originUri` (an AP-dedup identity hint, server-internal),
- *     `id` (parallels the space projection — AP identity hint with no
- *     Tier 1 use case), and `spaces[]` (unused on the public surface — the
- *     event's chosen sub-space is carried independently on `event.space`,
- *     so the array is an internal leak vector for nested originUri/clientId).
- *     Absent / null location collapses to `location: null` so the public
- *     contract stays stable.
+ * Allow-listed fields: id, urlName, mediaFocalPointX, mediaFocalPointY,
+ * mediaZoom, content. Drops the internal FKs `calendarId` and `mediaId`.
  *
- * CalendarEventSchedule.toObject() on the shared model remains the full
- * authenticated shape; shaping here is strictly the public API layer's
- * responsibility (per DEC-003 domain boundaries and DEC-004 privacy-first).
+ * Per DEC-003 the canonical `EventSeries.toObject()` shape is unchanged;
+ * the privacy boundary is a property of the audience, not the data
+ * (authenticated APIs need the full shape for cross-resource navigation).
+ */
+function toPublicSeriesObject(series: EventSeries | Record<string, any>): Record<string, any> {
+  const obj = series instanceof EventSeries ? series.toObject() : series;
+  return {
+    id: obj.id,
+    urlName: obj.urlName,
+    mediaFocalPointX: obj.mediaFocalPointX,
+    mediaFocalPointY: obj.mediaFocalPointY,
+    mediaZoom: obj.mediaZoom,
+    content: obj.content,
+  };
+}
+
+/**
+ * Shapes a raw EventCategory object for public consumption via an explicit
+ * allow-list. Accepts either a model instance (and calls `.toObject()`
+ * internally) or an already-serialized plain object.
+ *
+ * Allow-listed fields: id (DEC-005 — category.id is the public identifier
+ * within a calendar context), eventCount, content. Drops the internal FK
+ * `calendarId`.
+ *
+ * Per DEC-003 the canonical `EventCategory.toObject()` shape is unchanged.
+ */
+function toPublicCategoryObject(category: EventCategory | Record<string, any>): Record<string, any> {
+  const obj = category instanceof EventCategory ? category.toObject() : category;
+  return {
+    id: obj.id,
+    eventCount: obj.eventCount,
+    content: obj.content,
+  };
+}
+
+/**
+ * Shapes a raw event object (from CalendarEvent.toObject()) for public
+ * consumption via an explicit, file-uniform allow-list.
+ *
+ * Why allow-list (not delete-by-name): future additions to
+ * `CalendarEvent.toObject()` (and the nested `*.toObject()` shapes it
+ * composes) must fail loudly, not silently leak.
+ *
+ * Why in the public domain (not on the model): authenticated calendar/owner
+ * APIs legitimately need the full shape — `calendarId`, `locationId`,
+ * `spaceId`, `mediaId` are required for cross-resource navigation. Per
+ * DEC-003 the canonical `*.toObject()` shape stays full; per DEC-004 the
+ * privacy boundary is a property of the audience (Tier 1 anonymous public).
+ *
+ * Event root allow-list:
+ *   id, date, repostStatus, isRepost, sourceCalendar, mediaFocalPointX,
+ *   mediaFocalPointY, mediaZoom, eventSourceUrl, externalUrl, urlPrompt,
+ *   isRecurring, recurrenceSummary, content, plus projected location, space,
+ *   media, series, categories.
+ *
+ * Dropped from the event root: calendarId, locationId, spaceId, mediaId
+ * (internal FKs), schedules (cancellation / hide-from-public metadata),
+ * recurrenceText (legacy English-only field).
+ *
+ * Nested-object projections (all allow-listed, all bound to the public
+ * audience's minimum need):
+ *   - `media` → `{ id, mimeType }`.
+ *   - `space` → `{ content }`; absent/null collapses to `null`.
+ *   - `location` → address-display fields + `content`; drops `originUri`,
+ *     `id`, and `spaces[]`; absent/null collapses to `null`.
+ *   - `series` → via `toPublicSeriesObject`; absent/null collapses to `null`.
+ *   - `categories[]` → via `toPublicCategoryObject` for each row.
+ *
+ * `isRecurring` and `recurrenceSummary` are computed here (not carried from
+ * the model) so the model can keep the full authenticated payload while
+ * presentation receives a localized-summary intent.
  */
 function toPublicEventObject(eventObj: Record<string, any>): Record<string, any> {
   const rawSchedules = Array.isArray(eventObj.schedules) ? eventObj.schedules : [];
@@ -69,47 +123,24 @@ function toPublicEventObject(eventObj: Record<string, any>): Record<string, any>
   const summary = getRecurrenceSummary(scheduleModels);
   const isRecurring = summary !== null;
 
-  // Strip schedules and recurrenceText from the output; build a fresh object
-  // so downstream spread/mutation cannot reintroduce internal fields.
-  const publicObj: Record<string, any> = {
-    ...eventObj,
-    isRecurring,
-    recurrenceSummary: summary,
-  };
-  delete publicObj.schedules;
-  delete publicObj.recurrenceText;
+  // Project media to { id, mimeType } only — internal fields such as
+  // calendarId, sha256, originalFilename, fileSize, and status are removed.
+  const media = eventObj.media
+    ? { id: eventObj.media.id, mimeType: eventObj.media.mimeType }
+    : null;
 
-  if (publicObj.media) {
-    publicObj.media = {
-      id: publicObj.media.id,
-      mimeType: publicObj.media.mimeType,
-    };
-  }
+  // Project space to { content } only. Drops id, placeId, and originUri.
+  // Absent / null space collapses to `null` so the public contract stays stable.
+  const space = eventObj.space ? { content: eventObj.space.content } : null;
 
-  // Project space to { content } only. Drops id, placeId, and originUri
-  // (all internal identifiers / AP-dedup hints with no public use case).
-  // `space` may be omitted on the input object (older callers) or explicitly
-  // null; both collapse to `space: null` so the public contract stays stable.
-  if (publicObj.space) {
-    publicObj.space = { content: publicObj.space.content };
-  }
-  else {
-    publicObj.space = null;
-  }
-
-  // Project location to address-display fields + content only. Drops:
-  //   - `originUri` (AP-dedup identity hint, server-internal)
-  //   - `id` (parallels the space projection — AP identity hint with no
-  //     Tier 1 use case)
-  //   - `spaces[]` (unused on the public surface — `event.space` carries the
-  //     selected sub-space; the array is an internal leak vector for nested
-  //     originUri / clientId on each space row)
-  // Allow-list, not delete-by-name, so future additions to
-  // EventLocation.toObject() do not silently leak. Absent / null location
-  // collapses to `location: null` so the public contract stays stable.
-  if (publicObj.location) {
-    const loc = publicObj.location;
-    publicObj.location = {
+  // Project location to address-display fields + content only. Drops
+  // `originUri` (AP-dedup identity hint), `id` (parallels the space projection),
+  // and `spaces[]` (the event's chosen sub-space is carried on `event.space`;
+  // the array is an internal leak vector for nested originUri / clientId).
+  let location: Record<string, any> | null = null;
+  if (eventObj.location) {
+    const loc = eventObj.location;
+    location = {
       name: loc.name,
       address: loc.address,
       city: loc.city,
@@ -119,11 +150,35 @@ function toPublicEventObject(eventObj: Record<string, any>): Record<string, any>
       content: loc.content,
     };
   }
-  else {
-    publicObj.location = null;
-  }
 
-  return publicObj;
+  const series = eventObj.series ? toPublicSeriesObject(eventObj.series) : null;
+  const categories = Array.isArray(eventObj.categories)
+    ? eventObj.categories.map((c: Record<string, any>) => toPublicCategoryObject(c))
+    : [];
+
+  // Explicit allow-list build, not a spread-then-delete: future additions to
+  // CalendarEvent.toObject() must fail loudly here.
+  return {
+    id: eventObj.id,
+    date: eventObj.date,
+    repostStatus: eventObj.repostStatus,
+    isRepost: eventObj.isRepost,
+    sourceCalendar: eventObj.sourceCalendar,
+    mediaFocalPointX: eventObj.mediaFocalPointX,
+    mediaFocalPointY: eventObj.mediaFocalPointY,
+    mediaZoom: eventObj.mediaZoom,
+    eventSourceUrl: eventObj.eventSourceUrl,
+    externalUrl: eventObj.externalUrl,
+    urlPrompt: eventObj.urlPrompt,
+    isRecurring,
+    recurrenceSummary: summary,
+    content: eventObj.content,
+    location,
+    space,
+    media,
+    series,
+    categories,
+  };
 }
 
 /**
@@ -230,12 +285,10 @@ export default class CalendarRoutes {
       const categoriesWithCounts = await this.service.listCategoriesForCalendar(calendar, options);
 
       res.json(
-        categoriesWithCounts.map(({ category, eventCount }) => {
-          return {
-            ...category.toObject(),
-            eventCount,
-          };
-        }),
+        categoriesWithCounts.map(({ category, eventCount }) => ({
+          ...toPublicCategoryObject(category),
+          eventCount,
+        })),
       );
     }
     catch (error: any) {
@@ -271,7 +324,7 @@ export default class CalendarRoutes {
       const seriesWithCounts = await this.service.listSeriesForCalendar(calendar);
       res.json(
         seriesWithCounts.map(({ series, eventCount }) => ({
-          ...series.toObject(),
+          ...toPublicSeriesObject(series),
           eventCount,
         })),
       );
@@ -323,7 +376,7 @@ export default class CalendarRoutes {
       const { events, total } = await this.service.getSeriesEvents(series.id, calendar.id, limit, offset);
 
       res.json({
-        ...series.toObject(),
+        ...toPublicSeriesObject(series),
         events: events.map(event => toPublicEventObject(event.toObject())),
         pagination: {
           total,
@@ -424,13 +477,7 @@ export default class CalendarRoutes {
         instances = await this.service.listEventInstances(calendar);
       }
 
-      res.json(instances.map((instance) => {
-        const obj = instance.toObject();
-        return {
-          ...obj,
-          event: toPublicEventObject(obj.event),
-        };
-      }));
+      res.json(instances.map(toPublicInstanceObject));
     }
     catch (error: any) {
       // Log the full error for debugging

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -60,8 +60,13 @@ function toPublicSeriesObject(series: EventSeries | Record<string, any>): Record
  * internally) or an already-serialized plain object.
  *
  * Allow-listed fields: id (DEC-005 — category.id is the public identifier
- * within a calendar context), eventCount, content. Drops the internal FK
- * `calendarId`.
+ * within a calendar context), content. Drops the internal FK `calendarId`.
+ *
+ * `eventCount` is not part of this projection — it is a service-supplied
+ * aggregate, not a property of the category. The `listCategories` handler
+ * augments the projection with `eventCount` from its service tuple; the
+ * nested `event.categories[]` path has no use for a count and does not
+ * include one. This mirrors `toPublicSeriesObject` which is also count-free.
  *
  * Per DEC-003 the canonical `EventCategory.toObject()` shape is unchanged.
  */
@@ -69,7 +74,6 @@ function toPublicCategoryObject(category: EventCategory | Record<string, any>): 
   const obj = category instanceof EventCategory ? category.toObject() : category;
   return {
     id: obj.id,
-    eventCount: obj.eventCount,
     content: obj.content,
   };
 }

--- a/src/server/public/test/events-api.test.ts
+++ b/src/server/public/test/events-api.test.ts
@@ -11,6 +11,8 @@ import { EventNotFoundError } from '@/common/exceptions/calendar';
 import CalendarEventInstance from '@/common/model/event_instance';
 import { EventSeries } from '@/common/model/event_series';
 import { EventSeriesContent } from '@/common/model/event_series_content';
+import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
 import { EventLocation, EventLocationContent, EventLocationSpace, EventLocationSpaceContent } from '@/common/model/location';
 import { Media } from '@/common/model/media';
 import { testApp } from '@/server/common/test/lib/express';
@@ -414,6 +416,119 @@ describe('Public API - toPublicEventObject shape contract', () => {
     nestedSpace.addContent(new EventLocationSpaceContent('en', 'Side Room', 'Hearing loop'));
     location.spaces = [nestedSpace];
     return location;
+  }
+
+  /**
+   * Public Series projection contract: the response must allow-list only
+   * `{ id, urlName, mediaFocalPointX, mediaFocalPointY, mediaZoom, content }`.
+   * Internal FKs (`calendarId`, `mediaId`) must never appear on the public
+   * surface — they identify internal database rows and have no Tier 1
+   * anonymous-public use case.
+   */
+  function assertSeriesProjection(seriesBody: Record<string, any>) {
+    expect(seriesBody).not.toBeNull();
+    // Allow-listed fields are present
+    expect(seriesBody.id).toBe('series-1');
+    expect(seriesBody.urlName).toBe('yoga-classes');
+    expect(seriesBody.mediaFocalPointX).toBeDefined();
+    expect(seriesBody.mediaFocalPointY).toBeDefined();
+    expect(seriesBody.mediaZoom).toBeDefined();
+    expect(seriesBody.content).toBeDefined();
+    expect(seriesBody.content.en).toBeDefined();
+    expect(seriesBody.content.en.name).toBe('Yoga Classes');
+    // The public projection must contain only the allow-listed keys.
+    expect(Object.keys(seriesBody).sort()).toEqual(
+      ['content', 'id', 'mediaFocalPointX', 'mediaFocalPointY', 'mediaZoom', 'urlName'],
+    );
+    // Spell out the disallowed internal FKs for clarity / future regressions.
+    expect(seriesBody.calendarId).toBeUndefined();
+    expect(seriesBody.mediaId).toBeUndefined();
+  }
+
+  function makeSeries(): EventSeries {
+    const series = new EventSeries('series-1', 'cal-id', 'yoga-classes', 'media-99');
+    series.mediaFocalPointX = 0.4;
+    series.mediaFocalPointY = 0.6;
+    series.mediaZoom = 1.2;
+    series.addContent(new EventSeriesContent('en', 'Yoga Classes', 'Weekly yoga.'));
+    return series;
+  }
+
+  /**
+   * Public Category projection contract: the response must allow-list only
+   * `{ id, eventCount, content }`. The internal FK `calendarId` must never
+   * appear on the public surface — DEC-005 establishes that category.id is
+   * the public identifier within a calendar context (the calendar is already
+   * established by the API route).
+   */
+  function assertCategoryProjection(categoryBody: Record<string, any>) {
+    expect(categoryBody).not.toBeNull();
+    // Allow-listed fields are present
+    expect(categoryBody.id).toBe('cat-1');
+    expect(typeof categoryBody.eventCount).toBe('number');
+    expect(categoryBody.content).toBeDefined();
+    expect(categoryBody.content.en).toBeDefined();
+    expect(categoryBody.content.en.name).toBe('Music');
+    // The public projection must contain only the allow-listed keys.
+    expect(Object.keys(categoryBody).sort()).toEqual(['content', 'eventCount', 'id']);
+    // Spell out the disallowed internal FK for clarity / future regressions.
+    expect(categoryBody.calendarId).toBeUndefined();
+  }
+
+  function makeCategory(): EventCategory {
+    const category = new EventCategory('cat-1', 'cal-id');
+    category.eventCount = 0;
+    category.addContent(new EventCategoryContent('en', 'Music'));
+    return category;
+  }
+
+  /**
+   * Public Event root projection contract: response must allow-list only the
+   * documented public fields. Internal FKs (`calendarId`, `locationId`,
+   * `spaceId`, `mediaId`) and internal-only fields (`schedules`,
+   * `recurrenceText`) must never appear on the public surface.
+   *
+   * Nested objects (location, space, media, series, categories) are checked
+   * independently by their own `assert*Projection` helpers.
+   */
+  function assertEventRootProjection(eventBody: Record<string, any>) {
+    expect(eventBody).not.toBeNull();
+
+    // Positive allow-list assertion. Optional fields (media/space/location/series/
+    // categories) may be present or absent depending on the fixture, but the
+    // set of keys must never contain anything outside this allow-list.
+    const allowed = new Set([
+      'id',
+      'date',
+      'repostStatus',
+      'isRepost',
+      'sourceCalendar',
+      'mediaFocalPointX',
+      'mediaFocalPointY',
+      'mediaZoom',
+      'eventSourceUrl',
+      'externalUrl',
+      'urlPrompt',
+      'isRecurring',
+      'recurrenceSummary',
+      'content',
+      'location',
+      'space',
+      'media',
+      'series',
+      'categories',
+    ]);
+    for (const key of Object.keys(eventBody)) {
+      expect(allowed.has(key)).toBe(true);
+    }
+
+    // Disallowed internal fields must be absent.
+    expect(eventBody.calendarId).toBeUndefined();
+    expect(eventBody.locationId).toBeUndefined();
+    expect(eventBody.spaceId).toBeUndefined();
+    expect(eventBody.mediaId).toBeUndefined();
+    expect(eventBody.schedules).toBeUndefined();
+    expect(eventBody.recurrenceText).toBeUndefined();
   }
 
   beforeEach(() => {
@@ -1056,6 +1171,244 @@ describe('Public API - toPublicEventObject shape contract', () => {
       expect(response.status).toBe(200);
       expect(response.body.events).toHaveLength(1);
       assertLocationProjection(response.body.events[0].location);
+    });
+  });
+
+  /**
+   * Public Event root projection contract:
+   *   - Top-level keys must be the documented allow-list only.
+   *   - Internal FKs (calendarId, locationId, spaceId, mediaId) and internal
+   *     fields (schedules, recurrenceText) must never appear.
+   *
+   * Covered for every public handler that returns event objects: getEvent,
+   * listInstances (via wrapping instance), getEventInstance (via wrapping
+   * instance), and getSeries (via events[]).
+   */
+  describe('event root projection', () => {
+    const EVENT_PROJ_UUID = '44444444-4444-4444-8444-444444444444';
+    const VALID_SLUG = '20260508-1800';
+
+    function makeEventWithFkLeakSurface(): CalendarEvent {
+      // Construct an event with every field set so any spread-then-leak path
+      // surfaces in the response. Schedules, location, space, media, series,
+      // categories all populated.
+      const event = new CalendarEvent(EVENT_PROJ_UUID, 'cal-id');
+      const schedule = new CalendarEventSchedule();
+      schedule.frequency = EventFrequency.WEEKLY;
+      schedule.interval = 1;
+      schedule.byDay = ['MO'];
+      schedule.isExclusion = false;
+      event.schedules = [schedule];
+      event.locationId = 'loc-row-1';
+      event.location = makeLocation();
+      event.space = makeSpace();
+      event.media = new Media('media-1', 'cal-id', 'sha', 'photo.jpg', 'image/jpeg', 100, 'approved');
+      event.mediaId = 'media-1';
+      event.series = makeSeries();
+      event.categories = [makeCategory()];
+      return event;
+    }
+
+    it('getEvent: returns only allow-listed event-root keys; FKs and schedules absent', async () => {
+      const event = makeEventWithFkLeakSurface();
+      apiSandbox.stub(publicInterface, 'getEventById').resolves(event);
+
+      router.get('/handler/:id', (req, res) => {
+        routes.getEvent(req, res);
+      });
+
+      const response = await request(testApp(router)).get(`/handler/${EVENT_PROJ_UUID}`);
+
+      expect(response.status).toBe(200);
+      assertEventRootProjection(response.body);
+    });
+
+    it('listInstances: returns only allow-listed event-root keys on each instance event', async () => {
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const event = makeEventWithFkLeakSurface();
+      const instance = new CalendarEventInstance('inst-1', event, DateTime.now(), null);
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(calendar);
+      apiSandbox.stub(publicInterface, 'listEventInstances').resolves([instance]);
+
+      router.get('/handler', (req, res) => {
+        req.params.calendar = 'test-calendar';
+        routes.listInstances(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(1);
+      assertEventRootProjection(response.body[0].event);
+      // Also: instance-row calendarId must not leak.
+      expect(response.body[0].calendarId).toBeUndefined();
+    });
+
+    it('getEventInstance: returns only allow-listed event-root keys on the wrapped event', async () => {
+      const event = makeEventWithFkLeakSurface();
+      const instance = new CalendarEventInstance('inst-1', event, DateTime.utc(2026, 5, 8, 18, 0), null);
+      apiSandbox.stub(publicInterface, 'findOrMaterializeInstanceWithDetails').resolves(instance);
+
+      router.get('/handler/:eventId/:startTime', (req, res) => {
+        routes.getEventInstance(req, res);
+      });
+
+      const response = await request(testApp(router)).get(`/handler/${EVENT_PROJ_UUID}/${VALID_SLUG}`);
+
+      expect(response.status).toBe(200);
+      assertEventRootProjection(response.body.event);
+    });
+
+    it('getSeries: returns only allow-listed event-root keys on each event in events[]', async () => {
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const series = makeSeries();
+
+      const event = makeEventWithFkLeakSurface();
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(calendar);
+      apiSandbox.stub(publicInterface, 'getSeriesByUrlName').resolves(series);
+      apiSandbox.stub(publicInterface, 'getSeriesEvents').resolves({ events: [event], total: 1 });
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        req.params.seriesUrlName = 'yoga-classes';
+        routes.getSeries(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body.events).toHaveLength(1);
+      assertEventRootProjection(response.body.events[0]);
+    });
+  });
+
+  /**
+   * Public Series projection contract:
+   *   - Series allow-list applies wherever a series is rendered: top-level
+   *     of getSeries, each row of listSeries, and the nested
+   *     event.series object inside getEvent / listInstances / getEventInstance
+   *     / getSeries.events[].
+   *   - `calendarId` and `mediaId` are internal FKs and must never appear.
+   */
+  describe('series projection', () => {
+    const SERIES_PROJ_EVENT_UUID = '55555555-5555-4555-8555-555555555555';
+
+    it('getSeries: returns the top-level series allow-list; calendarId and mediaId absent', async () => {
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const series = makeSeries();
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(calendar);
+      apiSandbox.stub(publicInterface, 'getSeriesByUrlName').resolves(series);
+      apiSandbox.stub(publicInterface, 'getSeriesEvents').resolves({ events: [], total: 0 });
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        req.params.seriesUrlName = 'yoga-classes';
+        routes.getSeries(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler');
+
+      expect(response.status).toBe(200);
+      // The response wraps the series projection with `events` and `pagination`.
+      // Extract just the series-shaped keys for the projection assertion.
+      const { events, pagination, ...seriesBody } = response.body;
+      expect(events).toEqual([]);
+      expect(pagination).toBeDefined();
+      assertSeriesProjection(seriesBody);
+    });
+
+    it('listSeries: returns the series allow-list on each row, augmented with eventCount; calendarId and mediaId absent', async () => {
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const series = makeSeries();
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(calendar);
+      apiSandbox.stub(publicInterface, 'listSeriesForCalendar').resolves([{ series, eventCount: 7 }]);
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        routes.listSeries(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(1);
+      const row = response.body[0];
+      // Row carries an `eventCount` on top of the series allow-list.
+      expect(row.eventCount).toBe(7);
+      const { eventCount: _eventCount, ...seriesBody } = row;
+      assertSeriesProjection(seriesBody);
+    });
+
+    it('getEvent: returns the series allow-list on event.series; calendarId and mediaId absent', async () => {
+      const event = new CalendarEvent(SERIES_PROJ_EVENT_UUID, 'cal-id');
+      event.schedules = [];
+      event.series = makeSeries();
+
+      apiSandbox.stub(publicInterface, 'getEventById').resolves(event);
+
+      router.get('/handler/:id', (req, res) => {
+        routes.getEvent(req, res);
+      });
+
+      const response = await request(testApp(router)).get(`/handler/${SERIES_PROJ_EVENT_UUID}`);
+
+      expect(response.status).toBe(200);
+      assertSeriesProjection(response.body.series);
+    });
+  });
+
+  /**
+   * Public Category projection contract:
+   *   - Category allow-list applies wherever a category is rendered: each
+   *     row of listCategories, and each entry in event.categories[] inside
+   *     getEvent / listInstances / getEventInstance / getSeries.events[].
+   *   - `calendarId` is an internal FK and must never appear (DEC-005:
+   *     category.id is the public identifier within a calendar context).
+   */
+  describe('category projection', () => {
+    const CATEGORY_PROJ_EVENT_UUID = '66666666-6666-4666-8666-666666666666';
+
+    it('listCategories: returns the category allow-list on each row, augmented with eventCount; calendarId absent', async () => {
+      const calendar = new Calendar('cal-id', 'test-calendar');
+      const category = makeCategory();
+
+      apiSandbox.stub(publicInterface, 'getCalendarByName').resolves(calendar);
+      apiSandbox.stub(publicInterface, 'listCategoriesForCalendar').resolves([{ category, eventCount: 3 }]);
+
+      router.get('/handler', (req, res) => {
+        req.params.urlName = 'test-calendar';
+        routes.listCategories(req, res);
+      });
+
+      const response = await request(testApp(router)).get('/handler');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveLength(1);
+      const row = response.body[0];
+      expect(row.eventCount).toBe(3);
+      assertCategoryProjection(row);
+    });
+
+    it('getEvent: returns the category allow-list on each entry of event.categories[]; calendarId absent', async () => {
+      const event = new CalendarEvent(CATEGORY_PROJ_EVENT_UUID, 'cal-id');
+      event.schedules = [];
+      event.categories = [makeCategory()];
+
+      apiSandbox.stub(publicInterface, 'getEventById').resolves(event);
+
+      router.get('/handler/:id', (req, res) => {
+        routes.getEvent(req, res);
+      });
+
+      const response = await request(testApp(router)).get(`/handler/${CATEGORY_PROJ_EVENT_UUID}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.categories).toHaveLength(1);
+      assertCategoryProjection(response.body.categories[0]);
     });
   });
 });

--- a/src/server/public/test/events-api.test.ts
+++ b/src/server/public/test/events-api.test.ts
@@ -427,12 +427,12 @@ describe('Public API - toPublicEventObject shape contract', () => {
    */
   function assertSeriesProjection(seriesBody: Record<string, any>) {
     expect(seriesBody).not.toBeNull();
-    // Allow-listed fields are present
+    // Allow-listed fields carry the values set by makeSeries().
     expect(seriesBody.id).toBe('series-1');
     expect(seriesBody.urlName).toBe('yoga-classes');
-    expect(seriesBody.mediaFocalPointX).toBeDefined();
-    expect(seriesBody.mediaFocalPointY).toBeDefined();
-    expect(seriesBody.mediaZoom).toBeDefined();
+    expect(seriesBody.mediaFocalPointX).toBe(0.4);
+    expect(seriesBody.mediaFocalPointY).toBe(0.6);
+    expect(seriesBody.mediaZoom).toBe(1.2);
     expect(seriesBody.content).toBeDefined();
     expect(seriesBody.content.en).toBeDefined();
     expect(seriesBody.content.en.name).toBe('Yoga Classes');
@@ -456,23 +456,29 @@ describe('Public API - toPublicEventObject shape contract', () => {
 
   /**
    * Public Category projection contract: the response must allow-list only
-   * `{ id, eventCount, content }`. The internal FK `calendarId` must never
-   * appear on the public surface — DEC-005 establishes that category.id is
-   * the public identifier within a calendar context (the calendar is already
-   * established by the API route).
+   * `{ id, content }`. The internal FK `calendarId` must never appear on the
+   * public surface — DEC-005 establishes that category.id is the public
+   * identifier within a calendar context (the calendar is already established
+   * by the API route).
+   *
+   * `eventCount` is a service-supplied aggregate, not part of the projection.
+   * The `listCategories` handler augments rows with it; callers that receive
+   * such a row should destructure the augmentation off before asserting the
+   * bare projection, mirroring how `listSeries` is tested.
    */
   function assertCategoryProjection(categoryBody: Record<string, any>) {
     expect(categoryBody).not.toBeNull();
-    // Allow-listed fields are present
+    // Allow-listed fields carry the values set by makeCategory().
     expect(categoryBody.id).toBe('cat-1');
-    expect(typeof categoryBody.eventCount).toBe('number');
     expect(categoryBody.content).toBeDefined();
     expect(categoryBody.content.en).toBeDefined();
     expect(categoryBody.content.en.name).toBe('Music');
     // The public projection must contain only the allow-listed keys.
-    expect(Object.keys(categoryBody).sort()).toEqual(['content', 'eventCount', 'id']);
+    expect(Object.keys(categoryBody).sort()).toEqual(['content', 'id']);
     // Spell out the disallowed internal FK for clarity / future regressions.
     expect(categoryBody.calendarId).toBeUndefined();
+    // `eventCount` is not part of this projection.
+    expect(categoryBody.eventCount).toBeUndefined();
   }
 
   function makeCategory(): EventCategory {
@@ -494,33 +500,31 @@ describe('Public API - toPublicEventObject shape contract', () => {
   function assertEventRootProjection(eventBody: Record<string, any>) {
     expect(eventBody).not.toBeNull();
 
-    // Positive allow-list assertion. Optional fields (media/space/location/series/
-    // categories) may be present or absent depending on the fixture, but the
-    // set of keys must never contain anything outside this allow-list.
-    const allowed = new Set([
-      'id',
+    // Bidirectional allow-list assertion. `toPublicEventObject` always emits
+    // every field as a key (optional nested objects collapse to null, not
+    // omitted), so the key set is fixed. `toEqual` catches both an extra key
+    // (FK leak) and a missing required key (dropped public field).
+    expect(Object.keys(eventBody).sort()).toEqual([
+      'categories',
+      'content',
       'date',
-      'repostStatus',
+      'eventSourceUrl',
+      'externalUrl',
+      'id',
+      'isRecurring',
       'isRepost',
-      'sourceCalendar',
+      'location',
+      'media',
       'mediaFocalPointX',
       'mediaFocalPointY',
       'mediaZoom',
-      'eventSourceUrl',
-      'externalUrl',
-      'urlPrompt',
-      'isRecurring',
       'recurrenceSummary',
-      'content',
-      'location',
-      'space',
-      'media',
+      'repostStatus',
       'series',
-      'categories',
+      'sourceCalendar',
+      'space',
+      'urlPrompt',
     ]);
-    for (const key of Object.keys(eventBody)) {
-      expect(allowed.has(key)).toBe(true);
-    }
 
     // Disallowed internal fields must be absent.
     expect(eventBody.calendarId).toBeUndefined();
@@ -1286,10 +1290,13 @@ describe('Public API - toPublicEventObject shape contract', () => {
 
   /**
    * Public Series projection contract:
-   *   - Series allow-list applies wherever a series is rendered: top-level
-   *     of getSeries, each row of listSeries, and the nested
-   *     event.series object inside getEvent / listInstances / getEventInstance
-   *     / getSeries.events[].
+   *   - Series allow-list applies wherever a series is rendered. This block
+   *     covers the top-level shape from getSeries, the per-row shape from
+   *     listSeries, and the nested `event.series` shape from getEvent. The
+   *     same projection helper feeds the nested series in listInstances /
+   *     getEventInstance / getSeries.events[]; the cross-cutting
+   *     `event root projection` block exercises those four event handlers
+   *     with a populated fixture, guarding against the broader FK leak class.
    *   - `calendarId` and `mediaId` are internal FKs and must never appear.
    */
   describe('series projection', () => {
@@ -1363,9 +1370,13 @@ describe('Public API - toPublicEventObject shape contract', () => {
 
   /**
    * Public Category projection contract:
-   *   - Category allow-list applies wherever a category is rendered: each
-   *     row of listCategories, and each entry in event.categories[] inside
-   *     getEvent / listInstances / getEventInstance / getSeries.events[].
+   *   - Category allow-list applies wherever a category is rendered. This
+   *     block covers the per-row shape from listCategories and the nested
+   *     `event.categories[]` shape from getEvent. The same projection helper
+   *     feeds the nested categories in listInstances / getEventInstance /
+   *     getSeries.events[]; the cross-cutting `event root projection` block
+   *     exercises those four event handlers with a populated fixture,
+   *     guarding against the broader FK leak class.
    *   - `calendarId` is an internal FK and must never appear (DEC-005:
    *     category.id is the public identifier within a calendar context).
    */
@@ -1389,8 +1400,10 @@ describe('Public API - toPublicEventObject shape contract', () => {
       expect(response.status).toBe(200);
       expect(response.body).toHaveLength(1);
       const row = response.body[0];
+      // Row carries an `eventCount` on top of the category allow-list.
       expect(row.eventCount).toBe(3);
-      assertCategoryProjection(row);
+      const { eventCount: _eventCount, ...categoryBody } = row;
+      assertCategoryProjection(categoryBody);
     });
 
     it('getEvent: returns the category allow-list on each entry of event.categories[]; calendarId absent', async () => {


### PR DESCRIPTION
## Summary

Convert every `*.toObject()` spread in `src/server/public/api/v1/calendar.ts` into explicit allow-list projections so anonymous Tier-1 visitors never receive internal foreign-key UUIDs (`calendarId`, `locationId`, `spaceId`, `mediaId`).

- Add `toPublicSeriesObject` and `toPublicCategoryObject` helpers parallel to the existing `toPublicInstanceObject`. Each is a pure shape projection over its allow-list.
- Rewrite `toPublicEventObject` as an explicit allow-list build (not spread-then-delete). Nested `event.series` projects via `toPublicSeriesObject`; nested `event.categories[]` projects via `toPublicCategoryObject`.
- Switch `listInstances` to call `toPublicInstanceObject` directly so instance-row `calendarId` no longer leaks.
- Switch `listCategories` / `listSeries` / `getSeries` to use the new helpers, augmented with the service-supplied `eventCount` / `events` / `pagination` at the call site.
- Three new test describe blocks (`event root projection`, `series projection`, `category projection`) parallel to the existing `space projection` / `location projection`, each pairing positive `Object.keys().sort()` allow-list assertions with per-field absence assertions for the dropped internal FKs.

The canonical `*.toObject()` shapes on `CalendarEvent`, `EventSeries`, `EventCategory`, and `CalendarEventInstance` are **unchanged** — per DEC-003 the privacy boundary lives in the public API layer, not on the model. Authenticated calendar/owner APIs continue to receive the full payload they need for cross-resource navigation. The companion bead pv-if96 will cover the authenticated calendar/location surface.

Closes **pv-3vso**. Driven by **DEC-004** (Tier-1 anonymous data minimization) and **DEC-003** (privacy boundary as audience property, not data property). Extends the **pv-o9gl** pattern (PR #296).

## Advisor / auditor passes

`/shape-bead` review: privacy / testing / architecture / consistency advisors all APPROVED after one consistency round trip (REQUEST CHANGES → APPROVE) that converted a mixed delete-by-name + allow-list pattern into a file-wide allow-list.

Post-implementation audits: privacy / testing / consistency / complexity were PASS WITH WARNINGS; architecture and security were PASS. The three converging warnings (a misleading `eventCount` field on `toPublicCategoryObject`, a one-directional event-root assertion, and a `toBeDefined()` weak check on known fixture values) were addressed in the second commit on this branch.

## Test plan

- [x] `npx vitest run src/server/public/test/events-api.test.ts` — 46 tests pass (37 prior + 9 new)
- [x] `npx vitest run src/server/public/test/integration/event_instance_api.test.ts` — 10 tests pass
- [x] `npm run lint` — 0 errors (277 pre-existing warnings, unchanged)
- [x] Full `build-guardian` sequential suite: unit (7829), integration (585), build, e2e — all pv-3vso-touched paths PASS. Two pre-existing e2e infrastructure failures unrelated to this PR (port 3102 EADDRINUSE in admin-moderation; missing docker federation TLS cert in import-sources).