### PR TITLE
docs: tighten voice and structure of follow-and-repost guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,7 +57,7 @@ export default defineConfig({
           text: 'Connect with other calendars',
           items: [
             { text: 'Decide when to make a calendar', link: '/guides/calendar-owners/when-to-create-a-calendar' },
-            { text: 'Follow other calendars and repost their events', link: '/guides/calendar-owners/follow-and-repost' },
+            { text: 'Bring in events from other calendars', link: '/guides/calendar-owners/follow-and-repost' },
             { text: 'Match categories from other calendars to yours', link: '/guides/calendar-owners/category-matching' },
             { text: 'Be a good neighbor across calendars', link: '/guides/calendar-owners/federation-etiquette' },
           ],

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -1,16 +1,14 @@
 # Bring in events from other calendars
 
-The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about bringing some of *their* events onto *your* calendar — finding the calendars that matter to your community, deciding what to do with what shows up, and choosing what to share onward.
-
-The mechanism underneath is ActivityPub federation. The interface uses "Follow" and "Repost" on the buttons, and this guide names those buttons literally when walking you through them — but also describes what they *do* in plainer terms: connecting to another calendar, and publishing an event from it onto yours.
+The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about bringing some of *their* events onto *your* calendar — finding the calendars that matter to your community, deciding what to do with what shows up, and choosing what to share.
 
 ## Two steps, on purpose
 
-The action splits into two stages, and the separation matters.
+Sharing events happens in two stages, and the separation matters.
 
 **Connect.** You point your calendar at another one — say, the music venue's — and from then on, their events arrive in a stream visible only to you. Nothing about your *public* calendar has changed yet; your visitors still see exactly what they saw before. A connection is a private feed for you, the owner, to look through.
 
-**Publish.** When an event in that private feed is worth surfacing on your public calendar, you publish it. *Now* visitors see it. Publishing can happen by hand — one event at a time, deliberately — or by rule, where you've told Pavillion to publish certain incoming events automatically.
+**Publish.** When an event in that private feed is worth surfacing on your public calendar, you repost it. *Now* visitors see it. Reposting can happen by hand — one event at a time, deliberately — or by rule, where you've told Pavillion to publish certain incoming events automatically.
 
 The separation is what gives you editorial control. Connecting to a calendar doesn't commit you to publishing anything from it; it just opens the door so you can decide.
 
@@ -21,24 +19,20 @@ There's no central directory of Pavillion calendars. Federation works the same w
 A few starting places:
 
 - **Calendars listed on the websites of organizations you already work with.** A neighborhood association, a music venue, an arts council, a coworking space, a climate or mutual-aid group. Their site footer or events page often points at their calendar.
-- **The sources behind events you already like.** On a calendar you trust, reposted events link back to the calendar they came from — a small calendar-name link beneath the event title. If a particular source keeps showing up on calendars you respect, that's a good signal it's worth connecting to yourself.
+- **The sources behind events you already like.** On a calendar you trust, reposted events link back to the calendar they came from — a small calendar-name link beneath the event title. If a particular source keeps showing up on calendars you respect with events that fit your own calendar, that's a good signal it's worth connecting to yourself.
 - **Word of mouth.** Other calendar owners will tell you which calendars to track. The federated network tends to grow through introductions, not directory listings.
 
-Calendar handles take the shape `calendar-name@domain.example`. The part before the `@` is the calendar's URL handle on its instance; the part after is the instance's domain. *`riverbend-folk@arts.example`* points at the `riverbend-folk` calendar on `arts.example`. (Calendars on your *own* instance can be referenced by just their URL handle — `riverbend-folk` is enough if you're both running on the same instance.)
+Calendar handles take the shape `calendar-name@domain.example`. The part before the `@` is the calendar's URL handle on its instance; the part after is the instance's domain. *`riverbend-folk@arts.example`* points at the `riverbend-folk` calendar on `arts.example`. (Calendars on your *own* instance can be referenced by just their URL handle — `riverbend-folk` is enough if you're both hosted on the same instance.)
 
 ## Connect to a calendar
 
-Open <Btn>Feed</Btn> from the main navigation. The Feed has three tabs: **Events** (events from calendars you're connected to), **Following** (the calendars you've connected to), and **Followers** (calendars connected to yours). If you run more than one calendar, a calendar selector at the top scopes the feed — connections are *per-calendar*, not per-account; each of your calendars has its own list, its own feed, and its own followers.
+Connecting lives in **Feed > Following**. If you run more than one calendar, the selector at the top loads the right feed — connections are *per-calendar*, not per-account; each of your calendars has its own list, its own feed, and its own followers.
 
-In the **Following** tab, click <Btn>Follow a Calendar</Btn>. A dialog opens with one field: the calendar's identifier — `name@domain.example` for a remote calendar, or just `name` for one on your own instance.
+Click <Btn>Follow a Calendar</Btn> and type the identifier — `name@domain.example` for a remote calendar, or just `name` for one on your own instance. Pavillion looks it up and shows a preview matching the calendar's public page; use it to confirm you've got the right one. The auto-repost toggles below the preview control what happens to *new* events arriving from this connection from now on — see [Let rules publish for you](#let-rules-publish-for-you) below for what each one does. If you're not sure what to pick, leave both off; you can publish any individual event by hand, and you can change these toggles for any connection at any time.
 
-Type the identifier. Pavillion looks the calendar up after a brief pause and shows you a preview — the calendar's name, description, and domain. The preview is everything you'd see on the calendar's public page; use it to confirm you've got the right one before connecting.
+Click <Btn>Follow</Btn>. Once the source server accepts the request (usually immediate), their events start arriving in your feed.
 
-Below the preview are the auto-repost toggles. They control what happens automatically when *new* events arrive from this calendar from now on — see [Let rules publish for you](#let-rules-publish-for-you) below for what each one does. If you're not sure what to pick, leave both off; you can publish any individual event by hand later, and you can change these toggles for any connection at any time.
-
-Click <Btn>Follow</Btn>. Pavillion sends a follow request to the source calendar; once their server has accepted it (which is usually immediate), their events start arriving in your feed.
-
-To disconnect entirely, find the calendar's row in the **Following** tab and click <Btn>Unfollow</Btn>. That's a heavier action than unpublishing a single event — it ends the connection completely, no future events flow in, and any auto-repost rules on the connection go away with it.
+To disconnect entirely, find the row in the **Following** tab and click <Btn>Unfollow</Btn>. That's a heavier action than unpublishing a single event — it ends the connection completely, no future events flow in, and any auto-repost rules on the connection go away with it.
 
 ::: tip <Lightbulb /> A note on the optional category-matching step.
 Right after a successful connection, a second step in the dialog offers to match the source calendar's categories to your own — *their* `Live Music` to *your* `Concerts`, for example. Setting these up now means any event you publish from this calendar — by hand or by rule — lands in the right category on yours without re-tagging. You can skip the step and configure it later from the **Match categories** link on the connection's row in your Following tab; the category-matching guide covers the details.
@@ -46,13 +40,13 @@ Right after a successful connection, a second step in the dialog offers to match
 
 ## What lands in your feed
 
-The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging genuinely problematic content — spam, harassment, misleading information, or content that violates your instance's policies. If an event just isn't a fit for your calendar, don't report it; not publishing it is the right response.
+The feed is your editorial space; the calendar is your public face. A visitor to your public page never sees what's in your feed — they see what you've already published. In the **Events** tab, each incoming event is something you *could* publish, not something that already is.
 
-A visitor to your public page never sees what's in your feed — they see what you've already published. The feed is your editorial space; the calendar is your public face.
+Alongside <Btn>Repost</Btn> and <Btn>Details</Btn>, each row has a <Btn>Report</Btn> button. Report is for genuinely problematic content — spam, harassment, misleading information, or content that violates your instance's policies. If an event just isn't a fit for your calendar, don't report it; not publishing it is the right response.
 
 ## Publish an event by hand
 
-In the Feed > Events tab, find an event you want on your public calendar and click <Btn>Repost</Btn>. If the source event has categories that aren't yet matched to one of yours, a small dialog opens letting you pick the right local categories — or pull the source's category names onto your calendar in one click, if you'd like to adopt them as new categories of your own. Confirm, and the event lands on your public calendar.
+In the **Feed > Events** tab, find an event you want on your public calendar and click <Btn>Repost</Btn>. If the source event has categories that aren't yet matched to one of yours, a small dialog opens letting you pick the right local categories — or pull the source's category names onto your calendar in one click, if you'd like to adopt them as new categories of your own. Confirm, and the event lands on your public calendar.
 
 The button on that event in your feed now reads **Reposted**, in green. To unpublish, click the **Reposted** label — see [Unpublish an event](#unpublish-an-event) below.
 
@@ -70,14 +64,14 @@ Both rules are forward-only. Turning a toggle on doesn't reach back and publish 
 Rule-published events show up on your calendar like any other published event, with one small visible difference *in your feed*: the button reads **Auto-posted** in muted gray rather than **Reposted** in green. That's so you can tell at a glance which events you chose by hand and which arrived through a rule. Visitors to your public calendar see the same thing either way.
 
 ::: tip <Lightbulb /> A note on auto-repost and category matching.
-Rule-driven publishing works best when category matching is set up first. Without matchings, a rule-published event can land on your calendar with no categories — it'll publish, but it won't show up under any of your filters and won't appear under "more like this" on related events. The category-matching guide walks through the rules; if you're enabling auto-repost on a connection you didn't pre-map, take a minute to set the mappings up afterwards.
+Rule-driven publishing works best when category matching is set up first. Without matchings, a rule-published event can land on your calendar with no categories — it'll publish, but it won't show up under any of your filters. The category-matching guide walks through the rules; if you're enabling auto-repost on a connection you didn't pre-map, take a minute to set the mappings up afterwards.
 :::
 
 ## Unpublish an event
 
-In the Feed > Events tab, click the **Reposted** or **Auto-posted** label on any event currently on your calendar. The event is removed from your calendar immediately — visitors no longer see it there.
+In the **Feed > Events** tab, click the **Reposted** or **Auto-posted** label on any event currently on your calendar. The event is removed from your calendar immediately — visitors no longer see it there.
 
-The unpublish *sticks*. If the source calendar later edits and re-broadcasts that same event — a name change, a venue update, a re-share — your calendar does **not** pick it up again. Once you've said no to a particular event, your no is durable; the source can't accidentally undo your decision by republishing.
+The unpublish *sticks*. If the source calendar later edits and re-broadcasts that same event — a name change, a venue update, a re-share — your calendar does **not** pick it up again. Once you've said no to a particular event, your decision is durable; the source can't accidentally undo your decision by republishing.
 
 Two clarifications about the stickiness:
 
@@ -88,7 +82,7 @@ If you change your mind, click <Btn>Repost</Btn> on the same event in your feed;
 
 ## When other calendars connect to yours
 
-Everything above is *you* reaching out to other calendars. The inverse also happens: other calendars connect to yours, and they may publish your events onto theirs. The <Btn>Inbox</Btn> in the main navigation is where you see that activity — notifications when a new calendar follows yours, or when one of your events gets reposted somewhere else.
+Everything above is *you* reaching out to other calendars. The inverse also happens: other calendars can connect to yours, and they may publish your events onto theirs. The <Btn>Inbox</Btn> in the main navigation is where you see that activity — notifications when a new calendar follows yours, or when one of your events gets reposted somewhere else.
 
 The inbox doesn't fill up because *you* connected to another calendar; it fills up because *they* connected to you. The mechanics of being followed, and what to do about reports raised against your events, are covered in the federation-etiquette and moderation guides.
 
@@ -102,11 +96,11 @@ Most calendar owners who repost events face this choice within their first few w
 
 Two things about this choice:
 
-**It isn't binary.** Auto-repost rules are per-connection. You can be an aggregator for some sources (the city's parks-and-rec calendar, where you trust everything they post) and curated for others (a peer venue, where their events are interesting but you want the final say). Most established calendars end up a mix.
+**It isn't binary.** Auto-repost rules are per-connection. You can be an aggregator for some sources (the city's parks-and-rec calendar, where you trust everything they post) and curated for others (a peer venue, where their events are interesting but you want the final say).
 
-**You can change posture later, but the directions aren't symmetric.** Switching from curated to aggregator is straightforward — flip the toggles on existing connections, set up category matchings, accept the increased throughput. Switching the other way is harder; once visitors associate your calendar with a particular flow, dropping a stream of auto-published events they were used to seeing is a noticeable change. Lean toward starting curated and opening up later, rather than starting open and tightening down.
+**You can change your mind later.** Switching from curated to aggregator is straightforward — flip the toggles on existing connections, set up category matchings, accept the increased throughput. Switching the other way is harder; once visitors associate your calendar with a particular flow, dropping a stream of auto-published events they were used to seeing is a noticeable change. Lean toward starting curated and opening up later, rather than starting open and tightening down.
 
-The right starting posture depends on your calendar's purpose and your editorial bandwidth. A small volunteer group with one editor and a few hours a week probably can't sustain a curated calendar of fifty connected sources; an aggregator posture lets the rules carry the load. A neighborhood newsletter run by a single careful editor probably *should* be curated; visitors come to it for the editor's judgment, and an unfiltered firehose loses that.
+The right starting posture depends on your calendar's purpose and your editorial bandwidth. A small volunteer group with one editor and a few hours a week probably can't sustain a curated calendar of fifty connected sources; an aggregator mindset lets the rules carry the load. A neighborhood newsletter run by a single careful editor probably *should* be curated; visitors come to it for the editor's judgment, and an unfiltered firehose loses that.
 
 ::: tip <Lightbulb /> A note on the first month.
 Like the category list, your aggregator-vs-curated posture is a draft, not a commitment. Watch what kinds of events actually flow through your connections for a month or two before tuning the toggles. The connections that consistently surface things worth publishing are obvious by then — and the ones that mostly add noise are obvious too.

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -48,7 +48,7 @@ Right after a successful connection, a second step in the dialog offers to match
 
 Two things populate as a result of connecting to another calendar.
 
-**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging anything that doesn't belong.
+**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging genuinely problematic content — spam, harassment, misleading information, or content that violates your instance's policies. If an event just isn't a fit for your calendar, don't report it; not publishing it is the right response.
 
 **Your inbox.** The <Btn>Inbox</Btn> in the main navigation is the activity log for *your* calendar — notifications when someone new connects to you, or when another calendar publishes one of your events on theirs. Connecting to a calendar doesn't directly change your inbox; the inbox is about what other calendars are doing with *yours*.
 

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -1,10 +1,20 @@
-# Follow other calendars and repost their events
+# Bring in events from other calendars
 
-The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about connecting your calendar to theirs — finding the calendars that matter to your community, deciding what to do with what shows up in your feed, and choosing what to share back.
+The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about bringing some of *their* events onto *your* calendar — finding the calendars that matter to your community, deciding what to do with what shows up, and choosing what to share onward.
 
-The mechanism underneath is ActivityPub federation, but most of the time the right words are *follow*, *share*, *connect*, and *repost*. Federation jargon shows up in this guide only where it surfaces in the interface — the part where you type a calendar identifier shaped like `name@domain.example` is one of them, because that's what you'll see on the screen.
+The mechanism underneath is ActivityPub federation. The interface uses "Follow" and "Repost" on the buttons, and this guide names those buttons literally when walking you through them — but also describes what they *do* in plainer terms: connecting to another calendar, and publishing an event from it onto yours.
 
-## Find calendars to follow
+## Two steps, on purpose
+
+The action splits into two stages, and the separation matters.
+
+**Connect.** You point your calendar at another one — say, the music venue's — and from then on, their events arrive in a stream visible only to you. Nothing about your *public* calendar has changed yet; your visitors still see exactly what they saw before. A connection is a private feed for you, the owner, to look through.
+
+**Publish.** When an event in that private feed is worth surfacing on your public calendar, you publish it. *Now* visitors see it. Publishing can happen by hand — one event at a time, deliberately — or by rule, where you've told Pavillion to publish certain incoming events automatically.
+
+The separation is what gives you editorial control. Connecting to a calendar doesn't commit you to publishing anything from it; it just opens the door so you can decide.
+
+## Find calendars worth connecting to
 
 There's no central directory of Pavillion calendars. Federation works the same way email does: to connect to someone's calendar, you need its address, and the way you get its address is the same way you'd get someone's email — ask, look at their website, find it in another calendar's "calendars they follow" list.
 
@@ -16,94 +26,84 @@ A few starting places:
 
 Calendar handles take the shape `calendar-name@domain.example`. The part before the `@` is the calendar's URL handle on its instance; the part after is the instance's domain. *`riverbend-folk@arts.example`* points at the `riverbend-folk` calendar on `arts.example`. (Calendars on your *own* instance can be referenced by just their URL handle — `riverbend-folk` is enough if you're both running on the same instance.)
 
-## Follow a calendar
+## Connect to a calendar
 
-Open <Btn>Feed</Btn> from the main navigation. The Feed has three tabs: **Events** (events from calendars you follow), **Following** (calendars you've connected to), and **Followers** (calendars connected to yours). If you run more than one calendar, a calendar selector at the top scopes the feed — your follows are *per-calendar*, not per-account; each of your calendars has its own list, its own feed, and its own followers.
+Open <Btn>Feed</Btn> from the main navigation. The Feed has three tabs: **Events** (events from calendars you're connected to), **Following** (the calendars you've connected to), and **Followers** (calendars connected to yours). If you run more than one calendar, a calendar selector at the top scopes the feed — connections are *per-calendar*, not per-account; each of your calendars has its own list, its own feed, and its own followers.
 
 In the **Following** tab, click <Btn>Follow a Calendar</Btn>. A dialog opens with one field: the calendar's identifier — `name@domain.example` for a remote calendar, or just `name` for one on your own instance.
 
 Type the identifier. Pavillion looks the calendar up after a brief pause and shows you a preview — the calendar's name, description, and domain. The preview is everything you'd see on the calendar's public page; use it to confirm you've got the right one before connecting.
 
-Below the preview are the auto-repost toggles. They control what happens automatically when events arrive from this calendar — see [Set up auto-repost](#set-up-auto-repost) below for what each one does. If you're not sure what to pick, leave both off; you can manually repost any individual event later, and you can change these toggles for any follow at any time.
+Below the preview are the auto-repost toggles. They control what happens automatically when events arrive from this calendar — see [Let rules publish for you](#let-rules-publish-for-you) below for what each one does. If you're not sure what to pick, leave both off; you can publish any individual event by hand later, and you can change these toggles for any connection at any time.
 
 Click <Btn>Follow</Btn>. Pavillion sends a follow request to the source calendar; once their server has accepted it (which is usually immediate), their events start arriving in your feed.
 
-To stop following a calendar entirely, find its row in the **Following** tab and click <Btn>Unfollow</Btn>. That's a heavier action than undoing a single repost — it disconnects the two calendars completely, no future events flow in, and any auto-repost rules on the follow go away with it.
+To disconnect entirely, find the calendar's row in the **Following** tab and click <Btn>Unfollow</Btn>. That's a heavier action than unpublishing a single event — it ends the connection completely, no future events flow in, and any auto-repost rules on the connection go away with it.
 
 ::: tip <Lightbulb /> A note on the optional category-matching step.
-Right after a successful follow, a second step in the dialog offers to match the source calendar's categories to your own — *their* `Live Music` to *your* `Concerts`, for example. Setting these up now means any event you repost from this calendar — manually or automatically — lands in the right category on yours without re-tagging. You can skip the step and configure it later from the **Match categories** link on the follow's row in your Following tab; the category-matching guide covers the details.
+Right after a successful connection, a second step in the dialog offers to match the source calendar's categories to your own — *their* `Live Music` to *your* `Concerts`, for example. Setting these up now means any event you publish from this calendar — by hand or by rule — lands in the right category on yours without re-tagging. You can skip the step and configure it later from the **Match categories** link on the connection's row in your Following tab; the category-matching guide covers the details.
 :::
 
-## What shows up after you follow
+## What lands in your feed
 
-Two things populate as a result of a follow.
+Two things populate as a result of connecting to another calendar.
 
-**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one follows, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* repost. Each row has a <Btn>Repost</Btn> button for sharing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging anything that doesn't belong.
+**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging anything that doesn't belong.
 
-**Your inbox.** The <Btn>Inbox</Btn> in the main navigation is the activity log for *your* calendar — notifications when someone new follows you, or when another calendar reposts one of your events. Following a calendar doesn't directly change your inbox; the inbox is about what other calendars are doing with *yours*.
+**Your inbox.** The <Btn>Inbox</Btn> in the main navigation is the activity log for *your* calendar — notifications when someone new connects to you, or when another calendar publishes one of your events on theirs. Connecting to a calendar doesn't directly change your inbox; the inbox is about what other calendars are doing with *yours*.
 
-In short: **the feed is what's coming in. The inbox is what's happening to your work.**
+In short: **the feed is what's coming in. The inbox is what's happening to your work.** A visitor to your public page never sees what's in your feed — they see what you've already published. The feed is your editorial space; the calendar is your public face.
 
-## Seeing an event vs. reposting it
+## Publish an event by hand
 
-This is the distinction that trips up new owners most often.
+In the Feed > Events tab, find an event you want on your public calendar and click <Btn>Repost</Btn>. If the source event has categories that aren't yet matched to one of yours, a small dialog opens letting you pick the right local categories — or pull the source's category names onto your calendar in one click, if you'd like to adopt them as new categories of your own. Confirm, and the event lands on your public calendar.
 
-**Following a calendar lets you see their events.** Their events show up in your Feed > Events tab. You — the owner — can browse them. You can click into any event for full details. You can decide which ones are worth sharing. None of that changes your public calendar.
+The button on that event in your feed now reads **Reposted**, in green. To unpublish, click the **Reposted** label — see [Unpublish an event](#unpublish-an-event) below.
 
-**Reposting an event puts it on your public calendar.** Once you repost, the event appears on your calendar's public page alongside your own events. Anyone visiting your calendar sees it. Anyone reposting from *your* calendar can pick it up too.
+Publishing by hand is the right pace when you want editorial control over what lands on your calendar. You see a steady stream of incoming events, you decide which ones serve your community, you pick those.
 
-A visitor to your public page does *not* see what's in your feed. They see what's on your calendar. Following without reposting is a private stream for you to triage; reposting is the act that makes an event part of your public face.
+## Let rules publish for you
 
-## Repost an event manually
+If the calendar you're connected to posts the kind of events you'd publish almost every time anyway, you can let a rule do it for you. From the **Following** tab, find the connection's row and use the toggles in its right-hand column. There are two, in nesting order:
 
-In the Feed > Events tab, find an event you want to repost and click <Btn>Repost</Btn>. If the source event has categories that aren't yet matched to one of yours, a small dialog opens letting you pick the right local categories — or pull the source's category names onto your calendar in one click, if you'd like to adopt them as new categories of your own. Confirm, and the event lands on your public calendar.
+- **Auto-repost original events.** When the source calendar posts an event of their own, publish it on yours automatically.
+- **Also auto-repost shared events.** Only available when the first toggle is on. When the source calendar *itself* publishes an event from another calendar, publish their repost too. This is how an event from a third calendar two hops away can end up on yours; turn it on if you trust the source's editorial taste, off if you only want the events they originate themselves.
 
-The button on that event in your feed now reads **Reposted**, in green. To undo the repost, click the **Reposted** label — see [Undo a repost](#undo-a-repost) below.
-
-Manual reposting is the right pace when you want editorial control over what lands on your calendar. You see a steady stream of incoming events, you decide which ones serve your community, you pick those.
-
-## Set up auto-repost
-
-If the calendar you're following posts the kinds of events you'd repost almost every time anyway, auto-repost spares you the click. From the **Following** tab, find the follow's row and use the toggles in its right-hand column. There are two, in nesting order:
-
-- **Auto-repost original events.** When the source calendar posts an event of their own, repost it onto yours automatically.
-- **Also auto-repost shared events.** Only available when the first toggle is on. When the source calendar *itself* reposts an event from another calendar, repost their repost too. This is how an event from a third calendar two hops away can end up on yours; turn it on if you trust the source's editorial taste, off if you only want the events they originate themselves.
-
-Auto-reposted events show up on your calendar like any other repost, with one small visible difference *in your feed*: the button reads **Auto-posted** in muted gray rather than **Reposted** in green. That's so you can tell at a glance which events you chose by hand and which arrived through a rule. Visitors to your public calendar see the same thing either way.
+Rule-published events show up on your calendar like any other published event, with one small visible difference *in your feed*: the button reads **Auto-posted** in muted gray rather than **Reposted** in green. That's so you can tell at a glance which events you chose by hand and which arrived through a rule. Visitors to your public calendar see the same thing either way.
 
 ::: tip <Lightbulb /> A note on auto-repost and category matching.
-Auto-repost works best when category matching is set up first. Without matchings, an auto-reposted event can land on your calendar with no categories — it'll publish, but it won't show up under any of your filters and won't appear under "more like this" on related events. The category-matching guide walks through the rules; if you're enabling auto-repost on a follow you didn't pre-map, take a minute to set the mappings up afterwards.
+Rule-driven publishing works best when category matching is set up first. Without matchings, a rule-published event can land on your calendar with no categories — it'll publish, but it won't show up under any of your filters and won't appear under "more like this" on related events. The category-matching guide walks through the rules; if you're enabling auto-repost on a connection you didn't pre-map, take a minute to set the mappings up afterwards.
 :::
 
-## Undo a repost
+## Unpublish an event
 
 In the Feed > Events tab, click the **Reposted** or **Auto-posted** label on any event currently on your calendar. The event is removed from your calendar immediately — visitors no longer see it there.
 
-The undo *sticks*. If the source calendar later edits and re-broadcasts that same event — a name change, a venue update, a re-share — your calendar does **not** pick it up again. Once you've said no to a particular event, your no is durable; the source can't accidentally undo your decision by republishing.
+The unpublish *sticks*. If the source calendar later edits and re-broadcasts that same event — a name change, a venue update, a re-share — your calendar does **not** pick it up again. Once you've said no to a particular event, your no is durable; the source can't accidentally undo your decision by republishing.
 
 Two clarifications about the stickiness:
 
-- **It's per-calendar, not per-account.** If you run two calendars and you've unposted an event on one, the other is unaffected. Each calendar's editorial decisions belong to that calendar alone.
-- **It applies to that one event, not to the whole follow.** Unposting a single concert doesn't mean you've stopped following the venue or stopped getting their other events. Future events from the same source still flow through the same way.
+- **It's per-calendar, not per-account.** If you run two calendars and you've unpublished an event on one, the other is unaffected. Each calendar's editorial decisions belong to that calendar alone.
+- **It applies to that one event, not to the whole connection.** Unpublishing a single concert doesn't mean you've disconnected from the venue or stopped getting their other events. Future events from the same source still flow through the same way.
 
-If you change your mind, click <Btn>Repost</Btn> on the same event in your feed; the manual repost overrides the prior unpost and the event is back on your calendar.
+If you change your mind, click <Btn>Repost</Btn> on the same event in your feed; that publishes it again, overriding the prior unpublish, and the event is back on your calendar.
 
 ## Aggregator vs. curated: a framing decision
 
 Most calendar owners face this choice within their first few weeks of running a calendar. It's a question you'll probably revisit a few times as your calendar grows.
 
-**An aggregator calendar follows broadly and auto-reposts most of what comes in.** The bias is toward inclusion: anyone running events relevant to your community gets surfaced on your calendar, with category-matching rules doing most of the editorial work. The result is a busy calendar that functions as a regional or topical clearinghouse — *the* place to look up "what's happening this weekend in our town" or "all climate-action events in the region this month." A municipality's all-events calendar, a coworking space's tech-meetup roundup, or a regional arts council page tend to be aggregators.
+**An aggregator calendar connects broadly and lets rules publish most of what comes in.** The bias is toward inclusion: anyone running events relevant to your community gets surfaced on your calendar, with category-matching rules doing most of the editorial work. The result is a busy calendar that functions as a regional or topical clearinghouse — *the* place to look up "what's happening this weekend in our town" or "all climate-action events in the region this month." A municipality's all-events calendar, a coworking space's tech-meetup roundup, or a regional arts council page tend to be aggregators.
 
-**A curated calendar follows selectively and reposts deliberately, mostly by hand.** The bias is toward editorial fit: a smaller list of events that meet a higher bar, individually picked, sometimes re-introduced or re-framed in description. The result is a calendar that earns visitors' trust through what it leaves *out* as much as what it includes — *the* place to look up "the events the editor of this calendar personally vouches for." A neighborhood association's "what we recommend this week" or a single venue's hand-picked partner-event list tend to be curated.
+**A curated calendar connects selectively and publishes deliberately, mostly by hand.** The bias is toward editorial fit: a smaller list of events that meet a higher bar, individually picked, sometimes re-introduced or re-framed in description. The result is a calendar that earns visitors' trust through what it leaves *out* as much as what it includes — *the* place to look up "the events the editor of this calendar personally vouches for." A neighborhood association's "what we recommend this week" or a single venue's hand-picked partner-event list tend to be curated.
 
 Two things about this choice:
 
-**It isn't binary.** Auto-repost rules are per-follow. You can be an aggregator for some sources (the city's parks-and-rec calendar, where you trust everything they post) and curated for others (a peer venue, where their events are interesting but you want the final say). Most established calendars end up a mix.
+**It isn't binary.** Auto-repost rules are per-connection. You can be an aggregator for some sources (the city's parks-and-rec calendar, where you trust everything they post) and curated for others (a peer venue, where their events are interesting but you want the final say). Most established calendars end up a mix.
 
-**You can change posture later, but the directions aren't symmetric.** Switching from curated to aggregator is straightforward — flip the toggles on existing follows, set up category matchings, accept the increased throughput. Switching the other way is harder; once visitors associate your calendar with a particular flow, dropping a stream of auto-reposts they were used to seeing is a noticeable change. Lean toward starting curated and opening up later, rather than starting open and tightening down.
+**You can change posture later, but the directions aren't symmetric.** Switching from curated to aggregator is straightforward — flip the toggles on existing connections, set up category matchings, accept the increased throughput. Switching the other way is harder; once visitors associate your calendar with a particular flow, dropping a stream of auto-published events they were used to seeing is a noticeable change. Lean toward starting curated and opening up later, rather than starting open and tightening down.
 
-The right starting posture depends on your calendar's purpose and your editorial bandwidth. A small volunteer group with one editor and a few hours a week probably can't sustain a curated calendar of fifty followed sources; an aggregator posture lets the rules carry the load. A neighborhood newsletter run by a single careful editor probably *should* be curated; visitors come to it for the editor's judgment, and an unfiltered firehose loses that.
+The right starting posture depends on your calendar's purpose and your editorial bandwidth. A small volunteer group with one editor and a few hours a week probably can't sustain a curated calendar of fifty connected sources; an aggregator posture lets the rules carry the load. A neighborhood newsletter run by a single careful editor probably *should* be curated; visitors come to it for the editor's judgment, and an unfiltered firehose loses that.
 
 ::: tip <Lightbulb /> A note on the first month.
-Like the category list, your aggregator-vs-curated posture is a draft, not a commitment. Watch what kinds of events actually flow through your follows for a month or two before tuning the toggles. The follows that consistently surface things worth reposting are obvious by then — and the ones that mostly add noise are obvious too.
+Like the category list, your aggregator-vs-curated posture is a draft, not a commitment. Watch what kinds of events actually flow through your connections for a month or two before tuning the toggles. The connections that consistently surface things worth publishing are obvious by then — and the ones that mostly add noise are obvious too.
 :::

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -16,12 +16,12 @@ The separation is what gives you editorial control. Connecting to a calendar doe
 
 ## Find calendars worth connecting to
 
-There's no central directory of Pavillion calendars. Federation works the same way email does: to connect to someone's calendar, you need its address, and the way you get its address is the same way you'd get someone's email — ask, look at their website, find it in another calendar's "calendars they follow" list.
+There's no central directory of Pavillion calendars. Federation works the same way email does: to connect to someone's calendar, you need its address, and the way you get its address is the same way you'd get someone's email — ask, or look at their website.
 
 A few starting places:
 
 - **Calendars listed on the websites of organizations you already work with.** A neighborhood association, a music venue, an arts council, a coworking space, a climate or mutual-aid group. Their site footer or events page often points at their calendar.
-- **The follow list on calendars you do know.** Once you've got one foothold — your local arts council, say — open their calendar and look at who *they* follow. That's a curated list of peers and partners they consider worth tracking, which is usually a good starting set for you too.
+- **The sources behind events you already like.** On a calendar you trust, reposted events link back to the calendar they came from — a small calendar-name link beneath the event title. If a particular source keeps showing up on calendars you respect, that's a good signal it's worth connecting to yourself.
 - **Word of mouth.** Other calendar owners will tell you which calendars to track. The federated network tends to grow through introductions, not directory listings.
 
 Calendar handles take the shape `calendar-name@domain.example`. The part before the `@` is the calendar's URL handle on its instance; the part after is the instance's domain. *`riverbend-folk@arts.example`* points at the `riverbend-folk` calendar on `arts.example`. (Calendars on your *own* instance can be referenced by just their URL handle — `riverbend-folk` is enough if you're both running on the same instance.)

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -34,7 +34,7 @@ In the **Following** tab, click <Btn>Follow a Calendar</Btn>. A dialog opens wit
 
 Type the identifier. Pavillion looks the calendar up after a brief pause and shows you a preview — the calendar's name, description, and domain. The preview is everything you'd see on the calendar's public page; use it to confirm you've got the right one before connecting.
 
-Below the preview are the auto-repost toggles. They control what happens automatically when events arrive from this calendar — see [Let rules publish for you](#let-rules-publish-for-you) below for what each one does. If you're not sure what to pick, leave both off; you can publish any individual event by hand later, and you can change these toggles for any connection at any time.
+Below the preview are the auto-repost toggles. They control what happens automatically when *new* events arrive from this calendar from now on — see [Let rules publish for you](#let-rules-publish-for-you) below for what each one does. If you're not sure what to pick, leave both off; you can publish any individual event by hand later, and you can change these toggles for any connection at any time.
 
 Click <Btn>Follow</Btn>. Pavillion sends a follow request to the source calendar; once their server has accepted it (which is usually immediate), their events start arriving in your feed.
 
@@ -62,8 +62,10 @@ Publishing by hand is the right pace when you want editorial control over what l
 
 If the calendar you're connected to posts the kind of events you'd publish almost every time anyway, you can let a rule do it for you. From the **Following** tab, find the connection's row and use the toggles in its right-hand column. There are two, in nesting order:
 
-- **Auto-repost original events.** When the source calendar posts an event of their own, publish it on yours automatically.
-- **Also auto-repost shared events.** Only available when the first toggle is on. When the source calendar *itself* publishes an event from another calendar, publish their repost too. This is how an event from a third calendar two hops away can end up on yours; turn it on if you trust the source's editorial taste, off if you only want the events they originate themselves.
+- **Auto-repost original events.** From now on, when the source calendar posts an event of their own, publish it on yours automatically.
+- **Also auto-repost shared events.** Only available when the first toggle is on. From now on, when the source calendar *itself* publishes an event from another calendar, publish their repost too. This is how an event from a third calendar two hops away can end up on yours; turn it on if you trust the source's editorial taste, off if you only want the events they originate themselves.
+
+Both rules are forward-only. Turning a toggle on doesn't reach back and publish events from this calendar that are already sitting in your feed — only events that arrive from the source *after* the toggle is on get auto-published. To put already-arrived events on your calendar, publish them by hand from the **Events** tab.
 
 Rule-published events show up on your calendar like any other published event, with one small visible difference *in your feed*: the button reads **Auto-posted** in muted gray rather than **Reposted** in green. That's so you can tell at a glance which events you chose by hand and which arrived through a rule. Visitors to your public calendar see the same thing either way.
 

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -1,35 +1,109 @@
 # Follow other calendars and repost their events
 
-> Status: stub. Full guide coming before launch.
-
 The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about connecting your calendar to theirs — finding the calendars that matter to your community, deciding what to do with what shows up in your feed, and choosing what to share back.
 
-The mechanism underneath is ActivityPub federation, but you don't have to think in those terms. Most of the time the right words are *follow*, *share*, *connect*, and *repost*.
+The mechanism underneath is ActivityPub federation, but most of the time the right words are *follow*, *share*, *connect*, and *repost*. Federation jargon shows up in this guide only where it surfaces in the interface — the part where you type a calendar identifier shaped like `name@domain.example` is one of them, because that's what you'll see on the screen.
 
 ## Find calendars to follow
 
-Where to look — nearby communities, partner organizations, allied groups in your topic area.
+There's no central directory of Pavillion calendars. Federation works the same way email does: to connect to someone's calendar, you need its address, and the way you get its address is the same way you'd get someone's email — ask, look at their website, find it in another calendar's "calendars they follow" list.
+
+A few starting places:
+
+- **Calendars listed on the websites of organizations you already work with.** A neighborhood association, a music venue, an arts council, a coworking space, a climate or mutual-aid group. Their site footer or events page often points at their calendar.
+- **The follow list on calendars you do know.** Once you've got one foothold — your local arts council, say — open their calendar and look at who *they* follow. That's a curated list of peers and partners they consider worth tracking, which is usually a good starting set for you too.
+- **Word of mouth.** Other calendar owners will tell you which calendars to track. The federated network tends to grow through introductions, not directory listings.
+
+Calendar handles take the shape `calendar-name@domain.example`. The part before the `@` is the calendar's URL handle on its instance; the part after is the instance's domain. *`riverbend-folk@arts.example`* points at the `riverbend-folk` calendar on `arts.example`. (Calendars on your *own* instance can be referenced by just their URL handle — `riverbend-folk` is enough if you're both running on the same instance.)
 
 ## Follow a calendar
 
-What happens when you do. What appears in your feed and inbox afterward.
+Open <Btn>Feed</Btn> from the main navigation. The Feed has three tabs: **Events** (events from calendars you follow), **Following** (calendars you've connected to), and **Followers** (calendars connected to yours). If you run more than one calendar, a calendar selector at the top scopes the feed — your follows are *per-calendar*, not per-account; each of your calendars has its own list, its own feed, and its own followers.
+
+In the **Following** tab, click <Btn>Follow a Calendar</Btn>. A dialog opens with one field: the calendar's identifier — `name@domain.example` for a remote calendar, or just `name` for one on your own instance.
+
+Type the identifier. Pavillion looks the calendar up after a brief pause and shows you a preview — the calendar's name, description, and domain. The preview is everything you'd see on the calendar's public page; use it to confirm you've got the right one before connecting.
+
+Below the preview are the auto-repost toggles. They control what happens automatically when events arrive from this calendar — see [Set up auto-repost](#set-up-auto-repost) below for what each one does. If you're not sure what to pick, leave both off; you can manually repost any individual event later, and you can change these toggles for any follow at any time.
+
+Click <Btn>Follow</Btn>. Pavillion sends a follow request to the source calendar; once their server has accepted it (which is usually immediate), their events start arriving in your feed.
+
+To stop following a calendar entirely, find its row in the **Following** tab and click <Btn>Unfollow</Btn>. That's a heavier action than undoing a single repost — it disconnects the two calendars completely, no future events flow in, and any auto-repost rules on the follow go away with it.
+
+::: tip <Lightbulb /> A note on the optional category-matching step.
+Right after a successful follow, a second step in the dialog offers to match the source calendar's categories to your own — *their* `Live Music` to *your* `Concerts`, for example. Setting these up now means any event you repost from this calendar — manually or automatically — lands in the right category on yours without re-tagging. You can skip the step and configure it later from the **Match categories** link on the follow's row in your Following tab; the category-matching guide covers the details.
+:::
+
+## What shows up after you follow
+
+Two things populate as a result of a follow.
+
+**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one follows, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* repost. Each row has a <Btn>Repost</Btn> button for sharing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging anything that doesn't belong.
+
+**Your inbox.** The <Btn>Inbox</Btn> in the main navigation is the activity log for *your* calendar — notifications when someone new follows you, or when another calendar reposts one of your events. Following a calendar doesn't directly change your inbox; the inbox is about what other calendars are doing with *yours*.
+
+In short: **the feed is what's coming in. The inbox is what's happening to your work.**
 
 ## Seeing an event vs. reposting it
 
-Following a calendar lets you *see* their events. Reposting puts those events on *your* calendar for your visitors to see. Different actions.
+This is the distinction that trips up new owners most often.
+
+**Following a calendar lets you see their events.** Their events show up in your Feed > Events tab. You — the owner — can browse them. You can click into any event for full details. You can decide which ones are worth sharing. None of that changes your public calendar.
+
+**Reposting an event puts it on your public calendar.** Once you repost, the event appears on your calendar's public page alongside your own events. Anyone visiting your calendar sees it. Anyone reposting from *your* calendar can pick it up too.
+
+A visitor to your public page does *not* see what's in your feed. They see what's on your calendar. Following without reposting is a private stream for you to triage; reposting is the act that makes an event part of your public face.
 
 ## Repost an event manually
 
-The one-at-a-time path. When this is the right approach.
+In the Feed > Events tab, find an event you want to repost and click <Btn>Repost</Btn>. If the source event has categories that aren't yet matched to one of yours, a small dialog opens letting you pick the right local categories — or pull the source's category names onto your calendar in one click, if you'd like to adopt them as new categories of your own. Confirm, and the event lands on your public calendar.
 
-## Set up auto-repost rules
+The button on that event in your feed now reads **Reposted**, in green. To undo the repost, click the **Reposted** label — see [Undo a repost](#undo-a-repost) below.
 
-The automatic path. When this is the right approach, and the kinds of rules that work well.
+Manual reposting is the right pace when you want editorial control over what lands on your calendar. You see a steady stream of incoming events, you decide which ones serve your community, you pick those.
+
+## Set up auto-repost
+
+If the calendar you're following posts the kinds of events you'd repost almost every time anyway, auto-repost spares you the click. From the **Following** tab, find the follow's row and use the toggles in its right-hand column. There are two, in nesting order:
+
+- **Auto-repost original events.** When the source calendar posts an event of their own, repost it onto yours automatically.
+- **Also auto-repost shared events.** Only available when the first toggle is on. When the source calendar *itself* reposts an event from another calendar, repost their repost too. This is how an event from a third calendar two hops away can end up on yours; turn it on if you trust the source's editorial taste, off if you only want the events they originate themselves.
+
+Auto-reposted events show up on your calendar like any other repost, with one small visible difference *in your feed*: the button reads **Auto-posted** in muted gray rather than **Reposted** in green. That's so you can tell at a glance which events you chose by hand and which arrived through a rule. Visitors to your public calendar see the same thing either way.
+
+::: tip <Lightbulb /> A note on auto-repost and category matching.
+Auto-repost works best when category matching is set up first. Without matchings, an auto-reposted event can land on your calendar with no categories — it'll publish, but it won't show up under any of your filters and won't appear under "more like this" on related events. The category-matching guide walks through the rules; if you're enabling auto-repost on a follow you didn't pre-map, take a minute to set the mappings up afterwards.
+:::
 
 ## Undo a repost
 
-How "unpost" works, and why it sticks — once you've said no to an event, the source can re-broadcast it without it reappearing on your calendar.
+In the Feed > Events tab, click the **Reposted** or **Auto-posted** label on any event currently on your calendar. The event is removed from your calendar immediately — visitors no longer see it there.
+
+The undo *sticks*. If the source calendar later edits and re-broadcasts that same event — a name change, a venue update, a re-share — your calendar does **not** pick it up again. Once you've said no to a particular event, your no is durable; the source can't accidentally undo your decision by republishing.
+
+Two clarifications about the stickiness:
+
+- **It's per-calendar, not per-account.** If you run two calendars and you've unposted an event on one, the other is unaffected. Each calendar's editorial decisions belong to that calendar alone.
+- **It applies to that one event, not to the whole follow.** Unposting a single concert doesn't mean you've stopped following the venue or stopped getting their other events. Future events from the same source still flow through the same way.
+
+If you change your mind, click <Btn>Repost</Btn> on the same event in your feed; the manual repost overrides the prior unpost and the event is back on your calendar.
 
 ## Aggregator vs. curated: a framing decision
 
-The early call most calendar owners face. An aggregator calendar pulls broadly and automatically; a curated calendar selects deliberately. The consequences of each posture, and how to change your mind later.
+Most calendar owners face this choice within their first few weeks of running a calendar. It's a question you'll probably revisit a few times as your calendar grows.
+
+**An aggregator calendar follows broadly and auto-reposts most of what comes in.** The bias is toward inclusion: anyone running events relevant to your community gets surfaced on your calendar, with category-matching rules doing most of the editorial work. The result is a busy calendar that functions as a regional or topical clearinghouse — *the* place to look up "what's happening this weekend in our town" or "all climate-action events in the region this month." A municipality's all-events calendar, a coworking space's tech-meetup roundup, or a regional arts council page tend to be aggregators.
+
+**A curated calendar follows selectively and reposts deliberately, mostly by hand.** The bias is toward editorial fit: a smaller list of events that meet a higher bar, individually picked, sometimes re-introduced or re-framed in description. The result is a calendar that earns visitors' trust through what it leaves *out* as much as what it includes — *the* place to look up "the events the editor of this calendar personally vouches for." A neighborhood association's "what we recommend this week" or a single venue's hand-picked partner-event list tend to be curated.
+
+Two things about this choice:
+
+**It isn't binary.** Auto-repost rules are per-follow. You can be an aggregator for some sources (the city's parks-and-rec calendar, where you trust everything they post) and curated for others (a peer venue, where their events are interesting but you want the final say). Most established calendars end up a mix.
+
+**You can change posture later, but the directions aren't symmetric.** Switching from curated to aggregator is straightforward — flip the toggles on existing follows, set up category matchings, accept the increased throughput. Switching the other way is harder; once visitors associate your calendar with a particular flow, dropping a stream of auto-reposts they were used to seeing is a noticeable change. Lean toward starting curated and opening up later, rather than starting open and tightening down.
+
+The right starting posture depends on your calendar's purpose and your editorial bandwidth. A small volunteer group with one editor and a few hours a week probably can't sustain a curated calendar of fifty followed sources; an aggregator posture lets the rules carry the load. A neighborhood newsletter run by a single careful editor probably *should* be curated; visitors come to it for the editor's judgment, and an unfiltered firehose loses that.
+
+::: tip <Lightbulb /> A note on the first month.
+Like the category list, your aggregator-vs-curated posture is a draft, not a commitment. Watch what kinds of events actually flow through your follows for a month or two before tuning the toggles. The follows that consistently surface things worth reposting are obvious by then — and the ones that mostly add noise are obvious too.
+:::

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -94,11 +94,11 @@ The inbox doesn't fill up because *you* connected to another calendar; it fills 
 
 ## Aggregator vs. curated: a framing decision
 
-Most calendar owners face this choice within their first few weeks of running a calendar. It's a question you'll probably revisit a few times as your calendar grows.
+Most calendar owners who repost events face this choice within their first few weeks of running a calendar. It's a question you'll probably revisit a few times as your calendar grows.
 
 **An aggregator calendar connects broadly and lets rules publish most of what comes in.** The bias is toward inclusion: anyone running events relevant to your community gets surfaced on your calendar, with category-matching rules doing most of the editorial work. The result is a busy calendar that functions as a regional or topical clearinghouse — *the* place to look up "what's happening this weekend in our town" or "all climate-action events in the region this month." A municipality's all-events calendar, a coworking space's tech-meetup roundup, or a regional arts council page tend to be aggregators.
 
-**A curated calendar connects selectively and publishes deliberately, mostly by hand.** The bias is toward editorial fit: a smaller list of events that meet a higher bar, individually picked, sometimes re-introduced or re-framed in description. The result is a calendar that earns visitors' trust through what it leaves *out* as much as what it includes — *the* place to look up "the events the editor of this calendar personally vouches for." A neighborhood association's "what we recommend this week" or a single venue's hand-picked partner-event list tend to be curated.
+**A curated calendar connects selectively and publishes deliberately, mostly by hand.** The bias is toward editorial fit: a smaller list of events that meet a higher bar, individually picked, each placed in your own categories. The result is a calendar that earns visitors' trust through what it leaves *out* as much as what it includes — *the* place to look up "the events the editor of this calendar personally vouches for." A neighborhood association's "what we recommend this week" or a single venue's hand-picked partner-event list tend to be curated.
 
 Two things about this choice:
 

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -46,13 +46,9 @@ Right after a successful connection, a second step in the dialog offers to match
 
 ## What lands in your feed
 
-Two things populate as a result of connecting to another calendar.
+The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging genuinely problematic content — spam, harassment, misleading information, or content that violates your instance's policies. If an event just isn't a fit for your calendar, don't report it; not publishing it is the right response.
 
-**Your feed.** The **Events** tab in the Feed section is the stream of incoming events from every calendar this one is connected to, newest first. A feed event isn't on your public calendar — it's just visible to you, the owner, as something you *could* publish. Each row has a <Btn>Repost</Btn> button for publishing it onto your calendar, plus a <Btn>Details</Btn> button for the full event view and a <Btn>Report</Btn> button for flagging genuinely problematic content — spam, harassment, misleading information, or content that violates your instance's policies. If an event just isn't a fit for your calendar, don't report it; not publishing it is the right response.
-
-**Your inbox.** The <Btn>Inbox</Btn> in the main navigation is the activity log for *your* calendar — notifications when someone new connects to you, or when another calendar publishes one of your events on theirs. Connecting to a calendar doesn't directly change your inbox; the inbox is about what other calendars are doing with *yours*.
-
-In short: **the feed is what's coming in. The inbox is what's happening to your work.** A visitor to your public page never sees what's in your feed — they see what you've already published. The feed is your editorial space; the calendar is your public face.
+A visitor to your public page never sees what's in your feed — they see what you've already published. The feed is your editorial space; the calendar is your public face.
 
 ## Publish an event by hand
 
@@ -87,6 +83,12 @@ Two clarifications about the stickiness:
 - **It applies to that one event, not to the whole connection.** Unpublishing a single concert doesn't mean you've disconnected from the venue or stopped getting their other events. Future events from the same source still flow through the same way.
 
 If you change your mind, click <Btn>Repost</Btn> on the same event in your feed; that publishes it again, overriding the prior unpublish, and the event is back on your calendar.
+
+## When other calendars connect to yours
+
+Everything above is *you* reaching out to other calendars. The inverse also happens: other calendars connect to yours, and they may publish your events onto theirs. The <Btn>Inbox</Btn> in the main navigation is where you see that activity — notifications when a new calendar follows yours, or when one of your events gets reposted somewhere else.
+
+The inbox doesn't fill up because *you* connected to another calendar; it fills up because *they* connected to you. The mechanics of being followed, and what to do about reports raised against your events, are covered in the federation-etiquette and moderation guides.
 
 ## Aggregator vs. curated: a framing decision
 

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -92,5 +92,5 @@ You have a calendar. You have one event on it. You have a URL you can share. The
 - **More events.** Add the rest of what's coming up. Events that repeat (weekly meetings, monthly meetups) — see the recurring-events guide. Series of distinct events under a program name — see the series guide.
 - **More structure.** A bigger event list benefits from a richer set of categories and a tidied-up list of places — those have their own guides.
 - **More people.** If you're not running this alone, invite editors so others can publish too — the editors guide covers that.
-- **More reach.** Find other calendars in your community to follow, and decide whether to repost their events onto yours — the follow-and-repost guide covers that. If you're migrating from an existing calendar (Google Calendar, Nextcloud, a WordPress plugin, an existing Gancio or Mobilizon calendar), the ICS-import guide shows how to bring that history in.
+- **More reach.** Find other calendars in your community to connect to, and decide which of their events to publish onto yours — the follow-and-repost guide covers that. If you're migrating from an existing calendar (Google Calendar, Nextcloud, a WordPress plugin, an existing Gancio or Mobilizon calendar), the ICS-import guide shows how to bring that history in.
 


### PR DESCRIPTION
## Motivation

A review of `docs/guides/calendar-owners/follow-and-repost.md` against the documentation-playbook turned up three places where the guide drifted from the voice and structure used in the most-developed exemplars (`categories.md`, `places.md`): a paragraph of meta-commentary about the guide's own translation strategy, a "Connect to a calendar" section that walked the reader through every dialog field and toggle, and a "What lands in your feed" section that opened by restating content from the prior section. Tightening these brings the guide back in line with the playbook so a co-editor reading it six months from now gets the same voice as the rest of the calendar-owners set.

## Approach

- Cut paragraph two from a description of the guide's editorial plan ("the interface uses Follow and Repost on the buttons, and this guide names those buttons literally...") to a single sentence that names ActivityPub and pivots to the plain-language verbs.
- Trimmed "Connect to a calendar" from six paragraphs to four. Dropped the three-tab walk-through and the per-step narration of the connect dialog. Preserved the load-bearing claims: per-calendar scoping, preview matches the calendar's public page, toggles default to off if unsure, Unfollow is the heavier action.
- Reordered "What lands in your feed" to lead with "The feed is your editorial space; the calendar is your public face" and fold the Events-tab definition into that frame instead of restating it as the section's opener.
- Smaller polish throughout: aligned "Publish" wording with the literal **Repost** button in the Two-steps overview, bolded **Feed > Events** breadcrumbs consistently, removed a couple of stray hedges and a redundant clause in the curated-vs-aggregator section.

## Validation

Re-read the revised guide top to bottom against the playbook's pre-publish checklist and the voice principles. Verified: first paragraph still names the reader and the topic, every section answers a specific question, decision points (curated vs. aggregator, by-hand vs. by-rule) still have a quick test, no-go regions (Report-button scope, Unfollow as heavy hammer) are still called out, cross-links to neighbor guides preserved. No code changes, no test impact.