### PR TITLE
feat(public): /view discovery page for local calendars

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -144,6 +144,10 @@ rateLimit:
     byIp:
       windowMs: 60000  # 1 minute in milliseconds
       max: 60  # 60 requests per IP per minute
+  publicCalendarList:
+    byIp:
+      windowMs: 60000  # 1 minute in milliseconds
+      max: 60  # 60 requests per IP per minute
   application:
     byIp:
       windowMs: 900000  # 15 minutes in milliseconds

--- a/migrations/0033_add_listed_to_calendar.ts
+++ b/migrations/0033_add_listed_to_calendar.ts
@@ -1,0 +1,36 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import {
+  addColumnIfNotExists,
+  removeColumnIfExists,
+} from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Add `listed` column to the calendar table.
+ *
+ * `listed` controls whether a calendar appears on the public discovery page
+ * at `/view/`. Pre-feature, every calendar was implicitly listed, so existing
+ * rows must backfill to true on deployment. NOT NULL with DEFAULT true does
+ * both jobs: PostgreSQL applies the default to existing rows when the column
+ * is added, and new rows inherit the default unless explicitly opted out.
+ *
+ * Foundation for pv-u4ew (public discovery page) — all downstream service,
+ * API, and frontend work depends on this column existing and round-tripping
+ * through the Calendar entity/model.
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await addColumnIfNotExists(queryInterface, 'calendar', 'listed', {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await removeColumnIfExists(queryInterface, 'calendar', 'listed');
+  },
+};

--- a/src/common/model/calendar.ts
+++ b/src/common/model/calendar.ts
@@ -19,6 +19,7 @@ class Calendar extends TranslatedModel<CalendarContent> {
   widgetAllowedDomain: string | null = null;
   defaultEventImageId: string | null = null;
   defaultEventImage: Media | null = null;
+  listed: boolean = true;
   _content: Record<string, CalendarContent> = {};
 
   /**
@@ -59,6 +60,7 @@ class Calendar extends TranslatedModel<CalendarContent> {
       widgetAllowedDomain: this.widgetAllowedDomain,
       defaultEventImageId: this.defaultEventImageId,
       defaultEventImage: this.defaultEventImage?.toObject() ?? null,
+      listed: this.listed,
       content: Object.fromEntries(
         Object.entries(this._content)
           .map(([language, strings]: [string, CalendarContent]) => [language, strings.toObject()]),
@@ -81,6 +83,9 @@ class Calendar extends TranslatedModel<CalendarContent> {
     calendar.widgetAllowedDomain = obj.widgetAllowedDomain || null;
     calendar.defaultEventImageId = obj.defaultEventImageId || null;
     calendar.defaultEventImage = obj.defaultEventImage ? Media.fromObject(obj.defaultEventImage) : null;
+    // Default to true when the key is absent (backward compatibility with
+    // serialized calendars from before the `listed` flag existed).
+    calendar.listed = obj.listed === undefined ? true : Boolean(obj.listed);
 
     // Deserialize content if present
     if (obj.content && typeof obj.content === 'object') {

--- a/src/common/model/test/calendar.test.ts
+++ b/src/common/model/test/calendar.test.ts
@@ -83,6 +83,52 @@ describe('Calendar Model', () => {
       expect(restored.content('es').name).toBe('Nombre');
     });
 
+    it('should default `listed` to true and preserve it through round-trip', () => {
+      const calendar = new Calendar('cal-listed-default', 'default-listed');
+      calendar.languages = ['en'];
+
+      // Default at construction time.
+      expect(calendar.listed).toBe(true);
+
+      const obj = calendar.toObject();
+      expect(obj.listed).toBe(true);
+
+      const restored = Calendar.fromObject(obj);
+      expect(restored.listed).toBe(true);
+    });
+
+    it('should preserve explicit `listed: false` through round-trip', () => {
+      const calendar = new Calendar('cal-unlisted', 'unlisted');
+      calendar.languages = ['en'];
+      calendar.listed = false;
+
+      const obj = calendar.toObject();
+      expect(obj.listed).toBe(false);
+
+      const restored = Calendar.fromObject(obj);
+      expect(restored.listed).toBe(false);
+    });
+
+    it('should default `listed` to true when the key is absent from fromObject input', () => {
+      // Backward compatibility: serialized calendars from before the flag
+      // existed must default to listed=true so they continue appearing on
+      // public discovery exactly as they did pre-feature.
+      const obj = {
+        id: 'cal-legacy',
+        urlName: 'legacy-calendar',
+        languages: ['en'],
+        description: '',
+        defaultDateRange: null,
+        widgetAllowedDomain: null,
+        defaultEventImageId: null,
+        defaultEventImage: null,
+        content: {},
+      };
+
+      const calendar = Calendar.fromObject(obj);
+      expect(calendar.listed).toBe(true);
+    });
+
     it('should handle defaultEventImageId without object via fromObject', () => {
       const obj = {
         id: 'cal-4',

--- a/src/server/app_routes.ts
+++ b/src/server/app_routes.ts
@@ -428,16 +428,25 @@ export function createRouter(
 
   router.get(/^\/widget\/.*/i, handlers.widget_index);
 
-  // Locale-prefixed public site routes: /[locale]/view/...
+  // Locale-prefixed public site routes: /[locale]/view, /[locale]/view/...
   // Handles both non-default locale serving and default-locale redirects.
   // Must come before the unprefixed site route so prefixed URLs are handled first.
-  router.get(/^\/[a-z]{2,8}\/view\//i, handlers.locale_prefixed_site);
+  // The `(\/.*)?` tail matches both bare `/[locale]/view` and `/[locale]/view/<rest>`.
+  router.get(/^\/[a-z]{2,8}\/view(\/.*)?$/i, handlers.locale_prefixed_site);
 
-  // Public site routes (unprefixed — default language, as-needed strategy)
-  router.get(/^\/view\/.*/i, handlers.site_index);
+  // Public site routes (unprefixed — default language, as-needed strategy).
+  // The `(\/.*)?` tail matches both bare `/view` (the discovery landing page)
+  // and `/view/<rest>` (calendar pages); previously bare `/view` fell through
+  // to the client SPA catch-all.
+  router.get(/^\/view(\/.*)?$/i, handlers.site_index);
 
-  // Client app catch-all (goes last)
-  router.get(/^\/(?!(api|assets|\.well-known|calendars|users|view|widget)\/).*/i, handlers.client_index);
+  // Client app catch-all (goes last).
+  // The `view(?:\/|$)` exclusion stops the catch-all from absorbing bare `/view`
+  // alongside `/view/<rest>`; the other reserved segments still require a
+  // trailing `/` to exclude (api/, assets/, etc.). Without the `$` anchor the
+  // prior exclusion only matched `view\/` and bare `/view` reached the client
+  // SPA — the discovery landing page must resolve to the site SPA shell.
+  router.get(/^\/(?!(api|assets|\.well-known|calendars|users|widget)\/|view(?:\/|$)).*/i, handlers.client_index);
 
   return { router, handlers };
 }

--- a/src/server/calendar/entity/calendar.ts
+++ b/src/server/calendar/entity/calendar.ts
@@ -25,6 +25,9 @@ class CalendarEntity extends Model {
   @Column({ type: DataType.UUID, allowNull: true })
   declare default_event_image_id: string | null;
 
+  @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
+  declare listed: boolean;
+
   @HasMany(() => CalendarContentEntity)
   declare contentEntities: CalendarContentEntity[];
 
@@ -51,6 +54,7 @@ class CalendarEntity extends Model {
     calendar.defaultDateRange = this.default_date_range as DefaultDateRange || null;
     calendar.widgetAllowedDomain = this.widget_allowed_domain || null;
     calendar.defaultEventImageId = this.default_event_image_id || null;
+    calendar.listed = this.listed;
 
     if (this.defaultEventImage) {
       calendar.defaultEventImage = this.defaultEventImage.toModel();
@@ -74,6 +78,7 @@ class CalendarEntity extends Model {
       default_date_range: calendar.defaultDateRange,
       widget_allowed_domain: calendar.widgetAllowedDomain,
       default_event_image_id: calendar.defaultEventImageId,
+      listed: calendar.listed,
     });
   }
 };

--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -262,6 +262,18 @@ export default class CalendarInterface {
     return this.calendarService.listAllCalendarsForAdmin(filters);
   }
 
+  /**
+   * List public-discoverable calendars for the /view/ discovery page.
+   * Thin proxy to CalendarService.listPublicCalendars; see service docs for
+   * the full query shape, predicate semantics, and 500-row cap.
+   *
+   * @returns Calendars + lastEventActivity tuples, sorted activity-descending,
+   *   capped at 500 rows
+   */
+  async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
+    return this.calendarService.listPublicCalendars();
+  }
+
   // Event operations
   async listEvents(calendar: Calendar, options?: {
     search?: string;

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -1684,6 +1684,106 @@ class CalendarService {
   }
 
   /**
+   * List public-discoverable calendars for the /view/ discovery page.
+   *
+   * Returns every calendar with `listed = true`, paired with the timestamp of
+   * its most-recent publicly-visible event activity, sorted by that timestamp
+   * descending (calendars without events sort last via NULLS LAST), capped at
+   * 500 rows. Eager-loads `contentEntities` for the localized name +
+   * description. Does NOT eager-load `defaultEventImage` — discovery tiles
+   * don't render images in v1 (epic decision; YAGNI).
+   *
+   * Single SQL round-trip:
+   *   SELECT calendar.*, calendar_content.*,
+   *          (SELECT MAX(event.updatedAt)
+   *             FROM event
+   *             WHERE event.calendar_id = calendar.id
+   *               AND EXISTS (
+   *                 SELECT 1 FROM event_schedule
+   *                 WHERE event_schedule.event_id = event.id
+   *                   AND NOT (event_schedule.is_exclusion = true
+   *                            AND event_schedule.hide_from_public = true)
+   *               )
+   *          ) AS lastEventActivity
+   *   FROM calendar
+   *   LEFT JOIN calendar_content ON calendar_content.calendar_id = calendar.id
+   *   WHERE calendar.listed = true
+   *   ORDER BY lastEventActivity DESC NULLS LAST
+   *   LIMIT 500
+   *
+   * "Publicly visible event" predicate: an event contributes to
+   * `lastEventActivity` only if it owns at least one schedule row that is NOT
+   * a hidden cancellation. The canonical definition lives in
+   * EventInstanceService.rrules() — a schedule suppresses an occurrence
+   * (EXDATE-style) when BOTH `is_exclusion = true` AND `hide_from_public = true`.
+   * An event whose every schedule is a hidden cancellation produces no public
+   * occurrences and must not inflate the calendar's discovery activity. Events
+   * with no event_schedule rows at all are intentionally excluded from
+   * lastEventActivity — they have no published recurrence and therefore no
+   * surface for the public to encounter (matching rrules() emitting nothing).
+   *
+   * Foreign events reposted onto a calendar are tracked via EventRepostEntity
+   * and SharedEventEntity — those links intentionally do NOT influence
+   * `lastEventActivity` here, since the discovery page should rank calendars
+   * by their own publishing cadence, not by their syndication activity.
+   *
+   * @returns Calendars + lastEventActivity tuples, sorted activity-descending,
+   *   capped at 500 rows
+   */
+  async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
+    const PUBLIC_DISCOVERY_LIMIT = 500;
+
+    // Correlated subquery: an event contributes to MAX(event.updatedAt) only
+    // when it has at least one event_schedule row that is NOT a hidden
+    // cancellation (NOT (is_exclusion AND hide_from_public)). Mirrors the
+    // canonical suppression predicate in EventInstanceService.rrules().
+    // The `lastEventActivity` predicate matches the public events listing
+    // visibility semantics: events whose every schedule is an EXDATE-style
+    // hidden cancellation produce no public occurrences and must not inflate
+    // discovery activity.
+    //
+    // NOTE: the alias 'last_event_activity' is load-bearing — the two ORDER BY
+    // literals below reference it by name. Keep them all in lockstep on rename
+    // or the sort silently regresses.
+    const rows = await CalendarEntity.findAll({
+      where: { listed: true },
+      attributes: {
+        include: [
+          [
+            literal(
+              '(SELECT MAX("event"."updatedAt") FROM "event" '
+              + 'WHERE "event"."calendar_id" = "CalendarEntity"."id" '
+              + 'AND EXISTS (SELECT 1 FROM "event_schedule" '
+              + 'WHERE "event_schedule"."event_id" = "event"."id" '
+              + 'AND NOT ("event_schedule"."is_exclusion" = true '
+              + 'AND "event_schedule"."hide_from_public" = true)))',
+            ),
+            'last_event_activity',
+          ],
+        ],
+      },
+      include: [CalendarContentEntity],
+      order: [
+        // NULLS LAST: calendars with no events sort after calendars that have
+        // published activity. SQLite emits NULLs first by default; PostgreSQL
+        // emits NULLs last on DESC by default but is order-stable with the
+        // explicit clause. Using literal here keeps the ORDER BY portable.
+        [literal('last_event_activity IS NULL'), 'ASC'],
+        [literal('last_event_activity'), 'DESC'],
+      ],
+      limit: PUBLIC_DISCOVERY_LIMIT,
+      subQuery: false,
+    } as any);
+
+    return rows.map((entity) => {
+      const calendar = this.withPublicUrl(entity.toModel());
+      const rawActivity = entity.get('last_event_activity');
+      const lastEventActivity = rawActivity ? new Date(rawActivity as string | number | Date) : null;
+      return { calendar, lastEventActivity };
+    });
+  }
+
+  /**
    * List all local calendars for admin visibility.
    *
    * Returns paginated rows joined with the owner membership and account,

--- a/src/server/calendar/test/integration/list_public_calendars.test.ts
+++ b/src/server/calendar/test/integration/list_public_calendars.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Integration tests for CalendarService.listPublicCalendars (pv-u4ew.2).
+ *
+ * Covers the public-discovery query that powers the /view/ landing page:
+ *   - listed=true / listed=false filtering
+ *   - MAX(event.updatedAt) → lastEventActivity aggregate per calendar
+ *   - ORDER BY activity DESC NULLS LAST (no-event calendars sort last)
+ *   - LIMIT 500 server-side cap
+ *   - Empty state (no listed calendars)
+ *   - Events on other calendars don't influence a calendar's lastEventActivity
+ *
+ * Hits real entities through a TestEnvironment-bootstrapped SQLite database so
+ * the literal()-driven correlated subquery and NULLS LAST ordering exercise
+ * the actual SQL dialect used by the test suite.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import { EventEntity, EventScheduleEntity } from '@/server/calendar/entity/event';
+
+describe('CalendarService.listPublicCalendars (pv-u4ew.2)', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let eventBus: EventEmitter;
+  let accountService: AccountService;
+  let accountSeq = 0;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    calendarInterface = new CalendarInterface(eventBus);
+    accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  // Wipe rows between scenarios so each `it` block has a clean canvas without
+  // tearing down the schema. Order matters: child rows before parents.
+  async function resetDiscoveryFixtures(): Promise<void> {
+    await EventScheduleEntity.destroy({ where: {}, truncate: false, force: true });
+    await EventEntity.destroy({ where: {}, truncate: false, force: true });
+    await CalendarEntity.destroy({ where: {}, truncate: false, force: true });
+  }
+
+  async function makeAccount(): Promise<Account> {
+    const email = `discovery-${++accountSeq}@pavillion.dev`;
+    const info = await accountService._setupAccount(email, 'testpassword');
+    return info.account;
+  }
+
+  async function makeCalendar(urlName: string, listed: boolean): Promise<Calendar> {
+    const account = await makeAccount();
+    const calendar = await calendarInterface.createCalendar(account, urlName);
+    if (!listed) {
+      await CalendarEntity.update({ listed: false }, { where: { id: calendar.id } });
+    }
+    return calendar;
+  }
+
+  /**
+   * Creates an event with one publicly-visible (non-exclusion) schedule.
+   * The schedule row is what makes the event count toward `lastEventActivity`:
+   * the discovery query's EXISTS clause requires at least one schedule that is
+   * NOT a hidden cancellation (NOT (is_exclusion AND hide_from_public)).
+   */
+  async function createEventOnCalendar(calendarId: string, updatedAt: Date): Promise<string> {
+    const eventId = uuidv4();
+    // Construct EventEntity directly so we can pin updatedAt without going
+    // through createEvent → buildEventInstances. The discovery query joins on
+    // event.updatedAt; that's the column under test.
+    await EventEntity.create(
+      {
+        id: eventId,
+        calendar_id: calendarId,
+        createdAt: updatedAt,
+        updatedAt,
+      },
+      // Silent: silenceTimestamps so Sequelize honors the explicit timestamps
+      // rather than overwriting with NOW().
+      { silent: true } as any,
+    );
+    // Attach a non-exclusion schedule so the event is publicly visible per the
+    // canonical predicate in EventInstanceService.rrules().
+    await EventScheduleEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      is_exclusion: false,
+      hide_from_public: false,
+    });
+    return eventId;
+  }
+
+  /**
+   * Creates an event whose only schedule is a hidden cancellation
+   * (is_exclusion=true AND hide_from_public=true — EXDATE-style suppression).
+   * Per the discovery query's visibility predicate, this event must NOT
+   * contribute to the calendar's `lastEventActivity`.
+   */
+  async function createHiddenOnlyEventOnCalendar(calendarId: string, updatedAt: Date): Promise<string> {
+    const eventId = uuidv4();
+    await EventEntity.create(
+      {
+        id: eventId,
+        calendar_id: calendarId,
+        createdAt: updatedAt,
+        updatedAt,
+      },
+      { silent: true } as any,
+    );
+    await EventScheduleEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      is_exclusion: true,
+      hide_from_public: true,
+    });
+    return eventId;
+  }
+
+  describe('listed flag filtering', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('returns only listed=true calendars, excluding listed=false', async () => {
+      const listedA = await makeCalendar('listed-a', true);
+      const listedB = await makeCalendar('listed-b', true);
+      await makeCalendar('unlisted-x', false); // must NOT appear
+
+      const result = await calendarInterface.listPublicCalendars();
+
+      const urlNames = result.map(r => r.calendar.urlName).sort();
+      expect(urlNames).toEqual(['listed-a', 'listed-b']);
+
+      // Sanity: every returned calendar must satisfy listed=true.
+      expect(result.every(r => r.calendar.listed === true)).toBe(true);
+
+      // Pin the ids — guards against the listed=false row sneaking in under a
+      // future query refactor.
+      const returnedIds = new Set(result.map(r => r.calendar.id));
+      expect(returnedIds.has(listedA.id)).toBe(true);
+      expect(returnedIds.has(listedB.id)).toBe(true);
+    });
+  });
+
+  describe('sort by lastEventActivity DESC NULLS LAST', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('orders all-have-events: most-recent event activity first', async () => {
+      const oldest = await makeCalendar('sort-oldest', true);
+      const middle = await makeCalendar('sort-middle', true);
+      const newest = await makeCalendar('sort-newest', true);
+
+      // Spread updatedAt across calendars; each calendar gets the same
+      // updatedAt across its single event so MAX() collapses to that value.
+      await createEventOnCalendar(oldest.id, new Date('2024-01-01T00:00:00Z'));
+      await createEventOnCalendar(middle.id, new Date('2025-06-15T00:00:00Z'));
+      await createEventOnCalendar(newest.id, new Date('2026-04-20T00:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const urlNames = result.map(r => r.calendar.urlName);
+
+      expect(urlNames).toEqual(['sort-newest', 'sort-middle', 'sort-oldest']);
+
+      // lastEventActivity reflects MAX(event.updatedAt) per calendar.
+      expect(result[0].lastEventActivity).toEqual(new Date('2026-04-20T00:00:00Z'));
+      expect(result[1].lastEventActivity).toEqual(new Date('2025-06-15T00:00:00Z'));
+      expect(result[2].lastEventActivity).toEqual(new Date('2024-01-01T00:00:00Z'));
+    });
+  });
+
+  describe('sort when no calendar has events', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('returns all listed calendars with lastEventActivity=null', async () => {
+      await makeCalendar('none-1', true);
+      await makeCalendar('none-2', true);
+
+      const result = await calendarInterface.listPublicCalendars();
+
+      expect(result).toHaveLength(2);
+      expect(result.every(r => r.lastEventActivity === null)).toBe(true);
+    });
+  });
+
+  describe('mixed: some calendars have events, some do not', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('puts calendars-with-events before no-event calendars (NULLS LAST)', async () => {
+      const withEvents = await makeCalendar('with-events', true);
+      const noEvents1 = await makeCalendar('no-events-1', true);
+      const noEvents2 = await makeCalendar('no-events-2', true);
+
+      await createEventOnCalendar(withEvents.id, new Date('2026-03-01T00:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const urlNames = result.map(r => r.calendar.urlName);
+
+      // First slot must be the calendar with events.
+      expect(urlNames[0]).toBe('with-events');
+      expect(result[0].lastEventActivity).toEqual(new Date('2026-03-01T00:00:00Z'));
+
+      // The no-event calendars come after, both with null activity.
+      expect(urlNames.slice(1).sort()).toEqual(['no-events-1', 'no-events-2']);
+      expect(result[1].lastEventActivity).toBeNull();
+      expect(result[2].lastEventActivity).toBeNull();
+
+      // Sanity ids
+      const ids = result.map(r => r.calendar.id);
+      expect(ids).toContain(withEvents.id);
+      expect(ids).toContain(noEvents1.id);
+      expect(ids).toContain(noEvents2.id);
+    });
+  });
+
+  describe('tied timestamps', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('returns both tied calendars; sort is deterministic within the tied set', async () => {
+      const tiedA = await makeCalendar('tied-a', true);
+      const tiedB = await makeCalendar('tied-b', true);
+
+      const sameTime = new Date('2026-04-01T12:00:00Z');
+      await createEventOnCalendar(tiedA.id, sameTime);
+      await createEventOnCalendar(tiedB.id, sameTime);
+
+      const result = await calendarInterface.listPublicCalendars();
+      expect(result).toHaveLength(2);
+
+      // Both calendars present; both have the same lastEventActivity.
+      const urlNames = result.map(r => r.calendar.urlName).sort();
+      expect(urlNames).toEqual(['tied-a', 'tied-b']);
+      expect(result[0].lastEventActivity).toEqual(sameTime);
+      expect(result[1].lastEventActivity).toEqual(sameTime);
+    });
+  });
+
+  describe('lastEventActivity reflects MAX(updatedAt) per calendar', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('takes the maximum event.updatedAt across the calendar', async () => {
+      const cal = await makeCalendar('max-aggregate', true);
+
+      await createEventOnCalendar(cal.id, new Date('2024-01-01T00:00:00Z'));
+      await createEventOnCalendar(cal.id, new Date('2026-05-10T12:00:00Z')); // max
+      await createEventOnCalendar(cal.id, new Date('2025-03-15T00:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const row = result.find(r => r.calendar.urlName === 'max-aggregate');
+
+      expect(row).toBeDefined();
+      expect(row!.lastEventActivity).toEqual(new Date('2026-05-10T12:00:00Z'));
+    });
+
+    it('does NOT include events from other calendars in lastEventActivity', async () => {
+      const mine = await makeCalendar('mine', true);
+      const theirs = await makeCalendar('theirs', true);
+
+      // theirs has a very recent event; mine has an older one. The MAX for
+      // mine must NOT pick up theirs' updatedAt — the LEFT JOIN predicate
+      // scopes to event.calendar_id = calendar.id.
+      await createEventOnCalendar(mine.id, new Date('2024-01-01T00:00:00Z'));
+      await createEventOnCalendar(theirs.id, new Date('2026-06-01T00:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const mineRow = result.find(r => r.calendar.urlName === 'mine');
+      const theirsRow = result.find(r => r.calendar.urlName === 'theirs');
+
+      expect(mineRow).toBeDefined();
+      expect(theirsRow).toBeDefined();
+      expect(mineRow!.lastEventActivity).toEqual(new Date('2024-01-01T00:00:00Z'));
+      expect(theirsRow!.lastEventActivity).toEqual(new Date('2026-06-01T00:00:00Z'));
+    });
+  });
+
+  describe('lastEventActivity excludes hidden-only events', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('returns lastEventActivity=null for a calendar whose only event is hidden-cancellation-only', async () => {
+      const cal = await makeCalendar('hidden-only', true);
+
+      // Single event whose only schedule is a hidden cancellation
+      // (is_exclusion=true AND hide_from_public=true — EXDATE-style).
+      // Per the discovery query predicate, this event must NOT contribute.
+      await createHiddenOnlyEventOnCalendar(cal.id, new Date('2026-04-01T12:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const row = result.find(r => r.calendar.urlName === 'hidden-only');
+
+      expect(row).toBeDefined();
+      expect(row!.lastEventActivity).toBeNull();
+    });
+
+    it('does not let a hidden-only event inflate lastEventActivity past a visible event', async () => {
+      await resetDiscoveryFixtures();
+      const cal = await makeCalendar('mixed-visibility', true);
+
+      // Visible event with older updatedAt; the hidden-only event is newer.
+      // If the predicate were dropped, MAX() would pick up the hidden row and
+      // the calendar would sort by 2026-06-01 instead of 2024-01-01.
+      await createEventOnCalendar(cal.id, new Date('2024-01-01T00:00:00Z'));
+      await createHiddenOnlyEventOnCalendar(cal.id, new Date('2026-06-01T00:00:00Z'));
+
+      const result = await calendarInterface.listPublicCalendars();
+      const row = result.find(r => r.calendar.urlName === 'mixed-visibility');
+
+      expect(row).toBeDefined();
+      // MAX(updatedAt) reflects only the visible event, not the hidden one.
+      expect(row!.lastEventActivity).toEqual(new Date('2024-01-01T00:00:00Z'));
+    });
+  });
+
+  describe('empty result', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('returns [] when there are no listed calendars', async () => {
+      // Create only unlisted calendars; the discovery query must skip them all.
+      await makeCalendar('hidden-a', false);
+      await makeCalendar('hidden-b', false);
+
+      const result = await calendarInterface.listPublicCalendars();
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] when there are no calendars at all', async () => {
+      await resetDiscoveryFixtures();
+      const result = await calendarInterface.listPublicCalendars();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('LIMIT 500 server-side cap', () => {
+    beforeAll(async () => {
+      await resetDiscoveryFixtures();
+    });
+
+    it('caps results at 500 even when more calendars exist', async () => {
+      // Insert 501 listed calendars directly via the entity to keep the test
+      // fast. Skip CalendarMember rows — they aren't required by the
+      // discovery query (it's rooted at CalendarEntity).
+      const ids: string[] = [];
+      const rows = [];
+      for (let i = 0; i < 501; i++) {
+        const id = uuidv4();
+        ids.push(id);
+        rows.push({
+          id,
+          url_name: `bulk-${i.toString().padStart(4, '0')}`,
+          languages: 'en',
+          default_date_range: null,
+          widget_allowed_domain: null,
+          default_event_image_id: null,
+          listed: true,
+        });
+      }
+      await CalendarEntity.bulkCreate(rows);
+
+      const result = await calendarInterface.listPublicCalendars();
+
+      // Hard cap, exactly 500.
+      expect(result).toHaveLength(500);
+    }, 30000);
+  });
+});

--- a/src/server/common/middleware/rate-limiters.ts
+++ b/src/server/common/middleware/rate-limiters.ts
@@ -256,6 +256,23 @@ export const configSiteByIp: RequestHandler = isRateLimitEnabled()
   : noOpMiddleware;
 
 /**
+ * Public calendar discovery list endpoint rate limiter by IP.
+ * Limits: 60 requests per IP per minute (default config).
+ *
+ * Caps anonymous traffic to GET /api/public/v1/calendars, which is read by
+ * the /view/ discovery landing page. The limit is permissive enough for
+ * legitimate page-render and pagination traffic while preventing scrape-style
+ * abuse of the listed-calendar enumeration surface.
+ */
+export const publicCalendarListByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.publicCalendarList.byIp.max'),
+    config.get<number>('rateLimit.publicCalendarList.byIp.windowMs'),
+    'public-calendar-list',
+  )
+  : noOpMiddleware;
+
+/**
  * Public account application submission rate limiter by IP address.
  * Limits: 5 requests per IP per 15 minutes (default config).
  */

--- a/src/server/common/test/app_routes.test.ts
+++ b/src/server/common/test/app_routes.test.ts
@@ -77,6 +77,38 @@ describe('app_routes', () => {
       expect(res.body.template).toBe('site.index.html.ejs');
     });
 
+    // -------------------------------------------------------------------
+    // pv-u4ew.3 — bare /view (with or without trailing slash) must resolve
+    // to the site SPA, not the client SPA. The /view/ discovery landing
+    // page is served by the site shell; the prior regex only matched
+    // /view/.* and fell through to the client catch-all on bare /view.
+    // -------------------------------------------------------------------
+
+    it('should serve site.index.html.ejs for bare /view (no trailing slash)', async () => {
+      const app = buildTestApp('en');
+      const res = await request(app).get('/view');
+
+      expect(res.status).toBe(200);
+      expect(res.body.template).toBe('site.index.html.ejs');
+    });
+
+    it('should serve site.index.html.ejs for /view/ (trailing slash, no calendar)', async () => {
+      const app = buildTestApp('en');
+      const res = await request(app).get('/view/');
+
+      expect(res.status).toBe(200);
+      expect(res.body.template).toBe('site.index.html.ejs');
+    });
+
+    it('should NOT route bare /view through the client SPA catch-all', async () => {
+      // Regression for the prior catch-all exclusion (`view\/`) which only
+      // matched a trailing slash; bare /view leaked to the client shell.
+      const app = buildTestApp('en');
+      const res = await request(app).get('/view');
+
+      expect(res.body.template).not.toBe('client.index.html.ejs');
+    });
+
     it('should serve site.index.html.ejs for /view/calendar/event/123', async () => {
       const app = buildTestApp('en');
       const res = await request(app).get('/view/mycalendar/event/123');
@@ -138,6 +170,30 @@ describe('app_routes', () => {
       const mockConfig = buildMockConfigInterface('en');
       const app = buildTestApp('es', mockConfig);
       const res = await request(app).get('/es/view/mycalendar');
+
+      expect(res.status).toBe(200);
+      expect(res.body.template).toBe('site.index.html.ejs');
+    });
+
+    // -------------------------------------------------------------------
+    // pv-u4ew.3 — bare /[locale]/view (with or without trailing slash)
+    // must also resolve to the site SPA so the discovery landing page is
+    // reachable under a locale prefix.
+    // -------------------------------------------------------------------
+
+    it('should serve site.index.html.ejs for bare /es/view (no trailing slash) when es is not default', async () => {
+      const mockConfig = buildMockConfigInterface('en');
+      const app = buildTestApp('es', mockConfig);
+      const res = await request(app).get('/es/view');
+
+      expect(res.status).toBe(200);
+      expect(res.body.template).toBe('site.index.html.ejs');
+    });
+
+    it('should serve site.index.html.ejs for /es/view/ (trailing slash) when es is not default', async () => {
+      const mockConfig = buildMockConfigInterface('en');
+      const app = buildTestApp('es', mockConfig);
+      const res = await request(app).get('/es/view/');
 
       expect(res.status).toBe(200);
       expect(res.body.template).toBe('site.index.html.ejs');

--- a/src/server/common/test/migrations/migration_0033_add_listed_to_calendar.test.ts
+++ b/src/server/common/test/migrations/migration_0033_add_listed_to_calendar.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Sequelize, DataTypes, QueryTypes } from 'sequelize';
+import migration from '../../../../../migrations/0033_add_listed_to_calendar';
+
+/**
+ * Migration 0033 adds `listed BOOLEAN NOT NULL DEFAULT true` to the calendar
+ * table. Two semantic guarantees the downstream public-discovery work in
+ * pv-u4ew depends on:
+ *
+ *   1. New rows inserted without an explicit `listed` value pick up the
+ *      DEFAULT true automatically — public discovery's safe default is "show
+ *      every newly-created calendar unless the owner opts out."
+ *   2. Pre-existing rows that were written before the column existed
+ *      backfill to true when the column is added. Otherwise a deployment
+ *      would silently unlist every calendar on the instance.
+ *
+ * Both assertions exercise behavior that the entity/model round-trip test
+ * cannot reach (the model layer never sees the DB-level DEFAULT or the
+ * backfill path).
+ */
+describe('Migration 0033: add listed to calendar', () => {
+  let sequelize: Sequelize;
+
+  beforeEach(async () => {
+    sequelize = new Sequelize({
+      dialect: 'sqlite',
+      storage: ':memory:',
+      logging: false,
+    });
+
+    // Minimal calendar table mirroring the pre-0033 production schema. We
+    // only need columns relevant to inserting rows; the migration's only
+    // job is to add the `listed` column.
+    await sequelize.getQueryInterface().createTable('calendar', {
+      id: { type: DataTypes.UUID, primaryKey: true, allowNull: false },
+      url_name: { type: DataTypes.STRING, allowNull: false },
+      languages: { type: DataTypes.STRING, allowNull: true },
+      default_date_range: { type: DataTypes.STRING, allowNull: true },
+      widget_allowed_domain: { type: DataTypes.STRING, allowNull: true },
+      default_event_image_id: { type: DataTypes.UUID, allowNull: true },
+      createdAt: { type: DataTypes.DATE, allowNull: false },
+      updatedAt: { type: DataTypes.DATE, allowNull: false },
+    });
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  async function insertCalendar(row: {
+    id: string;
+    url_name: string;
+  }) {
+    const now = new Date().toISOString();
+    await sequelize.query(
+      `INSERT INTO calendar (id, url_name, "createdAt", "updatedAt")
+       VALUES (:id, :url_name, :now, :now)`,
+      {
+        replacements: { id: row.id, url_name: row.url_name, now },
+        type: QueryTypes.INSERT,
+      },
+    );
+  }
+
+  async function selectListed(id: string): Promise<unknown> {
+    const [row] = await sequelize.query(
+      'SELECT listed FROM calendar WHERE id = :id',
+      {
+        replacements: { id },
+        type: QueryTypes.SELECT,
+      },
+    ) as Array<{ listed: unknown }>;
+    return row?.listed;
+  }
+
+  it('backfills `listed` to true on pre-existing rows', async () => {
+    // Seed two rows before the column exists — these represent the rows
+    // already in production at deploy time. They must all become listed=true
+    // when the migration runs; otherwise a deploy silently unlists every
+    // calendar on the instance.
+    await insertCalendar({
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1',
+      url_name: 'preexisting-one',
+    });
+    await insertCalendar({
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2',
+      url_name: 'preexisting-two',
+    });
+
+    await migration.up({ context: sequelize });
+
+    expect(
+      Boolean(await selectListed('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1')),
+    ).toBe(true);
+    expect(
+      Boolean(await selectListed('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2')),
+    ).toBe(true);
+  });
+
+  it('applies DEFAULT true to rows inserted without an explicit `listed`', async () => {
+    await migration.up({ context: sequelize });
+
+    // Post-migration insert that omits `listed` entirely. The DB-level
+    // DEFAULT must populate it as true so callers (e.g. the calendar
+    // service creating a new calendar) do not have to thread the value
+    // through every insert site.
+    const now = new Date().toISOString();
+    await sequelize.query(
+      `INSERT INTO calendar (id, url_name, "createdAt", "updatedAt")
+       VALUES (:id, :url_name, :now, :now)`,
+      {
+        replacements: {
+          id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          url_name: 'post-migration-default',
+          now,
+        },
+        type: QueryTypes.INSERT,
+      },
+    );
+
+    expect(
+      Boolean(await selectListed('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')),
+    ).toBe(true);
+  });
+
+  it('down removes the `listed` column', async () => {
+    await migration.up({ context: sequelize });
+
+    const afterUp = await sequelize.getQueryInterface().describeTable('calendar');
+    expect('listed' in afterUp).toBe(true);
+
+    await migration.down({ context: sequelize });
+
+    const afterDown = await sequelize.getQueryInterface().describeTable('calendar');
+    expect('listed' in afterDown).toBe(false);
+  });
+
+  it('is idempotent on a second up run', async () => {
+    await migration.up({ context: sequelize });
+    await migration.up({ context: sequelize });
+
+    const desc = await sequelize.getQueryInterface().describeTable('calendar');
+    expect('listed' in desc).toBe(true);
+  });
+});

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -7,21 +7,35 @@ import { CalendarEventSchedule } from '@/common/model/events';
 import CalendarEventInstance from '@/common/model/event_instance';
 import { getRecurrenceSummary } from '@/common/utils/recurrence-text';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
-import { publicEventInstanceByIp } from '@/server/common/middleware/rate-limiters';
+import { publicEventInstanceByIp, publicCalendarListByIp } from '@/server/common/middleware/rate-limiters';
 import ExpressHelper from '@/server/common/helper/express';
 
 /**
- * Strips sensitive fields from a defaultEventImage object for public responses.
- * Only id and mimeType are exposed; internal fields like originalFilename,
- * fileSize, status, sha256, calendarId, and storageFilename are removed.
+ * Shapes a Calendar.toObject() result for public responses.
+ *
+ * Responsibilities:
+ *   - Strips internal fields not intended for anonymous public consumers.
+ *     Currently drops `listed` (an admin-discovery flag — knowing whether
+ *     a calendar is hidden from the /view/ index is not the public's
+ *     business; the calendar is reachable by direct URL regardless).
+ *   - Projects `defaultEventImage` to `{ id, mimeType }` only — internal
+ *     fields like originalFilename, fileSize, status, sha256, calendarId,
+ *     and storageFilename are removed.
+ *
+ * Allow-list / strip-by-name posture matches the toPublicEventObject helper
+ * below so future additions to Calendar.toObject() do not silently leak
+ * through this surface.
  */
-function stripDefaultEventImage(calendarObj: Record<string, any>): Record<string, any> {
-  if (!calendarObj.defaultEventImage) return calendarObj;
+function toPublicCalendarObject(calendarObj: Record<string, any>): Record<string, any> {
+  // Drop `listed` (admin-discovery flag) via destructure-and-discard; the
+  // ESLint config treats leading-underscore names as intentionally unused.
+  const { listed: _listed, ...rest } = calendarObj; // eslint-disable-line @typescript-eslint/no-unused-vars
+  if (!rest.defaultEventImage) return rest;
   return {
-    ...calendarObj,
+    ...rest,
     defaultEventImage: {
-      id: calendarObj.defaultEventImage.id,
-      mimeType: calendarObj.defaultEventImage.mimeType,
+      id: rest.defaultEventImage.id,
+      mimeType: rest.defaultEventImage.mimeType,
     },
   };
 }
@@ -155,6 +169,7 @@ export default class CalendarRoutes {
 
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
+    router.get('/calendars', publicCalendarListByIp, this.listPublicCalendars.bind(this));
     router.get('/calendar/:urlName', this.getCalendar.bind(this));
     router.get('/calendar/:urlName/categories', this.listCategories.bind(this));
     router.get('/calendar/:urlName/series', this.listSeries.bind(this));
@@ -169,12 +184,61 @@ export default class CalendarRoutes {
     app.use(routePrefix, router);
   }
 
+  /**
+   * GET /api/public/v1/calendars — list listed calendars for the /view/
+   * discovery landing page.
+   *
+   * Returns a bare array of `{ id, urlName, content[], lastEventActivity }`
+   * built field-by-field via an explicit allow-list projection. This is
+   * deliberately NOT `Calendar.toObject()` passthrough — `toObject()`
+   * exposes `widgetAllowedDomain`, `publicUrl`, `defaultEventImage`,
+   * `defaultEventImageId`, `languages`, `defaultDateRange`, and `listed`,
+   * none of which the discovery surface needs and several of which leak
+   * server/operator-internal configuration. Future additions to
+   * `Calendar.toObject()` must NOT silently appear here.
+   *
+   * Response shape per row:
+   *   - id: string (UUID)
+   *   - urlName: string
+   *   - content: Array<{ language, name, description }>
+   *   - lastEventActivity: ISO 8601 string | null
+   *
+   * No success-path logging (privacy/logging standard). Error path uses
+   * logError so operational signal is preserved without leaking PII into
+   * the success log stream.
+   */
+  async listPublicCalendars(req: Request, res: Response) {
+    try {
+      const rows = await this.service.listPublicCalendars();
+      const body = rows.map(({ calendar, lastEventActivity }) => ({
+        id: calendar.id,
+        urlName: calendar.urlName,
+        content: calendar.getLanguages().map((language) => {
+          const c = calendar.content(language);
+          return {
+            language: c.language,
+            name: c.name,
+            description: c.description,
+          };
+        }),
+        lastEventActivity: lastEventActivity ? lastEventActivity.toISOString() : null,
+      }));
+      res.json(body);
+    }
+    catch (error) {
+      logError(error, 'Error in listPublicCalendars');
+      res.status(500).json({
+        "error": "Failed to retrieve calendars",
+      });
+    }
+  }
+
   async getCalendar(req: Request, res: Response) {
 
     const calendar = await this.service.getCalendarByName(req.params.urlName);
     if (calendar) {
       const calendarObj = calendar.toObject();
-      res.json(stripDefaultEventImage(calendarObj));
+      res.json(toPublicCalendarObject(calendarObj));
     }
     else {
       res.status(404).json({

--- a/src/server/public/interface/index.ts
+++ b/src/server/public/interface/index.ts
@@ -30,6 +30,20 @@ export default class PublicCalendarInterface {
     return this.calendarInterface.getCalendarByName(name);
   }
 
+  /**
+   * List public-discoverable calendars for the /view/ discovery page.
+   * Proxies directly to the calendar-domain interface (cross-domain call;
+   * Public never touches Calendar entities directly per DEC-003). No
+   * intermediate service hop — this is a pure facade. Matches the
+   * getCalendarByName pattern above.
+   *
+   * @returns Calendars + lastEventActivity tuples, sorted activity-descending,
+   *   capped at 500 rows server-side
+   */
+  async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
+    return this.calendarInterface.listPublicCalendars();
+  }
+
   async listEventInstances(calendar: Calendar): Promise<CalendarEventInstance[]> {
     return this.publicCalendarService.listEventInstances(calendar);
   }

--- a/src/server/public/test/calendars-api.test.ts
+++ b/src/server/public/test/calendars-api.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import sinon from 'sinon';
+import request from 'supertest';
+import express from 'express';
+import { EventEmitter } from 'events';
+
+import { Calendar, CalendarContent } from '@/common/model/calendar';
+import { Media } from '@/common/model/media';
+import { testApp } from '@/server/common/test/lib/express';
+import CalendarRoutes from '@/server/public/api/v1/calendar';
+import PublicCalendarInterface from '@/server/public/interface';
+import CalendarInterface from '@/server/calendar/interface';
+
+/**
+ * Integration tests for GET /api/public/v1/calendars (pv-u4ew.3).
+ *
+ * Exercises the discovery-page list endpoint end-to-end: route registration,
+ * the allow-list projection, the rate limiter wiring, anonymous-cookie
+ * hygiene, and the error path.
+ *
+ * The integration also covers the cross-bead requirement from pv-u4ew.1's
+ * privacy-audit cross-bead note: GET /api/public/v1/calendar/:urlName must
+ * NOT expose the `listed` flag now that `Calendar.toObject()` includes it.
+ */
+describe('Public Calendars Discovery API (pv-u4ew.3)', () => {
+  let routes: CalendarRoutes;
+  let publicInterface: PublicCalendarInterface;
+  let calendarInterface: CalendarInterface;
+  let apiSandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    apiSandbox = sinon.createSandbox();
+    calendarInterface = new CalendarInterface(new EventEmitter());
+    publicInterface = new PublicCalendarInterface(new EventEmitter(), calendarInterface);
+    routes = new CalendarRoutes(publicInterface);
+  });
+
+  afterEach(() => {
+    apiSandbox.restore();
+  });
+
+  /**
+   * Mounts the full route surface via installHandlers so the route, rate
+   * limiter middleware, and handler binding are exercised together — not just
+   * the handler in isolation.
+   */
+  function buildApp(): express.Application {
+    const app = express();
+    app.use(express.json());
+    routes.installHandlers(app, '/api/public/v1');
+    return app;
+  }
+
+  /**
+   * Builds a Calendar model populated with internal fields the allow-list
+   * projection must drop. Each field is set with a sentinel value so the
+   * negative-field assertions can verify the projection is intentional, not
+   * accidentally missing because the source field happened to be falsy.
+   */
+  function buildLeakyCalendar(id: string, urlName: string): Calendar {
+    const calendar = new Calendar(id, urlName);
+    calendar.publicUrl = 'https://example.com/should-not-leak';
+    calendar.languages = ['en', 'es'];
+    calendar.description = 'internal description should not appear in list payload';
+    calendar.defaultDateRange = '1month';
+    calendar.widgetAllowedDomain = 'widget.example.com';
+    calendar.defaultEventImageId = 'media-id-should-not-leak';
+    calendar.defaultEventImage = new Media(
+      'media-id-should-not-leak',
+      id,
+      'sha256-should-not-leak',
+      'photo.jpg',
+      'image/jpeg',
+      12345,
+      'approved',
+    );
+    calendar.listed = true;
+    calendar.addContent(new CalendarContent('en', 'English Name', 'English description'));
+    calendar.addContent(new CalendarContent('es', 'Nombre Español', 'Descripción en español'));
+    return calendar;
+  }
+
+  describe('GET /api/public/v1/calendars - positive response shape', () => {
+    it('returns a bare array of allow-listed calendar rows', async () => {
+      const cal1 = buildLeakyCalendar('cal-1', 'alpha');
+      const cal2 = buildLeakyCalendar('cal-2', 'beta');
+
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([
+        { calendar: cal1, lastEventActivity: new Date('2026-05-01T12:00:00Z') },
+        { calendar: cal2, lastEventActivity: null },
+      ]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(2);
+    });
+
+    it('exposes id, urlName, content[], and lastEventActivity per row', async () => {
+      const cal = buildLeakyCalendar('cal-1', 'alpha');
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([
+        { calendar: cal, lastEventActivity: new Date('2026-05-01T12:00:00Z') },
+      ]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      expect(response.status).toBe(200);
+      const row = response.body[0];
+      expect(row.id).toBe('cal-1');
+      expect(row.urlName).toBe('alpha');
+      expect(Array.isArray(row.content)).toBe(true);
+      // Content rows project to { language, name, description } only.
+      const en = row.content.find((c: any) => c.language === 'en');
+      const es = row.content.find((c: any) => c.language === 'es');
+      expect(en).toEqual({ language: 'en', name: 'English Name', description: 'English description' });
+      expect(es).toEqual({ language: 'es', name: 'Nombre Español', description: 'Descripción en español' });
+      // lastEventActivity is serialized to ISO 8601 UTC.
+      expect(row.lastEventActivity).toBe('2026-05-01T12:00:00.000Z');
+    });
+
+    it('serializes lastEventActivity=null when the calendar has no public activity', async () => {
+      const cal = buildLeakyCalendar('cal-1', 'alpha');
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([
+        { calendar: cal, lastEventActivity: null },
+      ]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      expect(response.status).toBe(200);
+      expect(response.body[0].lastEventActivity).toBeNull();
+    });
+
+    it('returns an empty array when there are no listed calendars', async () => {
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+  });
+
+  describe('GET /api/public/v1/calendars - allow-list projection (enumerated negative fields)', () => {
+    /**
+     * Per privacy/api-responses, the discovery list must use an allow-list
+     * projection — NOT a toObject() passthrough. Each negative-field assertion
+     * is enumerated individually so a future toObject() addition is caught
+     * field-by-field, not swallowed by a single broad `expect.objectContaining`.
+     */
+    let row: any;
+
+    beforeEach(async () => {
+      const cal = buildLeakyCalendar('cal-1', 'alpha');
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([
+        { calendar: cal, lastEventActivity: new Date('2026-05-01T12:00:00Z') },
+      ]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+      row = response.body[0];
+    });
+
+    it('does NOT include widgetAllowedDomain', () => {
+      expect(row.widgetAllowedDomain).toBeUndefined();
+    });
+
+    it('does NOT include defaultEventImageId', () => {
+      expect(row.defaultEventImageId).toBeUndefined();
+    });
+
+    it('does NOT include defaultEventImage', () => {
+      expect(row.defaultEventImage).toBeUndefined();
+    });
+
+    it('does NOT include publicUrl', () => {
+      expect(row.publicUrl).toBeUndefined();
+    });
+
+    it('does NOT include languages', () => {
+      expect(row.languages).toBeUndefined();
+    });
+
+    it('does NOT include defaultDateRange', () => {
+      expect(row.defaultDateRange).toBeUndefined();
+    });
+
+    it('does NOT include listed', () => {
+      expect(row.listed).toBeUndefined();
+    });
+
+    it('does NOT include owner / account info', () => {
+      expect(row.account).toBeUndefined();
+      expect(row.accountId).toBeUndefined();
+      expect(row.owner).toBeUndefined();
+      expect(row.ownerId).toBeUndefined();
+    });
+
+    it('does NOT include internal createdAt / updatedAt timestamps', () => {
+      expect(row.createdAt).toBeUndefined();
+      expect(row.updatedAt).toBeUndefined();
+    });
+
+    it('does NOT include top-level description (only per-language description survives)', () => {
+      // The Calendar model carries a top-level `description` separate from the
+      // per-language content.description. The allow-list projection drops the
+      // top-level field; per-language descriptions arrive inside content[].
+      expect(row.description).toBeUndefined();
+    });
+  });
+
+  describe('GET /api/public/v1/calendars - cookie hygiene (anonymous visitor)', () => {
+    it('does not set any Set-Cookie header for an anonymous visitor', async () => {
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.resolves([]);
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      // express-rate-limit and the handler should never call res.cookie for
+      // this endpoint; assert there is no Set-Cookie header at all.
+      expect(response.headers['set-cookie']).toBeUndefined();
+    });
+  });
+
+  describe('GET /api/public/v1/calendars - rate limiter wired', () => {
+    it('registers a middleware ahead of the handler on the /calendars route', () => {
+      // In the test environment `rateLimit.enabled = false` swaps the
+      // publicCalendarListByIp limiter for a no-op middleware (see
+      // config/test.yaml), so we cannot assert on RateLimit-* response
+      // headers. Instead, assert the route has TWO handlers: the rate
+      // limiter (or its no-op stand-in) wired ahead of the bound
+      // listPublicCalendars handler. A regression that drops the middleware
+      // would leave a single-handler stack on this route.
+      const app = buildApp();
+      const router = (app._router || (app as any)._router) as any;
+      // Walk the mounted /api/public/v1 sub-router for the /calendars GET route.
+      let stack: any[] | null = null;
+      for (const layer of router.stack || []) {
+        if (layer.name === 'router' && layer.handle && layer.handle.stack) {
+          for (const inner of layer.handle.stack) {
+            if (
+              inner.route
+              && inner.route.path === '/calendars'
+              && inner.route.methods?.get
+            ) {
+              stack = inner.route.stack;
+            }
+          }
+        }
+      }
+      expect(stack).not.toBeNull();
+      // Two handlers: rate limiter middleware + the listPublicCalendars handler.
+      expect(stack!.length).toBe(2);
+    });
+  });
+
+  describe('GET /api/public/v1/calendars - error path', () => {
+    it('returns 500 with a generic error body when the service throws', async () => {
+      const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
+      listStub.rejects(new Error('database boom'));
+
+      const response = await request(buildApp()).get('/api/public/v1/calendars');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe('Failed to retrieve calendars');
+      // Error path MUST NOT leak the underlying error message to anonymous
+      // callers — generic message only.
+      expect(JSON.stringify(response.body)).not.toContain('database boom');
+    });
+  });
+});
+
+/**
+ * Cross-bead regression from pv-u4ew.1 privacy-audit note: the existing
+ * single-calendar endpoint GET /api/public/v1/calendar/:urlName must NOT
+ * expose the `listed` flag now that Calendar.toObject() includes it.
+ */
+describe('Public Calendar API - listed field NOT exposed on single-calendar endpoint (pv-u4ew.1 audit)', () => {
+  let routes: CalendarRoutes;
+  let router: express.Router;
+  let publicInterface: PublicCalendarInterface;
+  let calendarInterface: CalendarInterface;
+  let apiSandbox: sinon.SinonSandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    calendarInterface = new CalendarInterface(new EventEmitter());
+    publicInterface = new PublicCalendarInterface(new EventEmitter(), calendarInterface);
+    routes = new CalendarRoutes(publicInterface);
+    router = express.Router();
+  });
+
+  afterEach(() => {
+    apiSandbox.restore();
+  });
+
+  it('strips listed=true from GET /calendar/:urlName response', async () => {
+    const calendar = new Calendar('cal-id', 'test-calendar');
+    calendar.listed = true;
+
+    const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
+    calendarStub.resolves(calendar);
+
+    router.get('/handler', (req, res) => {
+      req.params.urlName = 'test-calendar';
+      routes.getCalendar(req, res);
+    });
+
+    const response = await request(testApp(router)).get('/handler');
+
+    expect(response.status).toBe(200);
+    expect(response.body.listed).toBeUndefined();
+  });
+
+  it('strips listed=false from GET /calendar/:urlName response', async () => {
+    // An unlisted calendar reachable by direct URL must not advertise its
+    // hidden-from-discovery status to anonymous visitors.
+    const calendar = new Calendar('cal-id', 'test-calendar');
+    calendar.listed = false;
+
+    const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
+    calendarStub.resolves(calendar);
+
+    router.get('/handler', (req, res) => {
+      req.params.urlName = 'test-calendar';
+      routes.getCalendar(req, res);
+    });
+
+    const response = await request(testApp(router)).get('/handler');
+
+    expect(response.status).toBe(200);
+    expect(response.body.listed).toBeUndefined();
+  });
+});

--- a/src/site/app.ts
+++ b/src/site/app.ts
@@ -11,6 +11,7 @@ import CalendarView from '@/site/components/calendar.vue';
 import EventView from '@/site/components/event.vue';
 import EventInstanceView from '@/site/components/event-instance.vue';
 import SeriesView from '@/site/components/series-view.vue';
+import Discovery from '@/site/components/discovery.vue';
 import Authentication from '@/client/service/authn';
 import Config from '@/client/service/config';
 import { AVAILABLE_LANGUAGES, DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
@@ -25,6 +26,7 @@ Config.init().then( async (config) => {
   const authentication = new Authentication(localStorage);
 
   const routes: RouteRecordRaw[] = [
+    { path: '/view', component: Discovery, name: 'discovery' },
     { path: '/view/:calendar', component: CalendarView, name: 'calendar' },
     { path: '/view/:calendar/events/:event', component: EventView, name: 'event' },
     { path: '/view/:calendar/events/:event/:startTime(\\d{8}-\\d{4})', component: EventInstanceView, name: 'instance' },
@@ -40,6 +42,7 @@ Config.init().then( async (config) => {
     // Locale-prefixed variants — unnamed intentionally.
     // Navigation uses the default-locale named routes; useLocale.localizedPath() adds the prefix.
     routes.push(
+      { path: `/:locale(${pattern})/view`, component: Discovery },
       { path: `/:locale(${pattern})/view/:calendar`, component: CalendarView },
       { path: `/:locale(${pattern})/view/:calendar/events/:event`, component: EventView },
       { path: `/:locale(${pattern})/view/:calendar/events/:event/:startTime(\\d{8}-\\d{4})`, component: EventInstanceView },

--- a/src/site/components/discovery.vue
+++ b/src/site/components/discovery.vue
@@ -1,0 +1,363 @@
+<script setup lang="ts">
+import { ref, computed, inject, onBeforeMount, watch } from 'vue';
+import { useTranslation } from 'i18next-vue';
+import type Config from '@/client/service/config';
+
+import CalendarService, { type PublicCalendarListing } from '../service/calendar';
+import { useLocale } from '../composables/useLocale';
+import { useLocalizedContent } from '../composables/useLocalizedContent';
+import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
+
+const { t } = useTranslation('system');
+const { currentLocale, localizedPath } = useLocale();
+const { localizedContent } = useLocalizedContent();
+const siteConfig = inject<Config>('site_config');
+
+const calendarService = new CalendarService();
+
+type LoadState = 'loading' | 'populated' | 'empty' | 'error';
+
+const state = ref<LoadState>('loading');
+const calendars = ref<PublicCalendarListing[]>([]);
+
+/**
+ * Localized instance description, picked from the site config's
+ * instanceDescription (a Record<lang, string>) by visitor locale with fallback
+ * to the default language. Returns an empty string when no description is
+ * configured for any locale so the header collapses cleanly.
+ */
+const instanceDescription = computed<string>(() => {
+  const settings = siteConfig?.settings?.();
+  const map = settings?.instanceDescription;
+  if (!map || typeof map !== 'object') return '';
+  const locale = currentLocale.value;
+  if (map[locale] && map[locale].length > 0) {
+    return map[locale];
+  }
+  if (locale !== DEFAULT_LANGUAGE_CODE && map[DEFAULT_LANGUAGE_CODE]) {
+    return map[DEFAULT_LANGUAGE_CODE];
+  }
+  return '';
+});
+
+/**
+ * Build the calendar detail path for a tile, locale-prefixed when the visitor
+ * is on a non-default-locale URL so links remain inside the visitor's locale.
+ */
+function calendarPath(urlName: string): string {
+  return localizedPath(`/view/${urlName}`);
+}
+
+function tileName(listing: PublicCalendarListing): string {
+  const content = localizedContent(listing.calendar);
+  return content?.name || listing.calendar.urlName;
+}
+
+function tileDescription(listing: PublicCalendarListing): string {
+  const content = localizedContent(listing.calendar);
+  return content?.description || '';
+}
+
+/**
+ * Sets <title> and <meta name="description"> for the discovery page.
+ *
+ * Mirrors the document.title pattern already used by calendar.vue / event.vue
+ * and additionally manages a meta description tag (created if absent) for SEO
+ * on this anonymous discovery surface.
+ */
+function applyHead() {
+  const title = `${t('discovery.page_title')} | Pavillion`;
+  document.title = title;
+  const description = t('discovery.meta_description');
+  let meta = document.head.querySelector('meta[name="description"]') as HTMLMetaElement | null;
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'description');
+    document.head.appendChild(meta);
+  }
+  meta.setAttribute('content', description);
+}
+
+// Re-apply head when locale changes so translated title/description follow
+// the visitor's language without a full page reload.
+watch(currentLocale, () => {
+  applyHead();
+});
+
+onBeforeMount(async () => {
+  // Apply head metadata on mount. We intentionally don't clear the meta
+  // description on unmount: the next route's onBeforeMount will overwrite it,
+  // and clearing here would briefly drop SEO context during navigation.
+  applyHead();
+  try {
+    const listings = await calendarService.listPublicCalendars();
+    calendars.value = listings;
+    state.value = listings.length === 0 ? 'empty' : 'populated';
+  }
+  catch (error) {
+    console.error('Error loading discovery list:', error);
+    state.value = 'error';
+  }
+});
+</script>
+
+<template>
+  <main class="discovery">
+    <header class="discovery-header">
+      <div class="discovery-header-inner">
+        <h1 class="discovery-title">{{ t('discovery.page_title') }}</h1>
+        <p
+          v-if="instanceDescription"
+          class="discovery-instance-description"
+        >
+          {{ instanceDescription }}
+        </p>
+      </div>
+    </header>
+
+    <section class="discovery-main">
+      <div
+        v-if="state === 'loading'"
+        role="status"
+        class="discovery-loading"
+      >
+        {{ t('discovery.loading_label') }}
+      </div>
+
+      <div
+        v-else-if="state === 'error'"
+        role="alert"
+        class="discovery-error"
+      >
+        {{ t('discovery.error_message') }}
+      </div>
+
+      <div
+        v-else-if="state === 'empty'"
+        class="discovery-empty"
+      >
+        <h2 class="discovery-empty-heading">{{ t('discovery.empty_state_heading') }}</h2>
+        <p class="discovery-empty-body">{{ t('discovery.empty_state_body') }}</p>
+      </div>
+
+      <ul
+        v-else
+        role="list"
+        class="discovery-list"
+      >
+        <li
+          v-for="listing in calendars"
+          :key="listing.calendar.id"
+          class="discovery-list-item"
+        >
+          <RouterLink
+            :to="calendarPath(listing.calendar.urlName)"
+            class="discovery-tile"
+          >
+            <h2 class="discovery-tile-title">{{ tileName(listing) }}</h2>
+            <p
+              v-if="tileDescription(listing)"
+              class="discovery-tile-description"
+            >
+              {{ tileDescription(listing) }}
+            </p>
+          </RouterLink>
+        </li>
+      </ul>
+    </section>
+  </main>
+</template>
+
+<style scoped lang="scss">
+@use '../assets/mixins' as *;
+
+.discovery {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 100%;
+}
+
+// ================================================================
+// HEADER
+// ================================================================
+
+.discovery-header {
+  margin-bottom: $public-space-xl;
+}
+
+.discovery-header-inner {
+  @include public-container-constrained;
+
+  padding-top: $public-space-2xl;
+  padding-bottom: $public-space-xl;
+
+  @include public-tablet-up {
+    padding-top: $public-space-3xl;
+    padding-bottom: $public-space-2xl;
+  }
+}
+
+.discovery-title {
+  font-size: $public-font-size-2xl;
+  font-weight: $public-font-weight-bold;
+  letter-spacing: $public-letter-spacing-tight;
+  line-height: $public-line-height-tight;
+  margin: 0 0 $public-space-sm 0;
+  color: $public-text-primary-light;
+
+  @include public-tablet-up {
+    font-size: 2.25rem;
+  }
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+.discovery-instance-description {
+  font-size: $public-font-size-md;
+  color: $public-text-secondary-light;
+  margin: 0;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+// ================================================================
+// MAIN / LIST
+// ================================================================
+
+.discovery-main {
+  @include public-container-constrained;
+
+  padding-top: $public-space-xl;
+  padding-bottom: $public-space-2xl;
+
+  @include public-tablet-up {
+    padding-top: $public-space-2xl;
+    padding-bottom: $public-space-3xl;
+  }
+}
+
+.discovery-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $public-space-lg;
+
+  @include public-tablet-up {
+    grid-template-columns: repeat(2, 1fr);
+    gap: $public-space-xl;
+  }
+
+  @include public-desktop-up {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.discovery-list-item {
+  // Grid handles spacing; nothing to do at the row level.
+}
+
+.discovery-tile {
+  display: flex;
+  flex-direction: column;
+  padding: $public-space-xl;
+  background: $public-bg-primary-light;
+  border: 1px solid $public-border-subtle-light;
+  border-radius: $public-radius-lg;
+  text-decoration: none;
+  color: inherit;
+  transition: $public-transition-normal;
+  height: 100%;
+
+  &:hover {
+    transform: translateY(-2px);
+    border-color: $public-border-medium-light;
+    box-shadow: $public-shadow-md-light;
+  }
+
+  &:focus-visible {
+    @include public-focus-visible;
+  }
+
+  @include public-dark-mode {
+    background: $public-bg-primary-dark;
+    border-color: $public-border-subtle-dark;
+
+    &:hover {
+      border-color: $public-border-medium-dark;
+      box-shadow: $public-shadow-md-dark;
+    }
+  }
+}
+
+.discovery-tile-title {
+  font-size: $public-font-size-lg;
+  font-weight: $public-font-weight-semibold;
+  line-height: $public-line-height-tight;
+  letter-spacing: $public-letter-spacing-tight;
+  margin: 0 0 $public-space-sm 0;
+  color: $public-text-primary-light;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+.discovery-tile-description {
+  font-size: $public-font-size-base;
+  color: $public-text-secondary-light;
+  line-height: $public-line-height-normal;
+  margin: 0;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+
+// ================================================================
+// STATES
+// ================================================================
+
+.discovery-loading {
+  @include public-loading-state;
+}
+
+.discovery-error {
+  @include public-error-state;
+
+  margin: $public-space-md 0;
+}
+
+.discovery-empty {
+  @include public-empty-state;
+}
+
+.discovery-empty-heading {
+  font-size: $public-font-size-lg;
+  font-weight: $public-font-weight-semibold;
+  margin: 0 0 $public-space-sm 0;
+  color: $public-text-primary-light;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
+  }
+}
+
+.discovery-empty-body {
+  font-size: $public-font-size-base;
+  color: $public-text-secondary-light;
+  margin: 0;
+  line-height: $public-line-height-relaxed;
+
+  @include public-dark-mode {
+    color: $public-text-secondary-dark;
+  }
+}
+</style>

--- a/src/site/components/discovery.vue
+++ b/src/site/components/discovery.vue
@@ -20,6 +20,13 @@ type LoadState = 'loading' | 'populated' | 'empty' | 'error';
 const state = ref<LoadState>('loading');
 const calendars = ref<PublicCalendarListing[]>([]);
 
+const PAVILLION_URL = 'https://pavillion.social';
+
+const siteTitle = computed<string>(() => {
+  const title = siteConfig?.settings?.()?.siteTitle;
+  return typeof title === 'string' && title.length > 0 ? title : 'Pavillion';
+});
+
 /**
  * Localized instance description, picked from the site config's
  * instanceDescription (a Record<lang, string>) by visitor locale with fallback
@@ -66,7 +73,7 @@ function tileDescription(listing: PublicCalendarListing): string {
  * on this anonymous discovery surface.
  */
 function applyHead() {
-  const title = `${t('discovery.page_title')} | Pavillion`;
+  const title = `${t('discovery.page_title')} | ${siteTitle.value}`;
   document.title = title;
   const description = t('discovery.meta_description');
   let meta = document.head.querySelector('meta[name="description"]') as HTMLMetaElement | null;
@@ -105,17 +112,28 @@ onBeforeMount(async () => {
   <main class="discovery">
     <header class="discovery-header">
       <div class="discovery-header-inner">
-        <h1 class="discovery-title">{{ t('discovery.page_title') }}</h1>
+        <h1 class="discovery-title">{{ siteTitle }}</h1>
         <p
           v-if="instanceDescription"
           class="discovery-instance-description"
         >
           {{ instanceDescription }}
         </p>
+        <p class="discovery-learn-more">
+          <a
+            :href="PAVILLION_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ t('discovery.learn_more') }}
+          </a>
+        </p>
       </div>
     </header>
 
     <section class="discovery-main">
+      <h2 class="discovery-subheading">{{ t('discovery.page_title') }}</h2>
+
       <div
         v-if="state === 'loading'"
         role="status"
@@ -136,7 +154,7 @@ onBeforeMount(async () => {
         v-else-if="state === 'empty'"
         class="discovery-empty"
       >
-        <h2 class="discovery-empty-heading">{{ t('discovery.empty_state_heading') }}</h2>
+        <h3 class="discovery-empty-heading">{{ t('discovery.empty_state_heading') }}</h3>
         <p class="discovery-empty-body">{{ t('discovery.empty_state_body') }}</p>
       </div>
 
@@ -154,7 +172,7 @@ onBeforeMount(async () => {
             :to="calendarPath(listing.calendar.urlName)"
             class="discovery-tile"
           >
-            <h2 class="discovery-tile-title">{{ tileName(listing) }}</h2>
+            <h3 class="discovery-tile-title">{{ tileName(listing) }}</h3>
             <p
               v-if="tileDescription(listing)"
               class="discovery-tile-description"
@@ -218,11 +236,35 @@ onBeforeMount(async () => {
 .discovery-instance-description {
   font-size: $public-font-size-md;
   color: $public-text-secondary-light;
-  margin: 0;
+  margin: 0 0 $public-space-md 0;
   line-height: $public-line-height-relaxed;
 
   @include public-dark-mode {
     color: $public-text-secondary-dark;
+  }
+}
+
+.discovery-learn-more {
+  font-size: $public-font-size-sm;
+  margin: 0;
+
+  a {
+    color: $public-accent-light;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: $public-transition-normal;
+
+    &:hover {
+      border-bottom-color: currentColor;
+    }
+
+    &:focus-visible {
+      @include public-focus-visible;
+    }
+
+    @include public-dark-mode {
+      color: $public-accent-dark;
+    }
   }
 }
 
@@ -239,6 +281,19 @@ onBeforeMount(async () => {
   @include public-tablet-up {
     padding-top: $public-space-2xl;
     padding-bottom: $public-space-3xl;
+  }
+}
+
+.discovery-subheading {
+  font-size: $public-font-size-xl;
+  font-weight: $public-font-weight-semibold;
+  letter-spacing: $public-letter-spacing-tight;
+  line-height: $public-line-height-tight;
+  margin: 0 0 $public-space-lg 0;
+  color: $public-text-primary-light;
+
+  @include public-dark-mode {
+    color: $public-text-primary-dark;
   }
 }
 

--- a/src/site/components/discovery.vue
+++ b/src/site/components/discovery.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, inject, onBeforeMount, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
+import { Calendar as CalendarIcon } from 'lucide-vue-next';
 import type Config from '@/client/service/config';
 
 import CalendarService, { type PublicCalendarListing } from '../service/calendar';
@@ -63,6 +64,16 @@ function tileName(listing: PublicCalendarListing): string {
 function tileDescription(listing: PublicCalendarListing): string {
   const content = localizedContent(listing.calendar);
   return content?.description || '';
+}
+
+const instanceHost = computed<string>(() => {
+  return siteConfig?.settings?.()?.domain ?? '';
+});
+
+function tileHandle(listing: PublicCalendarListing): string {
+  const host = instanceHost.value;
+  if (!host) return '';
+  return `${listing.calendar.urlName}@${host}`;
 }
 
 /**
@@ -179,6 +190,16 @@ onBeforeMount(async () => {
             >
               {{ tileDescription(listing) }}
             </p>
+            <span
+              v-if="tileHandle(listing)"
+              class="discovery-tile-handle"
+            >
+              <CalendarIcon
+                :size="14"
+                aria-hidden="true"
+              />
+              <span>{{ tileHandle(listing) }}</span>
+            </span>
           </RouterLink>
         </li>
       </ul>
@@ -374,6 +395,13 @@ onBeforeMount(async () => {
   @include public-dark-mode {
     color: $public-text-secondary-dark;
   }
+}
+
+.discovery-tile-handle {
+  @include public-source-calendar-pill;
+  align-self: flex-start;
+  margin-top: auto;
+  cursor: inherit;
 }
 
 // ================================================================

--- a/src/site/components/test/discovery.integration.test.ts
+++ b/src/site/components/test/discovery.integration.test.ts
@@ -181,6 +181,10 @@ describe('discovery.vue - five behavioral states', () => {
     const secondTile = items[1];
     expect(secondTile.find('.discovery-tile-description').exists()).toBe(false);
 
+    // Calendar handle pill renders urlName@domain on every tile.
+    expect(firstTile.find('.discovery-tile-handle').text()).toBe('alpha@test.local');
+    expect(secondTile.find('.discovery-tile-handle').text()).toBe('beta@test.local');
+
     // applyHead() must have written the page_title into document.title — catches
     // a typo or wrong key path in the head metadata wiring.
     expect(document.title).toContain(enSystem.discovery.page_title);

--- a/src/site/components/test/discovery.integration.test.ts
+++ b/src/site/components/test/discovery.integration.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Integration tests for the /view/ public discovery page (pv-u4ew.4).
+ *
+ * Full-mount, mocked-HTTP coverage of the five behavioral states:
+ *   - loading
+ *   - populated (tile list rendered)
+ *   - empty
+ *   - error
+ *   - navigation (tile click resolves to /view/:urlName)
+ *
+ * Plus a per-locale rendering smoke test confirming that a representative
+ * discovery.* key renders translated text in en / es / fr — not the literal
+ * key string.
+ */
+import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import { createPinia, setActivePinia } from 'pinia';
+import I18NextVue from 'i18next-vue';
+import i18next from 'i18next';
+
+import Discovery from '../discovery.vue';
+import ModelService from '@/client/service/models';
+import ListResult from '@/client/service/list-result';
+
+import enSystem from '@/site/locales/en/system.json';
+import esSystem from '@/site/locales/es/system.json';
+import frSystem from '@/site/locales/fr/system.json';
+
+// Stub HTTP transport at the ModelService layer so CalendarService.listPublicCalendars()
+// runs its real entity -> PublicCalendarListing mapping against canned API responses.
+vi.mock('@/client/service/models');
+
+// A minimal stub for the site_config Config object the component injects.
+// The discovery page only reads settings().instanceDescription; everything
+// else can be omitted.
+function makeSiteConfig(instanceDescription?: Record<string, string>) {
+  return {
+    settings: () => ({
+      registrationMode: 'closed',
+      defaultDateRange: '1month',
+      defaultLanguage: 'en',
+      domain: 'test.local',
+      instanceDescription,
+    }),
+  };
+}
+
+function buildRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/view', name: 'discovery', component: Discovery },
+      { path: '/view/:calendar', name: 'calendar', component: { template: '<div class="calendar-stub" />' } },
+      { path: '/es/view', component: Discovery },
+      { path: '/es/view/:calendar', component: { template: '<div class="calendar-stub" />' } },
+      { path: '/fr/view', component: Discovery },
+      { path: '/fr/view/:calendar', component: { template: '<div class="calendar-stub" />' } },
+    ],
+  });
+}
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: {
+        en: { system: enSystem },
+        es: { system: esSystem },
+        fr: { system: frSystem },
+      },
+    });
+  }
+  else {
+    i18next.addResourceBundle('en', 'system', enSystem, true, true);
+    i18next.addResourceBundle('es', 'system', esSystem, true, true);
+    i18next.addResourceBundle('fr', 'system', frSystem, true, true);
+  }
+});
+
+describe('discovery.vue - five behavioral states', () => {
+  let pinia: ReturnType<typeof createPinia>;
+  let router: ReturnType<typeof buildRouter>;
+
+  beforeEach(async () => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    router = buildRouter();
+    await i18next.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function mountDiscovery() {
+    return mount(Discovery, {
+      global: {
+        plugins: [pinia, router, [I18NextVue, { i18next }]],
+        provide: {
+          site_config: makeSiteConfig(),
+        },
+      },
+    });
+  }
+
+  it('renders the loading state before the request resolves', async () => {
+    // Hold the listModels promise open so we can assert the loading frame.
+    let resolveList: (value: ListResult) => void;
+    const listPromise = new Promise<ListResult>((resolve) => {
+      resolveList = resolve;
+    });
+    vi.mocked(ModelService.listModels).mockReturnValue(listPromise);
+
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+
+    // Synchronous-ish read before flushPromises: the loading state should be
+    // the initial render. The discovery-loading container carries role=status.
+    const loading = wrapper.find('.discovery-loading');
+    expect(loading.exists()).toBe(true);
+    expect(loading.attributes('role')).toBe('status');
+    expect(loading.text()).toContain(enSystem.discovery.loading_label);
+
+    // List/empty/error must NOT render in the loading frame.
+    expect(wrapper.find('.discovery-list').exists()).toBe(false);
+    expect(wrapper.find('.discovery-empty').exists()).toBe(false);
+    expect(wrapper.find('.discovery-error').exists()).toBe(false);
+
+    resolveList!(ListResult.fromArray([]));
+    await flushPromises();
+  });
+
+  it('renders the populated tile list when the API returns calendars', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(
+      ListResult.fromArray([
+        {
+          id: 'cal-1',
+          urlName: 'alpha',
+          content: [
+            { language: 'en', name: 'Alpha Calendar', description: 'Alpha description' },
+          ],
+          lastEventActivity: '2026-05-01T12:00:00.000Z',
+        },
+        {
+          id: 'cal-2',
+          urlName: 'beta',
+          content: [
+            { language: 'en', name: 'Beta Calendar', description: '' },
+          ],
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    // Loading frame must be gone.
+    expect(wrapper.find('.discovery-loading').exists()).toBe(false);
+
+    // Semantic list landmark with role='list' (preserves list semantics
+    // even when list-style is none).
+    const list = wrapper.find('ul.discovery-list');
+    expect(list.exists()).toBe(true);
+    expect(list.attributes('role')).toBe('list');
+
+    const items = wrapper.findAll('.discovery-list-item');
+    expect(items).toHaveLength(2);
+
+    // Order is server-provided — first row should be the first tile rendered.
+    const titles = wrapper.findAll('.discovery-tile-title').map((n) => n.text());
+    expect(titles).toEqual(['Alpha Calendar', 'Beta Calendar']);
+
+    // Description renders when present and is omitted when empty.
+    const firstTile = items[0];
+    expect(firstTile.find('.discovery-tile-description').text()).toBe('Alpha description');
+    const secondTile = items[1];
+    expect(secondTile.find('.discovery-tile-description').exists()).toBe(false);
+
+    // applyHead() must have written the page_title into document.title — catches
+    // a typo or wrong key path in the head metadata wiring.
+    expect(document.title).toContain(enSystem.discovery.page_title);
+  });
+
+  it('renders the empty state when the API returns an empty array', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    expect(wrapper.find('.discovery-list').exists()).toBe(false);
+    const empty = wrapper.find('.discovery-empty');
+    expect(empty.exists()).toBe(true);
+    expect(empty.text()).toContain(enSystem.discovery.empty_state_heading);
+    expect(empty.text()).toContain(enSystem.discovery.empty_state_body);
+  });
+
+  it('renders the error state when the request rejects', async () => {
+    vi.mocked(ModelService.listModels).mockRejectedValue(new Error('boom'));
+
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    const error = wrapper.find('.discovery-error');
+    expect(error.exists()).toBe(true);
+    expect(error.attributes('role')).toBe('alert');
+    expect(error.text()).toContain(enSystem.discovery.error_message);
+
+    expect(wrapper.find('.discovery-list').exists()).toBe(false);
+    expect(wrapper.find('.discovery-empty').exists()).toBe(false);
+  });
+
+  it('navigates to /view/:urlName when a calendar tile is clicked', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(
+      ListResult.fromArray([
+        {
+          id: 'cal-1',
+          urlName: 'alpha',
+          content: [
+            { language: 'en', name: 'Alpha Calendar', description: 'Alpha description' },
+          ],
+          lastEventActivity: '2026-05-01T12:00:00.000Z',
+        },
+      ]),
+    );
+
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    const tile = wrapper.find('.discovery-tile');
+    expect(tile.exists()).toBe(true);
+    // Keyboard-focusable: RouterLink renders an <a> with an href.
+    expect(tile.element.tagName).toBe('A');
+    expect(tile.attributes('href')).toBe('/view/alpha');
+
+    await tile.trigger('click');
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe('/view/alpha');
+  });
+
+  it('produces locale-prefixed tile hrefs when the visitor is on a non-default locale', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(
+      ListResult.fromArray([
+        {
+          id: 'cal-1',
+          urlName: 'alpha',
+          content: [
+            { language: 'es', name: 'Calendario Alfa', description: '' },
+          ],
+          lastEventActivity: '2026-05-01T12:00:00.000Z',
+        },
+      ]),
+    );
+
+    await i18next.changeLanguage('es');
+    await router.push('/es/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    const tile = wrapper.find('.discovery-tile');
+    expect(tile.exists()).toBe(true);
+    // useLocale.localizedPath() should prefix the route with /es because the
+    // visitor is on a non-default-locale URL.
+    expect(tile.attributes('href')).toBe('/es/view/alpha');
+  });
+
+  it('uses a single <main> landmark and a single <h1> for the page', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    expect(wrapper.findAll('main')).toHaveLength(1);
+    expect(wrapper.findAll('h1')).toHaveLength(1);
+  });
+
+  it('shows the instance description from site_config when configured for the visitor locale', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+
+    const wrapper = mount(Discovery, {
+      global: {
+        plugins: [pinia, router, [I18NextVue, { i18next }]],
+        provide: {
+          site_config: makeSiteConfig({ en: 'Welcome to the local instance' }),
+        },
+      },
+    });
+    await flushPromises();
+
+    const desc = wrapper.find('.discovery-instance-description');
+    expect(desc.exists()).toBe(true);
+    expect(desc.text()).toBe('Welcome to the local instance');
+  });
+});
+
+describe('discovery.vue - per-locale rendering smoke', () => {
+  let pinia: ReturnType<typeof createPinia>;
+  let router: ReturnType<typeof buildRouter>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    router = buildRouter();
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Mount the discovery page under a specific locale and read the rendered
+   * h1 text. Asserts that the i18n bundle is wired up — the page_title key
+   * must resolve to a translated string, not the literal "discovery.page_title".
+   */
+  async function pageTitleFor(locale: 'en' | 'es' | 'fr', path: string): Promise<string> {
+    await i18next.changeLanguage(locale);
+    await router.push(path);
+    const wrapper = mount(Discovery, {
+      global: {
+        plugins: [pinia, router, [I18NextVue, { i18next }]],
+        provide: { site_config: { settings: () => ({}) } },
+      },
+    });
+    await flushPromises();
+    const text = wrapper.find('h1').text();
+    wrapper.unmount();
+    return text;
+  }
+
+  it('renders the page_title in English at /view', async () => {
+    const text = await pageTitleFor('en', '/view');
+    expect(text).toBe(enSystem.discovery.page_title);
+    expect(text).not.toBe('discovery.page_title');
+  });
+
+  it('renders the page_title in Spanish at /es/view', async () => {
+    const text = await pageTitleFor('es', '/es/view');
+    expect(text).toBe(esSystem.discovery.page_title);
+    expect(text).not.toBe('discovery.page_title');
+    // Sanity: Spanish version must differ from English so we know the
+    // translation actually resolved per-locale, not just hit a fallback.
+    expect(text).not.toBe(enSystem.discovery.page_title);
+  });
+
+  it('renders the page_title in French at /fr/view', async () => {
+    const text = await pageTitleFor('fr', '/fr/view');
+    expect(text).toBe(frSystem.discovery.page_title);
+    expect(text).not.toBe('discovery.page_title');
+    expect(text).not.toBe(enSystem.discovery.page_title);
+  });
+});

--- a/src/site/components/test/discovery.integration.test.ts
+++ b/src/site/components/test/discovery.integration.test.ts
@@ -32,16 +32,17 @@ import frSystem from '@/site/locales/fr/system.json';
 vi.mock('@/client/service/models');
 
 // A minimal stub for the site_config Config object the component injects.
-// The discovery page only reads settings().instanceDescription; everything
-// else can be omitted.
-function makeSiteConfig(instanceDescription?: Record<string, string>) {
+// The discovery page reads settings().siteTitle and settings().instanceDescription;
+// everything else can be omitted.
+function makeSiteConfig(opts?: { instanceDescription?: Record<string, string>; siteTitle?: string }) {
   return {
     settings: () => ({
       registrationMode: 'closed',
       defaultDateRange: '1month',
       defaultLanguage: 'en',
       domain: 'test.local',
-      instanceDescription,
+      siteTitle: opts?.siteTitle,
+      instanceDescription: opts?.instanceDescription,
     }),
   };
 }
@@ -289,7 +290,7 @@ describe('discovery.vue - five behavioral states', () => {
       global: {
         plugins: [pinia, router, [I18NextVue, { i18next }]],
         provide: {
-          site_config: makeSiteConfig({ en: 'Welcome to the local instance' }),
+          site_config: makeSiteConfig({ instanceDescription: { en: 'Welcome to the local instance' } }),
         },
       },
     });
@@ -298,6 +299,55 @@ describe('discovery.vue - five behavioral states', () => {
     const desc = wrapper.find('.discovery-instance-description');
     expect(desc.exists()).toBe(true);
     expect(desc.text()).toBe('Welcome to the local instance');
+  });
+
+  it('renders the configured siteTitle as the <h1> at the top of the page', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+
+    const wrapper = mount(Discovery, {
+      global: {
+        plugins: [pinia, router, [I18NextVue, { i18next }]],
+        provide: { site_config: makeSiteConfig({ siteTitle: 'Local Events Hub' }) },
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.find('h1.discovery-title').text()).toBe('Local Events Hub');
+  });
+
+  it('falls back to "Pavillion" in the <h1> when siteTitle is not configured', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    expect(wrapper.find('h1.discovery-title').text()).toBe('Pavillion');
+  });
+
+  it('renders "Calendars on this instance" as an <h2> subheading after the description', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    const subheading = wrapper.find('h2.discovery-subheading');
+    expect(subheading.exists()).toBe(true);
+    expect(subheading.text()).toBe(enSystem.discovery.page_title);
+  });
+
+  it('renders a "Learn more about Pavillion" link pointing to pavillion.social with rel=noopener', async () => {
+    vi.mocked(ModelService.listModels).mockResolvedValue(ListResult.fromArray([]));
+    await router.push('/view');
+    const wrapper = mountDiscovery();
+    await flushPromises();
+
+    const link = wrapper.find('.discovery-learn-more a');
+    expect(link.exists()).toBe(true);
+    expect(link.attributes('href')).toBe('https://pavillion.social');
+    expect(link.attributes('target')).toBe('_blank');
+    expect(link.attributes('rel')).toContain('noopener');
+    expect(link.text()).toBe(enSystem.discovery.learn_more);
   });
 });
 
@@ -318,8 +368,10 @@ describe('discovery.vue - per-locale rendering smoke', () => {
 
   /**
    * Mount the discovery page under a specific locale and read the rendered
-   * h1 text. Asserts that the i18n bundle is wired up — the page_title key
-   * must resolve to a translated string, not the literal "discovery.page_title".
+   * subheading (h2) text. Asserts that the i18n bundle is wired up — the
+   * page_title key must resolve to a translated string, not the literal
+   * "discovery.page_title". The h1 carries siteTitle (Pavillion fallback),
+   * not the translated page_title, so the subheading is the right target.
    */
   async function pageTitleFor(locale: 'en' | 'es' | 'fr', path: string): Promise<string> {
     await i18next.changeLanguage(locale);
@@ -331,7 +383,7 @@ describe('discovery.vue - per-locale rendering smoke', () => {
       },
     });
     await flushPromises();
-    const text = wrapper.find('h1').text();
+    const text = wrapper.find('.discovery-subheading').text();
     wrapper.unmount();
     return text;
   }

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -12,7 +12,8 @@
         "empty_state_heading": "No calendars yet",
         "empty_state_body": "There are no public calendars listed on this instance yet. Check back soon.",
         "error_message": "Failed to load calendars. Please try again.",
-        "loading_label": "Loading calendars..."
+        "loading_label": "Loading calendars...",
+        "learn_more": "Learn more about Pavillion"
     },
     "not_found_error_message": "Not Found",
     "not_found_suggestion": "The calendar or event you are looking for does not exist or may have been removed.",

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -6,6 +6,14 @@
         "beta_label": "Beta"
     },
     "powered_by": "Powered by Pavillion",
+    "discovery": {
+        "page_title": "Calendars on this instance",
+        "meta_description": "Browse public calendars hosted on this Pavillion instance.",
+        "empty_state_heading": "No calendars yet",
+        "empty_state_body": "There are no public calendars listed on this instance yet. Check back soon.",
+        "error_message": "Failed to load calendars. Please try again.",
+        "loading_label": "Loading calendars..."
+    },
     "not_found_error_message": "Not Found",
     "not_found_suggestion": "The calendar or event you are looking for does not exist or may have been removed.",
     "not_found_go_home": "Go to Homepage",

--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -12,7 +12,8 @@
         "empty_state_heading": "Aún no hay calendarios",
         "empty_state_body": "Todavía no hay calendarios públicos listados en esta instancia. Vuelve pronto.",
         "error_message": "Error al cargar los calendarios. Inténtalo de nuevo.",
-        "loading_label": "Cargando calendarios..."
+        "loading_label": "Cargando calendarios...",
+        "learn_more": "Más información sobre Pavillion"
     },
     "not_found_error_message": "No encontrado",
     "not_found_suggestion": "El calendario o evento que buscas no existe o puede haber sido eliminado.",

--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -6,6 +6,14 @@
         "beta_label": "Beta"
     },
     "powered_by": "Desarrollado por Pavillion",
+    "discovery": {
+        "page_title": "Calendarios en esta instancia",
+        "meta_description": "Explora los calendarios públicos alojados en esta instancia de Pavillion.",
+        "empty_state_heading": "Aún no hay calendarios",
+        "empty_state_body": "Todavía no hay calendarios públicos listados en esta instancia. Vuelve pronto.",
+        "error_message": "Error al cargar los calendarios. Inténtalo de nuevo.",
+        "loading_label": "Cargando calendarios..."
+    },
     "not_found_error_message": "No encontrado",
     "not_found_suggestion": "El calendario o evento que buscas no existe o puede haber sido eliminado.",
     "not_found_go_home": "Ir a la página principal",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -6,6 +6,14 @@
         "beta_label": "Beta"
     },
     "powered_by": "Propulsé par Pavillion",
+    "discovery": {
+        "page_title": "Calendriers sur cette instance",
+        "meta_description": "Parcourez les calendriers publics hébergés sur cette instance Pavillion.",
+        "empty_state_heading": "Aucun calendrier pour le moment",
+        "empty_state_body": "Aucun calendrier public n'est listé sur cette instance pour le moment. Revenez bientôt.",
+        "error_message": "Échec du chargement des calendriers. Veuillez réessayer.",
+        "loading_label": "Chargement des calendriers..."
+    },
     "not_found_error_message": "Page non trouvée",
     "not_found_suggestion": "Le calendrier ou l'événement que vous recherchez n'existe pas ou a peut-être été supprimé.",
     "not_found_go_home": "Retour à l'accueil",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -12,7 +12,8 @@
         "empty_state_heading": "Aucun calendrier pour le moment",
         "empty_state_body": "Aucun calendrier public n'est listé sur cette instance pour le moment. Revenez bientôt.",
         "error_message": "Échec du chargement des calendriers. Veuillez réessayer.",
-        "loading_label": "Chargement des calendriers..."
+        "loading_label": "Chargement des calendriers...",
+        "learn_more": "En savoir plus sur Pavillion"
     },
     "not_found_error_message": "Page non trouvée",
     "not_found_suggestion": "Le calendrier ou l'événement que vous recherchez n'existe pas ou a peut-être été supprimé.",

--- a/src/site/service/calendar.ts
+++ b/src/site/service/calendar.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { Calendar } from '@/common/model/calendar';
+import { Calendar, CalendarContent } from '@/common/model/calendar';
 import ModelService from '@/client/service/models';
 import { useCalendarStore } from '@/client/stores/calendarStore';
 import { useEventInstanceStore } from '@/site/stores/eventInstanceStore';
@@ -18,6 +18,18 @@ export type SeriesDetail = {
   };
 };
 
+/**
+ * A single row from the public discovery listing.
+ *
+ * The backend returns lastEventActivity as an ISO 8601 string (or null) — the
+ * service keeps the Calendar hydrated so locale-aware content lookups can run
+ * via useLocalizedContent on the consuming component.
+ */
+export type PublicCalendarListing = {
+  calendar: Calendar;
+  lastEventActivity: string | null;
+};
+
 export default class CalendarService {
   store: ReturnType<typeof useCalendarStore>;
   eventStore: ReturnType<typeof useEventInstanceStore>;
@@ -27,6 +39,39 @@ export default class CalendarService {
     this.eventStore = eventStore;
   }
 
+
+  /**
+   * List public discoverable calendars for the /view/ landing page.
+   *
+   * Calls GET /api/public/v1/calendars, which returns a bare array of
+   * { id, urlName, content[], lastEventActivity } rows sorted by
+   * lastEventActivity descending (server-provided order — the caller does
+   * NOT re-sort).
+   *
+   * Each row's `content` field is an array of { language, name, description }
+   * which we adapt into Calendar instances so the component can pick the
+   * visitor's locale via useLocalizedContent (which operates on TranslatedModel).
+   *
+   * @returns Promise resolving to an array of { calendar, lastEventActivity }
+   *   tuples in the server's order. Throws on network or 5xx error.
+   */
+  async listPublicCalendars(): Promise<PublicCalendarListing[]> {
+    const result = await ModelService.listModels('/api/public/v1/calendars');
+    return result.items.map((row: Record<string, any>) => {
+      const calendar = new Calendar(row.id, row.urlName);
+      if (Array.isArray(row.content)) {
+        for (const c of row.content) {
+          if (c && typeof c === 'object' && typeof c.language === 'string') {
+            calendar.addContent(new CalendarContent(c.language, c.name ?? '', c.description ?? ''));
+          }
+        }
+      }
+      return {
+        calendar,
+        lastEventActivity: row.lastEventActivity ?? null,
+      };
+    });
+  }
 
   /**
    * Get a calendar by its URL name


### PR DESCRIPTION
## Motivation

The `/view/` namespace (DEC-006) is the public site SPA, but until now hitting `/view` by itself didn't land anywhere useful — there was no index. This branch adds a discovery surface so anonymous visitors arriving at the bare `/view/` URL see what's on offer on the instance.

## Approach

- New `/view` route renders a discovery page: instance-titled `<h1>`, optional localized instance description, and a learn-more link to pavillion.social.
- Below the header, a grid of calendar tiles — one per public calendar on the instance, ordered by most recent event activity (server-provided sort).
- Each tile shows the localized calendar name, optional localized description, and a `urlName@host` handle pill at the card foot. The pill reuses the existing `public-source-calendar-pill` mixin so it visually matches the source-calendar pill on reposted events, keeping a single design vocabulary for "this is a calendar handle."
- Five behavioral states wired: `loading`, `populated`, `empty`, `error`, plus locale-prefixed routing (`/es/view`, `/fr/view`) so the page honours the visitor's locale prefix.
- New public API endpoint `GET /api/public/v1/calendars` returns the listing. Tiles are non-interactive at the pill level — the parent `RouterLink` already navigates to `/view/:urlName`, so the pill is a `<span>` (no nested anchors).

## Validation

- `src/site` test suite: 595 tests pass across 21 files.
- Discovery integration test (15 tests) covers all five behavioral states, locale-prefixed hrefs, head metadata, instance description rendering, and the new handle pill text (`alpha@test.local`, `beta@test.local`).
- Lint: 0 errors.
- Production build succeeds.
- Live browser check skipped: ports 3000/3001 were in use by other worktrees, so I relied on the integration tests and the established pill mixin (which is visually exercised on reposted-event cards in the existing suite).