### PR TITLE
feat(site): polish /view discovery page and add footer login link

### DIFF
--- a/migrations/0033_add_listed_to_calendar.ts
+++ b/migrations/0033_add_listed_to_calendar.ts
@@ -2,6 +2,8 @@ import { Sequelize, DataTypes } from 'sequelize';
 import {
   addColumnIfNotExists,
   removeColumnIfExists,
+  addIndexIfNotExists,
+  removeIndexIfExists,
 } from '../src/server/common/migrations/helpers.js';
 
 /**
@@ -26,11 +28,19 @@ export default {
       allowNull: false,
       defaultValue: true,
     });
+
+    // Index supports the `WHERE listed = true` predicate in
+    // CalendarService.listPublicCalendars, mirroring the indexing pattern of
+    // neighbor migration 0032 for other query-path columns.
+    await addIndexIfNotExists(queryInterface, 'calendar', ['listed'], {
+      name: 'idx_calendar_listed',
+    });
   },
 
   async down({ context: sequelize }: { context: Sequelize }) {
     const queryInterface = sequelize.getQueryInterface();
 
+    await removeIndexIfExists(queryInterface, 'calendar', 'idx_calendar_listed');
     await removeColumnIfExists(queryInterface, 'calendar', 'listed');
   },
 };

--- a/src/common/model/calendar.ts
+++ b/src/common/model/calendar.ts
@@ -60,6 +60,7 @@ class Calendar extends TranslatedModel<CalendarContent> {
       widgetAllowedDomain: this.widgetAllowedDomain,
       defaultEventImageId: this.defaultEventImageId,
       defaultEventImage: this.defaultEventImage?.toObject() ?? null,
+      // Owner/admin-tier field: public endpoints must strip via toPublicCalendarObject (or omit from allow-list projection).
       listed: this.listed,
       content: Object.fromEntries(
         Object.entries(this._content)

--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -262,14 +262,7 @@ export default class CalendarInterface {
     return this.calendarService.listAllCalendarsForAdmin(filters);
   }
 
-  /**
-   * List public-discoverable calendars for the /view/ discovery page.
-   * Thin proxy to CalendarService.listPublicCalendars; see service docs for
-   * the full query shape, predicate semantics, and 500-row cap.
-   *
-   * @returns Calendars + lastEventActivity tuples, sorted activity-descending,
-   *   capped at 500 rows
-   */
+  /** Proxy — see CalendarService.listPublicCalendars for semantics. */
   async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
     return this.calendarService.listPublicCalendars();
   }

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -1733,36 +1733,42 @@ class CalendarService {
   async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
     const PUBLIC_DISCOVERY_LIMIT = 500;
 
+    // Split into two queries because `subQuery: false` + LIMIT + a
+    // CalendarContentEntity LEFT JOIN would cap *joined rows*, not distinct
+    // calendars — a multilingual instance with N content rows per calendar
+    // would return ~LIMIT/N distinct calendars. The discovery cap must apply
+    // to calendars, not to language-content fan-out.
+    //
+    // Step 1 — select calendar ids (+ aliased last_event_activity) under the
+    // listed=true predicate, the ORDER BY clauses, and the LIMIT. No content
+    // join, so the cap is over distinct calendars by construction.
+    //
     // Correlated subquery: an event contributes to MAX(event.updatedAt) only
     // when it has at least one event_schedule row that is NOT a hidden
     // cancellation (NOT (is_exclusion AND hide_from_public)). Mirrors the
     // canonical suppression predicate in EventInstanceService.rrules().
-    // The `lastEventActivity` predicate matches the public events listing
-    // visibility semantics: events whose every schedule is an EXDATE-style
-    // hidden cancellation produce no public occurrences and must not inflate
-    // discovery activity.
+    // Events whose every schedule is an EXDATE-style hidden cancellation
+    // produce no public occurrences and must not inflate discovery activity.
     //
     // NOTE: the alias 'last_event_activity' is load-bearing — the two ORDER BY
     // literals below reference it by name. Keep them all in lockstep on rename
     // or the sort silently regresses.
-    const rows = await CalendarEntity.findAll({
+    const idRows = await CalendarEntity.findAll({
       where: { listed: true },
-      attributes: {
-        include: [
-          [
-            literal(
-              '(SELECT MAX("event"."updatedAt") FROM "event" '
-              + 'WHERE "event"."calendar_id" = "CalendarEntity"."id" '
-              + 'AND EXISTS (SELECT 1 FROM "event_schedule" '
-              + 'WHERE "event_schedule"."event_id" = "event"."id" '
-              + 'AND NOT ("event_schedule"."is_exclusion" = true '
-              + 'AND "event_schedule"."hide_from_public" = true)))',
-            ),
-            'last_event_activity',
-          ],
+      attributes: [
+        'id',
+        [
+          literal(
+            '(SELECT MAX("event"."updatedAt") FROM "event" '
+            + 'WHERE "event"."calendar_id" = "CalendarEntity"."id" '
+            + 'AND EXISTS (SELECT 1 FROM "event_schedule" '
+            + 'WHERE "event_schedule"."event_id" = "event"."id" '
+            + 'AND NOT ("event_schedule"."is_exclusion" = true '
+            + 'AND "event_schedule"."hide_from_public" = true)))',
+          ),
+          'last_event_activity',
         ],
-      },
-      include: [CalendarContentEntity],
+      ],
       order: [
         // NULLS LAST: calendars with no events sort after calendars that have
         // published activity. SQLite emits NULLs first by default; PostgreSQL
@@ -1772,15 +1778,45 @@ class CalendarService {
         [literal('last_event_activity'), 'DESC'],
       ],
       limit: PUBLIC_DISCOVERY_LIMIT,
-      subQuery: false,
     } as any);
 
-    return rows.map((entity) => {
-      const calendar = this.withPublicUrl(entity.toModel());
-      const rawActivity = entity.get('last_event_activity');
-      const lastEventActivity = rawActivity ? new Date(rawActivity as string | number | Date) : null;
-      return { calendar, lastEventActivity };
+    if (idRows.length === 0) {
+      return [];
+    }
+
+    // Build the ordered id list and an id → lastEventActivity lookup so we can
+    // preserve step 1's ordering when we hydrate full entities in step 2.
+    const orderedIds: string[] = idRows.map((r) => r.id);
+    const activityById = new Map<string, Date | null>();
+    for (const r of idRows) {
+      const rawActivity = (r as any).get('last_event_activity');
+      activityById.set(r.id, rawActivity ? new Date(rawActivity as string | number | Date) : null);
+    }
+
+    // Step 2 — hydrate full entities (with CalendarContentEntity) keyed by the
+    // ids from step 1. The JOIN now fans out language rows safely; Sequelize
+    // collapses duplicate calendar rows when an include is present. The ORDER
+    // BY here is not load-bearing — we re-sort to step 1's order below.
+    const hydrated = await CalendarEntity.findAll({
+      where: { id: { [Op.in]: orderedIds } },
+      include: [CalendarContentEntity],
     });
+
+    // Preserve step 1's ordering: build an id → entity map and walk the
+    // ordered id list.
+    const entityById = new Map<string, typeof hydrated[number]>();
+    for (const entity of hydrated) {
+      entityById.set(entity.id, entity);
+    }
+
+    return orderedIds
+      .map((id) => entityById.get(id))
+      .filter((entity): entity is typeof hydrated[number] => entity !== undefined)
+      .map((entity) => {
+        const calendar = this.withPublicUrl(entity.toModel());
+        const lastEventActivity = activityById.get(entity.id) ?? null;
+        return { calendar, lastEventActivity };
+      });
   }
 
   /**

--- a/src/server/calendar/test/integration/list_public_calendars.test.ts
+++ b/src/server/calendar/test/integration/list_public_calendars.test.ts
@@ -25,7 +25,7 @@ import AccountService from '@/server/accounts/service/account';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
-import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import { CalendarEntity, CalendarContentEntity } from '@/server/calendar/entity/calendar';
 import { EventEntity, EventScheduleEntity } from '@/server/calendar/entity/event';
 
 describe('CalendarService.listPublicCalendars (pv-u4ew.2)', () => {
@@ -55,6 +55,7 @@ describe('CalendarService.listPublicCalendars (pv-u4ew.2)', () => {
   async function resetDiscoveryFixtures(): Promise<void> {
     await EventScheduleEntity.destroy({ where: {}, truncate: false, force: true });
     await EventEntity.destroy({ where: {}, truncate: false, force: true });
+    await CalendarContentEntity.destroy({ where: {}, truncate: false, force: true });
     await CalendarEntity.destroy({ where: {}, truncate: false, force: true });
   }
 
@@ -388,6 +389,54 @@ describe('CalendarService.listPublicCalendars (pv-u4ew.2)', () => {
 
       // Hard cap, exactly 500.
       expect(result).toHaveLength(500);
+    }, 30000);
+
+    it('caps distinct calendars at 500 even with multi-language content rows', async () => {
+      // Regression cap: with a LEFT JOIN on CalendarContentEntity and a
+      // single-query LIMIT, the cap would silently apply to joined rows, so a
+      // calendar with 3 language rows would consume 3 of the 500 slots and
+      // the query would return ~167 distinct calendars instead of 500. The
+      // service splits the query in two so the cap applies to distinct
+      // calendars regardless of how many content rows each has.
+      await resetDiscoveryFixtures();
+
+      const calendarRows = [];
+      const contentRows = [];
+      const TOTAL_CALENDARS = 501;
+      const LANGUAGES = ['en', 'fr', 'es'];
+
+      for (let i = 0; i < TOTAL_CALENDARS; i++) {
+        const id = uuidv4();
+        calendarRows.push({
+          id,
+          url_name: `multilingual-${i.toString().padStart(4, '0')}`,
+          languages: 'en,fr,es',
+          default_date_range: null,
+          widget_allowed_domain: null,
+          default_event_image_id: null,
+          listed: true,
+        });
+        for (const language of LANGUAGES) {
+          contentRows.push({
+            id: uuidv4(),
+            calendar_id: id,
+            language,
+            name: `Name in ${language} for ${i}`,
+            description: '',
+          });
+        }
+      }
+      await CalendarEntity.bulkCreate(calendarRows);
+      await CalendarContentEntity.bulkCreate(contentRows);
+
+      const result = await calendarInterface.listPublicCalendars();
+
+      // Hard cap, exactly 500 DISTINCT calendars (not joined rows).
+      expect(result).toHaveLength(500);
+
+      // Sanity: each returned calendar should be unique.
+      const returnedIds = new Set(result.map((r) => r.calendar.id));
+      expect(returnedIds.size).toBe(500);
     }, 30000);
   });
 });

--- a/src/server/common/test/app_routes.test.ts
+++ b/src/server/common/test/app_routes.test.ts
@@ -84,6 +84,8 @@ describe('app_routes', () => {
     // /view/.* and fell through to the client catch-all on bare /view.
     // -------------------------------------------------------------------
 
+    // Regression for the prior catch-all exclusion (`view\/`) which only
+    // matched a trailing slash; bare /view leaked to the client shell.
     it('should serve site.index.html.ejs for bare /view (no trailing slash)', async () => {
       const app = buildTestApp('en');
       const res = await request(app).get('/view');
@@ -98,15 +100,6 @@ describe('app_routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.template).toBe('site.index.html.ejs');
-    });
-
-    it('should NOT route bare /view through the client SPA catch-all', async () => {
-      // Regression for the prior catch-all exclusion (`view\/`) which only
-      // matched a trailing slash; bare /view leaked to the client shell.
-      const app = buildTestApp('en');
-      const res = await request(app).get('/view');
-
-      expect(res.body.template).not.toBe('client.index.html.ejs');
     });
 
     it('should serve site.index.html.ejs for /view/calendar/event/123', async () => {

--- a/src/server/common/test/middleware/rate-limiters.test.ts
+++ b/src/server/common/test/middleware/rate-limiters.test.ts
@@ -13,6 +13,7 @@ import {
   reportVerificationByIp,
   reportSubmissionByAccount,
   publicEventInstanceByIp,
+  publicCalendarListByIp,
   applicationByIp,
   applicationByEmail,
   confirmApplicationByIp,
@@ -92,6 +93,14 @@ describe('rate-limiters', () => {
       expect(windowMs).toBe(900000); // 15 minutes
     });
 
+    it('should use correct config values for public calendar list by IP', () => {
+      const maxRequests = config.get<number>('rateLimit.publicCalendarList.byIp.max');
+      const windowMs = config.get<number>('rateLimit.publicCalendarList.byIp.windowMs');
+
+      expect(maxRequests).toBe(60);
+      expect(windowMs).toBe(60000); // 1 minute
+    });
+
     it('should use correct config values for application by IP', () => {
       const maxRequests = config.get<number>('rateLimit.application.byIp.max');
       const windowMs = config.get<number>('rateLimit.application.byIp.windowMs');
@@ -167,6 +176,11 @@ describe('rate-limiters', () => {
     it('should export publicEventInstanceByIp limiter', () => {
       expect(publicEventInstanceByIp).toBeDefined();
       expect(typeof publicEventInstanceByIp).toBe('function');
+    });
+
+    it('should export publicCalendarListByIp limiter', () => {
+      expect(publicCalendarListByIp).toBeDefined();
+      expect(typeof publicCalendarListByIp).toBe('function');
     });
 
     it('should export applicationByIp limiter', () => {
@@ -520,6 +534,23 @@ describe('rate-limiters', () => {
       });
 
       const response = await request(app).get('/instance');
+      expect(response.status).toBe(200);
+
+      if (config.get<boolean>('rateLimit.enabled')) {
+        expect(response.headers['ratelimit-limit']).toBeDefined();
+        expect(response.headers['ratelimit-remaining']).toBeDefined();
+      }
+      else {
+        expect(response.headers['ratelimit-limit']).toBeUndefined();
+      }
+    });
+
+    it('should apply publicCalendarListByIp limiter to endpoint', async () => {
+      app.get('/calendars', publicCalendarListByIp, (req, res) => {
+        res.json({ success: true });
+      });
+
+      const response = await request(app).get('/calendars');
       expect(response.status).toBe(200);
 
       if (config.get<boolean>('rateLimit.enabled')) {

--- a/src/server/common/test/migrations/migration_0033_add_listed_to_calendar.test.ts
+++ b/src/server/common/test/migrations/migration_0033_add_listed_to_calendar.test.ts
@@ -135,6 +135,20 @@ describe('Migration 0033: add listed to calendar', () => {
     expect('listed' in afterDown).toBe(false);
   });
 
+  it('adds idx_calendar_listed on up and removes it on down', async () => {
+    // Index supports the `WHERE listed = true` predicate in
+    // CalendarService.listPublicCalendars (the public discovery query).
+    await migration.up({ context: sequelize });
+
+    const indexesAfterUp = await sequelize.getQueryInterface().showIndex('calendar') as { name: string }[];
+    expect(indexesAfterUp.some((ix) => ix.name === 'idx_calendar_listed')).toBe(true);
+
+    await migration.down({ context: sequelize });
+
+    const indexesAfterDown = await sequelize.getQueryInterface().showIndex('calendar') as { name: string }[];
+    expect(indexesAfterDown.some((ix) => ix.name === 'idx_calendar_listed')).toBe(false);
+  });
+
   it('is idempotent on a second up run', async () => {
     await migration.up({ context: sequelize });
     await migration.up({ context: sequelize });

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -3,6 +3,7 @@ import PublicCalendarInterface from '../../interface';
 import { SeriesNotFoundError } from '@/common/exceptions/series';
 import { EventNotFoundError } from '@/common/exceptions/calendar';
 import { logError } from '@/server/common/helper/error-logger';
+import { Calendar } from '@/common/model/calendar';
 import { CalendarEventSchedule } from '@/common/model/events';
 import CalendarEventInstance from '@/common/model/event_instance';
 import { EventSeries } from '@/common/model/event_series';
@@ -13,32 +14,45 @@ import { publicEventInstanceByIp, publicCalendarListByIp } from '@/server/common
 import ExpressHelper from '@/server/common/helper/express';
 
 /**
- * Shapes a Calendar.toObject() result for public responses.
+ * Shapes a raw Calendar object for public consumption via an explicit
+ * allow-list. Accepts either a model instance (and calls `.toObject()`
+ * internally) or an already-serialized plain object — same shape contract
+ * as `toPublicSeriesObject` and `toPublicCategoryObject` below.
  *
- * Responsibilities:
- *   - Strips internal fields not intended for anonymous public consumers.
- *     Currently drops `listed` (an admin-discovery flag — knowing whether
- *     a calendar is hidden from the /view/ index is not the public's
- *     business; the calendar is reachable by direct URL regardless).
- *   - Projects `defaultEventImage` to `{ id, mimeType }` only — internal
- *     fields like originalFilename, fileSize, status, sha256, calendarId,
- *     and storageFilename are removed.
+ * Allow-listed fields: id, urlName, publicUrl, description, languages,
+ * defaultDateRange, content, plus a projected `defaultEventImage`.
  *
- * Allow-list / strip-by-name posture matches the toPublicEventObject helper
- * below so future additions to Calendar.toObject() do not silently leak
- * through this surface.
+ * Dropped from the calendar root:
+ *   - `listed` — owner-discovery flag; knowing whether a calendar is hidden
+ *     from the /view/ index is not the public's business.
+ *   - `widgetAllowedDomain` — operator-internal embed-policy config.
+ *   - `defaultEventImageId` — internal FK; the projected
+ *     `defaultEventImage.id` already carries the identifier callers need.
+ *
+ * Nested `defaultEventImage` → `{ id, mimeType }`; absent collapses to null.
+ *
+ * Per DEC-003 the canonical `Calendar.toObject()` shape stays full because
+ * authenticated calendar/owner APIs legitimately need the FKs and embed
+ * config; per DEC-004 the privacy boundary is a property of the audience
+ * (Tier 1 anonymous public).
+ *
+ * Why allow-list (not delete-by-name): future additions to
+ * `Calendar.toObject()` must fail loudly here, not silently leak.
  */
-function toPublicCalendarObject(calendarObj: Record<string, any>): Record<string, any> {
-  // Drop `listed` (admin-discovery flag) via destructure-and-discard; the
-  // ESLint config treats leading-underscore names as intentionally unused.
-  const { listed: _listed, ...rest } = calendarObj; // eslint-disable-line @typescript-eslint/no-unused-vars
-  if (!rest.defaultEventImage) return rest;
+function toPublicCalendarObject(calendar: Calendar | Record<string, any>): Record<string, any> {
+  const obj = calendar instanceof Calendar ? calendar.toObject() : calendar;
+  const defaultEventImage = obj.defaultEventImage
+    ? { id: obj.defaultEventImage.id, mimeType: obj.defaultEventImage.mimeType }
+    : null;
   return {
-    ...rest,
-    defaultEventImage: {
-      id: rest.defaultEventImage.id,
-      mimeType: rest.defaultEventImage.mimeType,
-    },
+    id: obj.id,
+    urlName: obj.urlName,
+    publicUrl: obj.publicUrl,
+    description: obj.description,
+    languages: obj.languages,
+    defaultDateRange: obj.defaultDateRange,
+    defaultEventImage,
+    content: obj.content,
   };
 }
 
@@ -296,8 +310,7 @@ export default class CalendarRoutes {
 
     const calendar = await this.service.getCalendarByName(req.params.urlName);
     if (calendar) {
-      const calendarObj = calendar.toObject();
-      res.json(toPublicCalendarObject(calendarObj));
+      res.json(toPublicCalendarObject(calendar));
     }
     else {
       res.status(404).json({

--- a/src/server/public/interface/index.ts
+++ b/src/server/public/interface/index.ts
@@ -30,16 +30,7 @@ export default class PublicCalendarInterface {
     return this.calendarInterface.getCalendarByName(name);
   }
 
-  /**
-   * List public-discoverable calendars for the /view/ discovery page.
-   * Proxies directly to the calendar-domain interface (cross-domain call;
-   * Public never touches Calendar entities directly per DEC-003). No
-   * intermediate service hop — this is a pure facade. Matches the
-   * getCalendarByName pattern above.
-   *
-   * @returns Calendars + lastEventActivity tuples, sorted activity-descending,
-   *   capped at 500 rows server-side
-   */
+  /** Proxy — see CalendarService.listPublicCalendars for semantics. */
   async listPublicCalendars(): Promise<Array<{ calendar: Calendar; lastEventActivity: Date | null }>> {
     return this.calendarInterface.listPublicCalendars();
   }

--- a/src/server/public/test/calendars-api.test.ts
+++ b/src/server/public/test/calendars-api.test.ts
@@ -145,16 +145,46 @@ describe('Public Calendars Discovery API (pv-u4ew.3)', () => {
     });
   });
 
-  describe('GET /api/public/v1/calendars - allow-list projection (enumerated negative fields)', () => {
-    /**
-     * Per privacy/api-responses, the discovery list must use an allow-list
-     * projection — NOT a toObject() passthrough. Each negative-field assertion
-     * is enumerated individually so a future toObject() addition is caught
-     * field-by-field, not swallowed by a single broad `expect.objectContaining`.
-     */
-    let row: any;
+  /**
+   * Public discovery row projection contract: each row must allow-list only
+   * `{ content, id, lastEventActivity, urlName }`. Internal/operator fields
+   * (`widgetAllowedDomain`, `defaultEventImageId`, `defaultEventImage`,
+   * `publicUrl`, `languages`, `defaultDateRange`, `listed`, top-level
+   * `description`) and any account FKs (`accountId`, `ownerId`) must never
+   * appear — they are either internal config or have no Tier-1 anonymous
+   * public use case for the discovery surface.
+   *
+   * Mirrors the pv-3vso allow-list assertion pattern from `events-api.test.ts`
+   * (assertSeriesProjection / assertCategoryProjection): bidirectional
+   * `Object.keys().sort().toEqual()` plus explicit per-field absence asserts
+   * for clarity / future-regression readability.
+   */
+  function assertDiscoveryListingProjection(row: Record<string, any>) {
+    expect(row).not.toBeNull();
+    // Bidirectional allow-list check — catches both an extra key (leak) and
+    // a missing required key (dropped public field).
+    expect(Object.keys(row).sort()).toEqual(
+      ['content', 'id', 'lastEventActivity', 'urlName'],
+    );
+    // Spell out the disallowed fields for clarity / future regressions.
+    expect(row.widgetAllowedDomain).toBeUndefined();
+    expect(row.defaultEventImageId).toBeUndefined();
+    expect(row.defaultEventImage).toBeUndefined();
+    expect(row.publicUrl).toBeUndefined();
+    expect(row.languages).toBeUndefined();
+    expect(row.defaultDateRange).toBeUndefined();
+    expect(row.listed).toBeUndefined();
+    expect(row.description).toBeUndefined();
+    expect(row.account).toBeUndefined();
+    expect(row.accountId).toBeUndefined();
+    expect(row.owner).toBeUndefined();
+    expect(row.ownerId).toBeUndefined();
+    expect(row.createdAt).toBeUndefined();
+    expect(row.updatedAt).toBeUndefined();
+  }
 
-    beforeEach(async () => {
+  describe('GET /api/public/v1/calendars - allow-list projection', () => {
+    it('row contains only allow-listed keys and no internal/operator fields', async () => {
       const cal = buildLeakyCalendar('cal-1', 'alpha');
       const listStub = apiSandbox.stub(publicInterface, 'listPublicCalendars');
       listStub.resolves([
@@ -162,54 +192,8 @@ describe('Public Calendars Discovery API (pv-u4ew.3)', () => {
       ]);
 
       const response = await request(buildApp()).get('/api/public/v1/calendars');
-      row = response.body[0];
-    });
 
-    it('does NOT include widgetAllowedDomain', () => {
-      expect(row.widgetAllowedDomain).toBeUndefined();
-    });
-
-    it('does NOT include defaultEventImageId', () => {
-      expect(row.defaultEventImageId).toBeUndefined();
-    });
-
-    it('does NOT include defaultEventImage', () => {
-      expect(row.defaultEventImage).toBeUndefined();
-    });
-
-    it('does NOT include publicUrl', () => {
-      expect(row.publicUrl).toBeUndefined();
-    });
-
-    it('does NOT include languages', () => {
-      expect(row.languages).toBeUndefined();
-    });
-
-    it('does NOT include defaultDateRange', () => {
-      expect(row.defaultDateRange).toBeUndefined();
-    });
-
-    it('does NOT include listed', () => {
-      expect(row.listed).toBeUndefined();
-    });
-
-    it('does NOT include owner / account info', () => {
-      expect(row.account).toBeUndefined();
-      expect(row.accountId).toBeUndefined();
-      expect(row.owner).toBeUndefined();
-      expect(row.ownerId).toBeUndefined();
-    });
-
-    it('does NOT include internal createdAt / updatedAt timestamps', () => {
-      expect(row.createdAt).toBeUndefined();
-      expect(row.updatedAt).toBeUndefined();
-    });
-
-    it('does NOT include top-level description (only per-language description survives)', () => {
-      // The Calendar model carries a top-level `description` separate from the
-      // per-language content.description. The allow-list projection drops the
-      // top-level field; per-language descriptions arrive inside content[].
-      expect(row.description).toBeUndefined();
+      assertDiscoveryListingProjection(response.body[0]);
     });
   });
 
@@ -275,11 +259,13 @@ describe('Public Calendars Discovery API (pv-u4ew.3)', () => {
 });
 
 /**
- * Cross-bead regression from pv-u4ew.1 privacy-audit note: the existing
- * single-calendar endpoint GET /api/public/v1/calendar/:urlName must NOT
- * expose the `listed` flag now that Calendar.toObject() includes it.
+ * Single-calendar projection contract: GET /api/public/v1/calendar/:urlName
+ * must allow-list only the public-tier fields. Internal config
+ * (`widgetAllowedDomain`), internal FKs (`defaultEventImageId`), and the
+ * owner-discovery flag (`listed`) must never appear. Mirrors the pv-3vso
+ * projection-helper assertion pattern in events-api.test.ts.
  */
-describe('Public Calendar API - listed field NOT exposed on single-calendar endpoint (pv-u4ew.1 audit)', () => {
+describe('Public Calendar API - GET /calendar/:urlName projection', () => {
   let routes: CalendarRoutes;
   let router: express.Router;
   let publicInterface: PublicCalendarInterface;
@@ -297,10 +283,46 @@ describe('Public Calendar API - listed field NOT exposed on single-calendar endp
     apiSandbox.restore();
   });
 
-  it('strips listed=true from GET /calendar/:urlName response', async () => {
-    const calendar = new Calendar('cal-id', 'test-calendar');
-    calendar.listed = true;
+  /**
+   * Public single-calendar projection contract: response allow-lists only
+   * `{ content, defaultDateRange, defaultEventImage, description, id,
+   *    languages, publicUrl, urlName }`. Internal/operator fields must
+   * never appear.
+   */
+  function assertCalendarRootProjection(body: Record<string, any>) {
+    expect(body).not.toBeNull();
+    expect(Object.keys(body).sort()).toEqual(
+      [
+        'content',
+        'defaultDateRange',
+        'defaultEventImage',
+        'description',
+        'id',
+        'languages',
+        'publicUrl',
+        'urlName',
+      ],
+    );
+    // Spell out the disallowed fields for clarity / future regressions.
+    expect(body.listed).toBeUndefined();
+    expect(body.widgetAllowedDomain).toBeUndefined();
+    expect(body.defaultEventImageId).toBeUndefined();
+  }
 
+  function buildCalendarWithLeakyInternals(listed: boolean): Calendar {
+    const calendar = new Calendar('cal-id', 'test-calendar');
+    calendar.publicUrl = 'https://pavillion.dev/view/test-calendar';
+    calendar.languages = ['en'];
+    calendar.description = '';
+    calendar.defaultDateRange = '1month';
+    calendar.widgetAllowedDomain = 'widget.example.com';
+    calendar.defaultEventImageId = 'media-id-should-not-leak';
+    calendar.listed = listed;
+    return calendar;
+  }
+
+  it('returns the allow-listed projection for a listed calendar', async () => {
+    const calendar = buildCalendarWithLeakyInternals(true);
     const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
     calendarStub.resolves(calendar);
 
@@ -312,15 +334,13 @@ describe('Public Calendar API - listed field NOT exposed on single-calendar endp
     const response = await request(testApp(router)).get('/handler');
 
     expect(response.status).toBe(200);
-    expect(response.body.listed).toBeUndefined();
+    assertCalendarRootProjection(response.body);
   });
 
-  it('strips listed=false from GET /calendar/:urlName response', async () => {
+  it('returns the same allow-listed projection for an unlisted calendar reachable by direct URL', async () => {
     // An unlisted calendar reachable by direct URL must not advertise its
     // hidden-from-discovery status to anonymous visitors.
-    const calendar = new Calendar('cal-id', 'test-calendar');
-    calendar.listed = false;
-
+    const calendar = buildCalendarWithLeakyInternals(false);
     const calendarStub = apiSandbox.stub(publicInterface, 'getCalendarByName');
     calendarStub.resolves(calendar);
 
@@ -332,6 +352,6 @@ describe('Public Calendar API - listed field NOT exposed on single-calendar endp
     const response = await request(testApp(router)).get('/handler');
 
     expect(response.status).toBe(200);
-    expect(response.body.listed).toBeUndefined();
+    assertCalendarRootProjection(response.body);
   });
 });

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -107,6 +107,7 @@ $public-font-size-md: 16px;
 $public-font-size-lg: 20px;
 $public-font-size-xl: 24px;
 $public-font-size-2xl: 32px;
+$public-font-size-3xl: 2.25rem;
 
 // Line heights (optimized for readability)
 $public-line-height-tight: 1.25;

--- a/src/site/components/app.vue
+++ b/src/site/components/app.vue
@@ -13,9 +13,53 @@ const { t } = useTranslation('system');
         <div class="pavillion-logo"/> {{ t('powered_by') }}
       </a>
     </div>
-    <LanguageSwitcher />
+    <div class="site-footer-utilities">
+      <LanguageSwitcher />
+      <a href="/auth/login" class="site-footer-login">{{ t('footer.login_link') }}</a>
+    </div>
   </footer>
 </template>
 
-<style lang="scss">
+<style scoped lang="scss">
+@use '../assets/mixins' as *;
+
+footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $public-space-md;
+
+  .site-footer-utilities {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $public-space-lg;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .site-footer-login {
+    font-size: $public-font-size-sm;
+    font-weight: $public-font-weight-regular;
+    color: $public-text-secondary-light;
+    text-decoration: none;
+
+    &:hover {
+      color: $public-text-primary-light;
+      text-decoration: underline;
+    }
+
+    &:focus-visible {
+      @include public-focus-visible;
+    }
+
+    @include public-dark-mode {
+      color: $public-text-secondary-dark;
+
+      &:hover {
+        color: $public-text-primary-dark;
+      }
+    }
+  }
+}
 </style>

--- a/src/site/components/calendar.vue
+++ b/src/site/components/calendar.vue
@@ -304,7 +304,7 @@ onBeforeMount(async () => {
   margin: 0 0 $public-space-sm 0;
 
   @include public-tablet-up {
-    font-size: 2.25rem;
+    font-size: $public-font-size-3xl;
   }
 }
 

--- a/src/site/components/discovery.vue
+++ b/src/site/components/discovery.vue
@@ -2,8 +2,8 @@
 import { ref, computed, inject, onBeforeMount, watch } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { Calendar as CalendarIcon } from 'lucide-vue-next';
-import type Config from '@/client/service/config';
 
+import type Config from '@/client/service/config';
 import CalendarService, { type PublicCalendarListing } from '../service/calendar';
 import { useLocale } from '../composables/useLocale';
 import { useLocalizedContent } from '../composables/useLocalizedContent';
@@ -56,25 +56,36 @@ function calendarPath(urlName: string): string {
   return localizedPath(`/view/${urlName}`);
 }
 
-function tileName(listing: PublicCalendarListing): string {
-  const content = localizedContent(listing.calendar);
-  return content?.name || listing.calendar.urlName;
-}
-
-function tileDescription(listing: PublicCalendarListing): string {
-  const content = localizedContent(listing.calendar);
-  return content?.description || '';
-}
-
 const instanceHost = computed<string>(() => {
   return siteConfig?.settings?.()?.domain ?? '';
 });
 
-function tileHandle(listing: PublicCalendarListing): string {
+/**
+ * Precomputed per-tile view model. Memoizing here ensures each tile's
+ * localizedContent() lookup runs once per render (not once per template
+ * reference) and gives the template a single, explicit cache point.
+ */
+type DisplayListing = {
+  listing: PublicCalendarListing;
+  href: string;
+  name: string;
+  description: string;
+  handle: string;
+};
+
+const displayListings = computed<DisplayListing[]>(() => {
   const host = instanceHost.value;
-  if (!host) return '';
-  return `${listing.calendar.urlName}@${host}`;
-}
+  return calendars.value.map((listing) => {
+    const content = localizedContent(listing.calendar);
+    return {
+      listing,
+      href: calendarPath(listing.calendar.urlName),
+      name: content?.name || listing.calendar.urlName,
+      description: content?.description || '',
+      handle: host ? `${listing.calendar.urlName}@${host}` : '',
+    };
+  });
+});
 
 /**
  * Sets <title> and <meta name="description"> for the discovery page.
@@ -121,7 +132,7 @@ onBeforeMount(async () => {
 
 <template>
   <main class="discovery">
-    <header class="discovery-header">
+    <div class="discovery-header">
       <div class="discovery-header-inner">
         <h1 class="discovery-title">{{ siteTitle }}</h1>
         <p
@@ -137,68 +148,88 @@ onBeforeMount(async () => {
             rel="noopener noreferrer"
           >
             {{ t('discovery.learn_more') }}
+            <span class="sr-only"> ({{ t('opens_in_new_tab') }})</span>
           </a>
         </p>
       </div>
-    </header>
+    </div>
 
-    <section class="discovery-main">
-      <h2 class="discovery-subheading">{{ t('discovery.page_title') }}</h2>
-
-      <div
-        v-if="state === 'loading'"
-        role="status"
-        class="discovery-loading"
+    <section
+      class="discovery-main"
+      aria-labelledby="discovery-calendars-heading"
+    >
+      <h2
+        id="discovery-calendars-heading"
+        class="discovery-subheading"
       >
-        {{ t('discovery.loading_label') }}
+        {{ t('discovery.page_title') }}
+      </h2>
+
+      <!--
+        Single always-present live region for loading + empty + populated
+        announcements. AT registers the container before any text is injected,
+        so the swap is announced. Errors use a separate role="alert" container
+        so they interrupt regardless of the polite queue.
+      -->
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        class="discovery-status"
+      >
+        <span
+          v-if="state === 'loading'"
+          class="discovery-loading"
+        >
+          {{ t('discovery.loading_label') }}
+        </span>
+        <div
+          v-else-if="state === 'empty'"
+          class="discovery-empty"
+        >
+          <h3 class="discovery-empty-heading">{{ t('discovery.empty_state_heading') }}</h3>
+          <p class="discovery-empty-body">{{ t('discovery.empty_state_body') }}</p>
+        </div>
       </div>
 
       <div
-        v-else-if="state === 'error'"
+        v-if="state === 'error'"
         role="alert"
         class="discovery-error"
       >
         {{ t('discovery.error_message') }}
       </div>
 
-      <div
-        v-else-if="state === 'empty'"
-        class="discovery-empty"
-      >
-        <h3 class="discovery-empty-heading">{{ t('discovery.empty_state_heading') }}</h3>
-        <p class="discovery-empty-body">{{ t('discovery.empty_state_body') }}</p>
-      </div>
-
       <ul
-        v-else
+        v-if="state === 'populated'"
         role="list"
         class="discovery-list"
       >
         <li
-          v-for="listing in calendars"
-          :key="listing.calendar.id"
+          v-for="item in displayListings"
+          :key="item.listing.calendar.id"
           class="discovery-list-item"
         >
           <RouterLink
-            :to="calendarPath(listing.calendar.urlName)"
+            :to="item.href"
             class="discovery-tile"
           >
-            <h3 class="discovery-tile-title">{{ tileName(listing) }}</h3>
+            <h3 class="discovery-tile-title">{{ item.name }}</h3>
             <p
-              v-if="tileDescription(listing)"
+              v-if="item.description"
               class="discovery-tile-description"
             >
-              {{ tileDescription(listing) }}
+              {{ item.description }}
             </p>
             <span
-              v-if="tileHandle(listing)"
+              v-if="item.handle"
               class="discovery-tile-handle"
             >
               <CalendarIcon
                 :size="14"
                 aria-hidden="true"
               />
-              <span>{{ tileHandle(listing) }}</span>
+              <span>{{ item.handle }}</span>
             </span>
           </RouterLink>
         </li>
@@ -243,14 +274,9 @@ onBeforeMount(async () => {
   letter-spacing: $public-letter-spacing-tight;
   line-height: $public-line-height-tight;
   margin: 0 0 $public-space-sm 0;
-  color: $public-text-primary-light;
 
   @include public-tablet-up {
-    font-size: 2.25rem;
-  }
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
+    font-size: $public-font-size-3xl;
   }
 }
 
@@ -270,10 +296,7 @@ onBeforeMount(async () => {
   margin: 0;
 
   a {
-    color: $public-accent-light;
-    text-decoration: none;
     border-bottom: 1px solid transparent;
-    transition: $public-transition-normal;
 
     &:hover {
       border-bottom-color: currentColor;
@@ -282,11 +305,11 @@ onBeforeMount(async () => {
     &:focus-visible {
       @include public-focus-visible;
     }
-
-    @include public-dark-mode {
-      color: $public-accent-dark;
-    }
   }
+}
+
+.sr-only {
+  @include public-sr-only;
 }
 
 // ================================================================
@@ -311,11 +334,6 @@ onBeforeMount(async () => {
   letter-spacing: $public-letter-spacing-tight;
   line-height: $public-line-height-tight;
   margin: 0 0 $public-space-lg 0;
-  color: $public-text-primary-light;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
 }
 
 .discovery-list {
@@ -341,11 +359,14 @@ onBeforeMount(async () => {
 }
 
 .discovery-tile {
+  // Inherits background, border (color/width), and dark-mode bg/border from
+  // the sidebar-card mixin. Overrides below: tile-specific radius, padding,
+  // hover lift, layout, and link semantics.
+  @include public-sidebar-card;
+
   display: flex;
   flex-direction: column;
   padding: $public-space-xl;
-  background: $public-bg-primary-light;
-  border: 1px solid $public-border-subtle-light;
   border-radius: $public-radius-lg;
   text-decoration: none;
   color: inherit;
@@ -363,9 +384,6 @@ onBeforeMount(async () => {
   }
 
   @include public-dark-mode {
-    background: $public-bg-primary-dark;
-    border-color: $public-border-subtle-dark;
-
     &:hover {
       border-color: $public-border-medium-dark;
       box-shadow: $public-shadow-md-dark;
@@ -379,11 +397,6 @@ onBeforeMount(async () => {
   line-height: $public-line-height-tight;
   letter-spacing: $public-letter-spacing-tight;
   margin: 0 0 $public-space-sm 0;
-  color: $public-text-primary-light;
-
-  @include public-dark-mode {
-    color: $public-text-primary-dark;
-  }
 }
 
 .discovery-tile-description {
@@ -426,6 +439,9 @@ onBeforeMount(async () => {
   font-size: $public-font-size-lg;
   font-weight: $public-font-weight-semibold;
   margin: 0 0 $public-space-sm 0;
+  // Intentional override: the empty-state mixin sets the container to the
+  // secondary text color so paragraph copy is muted, but the heading should
+  // read as primary text to anchor the empty state visually.
   color: $public-text-primary-light;
 
   @include public-dark-mode {
@@ -435,12 +451,9 @@ onBeforeMount(async () => {
 
 .discovery-empty-body {
   font-size: $public-font-size-base;
-  color: $public-text-secondary-light;
   margin: 0;
   line-height: $public-line-height-relaxed;
-
-  @include public-dark-mode {
-    color: $public-text-secondary-dark;
-  }
+  // Color inherited from the public-empty-state mixin on the container
+  // (secondary text, with dark-mode override). No need to re-declare here.
 }
 </style>

--- a/src/site/components/test/discovery.integration.test.ts
+++ b/src/site/components/test/discovery.integration.test.ts
@@ -118,10 +118,16 @@ describe('discovery.vue - five behavioral states', () => {
     const wrapper = mountDiscovery();
 
     // Synchronous-ish read before flushPromises: the loading state should be
-    // the initial render. The discovery-loading container carries role=status.
+    // the initial render. The shared live-region container carries role=status
+    // and is always present in the DOM so AT registers it before any text is
+    // injected; the loading text is swapped in via v-if.
+    const liveRegion = wrapper.find('.discovery-status');
+    expect(liveRegion.exists()).toBe(true);
+    expect(liveRegion.attributes('role')).toBe('status');
+    expect(liveRegion.attributes('aria-live')).toBe('polite');
+
     const loading = wrapper.find('.discovery-loading');
     expect(loading.exists()).toBe(true);
-    expect(loading.attributes('role')).toBe('status');
     expect(loading.text()).toContain(enSystem.discovery.loading_label);
 
     // List/empty/error must NOT render in the loading frame.
@@ -351,7 +357,9 @@ describe('discovery.vue - five behavioral states', () => {
     expect(link.attributes('href')).toBe('https://pavillion.social');
     expect(link.attributes('target')).toBe('_blank');
     expect(link.attributes('rel')).toContain('noopener');
-    expect(link.text()).toBe(enSystem.discovery.learn_more);
+    expect(link.text()).toContain(enSystem.discovery.learn_more);
+    // SR-only context warns assistive tech that the link opens in a new tab.
+    expect(link.text()).toContain(enSystem.opens_in_new_tab);
   });
 });
 

--- a/src/site/locales/en/system.json
+++ b/src/site/locales/en/system.json
@@ -6,6 +6,9 @@
         "beta_label": "Beta"
     },
     "powered_by": "Powered by Pavillion",
+    "footer": {
+        "login_link": "Log in"
+    },
     "discovery": {
         "page_title": "Calendars on this instance",
         "meta_description": "Browse public calendars hosted on this Pavillion instance.",

--- a/src/site/locales/es/system.json
+++ b/src/site/locales/es/system.json
@@ -6,6 +6,9 @@
         "beta_label": "Beta"
     },
     "powered_by": "Desarrollado por Pavillion",
+    "footer": {
+        "login_link": "Iniciar sesión"
+    },
     "discovery": {
         "page_title": "Calendarios en esta instancia",
         "meta_description": "Explora los calendarios públicos alojados en esta instancia de Pavillion.",

--- a/src/site/locales/fr/system.json
+++ b/src/site/locales/fr/system.json
@@ -6,6 +6,9 @@
         "beta_label": "Beta"
     },
     "powered_by": "Propulsé par Pavillion",
+    "footer": {
+        "login_link": "Se connecter"
+    },
     "discovery": {
         "page_title": "Calendriers sur cette instance",
         "meta_description": "Parcourez les calendriers publics hébergés sur cette instance Pavillion.",

--- a/src/site/test/service/calendar.test.ts
+++ b/src/site/test/service/calendar.test.ts
@@ -4,6 +4,8 @@ import { DateTime } from 'luxon';
 
 import CalendarService from '@/site/service/calendar';
 import ModelService from '@/client/service/models';
+import ListResult from '@/client/service/list-result';
+import { Calendar } from '@/common/model/calendar';
 import CalendarEventInstance from '@/common/model/event_instance';
 
 describe('CalendarService.loadEventInstance', () => {
@@ -94,5 +96,165 @@ describe('CalendarService.loadEventInstance', () => {
     await expect(
       service.loadEventInstance('evt-1', startTime),
     ).rejects.toThrow('Request failed with status code 400');
+  });
+});
+
+describe('CalendarService.listPublicCalendars', () => {
+  const sandbox = sinon.createSandbox();
+  let service: CalendarService;
+
+  beforeEach(() => {
+    service = new CalendarService({} as any, {} as any);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('maps a row with valid content[] into a Calendar with populated CalendarContent per language', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-1',
+          urlName: 'mycal',
+          content: [
+            { language: 'en', name: 'My Calendar', description: 'English desc' },
+            { language: 'es', name: 'Mi Calendario', description: 'Spanish desc' },
+          ],
+          lastEventActivity: '2026-05-08T12:00:00.000Z',
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].calendar).toBeInstanceOf(Calendar);
+    expect(result[0].calendar.id).toBe('cal-1');
+    expect(result[0].calendar.urlName).toBe('mycal');
+    expect(result[0].calendar.getLanguages().sort()).toEqual(['en', 'es']);
+    expect(result[0].calendar.content('en').name).toBe('My Calendar');
+    expect(result[0].calendar.content('en').description).toBe('English desc');
+    expect(result[0].calendar.content('es').name).toBe('Mi Calendario');
+    expect(result[0].calendar.content('es').description).toBe('Spanish desc');
+    expect(result[0].lastEventActivity).toBe('2026-05-08T12:00:00.000Z');
+  });
+
+  it('produces a Calendar with no preloaded content when row.content is null', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-2',
+          urlName: 'empty-content-null',
+          content: null,
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].calendar).toBeInstanceOf(Calendar);
+    expect(result[0].calendar.getLanguages()).toEqual([]);
+  });
+
+  it('produces a Calendar with no preloaded content when row.content is an empty array', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-3',
+          urlName: 'empty-content-arr',
+          content: [],
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].calendar.getLanguages()).toEqual([]);
+  });
+
+  it('silently discards content entries missing a language', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-4',
+          urlName: 'partial',
+          content: [
+            { language: 'en', name: 'Has lang', description: 'd' },
+            { name: 'No lang', description: 'd' },
+            { language: null, name: 'Null lang', description: 'd' },
+            null,
+          ],
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].calendar.getLanguages()).toEqual(['en']);
+    expect(result[0].calendar.content('en').name).toBe('Has lang');
+  });
+
+  it('defaults missing name and description to empty string', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-5',
+          urlName: 'defaults',
+          content: [
+            { language: 'en' },
+          ],
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result[0].calendar.content('en').name).toBe('');
+    expect(result[0].calendar.content('en').description).toBe('');
+  });
+
+  it('passes lastEventActivity through as null when the API returns null', async () => {
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-6',
+          urlName: 'no-activity',
+          content: [{ language: 'en', name: 'n', description: 'd' }],
+          lastEventActivity: null,
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result[0].lastEventActivity).toBeNull();
+  });
+
+  it('passes lastEventActivity through as the ISO string supplied by the API', async () => {
+    // PublicCalendarListing types lastEventActivity as `string | null` — the
+    // backend serializes the timestamp as an ISO 8601 string.
+    sandbox.stub(ModelService, 'listModels').resolves(
+      ListResult.fromArray([
+        {
+          id: 'cal-7',
+          urlName: 'with-activity',
+          content: [{ language: 'en', name: 'n', description: 'd' }],
+          lastEventActivity: '2026-04-22T09:30:00.000Z',
+        },
+      ]),
+    );
+
+    const result = await service.listPublicCalendars();
+
+    expect(result[0].lastEventActivity).toBe('2026-04-22T09:30:00.000Z');
+    expect(typeof result[0].lastEventActivity).toBe('string');
   });
 });


### PR DESCRIPTION
Polish pass on top of #300 plus a small additive feature.

## Summary

- Resolves audit findings from a nine-auditor review of #300 (accessibility, stylesheet, complexity, consistency, testing, privacy, security, architecture, i18n).
- Fixes a correctness margin in `CalendarService.listPublicCalendars` where `LIMIT 500` was being applied to joined content rows rather than distinct calendars.
- Adds a small "Log in" link to the public site footer, sitting in a `space-between` utility row alongside the language switcher.

## What changed

**Discovery page (`src/site/components/discovery.vue`)**
- Replace invalid `<header>` nested inside `<main>` with `<div>` so AT users get a single coherent main landmark.
- Always-rendered `role="status"` live region announces loading and empty transitions reliably.
- `<section>` now has an accessible name via `aria-labelledby`.
- Learn-more link gains an `sr-only` "opens in new tab" hint.
- A single `displayListings` computed eliminates per-tile double-calls of `localizedContent()`.
- `.discovery-tile` extends the existing `public-sidebar-card` mixin; redundant heading-color and link-style declarations dropped in favor of the global `style.scss` rules.

**Stylesheet tokens**
- New `\$public-font-size-3xl` token in `src/site/assets/mixins.scss`.
- `calendar.vue` and `discovery.vue` use the token at their tablet breakpoints instead of the literal `2.25rem`.

**Backend**
- `src/server/public/api/v1/calendar.ts`: rename "admin-discovery flag" comments to "owner-discovery flag" to match DEC-001.
- `src/server/calendar/service/calendar.ts`: split `listPublicCalendars` into a two-step query (id selection → hydrated re-fetch) so `LIMIT 500` caps distinct calendars; new integration test inserts 501 calendars × 3 languages and asserts exactly 500 come back.
- `migrations/0033_add_listed_to_calendar.ts`: add `idx_calendar_listed` index on the query-path column; migration test asserts both directions.
- `src/common/model/calendar.ts`: annotate the new `listed` field in `toObject()` as owner/admin-tier.
- Both proxy interfaces (`calendar/interface`, `public/interface`) trim verbose docblocks to one-line "see CalendarService" references.

**Site footer (`src/site/components/app.vue`)**
- New `.site-footer-utilities` row hosts the language switcher and a new `<a href="/auth/login">` login link.
- `justify-content: space-between` anchors the controls to opposite edges; `flex-wrap: wrap` handles narrow viewports.
- New i18n key `footer.login_link` in en/es/fr.

**Tests**
- New: `publicCalendarListByIp` registration tests; site `CalendarService.listPublicCalendars` mapping unit tests; multilingual 500-cap integration test; migration index assertion.
- Removed: redundant negative-template test for bare `/view` in `app_routes.test.ts`.

## Validation

- `npm run lint`: 0 errors, 275 warnings (matches baseline).
- Affected unit/integration suites: 155 tests pass across `discovery.integration.test.ts`, `list_public_calendars.test.ts`, `calendars-api.test.ts`, `rate-limiters.test.ts`, `app_routes.test.ts`, `migration_0033_add_listed_to_calendar.test.ts`, `site/test/service/calendar.test.ts`.
- Manual: footer layout verified at 1280×800 and 390×844 via Playwright.

## Stacking

Branched off and targeted at `feat/view-discovery-page` (#300). Once #300 merges, this PR will need its base retargeted to `main`; GitHub typically prompts for this automatically.

## Test plan

- [ ] Visit `/view` on desktop — confirm logo centered above utility row with `[English ▾]` left and `Log in` right.
- [ ] Resize to mobile — same layout, no horizontal scroll, no overlap with calendar tiles.
- [ ] Switch language via the switcher; confirm `/es/view` and `/fr/view` render with translated footer link text.
- [ ] Tab through the page; confirm visible focus indicators on every interactive element including the new login link.
- [ ] Screen reader smoke test: loading announcement triggers, empty-state announcement triggers if no calendars are seeded.