### PR TITLE
docs: add per-page SEO metadata and Open Graph tags to VitePress site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,12 +1,38 @@
 import { defineConfig } from 'vitepress';
 
+const SITE_URL = 'https://docs.pavillion.social';
+const SITE_NAME = 'Pavillion docs';
+
 export default defineConfig({
   title: 'Pavillion',
-  description: 'Federated events calendar documentation',
+  description: 'Guides for running and stewarding a Pavillion calendar — a federated, privacy-first events platform for community organizers and instance administrators.',
   cleanUrls: true,
+  sitemap: {
+    hostname: SITE_URL,
+  },
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/pavillion-logo.svg' }],
   ],
+  transformHead({ pageData, siteData }) {
+    const path = pageData.relativePath
+      .replace(/(^|\/)index\.md$/, '$1')
+      .replace(/\.md$/, '');
+    const url = `${SITE_URL}/${path}`;
+    const title = pageData.title || siteData.title;
+    const description = pageData.description || siteData.description;
+    const isHome = pageData.relativePath === 'index.md';
+    return [
+      ['link', { rel: 'canonical', href: url }],
+      ['meta', { property: 'og:type', content: isHome ? 'website' : 'article' }],
+      ['meta', { property: 'og:site_name', content: SITE_NAME }],
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: description }],
+      ['meta', { property: 'og:url', content: url }],
+      ['meta', { name: 'twitter:card', content: 'summary' }],
+      ['meta', { name: 'twitter:title', content: title }],
+      ['meta', { name: 'twitter:description', content: description }],
+    ];
+  },
   srcExclude: [
     'CODE_OF_CONDUCT.md',
     'CONTRIBUTING.md',

--- a/docs/guides/calendar-owners/account.md
+++ b/docs/guides/calendar-owners/account.md
@@ -1,3 +1,7 @@
+---
+description: Manage your Pavillion account — password, email address, and account-level settings that aren't tied to a specific calendar.
+---
+
 # Manage your account
 
 > Status: placeholder. This guide may be written after launch if it's needed; the account UI is mostly self-explanatory.

--- a/docs/guides/calendar-owners/cancel-event.md
+++ b/docs/guides/calendar-owners/cancel-event.md
@@ -1,3 +1,7 @@
+---
+description: Cancel vs. delete an event in Pavillion — what changes for visitors, when to use which, and how cancellations propagate to calendars reposting yours.
+---
+
 # Cancel an event the right way
 
 > Status: stub. Full guide coming before launch.

--- a/docs/guides/calendar-owners/categories.md
+++ b/docs/guides/calendar-owners/categories.md
@@ -1,3 +1,7 @@
+---
+description: Design a small, durable category vocabulary for your Pavillion calendar — filter the public page, link related events, and match across federated calendars.
+---
+
 # Organize events with categories
 
 Categories are the short list of buckets your events fall into — *Concert*, *Workshop*, *Community gathering*, *Volunteer days*. Visitors use them to filter your public page down to what they're looking for, and other calendars use them as the basis for matching when they repost your events alongside their own.

--- a/docs/guides/calendar-owners/category-matching.md
+++ b/docs/guides/calendar-owners/category-matching.md
@@ -1,3 +1,7 @@
+---
+description: Map categories from other calendars onto your own when reposting federated events — set up rules and handle mismatches in Pavillion.
+---
+
 # Match categories from other calendars to yours
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/editors.md
+++ b/docs/guides/calendar-owners/editors.md
@@ -1,3 +1,7 @@
+---
+description: Invite editors to your Pavillion calendar, manage their access, and understand what editors can and can't do compared to the calendar owner.
+---
+
 # Invite editors and manage their access
 
 Most calendars aren't run by one person. The volunteer who handles the music shows isn't the same person who handles the workshops, and neither of them wants to be the only one with the password. This guide is about adding people to the team — inviting editors, understanding what they can and can't do, removing someone when their role changes, and shaping access in ways that scale from a two-person project to a larger collective without losing track of who's allowed to do what.

--- a/docs/guides/calendar-owners/embed.md
+++ b/docs/guides/calendar-owners/embed.md
@@ -1,3 +1,7 @@
+---
+description: Embed your Pavillion calendar on your own website — generate the snippet, configure allowed domains, and choose what the widget shows.
+---
+
 # Embed your calendar on your own website
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/federation-etiquette.md
+++ b/docs/guides/calendar-owners/federation-etiquette.md
@@ -1,3 +1,7 @@
+---
+description: Be a good neighbor across federated Pavillion calendars — attribution, when not to repost, asking before pulling a whole calendar, and what unpost means.
+---
+
 # Be a good neighbor across calendars
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/follow-and-repost.md
+++ b/docs/guides/calendar-owners/follow-and-repost.md
@@ -1,3 +1,7 @@
+---
+description: Connect your Pavillion calendar to others, review incoming events in a private feed, and repost what fits onto your public calendar.
+---
+
 # Bring in events from other calendars
 
 The neighborhood association down the street already runs a calendar. So does the music venue across town and the regional climate-action group. This guide is about bringing some of *their* events onto *your* calendar — finding the calendars that matter to your community, deciding what to do with what shows up, and choosing what to share.

--- a/docs/guides/calendar-owners/funding.md
+++ b/docs/guides/calendar-owners/funding.md
@@ -1,3 +1,7 @@
+---
+description: Enable a community funding plan on your Pavillion calendar — voluntary contributions that sustain the calendar, closer to public radio than to a subscription.
+---
+
 # Set up community funding
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/ics-import.md
+++ b/docs/guides/calendar-owners/ics-import.md
@@ -1,3 +1,7 @@
+---
+description: Migrate events into Pavillion from Google Calendar, Nextcloud, WordPress, Gancio, Mobilizon, and other tools via standard ICS import.
+---
+
 # Migrate from another calendar via ICS import
 
 > Status: stub. Full guide coming before launch.

--- a/docs/guides/calendar-owners/identity.md
+++ b/docs/guides/calendar-owners/identity.md
@@ -1,3 +1,7 @@
+---
+description: Customize the public identity of your Pavillion calendar — display name, description, languages, branding, bio, and URL handle.
+---
+
 # Customize your calendar's identity
 
 > Status: placeholder. This guide will be written after launch, once the identity-customization surface stabilizes.

--- a/docs/guides/calendar-owners/index.md
+++ b/docs/guides/calendar-owners/index.md
@@ -1,3 +1,7 @@
+---
+description: Guides for running a calendar on Pavillion — create events, manage editors, federate with other calendars, and share with your community.
+---
+
 # For calendar owners
 
 These guides are for the people running calendars on Pavillion — community organizers, venue staff, neighborhood associations, regional councils, anyone whose job it is to publish events that other people can find.

--- a/docs/guides/calendar-owners/moderation.md
+++ b/docs/guides/calendar-owners/moderation.md
@@ -1,3 +1,7 @@
+---
+description: Handle visitor reports on your Pavillion calendar — review the queue, take action, and understand the boundary with instance-administrator moderation.
+---
+
 # Handle reports and content moderation
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/multilingual.md
+++ b/docs/guides/calendar-owners/multilingual.md
@@ -1,3 +1,7 @@
+---
+description: Publish events in multiple languages on Pavillion — translatable fields, adding translations, and fallback behavior when a visitor's language doesn't match.
+---
+
 # Publish in multiple languages
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/guides/calendar-owners/places.md
+++ b/docs/guides/calendar-owners/places.md
@@ -1,3 +1,7 @@
+---
+description: Save and reuse event venues on your Pavillion calendar — addresses, rooms and spaces inside a venue, and one-tap directions on the public event page.
+---
+
 # Manage event locations
 
 A *place* in Pavillion is an event location you save once and reuse — an address, a name, a few details. Create the venue once and you can link it to ten different events. Then, when the venue changes its name or you spot a typo in the address, you can fix it once and every event there is updated. (You'll manage them on the **Places** tab on your calendar page, alongside Events, Categories, and Series.)

--- a/docs/guides/calendar-owners/public-url.md
+++ b/docs/guides/calendar-owners/public-url.md
@@ -1,3 +1,7 @@
+---
+description: Share your Pavillion calendar's public URL and federation handle — what each one is for, what visitors see, and how to share them on the web or in a chat.
+---
+
 # Share your public calendar URL
 
 > Status: stub. Full guide coming before launch.

--- a/docs/guides/calendar-owners/quickstart.md
+++ b/docs/guides/calendar-owners/quickstart.md
@@ -1,3 +1,7 @@
+---
+description: Go from a fresh Pavillion login to a published calendar with one event you can share — a ten-to-fifteen-minute on-ramp for new calendar owners.
+---
+
 # Quickstart: from login to a published event
 
 This is your on-ramp. It takes you from "I just got a Pavillion account" to "I have a published calendar with one real event on it that I can share with a friend."

--- a/docs/guides/calendar-owners/recurring-events.md
+++ b/docs/guides/calendar-owners/recurring-events.md
@@ -1,3 +1,7 @@
+---
+description: Post a recurring event on Pavillion — set the schedule, handle exceptions and skipped weeks, and decide when an event has outgrown recurrence for a series.
+---
+
 # Post a recurring event
 
 Most calendars have at least one event that repeats — a weekly board meeting, a monthly meetup, a Tuesday-night open mic. This guide covers how to express those patterns in Pavillion, how to handle the inevitable exceptions ("we're skipping the week of Thanksgiving"), and how to tell when an event has outgrown recurrence and wants to be a series of distinct events instead.

--- a/docs/guides/calendar-owners/series.md
+++ b/docs/guides/calendar-owners/series.md
@@ -1,3 +1,7 @@
+---
+description: Group related events into a Pavillion series — a named program of distinct events that share an identity, like a concert season or a lecture run.
+---
+
 # Group related events into a series
 
 A series is a named program made up of distinct events that share an identity — a *Summer Music Series* of concerts on different dates with different performers, a *Fall Lecture Series* with a different speaker each Thursday, a *Neighborhood Repair Café* that meets monthly with a different focus or location each time. The events differ in their substance, but they belong together under one program name. A series is how you tell visitors *these are part of the same thing*, even when no two of them are alike.

--- a/docs/guides/calendar-owners/when-to-create-a-calendar.md
+++ b/docs/guides/calendar-owners/when-to-create-a-calendar.md
@@ -1,3 +1,7 @@
+---
+description: Decide when to create a new Pavillion calendar versus follow an existing one — and when categories handle the subdivision for a single community.
+---
+
 # Decide when to make a calendar (and when to follow one instead)
 
 > Status: placeholder. This guide will be written after launch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 layout: home
+title: Pavillion — Federated events calendar documentation
+titleTemplate: false
+description: Documentation for Pavillion, a federated, privacy-first events calendar. Guides for calendar owners, instance administrators, and contributing developers.
 
 hero:
   name: Pavillion


### PR DESCRIPTION
## Motivation

Every VitePress page in the documentation site was emitting the same boilerplate `<meta name="description" content="Federated events calendar documentation">` because no markdown file specified one — VitePress falls back to the site-wide description for any page that doesn't override it. On top of that, no Open Graph tags, Twitter Card tags, or canonical-URL tags were being generated at all. Practical consequences:

- Search engines saw 22 different pages with identical meta descriptions — bad for SERP relevance signals and useless as snippets.
- Links shared in Slack, Discord, Mastodon, or any social platform fell back to URL-only previews with no title card, no description, no image. For a federated-network product whose audience lives on Mastodon, that's a material miss.
- The home page's `<title>` was just `Pavillion` — no context for anyone arriving from a search result.

## Approach

Five fixes, scoped to the docs site only:

1. **Per-page descriptions.** Added a unique `description` frontmatter to all 20 calendar-owner guides and the section index. Each description is under ~160 characters (longest is 160, at Google's typical SERP cap).
2. **Sharpened site-wide description** in `docs/.vitepress/config.mts` so the fallback is meaningful for any new page that omits its own description.
3. **Home page title and description.** Added `title`, `titleTemplate: false`, and `description` to `docs/index.md` so the home `<title>` becomes `Pavillion — Federated events calendar documentation` instead of the bare brand name.
4. **Open Graph and Twitter Card tags via `transformHead`.** Added a hook in `config.mts` that emits, per page: `<link rel="canonical">`, `og:type` (website for home, article elsewhere), `og:site_name`, `og:title`, `og:description`, `og:url`, `twitter:card`, `twitter:title`, `twitter:description`. All derived from page frontmatter with site-level fallbacks.
5. **Canonical URLs and sitemap.** Set `sitemap.hostname` in `config.mts` so VitePress now emits a `sitemap.xml` covering all 21 URLs. Canonical hrefs and `og:url` values share the same `SITE_URL` constant.

The canonical host is `https://docs.pavillion.social`, matching the marketing site at `pavillion.social`. If the docs site is hosted elsewhere, only the `SITE_URL` constant at the top of `config.mts` needs to change — every page derives its canonical URL from it.

What was deliberately **not** done:

- No `og:image`. Cheapest add later is dropping a single 1200×630 PNG in `docs/public/` and referencing it in `transformHead`.
- No `robots` meta — defaults to indexable, which is correct for the production host.

## Validation

Ran `npm run docs:build` and inspected the generated HTML head of every page:

- All 21 page titles are unique. Home is now `Pavillion — Federated events calendar documentation`; all others follow the existing `<H1> | Pavillion` template.
- All 21 meta descriptions are unique and page-specific.
- Every page has a `<link rel="canonical">` pointing at the correct URL.
- Every page has the full set of Open Graph and Twitter Card tags. The home page uses `og:type=website`; guide pages use `og:type=article`.
- `sitemap.xml` is generated and lists all 21 URLs.
- Build is clean (2.46s, no warnings).