### PR TITLE
fix(funding): align provider webhook URL with mounted route

### DIFF
--- a/src/server/funding/service/provider/webhook_manager.ts
+++ b/src/server/funding/service/provider/webhook_manager.ts
@@ -32,6 +32,10 @@ export class WebhookManager {
    * @private
    */
   private getInstanceDomain(): string {
+    return this.enforceHttpsForRemoteHosts(this.resolveRawDomain());
+  }
+
+  private resolveRawDomain(): string {
     // Try to get domain from config
     try {
       if (config.has('server.domain')) {
@@ -55,5 +59,23 @@ export class WebhookManager {
     // Unconditional fallback to localhost for development/test environments
     // This handles cases where NODE_ENV might not be properly set in test environments
     return 'http://localhost:3000';
+  }
+
+  /**
+   * Upgrade http:// to https:// for any non-localhost host.
+   *
+   * Payment provider dashboards (Stripe, PayPal) reject non-HTTPS webhook URLs
+   * in production. A reverse proxy that terminates TLS in front of the app
+   * commonly leaves the in-cluster BASE_URL as http://, which would otherwise
+   * leak through into the URL we hand to the operator.
+   *
+   * Localhost is left as http:// so local development still works without
+   * generating a TLS certificate.
+   */
+  private enforceHttpsForRemoteHosts(url: string): string {
+    const isLocalhost = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(url);
+    if (isLocalhost) return url;
+    if (url.startsWith('http://')) return `https://${url.slice('http://'.length)}`;
+    return url;
   }
 }

--- a/src/server/funding/service/provider/webhook_manager.ts
+++ b/src/server/funding/service/provider/webhook_manager.ts
@@ -11,14 +11,18 @@ export class WebhookManager {
   /**
    * Generate webhook URL for a specific provider
    *
-   * Format: https://{domain}/api/funding/v1/webhooks/{provider_type}
+   * Format: https://{domain}/api/funding/webhooks/{provider_type}
+   *
+   * The webhook route is intentionally mounted without the /v1 prefix in
+   * src/server/funding/api/v1.ts — webhook URLs are pasted into third-party
+   * provider dashboards and should not churn with internal API version bumps.
    *
    * @param providerType - The provider type (stripe or paypal)
    * @returns Fully qualified webhook URL
    */
   generateWebhookUrl(providerType: ProviderType): string {
     const domain = this.getInstanceDomain();
-    return `${domain}/api/funding/v1/webhooks/${providerType}`;
+    return `${domain}/api/funding/webhooks/${providerType}`;
   }
 
   /**

--- a/src/server/funding/test/provider_webhook.test.ts
+++ b/src/server/funding/test/provider_webhook.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
+import express from 'express';
+import request from 'supertest';
 import { WebhookManager } from '../service/provider/webhook_manager';
+import WebhookRoutes from '../api/v1/webhooks';
 
 /**
  * Tests for WebhookManager Utility Service
@@ -26,7 +29,7 @@ describe('WebhookManager Utility Service', () => {
     const webhookUrl = webhookManager.generateWebhookUrl(providerType);
 
     // Webhook URL should contain the correct path structure
-    expect(webhookUrl).toContain('/api/funding/v1/webhooks/stripe');
+    expect(webhookUrl).toContain('/api/funding/webhooks/stripe');
     expect(webhookUrl).toContain('stripe');
   });
 
@@ -43,7 +46,31 @@ describe('WebhookManager Utility Service', () => {
     const webhookUrl = webhookManager.generateWebhookUrl('stripe');
 
     // Should generate a valid webhook URL path
-    expect(webhookUrl).toContain('/api/funding/v1/webhooks/');
+    expect(webhookUrl).toContain('/api/funding/webhooks/');
     expect(webhookUrl.length).toBeGreaterThan(0);
+  });
+
+  // Regression test for the bug where the wizard surfaced /api/funding/v1/webhooks/...
+  // but the route was mounted at /api/funding/webhooks/... — operators copied the
+  // generated URL into the Stripe Dashboard verbatim and every delivery 404'd.
+  it('should generate a URL whose path resolves to the mounted webhook route', async () => {
+    const generatedUrl = webhookManager.generateWebhookUrl('stripe');
+    const pathMatch = generatedUrl.match(/\/api\/funding\/[^?#]+/);
+    expect(pathMatch, `generated URL has no /api/funding path: ${generatedUrl}`).not.toBeNull();
+    const pathname = pathMatch![0];
+
+    const handleStripeWebhook = sandbox.stub().resolves();
+    const app = express();
+    const webhookRoutes = new WebhookRoutes({ handleStripeWebhook } as any);
+    webhookRoutes.installHandlers(app, '/api/funding');
+
+    // A request without a Stripe-Signature header reaches the handler and gets
+    // 400. A 404 means the generated path does not match the mounted route.
+    const response = await request(app)
+      .post(pathname)
+      .set('Content-Type', 'application/json')
+      .send('{}');
+
+    expect(response.status).not.toBe(404);
   });
 });

--- a/src/server/funding/test/provider_webhook.test.ts
+++ b/src/server/funding/test/provider_webhook.test.ts
@@ -73,4 +73,39 @@ describe('WebhookManager Utility Service', () => {
 
     expect(response.status).not.toBe(404);
   });
+
+  // Payment provider dashboards (Stripe, PayPal) reject non-HTTPS webhook URLs in
+  // production. If a deployment sets BASE_URL to http:// (typical when a reverse
+  // proxy terminates TLS in front of the app), the generator must still emit
+  // https:// so the URL the operator pastes is actually accepted.
+  describe('HTTPS enforcement', () => {
+    let originalBaseUrl: string | undefined;
+
+    beforeEach(() => {
+      originalBaseUrl = process.env.BASE_URL;
+    });
+
+    afterEach(() => {
+      if (originalBaseUrl === undefined) delete process.env.BASE_URL;
+      else process.env.BASE_URL = originalBaseUrl;
+    });
+
+    it('should upgrade BASE_URL http:// to https:// for non-localhost domains', () => {
+      process.env.BASE_URL = 'http://staging.pavillion.dev';
+      const url = webhookManager.generateWebhookUrl('stripe');
+      expect(url.startsWith('https://staging.pavillion.dev')).toBe(true);
+    });
+
+    it('should preserve BASE_URL https:// unchanged', () => {
+      process.env.BASE_URL = 'https://prod.pavillion.dev';
+      const url = webhookManager.generateWebhookUrl('stripe');
+      expect(url.startsWith('https://prod.pavillion.dev')).toBe(true);
+    });
+
+    it('should keep http:// for localhost so local dev still works', () => {
+      delete process.env.BASE_URL;
+      const url = webhookManager.generateWebhookUrl('stripe');
+      expect(url.startsWith('http://localhost')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Motivation

The add-provider setup wizard surfaced `/api/funding/v1/webhooks/<provider>` to operators as the URL to paste into Stripe/PayPal dashboards, but the webhook route is intentionally mounted at `/api/funding/webhooks/<provider>` (no `/v1`) — see the explanatory comment in `src/server/funding/api/v1.ts:39`. Operators copied the generated URL verbatim, every webhook delivery 404'd, and Stripe sent a warning that the staging endpoint would auto-disable after 29 consecutive failures.

The contradiction was codified in two separate test files that passed independently of each other:

- `src/server/funding/test/webhooks.test.ts` exercised the actual mount at `/api/funding/webhooks/stripe` — passed.
- `src/server/funding/test/provider_webhook.test.ts` asserted that `generateWebhookUrl` emitted `/api/funding/v1/webhooks/...` — also passed.

No test verified that the URL the wizard hands out can actually reach the mounted route, so the drift slipped through review.

The same investigation surfaced a second axis of the same incident: the staging Stripe Dashboard URL was `http://`, not `https://`. Caddy 308-redirected to https, Stripe (which does not follow redirects on webhook delivery) counted every retry as a delivery failure. The most plausible source was the URL generator passing `process.env.BASE_URL` through verbatim — a reverse proxy terminating TLS in front of the app commonly leaves the in-cluster BASE_URL as http://, and that string flowed straight into the wizard.

## Approach

Two commits, both targeting the URL generator:

**1. Path alignment (`25b9268`).** Change `generateWebhookUrl` to emit `/api/funding/webhooks/<provider>` so the wizard, the admin API response, and the route mount all agree. The two existing assertions that codified the buggy path are corrected, and a new regression test calls `generateWebhookUrl`, extracts the path, and POSTs against a real mounted `WebhookRoutes` instance — a 404 response fails the test, so any future drift between the generator and the mount is caught in CI rather than via Stripe's three-days-late email.

**2. Force HTTPS for non-localhost hosts (`af2568f`).** Defense-in-depth for the scheme axis. The URL generator now upgrades `http://` to `https://` for any non-localhost host. Localhost stays `http://` so local dev still works without a TLS certificate. Three new tests cover the upgrade, the no-op for already-https URLs, and the localhost carve-out.

The wizard UI is unchanged in both commits — it just receives a corrected string from the admin API now.

## Validation

- For the path fix: watched the regression test fail first with `expected 404 not to be 404` (confirming RED for the right reason — generator emitted the wrong path), then pass after the generator change.
- For the HTTPS fix: watched the upgrade test fail (`expected false to be true` against `url.startsWith('https://staging.pavillion.dev')`), then pass after the upgrade helper landed.
- All 322 funding tests pass (`npx vitest run src/server/funding/test`).
- Lint pass on changed files — 0 errors, only one pre-existing unused-variable warning in untouched code.
- Build-guardian gate against the first commit: lint PASS (0 errors, 276 pre-existing warnings), 7908 unit tests PASS, 599 integration tests PASS, frontend + widget SDK build PASS. 5 e2e tests failed for environmental reasons (server-process crashes, missing federation SSL certs, stale ports) matching the previously-known pre-existing failure set and unrelated to webhook code paths.

**Operator follow-up (not part of this PR):** the Stripe Dashboard webhook URL on staging needs to be manually corrected from `http://staging.pavillion.dev/api/funding/v1/webhooks/stripe` to `https://staging.pavillion.dev/api/funding/webhooks/stripe` before the auto-disable deadline. The code fix doesn't retroactively change anything that's already been told to Stripe.