### PR TITLE
test(activitypub): outbox skips local dispatch for non-Announce activities

### DIFF
--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -989,6 +989,66 @@ describe('processOutboxMessage — local/remote dispatcher split', () => {
     expect(updateStub.calledOnce).toBe(true);
   });
 
+  it('still HTTP POSTs Create activities even when recipient resolves to a local calendar', async () => {
+    // Regression test for the intentional half-migration in outbox.ts: only
+    // Announce activities are eligible for in-process local dispatch.
+    // Create/Update/Delete fall through to HTTP regardless of recipient
+    // locality, pending pv-fs02 (HTTP signatures) and a decision about
+    // whether to extend local dispatch to all activity types. If the type
+    // gate (`message.type === 'Announce'`) were removed from outbox.ts,
+    // this test would fail.
+    const eventBus = new EventEmitter();
+    const localCalendar = Calendar.fromObject({ id: 'local-cal-id' });
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+
+    const service = new ProcessOutboxService(eventBus, mockInbox);
+    // Stub local-calendar resolution defensively: if the type gate were
+    // broken, the dispatcher would consult this stub and route the recipient
+    // to in-process dispatch. The assertions below verify it stays unused.
+    sandbox
+      .stub(service.calendarActorService, 'getLocalCalendarByActorUri')
+      .resolves(localCalendar);
+    stubSigning(service, sandbox);
+
+    // Build a Create outbox message — Create is the type that exercises the
+    // half-migration gate. Setup parallels the Announce-local test above
+    // except for the activity type.
+    const createMessage = createMockCreateActivity(LOCAL_ACTOR_URL, {
+      type: 'Event',
+      id: `${LOCAL_ACTOR_URL}/events/123`,
+      name: 'Test Event',
+    });
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Create',
+      message: createMessage,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const axiosPostStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveInboxStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    getRecipientsStub.resolves([LOCAL_RECIPIENT_URI]);
+    resolveInboxStub.resolves('https://local.federation.test/calendars/localcal/inbox');
+
+    await service.processOutboxMessage(message);
+
+    expect(
+      (mockInbox.handleLocalAnnounceDispatch as sinon.SinonStub).called,
+      'handleLocalAnnounceDispatch must NOT be called for Create activities, even when recipient resolves locally',
+    ).toBe(false);
+    expect(
+      axiosPostStub.called,
+      'Create activities must be HTTP POSTed regardless of recipient locality (pending pv-fs02)',
+    ).toBe(true);
+    expect(updateStub.calledOnce).toBe(true);
+  });
+
   it('skips dispatch when getLocalCalendarByActorUri returns null for a local-looking actor with missing calendar', async () => {
     const eventBus = new EventEmitter();
     const mockInbox = {


### PR DESCRIPTION
## Motivation

The outbox dispatcher routes Announce activities to in-process local dispatch but falls through to HTTP for Create/Update/Delete, even when the recipient URI would resolve to a local calendar. This is an intentional half-migration — local dispatch was scoped to Announce while a separate decision is pending about whether to widen it to all activity types.

The routing was untested. If a future change accidentally removed the `message.type === 'Announce'` clause from the type gate, Create activities could end up bypassing HTTP signatures when delivered to local-looking recipients. That would be a federation-correctness regression with no test to catch it.

## Approach

One new regression test in `src/server/activitypub/test/service/outbox.test.ts`, placed inside the existing `processOutboxMessage — local/remote dispatcher split` describe block alongside the three sibling tests that cover the Announce path.

The test mirrors the Announce-local test's setup almost verbatim but switches the activity type to `Create`. Critically, it stubs `calendarActorService.getLocalCalendarByActorUri` to return a real local Calendar — if the type gate were broken, the dispatcher would consult the stub, get a non-null result, and route to `handleLocalAnnounceDispatch` instead of `axios.post`. With the gate intact, the stub is never consulted (Create short-circuits at the gate), so the test asserts the HTTP path was taken: `handleLocalAnnounceDispatch.called === false` and `axiosPostStub.called === true`.

No production code changes. The test documents existing behavior as a regression guard.

## Validation

- `npm run lint` — clean (0 errors; pre-existing warning count unchanged).
- `npx vitest run src/server/activitypub/test/service/outbox.test.ts` — 41/41 pass (was 40 pre-change).
- Full unit (7908) + integration (599) suites — pass.
- Mental mutation check: removing `&& message.type === 'Announce'` from the gate would route Create through in-process dispatch, flipping both assertions. Verified by reasoning through the dispatcher's branches.
- Reviewed by testing-auditor (PASS), consistency-auditor (PASS), and architecture-auditor (PASS).