### PR TITLE
refactor(activitypub): make ProcessOutboxService inboxService required

### DIFF
--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -37,24 +37,17 @@ class ProcessOutboxService {
   calendarService: CalendarInterface;
   calendarActorService: CalendarActorService;
   private userActorService: UserActorService;
-  private inboxService: ProcessInboxService | null;
+  private inboxService: ProcessInboxService;
 
   /**
    * @param eventBus - Shared event bus
-   * @param inboxService - Required in production (wired by ActivityPubInterface).
-   *   Optional only to preserve backward compatibility with existing test
-   *   fixtures that construct ProcessOutboxService(eventBus). When null,
-   *   local recipients fall back to HTTP delivery — pre-Phase-3 behavior,
-   *   a test-only degradation.
+   * @param inboxService - In-process inbox service used for local Announce dispatch.
    */
-  constructor(eventBus: EventEmitter, inboxService?: ProcessInboxService) {
+  constructor(eventBus: EventEmitter, inboxService: ProcessInboxService) {
     this.calendarService = new CalendarInterface(eventBus);
     this.calendarActorService = new CalendarActorService(this.calendarService);
     this.userActorService = new UserActorService(this.calendarService);
-    this.inboxService = inboxService ?? null;
-    if (!this.inboxService) {
-      logger.warn('[OUTBOX] constructed without ProcessInboxService — local recipients will degrade to HTTP delivery (test-only path)');
-    }
+    this.inboxService = inboxService;
   }
 
   /**
@@ -346,13 +339,14 @@ class ProcessOutboxService {
 
       let deliveryErrors: string[] = [];
 
+      // Decide whether this activity type can be served in-process (local) or
+      // must be HTTP-delivered (remote). Only Announce activities are eligible
+      // for in-process dispatch; Create/Update/Delete fall through to HTTP
+      // regardless of actor type, pending pv-fs02 (HTTP signatures) and a
+      // decision about whether to extend local dispatch to all activity types.
+      const canDispatchLocally = message.type === 'Announce';
+
       for (const recipient of recipients) {
-        // Decide whether this recipient can be served in-process (local) or
-        // must be HTTP-delivered (remote). Only Announce activities are eligible
-        // for in-process dispatch; Create/Update/Delete fall through to HTTP
-        // regardless of actor type, pending pv-fs02 (HTTP signatures) and a
-        // decision about whether to extend local dispatch to all activity types.
-        const canDispatchLocally = this.inboxService !== null && message.type === 'Announce';
         const localCalendar = canDispatchLocally
           ? await this.calendarActorService.getLocalCalendarByActorUri(recipient)
           : null;
@@ -360,7 +354,7 @@ class ProcessOutboxService {
         if (localCalendar) {
           // Local in-process path: skip HTTP entirely.
           try {
-            await this.inboxService!.handleLocalAnnounceDispatch(localCalendar, activity as AnnounceActivity);
+            await this.inboxService.handleLocalAnnounceDispatch(localCalendar, activity as AnnounceActivity);
             logger.info({ recipient }, '[OUTBOX-LOCAL] Dispatched in-process');
           }
           catch (error: any) {
@@ -390,8 +384,7 @@ class ProcessOutboxService {
         }
 
         // Remote HTTP path (covers: remote actors on other hosts, WebFinger
-        // handles, local non-Announce activities, and the test-only
-        // null-inboxService fallback).
+        // handles, local non-Announce activities).
         await this.deliverViaHttp(recipient, message, activity, deliveryErrors);
       }
 

--- a/src/server/activitypub/test/integration/flag-outbox.test.ts
+++ b/src/server/activitypub/test/integration/flag-outbox.test.ts
@@ -13,6 +13,7 @@ import { EventEmitter } from 'events';
 
 import { Calendar } from '@/common/model/calendar';
 import ProcessOutboxService from '@/server/activitypub/service/outbox';
+import ProcessInboxService from '@/server/activitypub/service/inbox';
 import { ActivityPubOutboxMessageEntity } from '@/server/activitypub/entity/activitypub';
 
 // Test constants
@@ -39,7 +40,10 @@ describe('Flag activity outbox processing', () => {
 
   beforeEach(() => {
     eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     stubSigning(service, sandbox);
   });
 

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -82,7 +82,10 @@ describe('resolveInbox', () => {
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
   });
 
@@ -152,7 +155,10 @@ describe('fetchProfileUrl', () => {
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
   });
 
@@ -216,7 +222,10 @@ describe('getRecipients', () => {
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
   });
 
   afterEach(() => {
@@ -271,7 +280,10 @@ describe('processOutboxMessage', () => {
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
   });
 
@@ -593,7 +605,10 @@ describe('processOutboxMessage — explicit `to` honoring for Update/Delete/Add'
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
   });
 
@@ -1109,7 +1124,10 @@ describe('deliverActivitySigned', () => {
 
   beforeEach(() => {
     const eventBus = new EventEmitter();
-    service = new ProcessOutboxService(eventBus);
+    const mockInbox = {
+      handleLocalAnnounceDispatch: sandbox.stub().resolves(),
+    } as unknown as ProcessInboxService;
+    service = new ProcessOutboxService(eventBus, mockInbox);
     vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
   });
 


### PR DESCRIPTION
## Motivation

`ProcessOutboxService.inboxService` was typed `ProcessInboxService | null` and had an optional constructor parameter solely so legacy test fixtures could construct the service with a single argument. Production wiring (`src/server/activitypub/interface/index.ts`) has always passed the inbox service. The shim hid that invariant in a runtime warn log and three `!` non-null assertions instead of stating it in the type.

The same path also re-evaluated `canDispatchLocally` per-recipient inside `processOutboxMessage`'s loop, even though every input to that check is loop-invariant.

## Approach

In `src/server/activitypub/service/outbox.ts`:

- Drop `?` and `| null` from the `inboxService` constructor parameter and class field. Remove the `?? null` coalescing, the construction-time warn log, and the `!` non-null assertion on the `handleLocalAnnounceDispatch` call.
- Hoist `canDispatchLocally` out of the recipient loop in `processOutboxMessage`. With `inboxService` required, the predicate simplifies to `message.type === 'Announce'`, which is a message-level decision; the per-recipient work (`getLocalCalendarByActorUri`) stays inside the loop where it belongs.
- Trim the JSDoc and a trailing inline comment that still referenced the now-removed test-only null-inboxService fallback.

In `src/server/activitypub/test/service/outbox.test.ts` and `src/server/activitypub/test/integration/flag-outbox.test.ts`:

- Update seven fixture call sites to construct a minimal `ProcessInboxService` stub (`{ handleLocalAnnounceDispatch: sandbox.stub().resolves() } as unknown as ProcessInboxService`). None of these tests exercise the local-dispatch branch, so the stub is inert in their cases. The dedicated `processOutboxMessage — local/remote dispatcher split` describe block continues to assert against the stub as before.

No behavior change beyond removing the warn log; no public API surface change beyond the constructor signature.

## Validation

- `npm run lint`: 0 errors (pre-existing warnings unchanged).
- Unit suite (`npx vitest run`): 7907/7907 pass.
- Integration suite: 599/599 pass, 5 skipped.
- `npm run build`: clean.
- Targeted outbox/inbox tests (`outbox.test.ts`, `flag-outbox.test.ts`, `outbox-local-dispatch.integration.test.ts`, `handle-local-announce-dispatch.integration.test.ts`, `auto-repost.integration.test.ts`): all green.

E2E failure unrelated to this branch: `tests/e2e/import-sources.spec.ts` requires `docker/federation/ssl/alpha.federation.local.crt`, which is generated locally by `docker/federation/start.sh` and not regenerated in this worktree. The diff has no overlap with the federation docker stack or ICS import code.

## Follow-up notes (non-blocking)

Per-bead auditor warnings to consider in a later cleanup:

- `mockInbox` literal is duplicated across the test files; extract a `buildMockInboxService(sandbox)` factory to match the precedent in `federation_publisher.test.ts`.
- The local-dispatch test verifies `handleLocalAnnounceDispatch.calledOnce` but not the arguments passed; consider tightening to `calledOnceWith(localCalendar, sinon.match.instanceOf(AnnounceActivity))`.
- No positive test that a `Create`/`Update` message with a local-host recipient skips `getLocalCalendarByActorUri`; the hoist's semantic effect is currently only verified by absence of failure.