### PR TITLE
test(activitypub): add receive-side HTTP signature verification e2e

### DIFF
--- a/tests/e2e/federation/helpers/strict_receive.ts
+++ b/tests/e2e/federation/helpers/strict_receive.ts
@@ -1,0 +1,140 @@
+/**
+ * Strict-Receive Helper for Federation Signature Tests
+ *
+ * Provides a way to flip beta into strict signature-receive mode
+ * (SKIP_SIGNATURES=false) for the duration of a single spec, then restore the
+ * default (SKIP_SIGNATURES=true) afterwards so other federation specs are
+ * unaffected.
+ *
+ * Why a container recreate is required:
+ *   verifyHttpSignature -> shouldSkipSignatures() reads process.env.SKIP_SIGNATURES
+ *   on every request (src/server/activitypub/helper/http_signature.ts:33-63).
+ *   The Node process inside the container inherits its env once at boot;
+ *   docker exec cannot mutate the parent process's env. The only way to flip
+ *   the value is to recreate the container with the new env.
+ *
+ * Strategy:
+ *   - Write a temporary docker-compose override file that sets the desired
+ *     SKIP_SIGNATURES value on instance_beta.
+ *   - `docker compose -f docker-compose.federation.yml -f <override> up -d
+ *     --no-deps instance_beta` recreates beta only, leaving alpha + nginx +
+ *     databases untouched.
+ *   - Poll beta's /health endpoint until it is ready before returning.
+ *
+ * The helper is intentionally scoped to instance_beta; flipping alpha is not
+ * needed for receive-side verification (alpha is the signer, beta is the
+ * verifier).
+ */
+
+import { execSync } from 'child_process';
+import { writeFileSync, unlinkSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import https from 'https';
+import { INSTANCE_BETA } from './instances';
+
+// Self-signed cert tolerance for local Docker federation environment
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+const COMPOSE_FILE = 'docker-compose.federation.yml';
+// PID-scoped to avoid collisions when concurrent Playwright workers (or
+// concurrent CI runs sharing the tmpdir) both invoke setBetaSkipSignatures.
+const OVERRIDE_PATH = join(tmpdir(), `pavillion-federation-strict-receive.${process.pid}.override.yml`);
+
+/**
+ * Build a minimal docker-compose override that flips SKIP_SIGNATURES on beta.
+ *
+ * Note: docker compose merges environment lists by KEY=VAL prefix, so naming
+ * the variable identically here replaces the value from the base compose file
+ * rather than appending a second entry.
+ */
+function buildOverrideYaml(skipSignatures: 'true' | 'false'): string {
+  return [
+    'services:',
+    '  instance_beta:',
+    '    environment:',
+    `      - SKIP_SIGNATURES=${skipSignatures}`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Poll beta's /health endpoint until it returns 200 or the deadline elapses.
+ *
+ * @param timeoutMs - Maximum time to wait for beta to come back up
+ * @param intervalMs - Polling interval
+ * @throws Error if beta does not become healthy before the deadline
+ */
+export async function waitForBetaHealthy(
+  timeoutMs = 60000,
+  intervalMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${INSTANCE_BETA.baseUrl}/health`, {
+        // @ts-ignore - agent is not in the TypeScript types but works at runtime
+        agent: httpsAgent,
+      });
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`/health returned ${response.status}`);
+    }
+    catch (error) {
+      lastError = error;
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(
+    `Beta did not become healthy within ${timeoutMs}ms (last error: ${String(lastError)})`,
+  );
+}
+
+/**
+ * Recreate the beta container with SKIP_SIGNATURES set to the requested value
+ * and wait for it to become healthy.
+ *
+ * @param value - 'true' to bypass signature verification (default),
+ *                'false' to enforce strict signature verification.
+ */
+export async function setBetaSkipSignatures(value: 'true' | 'false'): Promise<void> {
+  // Write the override file. Always rewrite so we never trust a stale file
+  // from a previous interrupted run.
+  writeFileSync(OVERRIDE_PATH, buildOverrideYaml(value), 'utf8');
+
+  // Recreate beta only. --no-deps avoids touching nginx/alpha/databases.
+  // --force-recreate ensures docker actually applies the new env even if the
+  // image and other config are unchanged.
+  execSync(
+    `docker compose -f ${COMPOSE_FILE} -f ${OVERRIDE_PATH} up -d --no-deps --force-recreate instance_beta`,
+    { stdio: 'pipe' },
+  );
+
+  await waitForBetaHealthy();
+}
+
+/**
+ * Restore beta to the default SKIP_SIGNATURES=true state (matching the base
+ * compose file) and clean up the override file. Safe to call in afterAll even
+ * if setBetaSkipSignatures was never called -- it simply recreates beta with
+ * the base config.
+ */
+export async function restoreBetaDefaultSignatures(): Promise<void> {
+  try {
+    execSync(
+      `docker compose -f ${COMPOSE_FILE} up -d --no-deps --force-recreate instance_beta`,
+      { stdio: 'pipe' },
+    );
+    await waitForBetaHealthy();
+  }
+  finally {
+    if (existsSync(OVERRIDE_PATH)) {
+      try {
+        unlinkSync(OVERRIDE_PATH);
+      }
+      catch { /* best-effort cleanup */ }
+    }
+  }
+}

--- a/tests/e2e/federation/signature_strict_receive.spec.ts
+++ b/tests/e2e/federation/signature_strict_receive.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * Strict-Receive HTTP Signature Verification
+ *
+ * Bead context: pv-3xit -- proves receive-side cryptographic verification of
+ * inbound ActivityPub HTTP signatures across the real Docker / nginx
+ * federation harness. The companion spec
+ * `tests/e2e/federation/signed_delivery.spec.ts` proves the outbound signing
+ * pipeline produces a syntactically valid signed POST. This spec proves the
+ * inbound side actually validates the cryptography end-to-end.
+ *
+ * Why a separate spec:
+ *   The federation harness sets SKIP_SIGNATURES=true on both instances by
+ *   default so unrelated federation specs do not pay a per-request signature
+ *   cost and do not need to chase signing regressions to make calendar
+ *   federation work. This spec flips SKIP_SIGNATURES=false on beta only for
+ *   the duration of its tests by recreating the beta container with an env
+ *   override, and restores the default afterwards. See
+ *   tests/e2e/federation/helpers/strict_receive.ts for details on why a
+ *   container recreate is required (the Node process reads process.env on
+ *   every request and docker exec cannot mutate the parent process's env).
+ *
+ * Coverage:
+ *   - Positive: a signed Create(Event) from alpha is cryptographically
+ *     verified by beta (SKIP_SIGNATURES=false) and the event propagates to
+ *     beta's follower feed.
+ *   - Negative (missing signature): a raw POST to beta's calendar inbox with
+ *     no Signature header is rejected with 400 (the http-signature library
+ *     throws MissingHeaderError, which the middleware maps to 400 Bad Request
+ *     -- see src/server/activitypub/helper/http_signature.ts:167-170).
+ *   - Negative (forged signature): a raw POST to beta's calendar inbox with
+ *     a syntactically valid but cryptographically invalid Signature header is
+ *     rejected with 401 (signature parses, then fails cryptographic
+ *     verification).
+ *
+ * In both negative cases, "rejected" means the inbox refuses to process the
+ * activity before any business logic runs. The exact status code differs by
+ * branch: 400 for missing-header (parse never starts), 401 for
+ * invalid-signature (parse succeeds, verification fails). Both prove the
+ * signature gate works.
+ *
+ * What this proves (and what it does NOT prove):
+ *   The positive case proves the full cross-container path -- alpha signs
+ *   with its real RSA key, nginx terminates TLS and forwards the request,
+ *   beta fetches alpha's public key, beta verifies the digest and signature.
+ *   The negative cases lock in the contract that the signature gate
+ *   short-circuits with 401 before any inbox business logic runs. They do
+ *   not exhaustively cover every possible forgery; deeper unit-level
+ *   coverage lives in
+ *   `src/server/activitypub/test/helper/http_signature.test.ts`.
+ *
+ * Prerequisites:
+ *   - Federation environment running: npm run federation:start
+ *   - /etc/hosts entries for alpha.federation.local and beta.federation.local
+ *   - Docker CLI available on PATH (the helper recreates the beta container).
+ */
+
+import { test, expect } from '@playwright/test';
+import https from 'https';
+import crypto from 'crypto';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  formatRemoteCalendarId,
+  generateCalendarName,
+} from './helpers/instances';
+import {
+  getToken,
+  createCalendar,
+  createEvent,
+  followCalendar,
+  getFeed,
+} from './helpers/api';
+import {
+  setBetaSkipSignatures,
+  restoreBetaDefaultSignatures,
+} from './helpers/strict_receive';
+
+// Self-signed cert tolerance for local Docker federation environment
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+/**
+ * Poll Beta's feed for an event matching the predicate. Polling avoids
+ * brittle fixed sleeps when federation latency varies. Returns the matching
+ * event or undefined on timeout.
+ */
+async function waitForFeedEvent(
+  token: string,
+  calendarId: string,
+  predicate: (e: { content: Record<string, { title: string }> }) => boolean,
+  timeoutMs = 30000,
+  intervalMs = 1000,
+): Promise<{ id: string; content: Record<string, { title: string }> } | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const feed = await getFeed(INSTANCE_BETA, token, calendarId);
+    const match = feed.events.find(predicate);
+    if (match) return match;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return undefined;
+}
+
+/**
+ * Build a minimal Create(Note) activity body suitable for posting to a
+ * calendar inbox. The exact shape is not load-bearing for the negative tests
+ * because verifyHttpSignature short-circuits before req.body is processed --
+ * what matters is that the request is well-formed enough to reach the
+ * signature middleware.
+ */
+function buildPlaceholderActivity(actorUrl: string): Record<string, unknown> {
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    type: 'Create',
+    actor: actorUrl,
+    object: {
+      type: 'Note',
+      content: 'strict-receive negative case probe',
+    },
+  };
+}
+
+test.describe.serial('Strict-Receive HTTP Signature Verification', () => {
+  let alphaToken: string;
+  let betaToken: string;
+  let alphaCalendar: { id: string; urlName: string };
+  let betaCalendar: { id: string; urlName: string };
+
+  test.beforeAll(async () => {
+    // The beta container recreate can take 30-60s on slow machines, plus
+    // calendar/follow setup. The hook itself needs a generous timeout via
+    // the option below; test.setTimeout() here extends the per-test timeout
+    // for tests in this describe block (which is also useful because the
+    // positive case waits for federation propagation under fresh-container
+    // state).
+    test.setTimeout(180000);
+
+    // Flip beta into strict-receive mode BEFORE creating tokens or calendars,
+    // because token acquisition and calendar creation talk to beta and need
+    // beta to be up.
+    await setBetaSkipSignatures('false');
+
+    alphaToken = await getToken(
+      INSTANCE_ALPHA,
+      INSTANCE_ALPHA.adminEmail,
+      INSTANCE_ALPHA.adminPassword,
+    );
+    betaToken = await getToken(
+      INSTANCE_BETA,
+      INSTANCE_BETA.adminEmail,
+      INSTANCE_BETA.adminPassword,
+    );
+
+    // Fresh calendars to avoid collisions with sibling specs.
+    alphaCalendar = await createCalendar(INSTANCE_ALPHA, alphaToken, {
+      urlName: generateCalendarName('asr'),
+      content: { en: { name: 'Alpha StrictReceive Calendar' } },
+    });
+    betaCalendar = await createCalendar(INSTANCE_BETA, betaToken, {
+      urlName: generateCalendarName('bsr'),
+      content: { en: { name: 'Beta StrictReceive Calendar' } },
+    });
+
+    // Beta follows alpha. The Follow itself is signed and -- crucially with
+    // SKIP_SIGNATURES=false on beta -- the Accept that comes back from alpha
+    // must also pass beta's signature gate. If this succeeds, the round-trip
+    // is already partially proven; the positive Create(Event) test below
+    // closes the loop with explicit event propagation.
+    const alphaRemoteId = formatRemoteCalendarId(alphaCalendar.urlName, INSTANCE_ALPHA);
+    await followCalendar(INSTANCE_BETA, betaToken, betaCalendar.id, alphaRemoteId);
+
+    // Allow the Follow/Accept handshake to settle before continuing.
+    await new Promise(resolve => setTimeout(resolve, 3000));
+  }, { timeout: 180000 });
+
+  test.afterAll(async () => {
+    // Always restore the default SKIP_SIGNATURES=true on beta so other
+    // federation specs in the same run (or a later run) are unaffected.
+    await restoreBetaDefaultSignatures();
+  }, { timeout: 180000 });
+
+  test('signed Create(Event) from alpha is cryptographically verified by beta', async () => {
+    // With SKIP_SIGNATURES=false on beta, this only succeeds if alpha's
+    // signed POST passes beta's verifyHttpSignature middleware -- meaning
+    // the real RSA signing + public key fetch + signature verification
+    // round-trip works end-to-end across the Docker/nginx path.
+    const title = `StrictReceive Create ${Date.now()}`;
+    await createEvent(INSTANCE_ALPHA, alphaToken, {
+      calendarId: alphaCalendar.id,
+      content: {
+        en: {
+          title,
+          description: 'Strict-receive cryptographic verification probe',
+        },
+      },
+      startTime: '2026-08-01T18:00:00Z',
+      endTime: '2026-08-01T20:00:00Z',
+    });
+
+    const propagated = await waitForFeedEvent(
+      betaToken,
+      betaCalendar.id,
+      (e) => e.content?.en?.title === title,
+    );
+
+    expect(
+      propagated,
+      'Signed Create(Event) must propagate to beta\'s feed under SKIP_SIGNATURES=false (proves receive-side cryptographic verification)',
+    ).toBeDefined();
+  });
+
+  test('unsigned POST to beta inbox is rejected with 400 (missing signature header)', async () => {
+    // No Signature header, no Digest header. The http-signature library
+    // throws MissingHeaderError, which the middleware's catch block maps to
+    // 400 Bad Request (http_signature.ts:167-170). This is distinct from the
+    // forged-signature path (next test) which returns 401 because the
+    // signature parses but fails cryptographic verification. Both branches
+    // prove the gate refuses to process the activity.
+    const inboxUrl = `${INSTANCE_BETA.baseUrl}/calendars/${betaCalendar.urlName}/inbox`;
+    const body = buildPlaceholderActivity(
+      `${INSTANCE_ALPHA.baseUrl}/calendars/${alphaCalendar.urlName}`,
+    );
+
+    const response = await fetch(inboxUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/activity+json',
+        Host: INSTANCE_BETA.domain,
+        Date: new Date().toUTCString(),
+      },
+      body: JSON.stringify(body),
+      // @ts-ignore - agent is not in the TypeScript types but works at runtime
+      agent: httpsAgent,
+    });
+
+    expect(
+      response.status,
+      'Unsigned POST to calendar inbox must be rejected with 400 by the signature gate (MissingHeaderError -> 400; the forged-signature path returns 401)',
+    ).toBe(400);
+  });
+
+  test('forged Signature header to beta inbox is rejected with 401', async () => {
+    // A syntactically valid Signature header but with garbage signature bytes
+    // and a keyId that points back at alpha's actor. verifyHttpSignature must
+    // fetch the public key and then reject when httpSignature.verifySignature
+    // returns false.
+    const inboxUrl = `${INSTANCE_BETA.baseUrl}/calendars/${betaCalendar.urlName}/inbox`;
+    const actorUrl = `${INSTANCE_ALPHA.baseUrl}/calendars/${alphaCalendar.urlName}`;
+    const keyId = `${actorUrl}#main-key`;
+    const body = buildPlaceholderActivity(actorUrl);
+    const bodyText = JSON.stringify(body);
+
+    // Cryptographically invalid signature bytes (base64 of a fixed string).
+    // The middleware verifies the digest BEFORE the signature; we compute a
+    // valid SHA-256 digest so the rejection definitively comes from the
+    // signature verification step rather than the digest check (both return
+    // 401, but this keeps the failure mode aligned with the test name).
+    const forgedSignature = Buffer.from('forged-signature-bytes-not-rsa').toString('base64');
+    const digest = `SHA-256=${crypto.createHash('sha256').update(bodyText).digest('base64')}`;
+
+    const response = await fetch(inboxUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/activity+json',
+        Host: INSTANCE_BETA.domain,
+        Date: new Date().toUTCString(),
+        Signature: [
+          `keyId="${keyId}"`,
+          'algorithm="rsa-sha256"',
+          'headers="(request-target) host date digest"',
+          `signature="${forgedSignature}"`,
+        ].join(','),
+        Digest: digest,
+      },
+      body: bodyText,
+      // @ts-ignore - agent is not in the TypeScript types but works at runtime
+      agent: httpsAgent,
+    });
+
+    expect(
+      response.status,
+      'Forged Signature header must be rejected with 401 (invalid digest or invalid signature)',
+    ).toBe(401);
+  });
+});

--- a/tests/e2e/federation/signed_delivery.spec.ts
+++ b/tests/e2e/federation/signed_delivery.spec.ts
@@ -21,16 +21,20 @@
  *
  *   This spec does NOT, on its own, prove that the receive-side cryptographic
  *   gate would reject a forged or unsigned request: the Docker federation
- *   harness sets SKIP_SIGNATURES=true on both instances, so
- *   verifyHttpSignature short-circuits on the receiver. The cryptographic
- *   round-trip (sign with a real RSA key, then verify with the matching
- *   public key, both with SKIP_SIGNATURES=false) is proven separately by the
- *   unit tests in
- *   `src/server/activitypub/test/helper/http_signature.test.ts`
- *   under describe block "HTTP Signature Cryptographic Round-Trip".
+ *   harness sets SKIP_SIGNATURES=true on both instances by default, so
+ *   verifyHttpSignature short-circuits on the receiver during this spec.
+ *   Receive-side cryptographic verification is proven separately at two
+ *   tiers:
+ *     - Unit (in-process round-trip):
+ *       `src/server/activitypub/test/helper/http_signature.test.ts`
+ *       under describe block "HTTP Signature Cryptographic Round-Trip".
+ *     - Federation e2e (cross-container, real RSA + nginx + Docker DNS):
+ *       `tests/e2e/federation/signature_strict_receive.spec.ts` (pv-3xit),
+ *       which flips beta to SKIP_SIGNATURES=false for its own duration and
+ *       restores the default afterwards so this spec is unaffected.
  *
- *   Together, this e2e (outbound pipeline) plus those unit tests
- *   (cryptographic verification) cover the bead's acceptance criteria.
+ *   Together, this e2e (outbound pipeline), the unit round-trip, and the
+ *   strict-receive federation spec cover the bead's acceptance criteria.
  *
  * Prerequisites:
  *   - Federation environment running: npm run federation:start


### PR DESCRIPTION
## Motivation

The federation Docker harness has been running with `SKIP_SIGNATURES=true` on both alpha and beta, which short-circuits `verifyHttpSignature` before any cryptographic check. As a result, the existing `signed_delivery.spec.ts` could not distinguish a correctly signed POST from a forged or unsigned one — its assertions on feed propagation and inbox-handler log entries would all pass even if the signing pipeline produced a syntactically valid but cryptographically wrong signature.

The receive-side cryptographic round-trip was previously proven only at unit tier (`src/server/activitypub/test/helper/http_signature.test.ts`), and even there `parseRequest` is stubbed to return `null` for the missing-header path. A regression in nginx routing, header normalization, or container DNS that broke signature validity in the live federation environment would not have been caught at any tier.

## Approach

Add a federation Playwright spec (`tests/e2e/federation/signature_strict_receive.spec.ts`) that flips beta into strict-receive mode for the duration of the spec and exercises the signature gate end-to-end through the real nginx/Express/middleware path.

A helper (`tests/e2e/federation/helpers/strict_receive.ts`) writes a PID-scoped tmpdir compose override and runs `docker compose -f docker-compose.federation.yml -f <override>.yml up -d --no-deps --force-recreate instance_beta`, polling `/health` until the container is ready. `afterAll` restores the default via the same mechanism and removes the override file in a `try/finally`. `process.env.SKIP_SIGNATURES` is read per-request inside `shouldSkipSignatures()`, so a container restart is the only way to flip it on a running instance — `docker exec` cannot mutate the parent Node process's env.

Three serial tests:

- Positive: signed `Create(Event)` from alpha propagates to beta's feed under strict-receive.
- Negative (missing signature): unsigned POST to beta's inbox returns 400 — the `http-signature` library throws `MissingHeaderError`, which `http_signature.ts:167-170` maps to 400.
- Negative (forged signature): POST with a valid SHA-256 digest but garbage signature bytes returns 401 — the gate parses the header, then fails `verifySignature`.

The 400/401 split is documented in the spec docblock and assertion messages so future readers don't mistake the missing-signature branch for a regression. Both `beforeAll` and `afterAll` pass `{ timeout: 180000 }` directly to extend hook timeouts beyond Playwright's default; `test.setTimeout()` inside a hook only extends per-test timeout, not hook timeout. The override path is PID-scoped to avoid collisions when concurrent Playwright workers share the system tmpdir.

`signed_delivery.spec.ts` docblock now cross-references the new spec and drops the prior "harness re-config is a separate infra concern" caveat that this work resolves.

## Validation

- `npm run lint`: 0 errors, 276 warnings (baseline preserved; no new warnings in the changed files).
- `npx tsc --noEmit`: no errors in the changed files.
- Unit and integration suites unchanged (no production code under `src/` was touched).
- The new spec requires the federation Docker harness; it cannot run in environments without Docker. Local validation: `npm run federation:start` then `npx playwright test --config=playwright.federation.config.ts tests/e2e/federation/signature_strict_receive.spec.ts`.
- Audited by testing-, security-, consistency-, and architecture-auditors. Initial findings (wrong expected status code on the unsigned-POST case; `test.setTimeout` inside hooks did not extend hook timeout) were resolved in a retry round. Remaining warnings (extending negative-case coverage to replay attacks and actor/signer mismatch; harness-wide globalSetup to recover from SIGKILL; per-spec project isolation under `fullyParallel: true`) are tracked as follow-up work.