### PR TITLE
fix(calendar): use NULLS LAST in public discovery ORDER BY

### DIFF
--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -1769,14 +1769,14 @@ class CalendarService {
           'last_event_activity',
         ],
       ],
-      order: [
-        // NULLS LAST: calendars with no events sort after calendars that have
-        // published activity. SQLite emits NULLs first by default; PostgreSQL
-        // emits NULLs last on DESC by default but is order-stable with the
-        // explicit clause. Using literal here keeps the ORDER BY portable.
-        [literal('last_event_activity IS NULL'), 'ASC'],
-        [literal('last_event_activity'), 'DESC'],
-      ],
+      // NULLS LAST: calendars with no events sort after calendars that have
+      // published activity. Both PostgreSQL (native, since 8.3) and SQLite
+      // (since 3.30) accept `NULLS LAST`. The previous two-clause form used
+      // `last_event_activity IS NULL` in the ORDER BY, which PostgreSQL rejects
+      // because output-column aliases are not visible inside expression contexts
+      // — only as bare ORDER BY terms. SQLite accepts the same SQL, so the
+      // SQLite-only integration tests masked the regression.
+      order: literal('last_event_activity DESC NULLS LAST'),
       limit: PUBLIC_DISCOVERY_LIMIT,
     } as any);
 


### PR DESCRIPTION
## Motivation

`GET /api/public/v1/calendars` returns 500 on the staging instance, breaking the `/view` discovery page. The endpoint failed silently in CI because the integration suite runs only against SQLite, while staging runs on PostgreSQL.

## Approach

Root cause in `src/server/calendar/service/calendar.ts` `listPublicCalendars`: the ORDER BY referenced the subquery alias `last_event_activity` inside an `IS NULL` expression:

```sql
ORDER BY last_event_activity IS NULL ASC, last_event_activity DESC
```

PostgreSQL only resolves SELECT-list aliases when they appear as a **bare** ORDER BY term. Inside an expression context like `IS NULL`, PG looks the name up against the tables and throws `column "last_event_activity" does not exist`. SQLite is more permissive and accepts the same SQL, which is why the existing SQLite-only integration tests passed while production failed. (The previous code comment also got Postgres's default null ordering backwards — PG emits `NULLS FIRST` on `DESC` by default, not last.)

Fix: replace the two-clause form with a single `last_event_activity DESC NULLS LAST` literal. `NULLS LAST` is supported natively by both Postgres (since 8.3) and SQLite (since 3.30, 2019).

## Validation

- Reproduced the failure against Postgres 16 with the original query — got the exact `column "last_event_activity" does not exist` error.
- Re-ran the same setup with the fix — Postgres and SQLite both produce the correct ordering (active calendars first by activity DESC, no-event calendars last).
- All 13 tests in `src/server/calendar/test/integration/list_public_calendars.test.ts` pass.
- build-guardian: lint, unit (7907), integration (599), build all pass. Three e2e failures are pre-existing and unrelated (admin accounts 404, category dialog timeout, ICS test missing a federation TLS cert).