### PR TITLE
feat(activitypub): backfill remote calendar history on new follow

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -223,11 +223,18 @@ run_migrations() {
 # Function to start the application
 start_app() {
   if is_federation; then
-    # Federation testing mode - backend only with hot-reload
-    log_info "Starting federation instance..."
-    log_info "  Backend:  http://localhost:3000"
-    log_info "========================================"
-    exec npx tsx watch src/server/app.ts
+    # Federation testing mode - hot-reload backend, with optional worker mode
+    if is_worker_mode "$@"; then
+      log_info "Starting federation worker with hot-reload..."
+      log_info "  Processing jobs from pg-boss queue"
+      log_info "========================================"
+      exec npx tsx watch src/server/app.ts -- --worker
+    else
+      log_info "Starting federation instance..."
+      log_info "  Backend:  http://localhost:3000"
+      log_info "========================================"
+      exec npx tsx watch src/server/app.ts
+    fi
   elif is_development; then
     # Development mode
     if is_worker_mode "$@"; then

--- a/docker-compose.federation.yml
+++ b/docker-compose.federation.yml
@@ -177,6 +177,88 @@ services:
       retries: 5
     restart: unless-stopped
 
+  # Worker for instance Alpha - processes pg-boss background jobs (e.g.
+  # activitypub:follow:backfill). The web instance is publish-only and never
+  # subscribes to the queue, so without a paired worker, follow-backfill jobs
+  # accumulate and are never executed.
+  worker_alpha:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    container_name: pavillion-federation-worker-alpha
+    depends_on:
+      db_alpha:
+        condition: service_healthy
+    environment:
+      - NODE_ENV=federation
+      - LOCAL_DOMAIN=alpha.federation.local
+      - DB_HOST=db_alpha
+      - DB_PORT=5432
+      - DB_NAME=alpha_db
+      - DB_USER=pavillion
+      - DB_PASSWORD=devpassword
+      # Web instance owns DB reset/seed; worker only subscribes to pg-boss
+      - DB_RESET=false
+      - SKIP_SIGNATURES=true
+      - ALLOW_PRIVATE_FEDERATION=true
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - CHOKIDAR_USEPOLLING=true
+    volumes:
+      - ./src:/app/src:cached
+      - ./config:/app/config:cached
+      - ./migrations:/app/migrations:cached
+      - ./layouts:/app/layouts:cached
+      - ./docker/federation/ssl:/app/docker/federation/ssl:ro
+      - ./tsconfig.json:/app/tsconfig.json:cached
+      - ./vite.config.ts:/app/vite.config.ts:cached
+      - /app/node_modules
+    command: ["--worker"]
+    networks:
+      federation_net:
+        aliases:
+          - worker_alpha
+    restart: unless-stopped
+
+  # Worker for instance Beta - see worker_alpha for rationale
+  worker_beta:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: development
+    container_name: pavillion-federation-worker-beta
+    depends_on:
+      db_beta:
+        condition: service_healthy
+    environment:
+      - NODE_ENV=federation
+      - LOCAL_DOMAIN=beta.federation.local
+      - DB_HOST=db_beta
+      - DB_PORT=5432
+      - DB_NAME=beta_db
+      - DB_USER=pavillion
+      - DB_PASSWORD=devpassword
+      - DB_RESET=false
+      - SKIP_SIGNATURES=true
+      - ALLOW_PRIVATE_FEDERATION=true
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - CHOKIDAR_USEPOLLING=true
+    volumes:
+      - ./src:/app/src:cached
+      - ./config:/app/config:cached
+      - ./migrations:/app/migrations:cached
+      - ./layouts:/app/layouts:cached
+      - ./docker/federation/ssl:/app/docker/federation/ssl:ro
+      - ./tsconfig.json:/app/tsconfig.json:cached
+      - ./vite.config.ts:/app/vite.config.ts:cached
+      - /app/node_modules
+    command: ["--worker"]
+    networks:
+      federation_net:
+        aliases:
+          - worker_beta
+    restart: unless-stopped
+
   # PostgreSQL database for alpha instance
   db_alpha:
     image: postgres:17

--- a/src/server/activitypub/api/v1/server.ts
+++ b/src/server/activitypub/api/v1/server.ts
@@ -495,7 +495,7 @@ export default class ActivityPubServerRoutes {
       }
 
       const domain: string = config.get('domain');
-      const outboxUrl = `https://${domain}/api/ap/v1/calendars/${calendar.urlName}/outbox`;
+      const outboxUrl = `https://${domain}/calendars/${calendar.urlName}/outbox`;
 
       // If no page param, return the collection summary
       if (req.query.page !== 'true') {

--- a/src/server/activitypub/events/index.ts
+++ b/src/server/activitypub/events/index.ts
@@ -9,6 +9,7 @@ import {
   AccountCreatedPayload,
   CalendarCreatedPayload,
   RemoteEditorRevokedPayload,
+  ActivityPubFollowAcceptedPayload,
 } from './types';
 import ActivityPubInterface from '../interface';
 import CreateActivity from '../model/action/create';
@@ -22,6 +23,7 @@ import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import UserActorService from '../service/user_actor';
 import CalendarActorService from '../service/calendar_actor';
 import CalendarInterface from '@/server/calendar/interface';
+import JobQueueService from '@/server/housekeeping/service/job-queue';
 import { Account } from '@/common/model/account';
 import { logError } from '@/server/common/helper/error-logger';
 import { Calendar } from '@/common/model/calendar';
@@ -33,11 +35,23 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
   private service: ActivityPubInterface;
   private userActorService: UserActorService;
   private calendarActorService: CalendarActorService;
+  private jobQueue: JobQueueService | null;
 
-  constructor(service: ActivityPubInterface, calendarInterface: CalendarInterface) {
+  /**
+   * @param jobQueue Optional pg-boss queue used to publish background jobs
+   *   such as `activitypub:follow:backfill`. When null (e.g. unit tests that
+   *   don't exercise the worker path), the affected handlers no-op with a
+   *   warning rather than throwing — see `handleFollowAccepted`.
+   */
+  constructor(
+    service: ActivityPubInterface,
+    calendarInterface: CalendarInterface,
+    jobQueue: JobQueueService | null = null,
+  ) {
     this.service = service;
     this.userActorService = new UserActorService(calendarInterface);
     this.calendarActorService = new CalendarActorService(calendarInterface);
+    this.jobQueue = jobQueue;
   }
 
   install(eventBus: EventEmitter): void {
@@ -49,6 +63,7 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
     eventBus.on('account.created', this.handleAccountCreated.bind(this));
     eventBus.on('calendar.created', this.handleCalendarCreated.bind(this));
     eventBus.on('remoteEditorRevoked', this.handleRemoteEditorRevoked.bind(this));
+    eventBus.on('activitypub:follow:accepted', this.handleFollowAccepted.bind(this));
   }
 
   /**
@@ -228,6 +243,35 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
   private handleRemoteEditorRevoked(payload: RemoteEditorRevokedPayload): void {
     this.service.invalidateAuthorizationCache(payload.calendarId, payload.actorUri);
     logger.info({ actorUri: payload.actorUri, calendarId: payload.calendarId }, 'Invalidated authorization cache for actor');
+  }
+
+  /**
+   * Publish a follow-backfill job in response to a remote Accept(Follow) that
+   * confirmed a follow we initiated. The actual outbox pull is performed by
+   * the worker (pv-cug3.4); this handler only enqueues the job and returns
+   * synchronously — no HTTP work happens on this code path.
+   *
+   * If the JobQueueService is not configured (typically a test harness that
+   * doesn't wire one up, or a process that never publishes jobs), we log a
+   * warning and skip publication. The worker side handles eventual delivery
+   * once a publisher is available; missing this enqueue means the follower's
+   * feed simply won't be backfilled until the next trigger.
+   */
+  private async handleFollowAccepted(payload: ActivityPubFollowAcceptedPayload): Promise<void> {
+    if (!this.jobQueue) {
+      logger.warn(
+        { followingCalendarId: payload.followingCalendarId, sourceActorUri: payload.sourceActorUri },
+        'JobQueueService not configured; skipping activitypub:follow:backfill publish',
+      );
+      return;
+    }
+
+    try {
+      await this.jobQueue.publish('activitypub:follow:backfill', payload);
+    }
+    catch (error) {
+      logError(error, '[ActivityPub] Failed to publish activitypub:follow:backfill job');
+    }
   }
 
   private async handleCalendarCreated(payload: CalendarCreatedPayload): Promise<void> {

--- a/src/server/activitypub/events/index.ts
+++ b/src/server/activitypub/events/index.ts
@@ -23,7 +23,7 @@ import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import UserActorService from '../service/user_actor';
 import CalendarActorService from '../service/calendar_actor';
 import CalendarInterface from '@/server/calendar/interface';
-import JobQueueService from '@/server/housekeeping/service/job-queue';
+import HousekeepingInterface from '@/server/housekeeping/interface';
 import { Account } from '@/common/model/account';
 import { logError } from '@/server/common/helper/error-logger';
 import { Calendar } from '@/common/model/calendar';
@@ -35,23 +35,24 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
   private service: ActivityPubInterface;
   private userActorService: UserActorService;
   private calendarActorService: CalendarActorService;
-  private jobQueue: JobQueueService | null;
+  private housekeepingInterface: HousekeepingInterface;
 
   /**
-   * @param jobQueue Optional pg-boss queue used to publish background jobs
-   *   such as `activitypub:follow:backfill`. When null (e.g. unit tests that
-   *   don't exercise the worker path), the affected handlers no-op with a
-   *   warning rather than throwing — see `handleFollowAccepted`.
+   * @param housekeepingInterface Cross-domain handle used to publish
+   *   background jobs (e.g. `activitypub:follow:backfill`) through the
+   *   housekeeping-owned pg-boss queue. Required — a missing wire is a
+   *   server-startup bug and must fail at construction time rather than
+   *   silently dropping queued work at runtime.
    */
   constructor(
     service: ActivityPubInterface,
     calendarInterface: CalendarInterface,
-    jobQueue: JobQueueService | null = null,
+    housekeepingInterface: HousekeepingInterface,
   ) {
     this.service = service;
     this.userActorService = new UserActorService(calendarInterface);
     this.calendarActorService = new CalendarActorService(calendarInterface);
-    this.jobQueue = jobQueue;
+    this.housekeepingInterface = housekeepingInterface;
   }
 
   install(eventBus: EventEmitter): void {
@@ -251,23 +252,15 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
    * the worker (pv-cug3.4); this handler only enqueues the job and returns
    * synchronously — no HTTP work happens on this code path.
    *
-   * If the JobQueueService is not configured (typically a test harness that
-   * doesn't wire one up, or a process that never publishes jobs), we log a
-   * warning and skip publication. The worker side handles eventual delivery
-   * once a publisher is available; missing this enqueue means the follower's
-   * feed simply won't be backfilled until the next trigger.
+   * Errors from the publish call are logged but not re-thrown. EventEmitter
+   * surfaces unhandled async errors as `error` events with no listeners,
+   * which terminates the Node process; swallowing here keeps a transient
+   * pg-boss outage from crashing the server, at the cost of a missed
+   * backfill that the next Accept (or manual trigger) will re-enqueue.
    */
   private async handleFollowAccepted(payload: ActivityPubFollowAcceptedPayload): Promise<void> {
-    if (!this.jobQueue) {
-      logger.warn(
-        { followingCalendarId: payload.followingCalendarId, sourceActorUri: payload.sourceActorUri },
-        'JobQueueService not configured; skipping activitypub:follow:backfill publish',
-      );
-      return;
-    }
-
     try {
-      await this.jobQueue.publish('activitypub:follow:backfill', payload);
+      await this.housekeepingInterface.publishJob('activitypub:follow:backfill', payload);
     }
     catch (error) {
       logError(error, '[ActivityPub] Failed to publish activitypub:follow:backfill job');

--- a/src/server/activitypub/events/types.ts
+++ b/src/server/activitypub/events/types.ts
@@ -35,3 +35,22 @@ export interface RemoteEditorRevokedPayload {
   calendarId: string;
   actorUri: string;
 }
+
+/**
+ * Emitted when a remote instance's Accept(Follow) confirms a follow we
+ * initiated on a remote-type target. Consumers (the in-domain handler)
+ * publish an `activitypub:follow:backfill` pg-boss job so the worker
+ * can pull the remote calendar's event history into Pavillion.
+ *
+ * - `followingCalendarId`: id of the local Calendar that initiated the follow
+ *   (FollowingCalendarEntity.calendar_id).
+ * - `calendarActorId`: id of the remote CalendarActorEntity being followed
+ *   (FollowingCalendarEntity.calendar_actor_id).
+ * - `sourceActorUri`: actor URI of the remote calendar whose outbox the
+ *   backfill worker will read.
+ */
+export interface ActivityPubFollowAcceptedPayload {
+  followingCalendarId: string;
+  calendarActorId: string;
+  sourceActorUri: string;
+}

--- a/src/server/activitypub/helper/remote-fetch.ts
+++ b/src/server/activitypub/helper/remote-fetch.ts
@@ -3,6 +3,10 @@ import { logError } from '@/server/common/helper/error-logger';
 import { REMOTE_OBJECT_FETCH_TIMEOUT_MS } from '@/server/common/constants';
 import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
 import { createLogger } from '@/server/common/helper/logger';
+import { Calendar } from '@/common/model/calendar';
+import CalendarActorService from '@/server/activitypub/service/calendar_actor';
+import CalendarInterface from '@/server/calendar/interface';
+import { EventEmitter } from 'events';
 
 const logger = createLogger('activitypub');
 
@@ -17,11 +21,78 @@ const USER_AGENT = 'Pavillion ActivityPub Server';
 const ACTIVITYPUB_ACCEPT_HEADER = 'application/activity+json';
 
 /**
+ * Builds the Signature/Date headers for a signed outbound GET on behalf of
+ * the given local calendar. Returns null on any failure (missing actor,
+ * missing private key, signing error) so the caller can decide whether to
+ * fail closed or fall back to an unsigned request. The current caller
+ * (`fetchRemoteObject`) fails closed by returning null when signing was
+ * requested but produced no headers — sending an unsigned GET after the
+ * caller asked for a signed one would silently degrade federation behavior
+ * for Mastodon-style peers that require signed GETs.
+ *
+ * Kept as a module-private helper rather than exported because the only
+ * outbound-signed-GET caller in the codebase is fetchRemoteObject; if a
+ * second caller appears, promote this to a shared helper.
+ *
+ * @param uri - The full target URI being fetched
+ * @param calendar - The local calendar whose actor keypair signs the request
+ */
+async function buildSignedGetHeaders(
+  uri: string,
+  calendar: Calendar,
+): Promise<{ Signature: string; Date: string } | null> {
+  try {
+    // The outbox uses an EventEmitter-wired CalendarInterface; for read-only
+    // actor lookup we don't need a live event bus, so a fresh emitter is fine.
+    const calendarService = new CalendarInterface(new EventEmitter());
+    const calendarActorService = new CalendarActorService(calendarService);
+
+    const actor = await calendarActorService.getActorByCalendarId(calendar.id);
+    if (!actor) {
+      logger.warn({ calendarId: calendar.id }, 'No calendar actor found for signing GET');
+      return null;
+    }
+
+    // signActivity returns an HttpSignature with all the pieces; assemble the
+    // Signature header string in the same format as POST delivery.
+    const sig = await calendarActorService.signActivity(
+      actor.actorUri,
+      // activity payload is unused for GET signing but the parameter is
+      // required by the shared signing primitive; pass an empty object.
+      {},
+      uri,
+      undefined, // no digest — GET has no body
+      'get',
+    );
+
+    return {
+      Signature: `keyId="${sig.keyId}",algorithm="${sig.algorithm}",headers="${sig.headers}",signature="${sig.signature}"`,
+      Date: sig.date,
+    };
+  }
+  catch (error) {
+    logError(error, `[ActivityPub] Failed to build signed GET headers for ${uri}`);
+    return null;
+  }
+}
+
+/**
  * Fetches a remote ActivityPub object by URI.
  *
  * This function performs an HTTP GET request to retrieve an ActivityPub object
  * from a remote server. It uses proper headers for ActivityPub content negotiation
  * and handles errors gracefully by returning null on failure.
+ *
+ * When a `signingCalendar` is provided, the outbound GET is HTTP-signed using
+ * that calendar's actor keypair. This is required by Mastodon 4+ and other AP
+ * servers that demand signed GETs on the outbox endpoint; without it those
+ * peers silently return zero results. When omitted, behavior is unchanged
+ * (unsigned GET) so existing callers continue to work.
+ *
+ * Signing failure (missing actor, missing private key, etc.) fails closed: if
+ * the caller asked for a signed GET and we cannot produce one, we return null
+ * rather than silently sending an unsigned request that would be rejected
+ * anyway by signature-requiring peers.
  *
  * SECURITY: Validates that the URI does not point to private IP addresses
  * to prevent SSRF (Server-Side Request Forgery) attacks.
@@ -31,17 +102,26 @@ const ACTIVITYPUB_ACCEPT_HEADER = 'application/activity+json';
  * validation has passed.
  *
  * @param uri - The URI of the remote ActivityPub object to fetch
+ * @param signingCalendar - Optional local calendar whose actor keypair signs
+ *   the outbound GET. When omitted, the request is sent unsigned.
  * @returns The parsed JSON object, or null if the fetch fails
  *
  * @example
  * ```typescript
+ * // Unsigned (legacy callers)
  * const event = await fetchRemoteObject('https://remote.example/events/123');
- * if (event) {
- *   console.log('Fetched event:', event.name);
- * }
+ *
+ * // Signed (Mastodon-compatible outbox pulls)
+ * const event = await fetchRemoteObject(
+ *   'https://remote.example/users/alice/outbox',
+ *   followingCalendar,
+ * );
  * ```
  */
-export async function fetchRemoteObject(uri: string): Promise<Record<string, unknown> | null> {
+export async function fetchRemoteObject(
+  uri: string,
+  signingCalendar?: Calendar,
+): Promise<Record<string, unknown> | null> {
   try {
     // SECURITY: Validate that the URL does not point to a private IP address
     // This prevents SSRF attacks where an attacker could probe internal networks
@@ -55,11 +135,25 @@ export async function fetchRemoteObject(uri: string): Promise<Record<string, unk
       return null;
     }
 
+    const headers: Record<string, string> = {
+      'Accept': ACTIVITYPUB_ACCEPT_HEADER,
+      'User-Agent': USER_AGENT,
+    };
+
+    // When a signing calendar is provided, attach HTTP Signature headers. Fail
+    // closed on any signing error — see buildSignedGetHeaders docstring.
+    if (signingCalendar) {
+      const signedHeaders = await buildSignedGetHeaders(uri, signingCalendar);
+      if (!signedHeaders) {
+        logger.error({ uri, calendarId: signingCalendar.id }, 'Signed GET requested but signing failed');
+        return null;
+      }
+      headers.Signature = signedHeaders.Signature;
+      headers.Date = signedHeaders.Date;
+    }
+
     const response = await axios.get(uri, {
-      headers: {
-        'Accept': ACTIVITYPUB_ACCEPT_HEADER,
-        'User-Agent': USER_AGENT,
-      },
+      headers,
       timeout: REMOTE_OBJECT_FETCH_TIMEOUT_MS,
       maxRedirects: 0,
     });

--- a/src/server/activitypub/helper/remote-fetch.ts
+++ b/src/server/activitypub/helper/remote-fetch.ts
@@ -77,6 +77,22 @@ async function buildSignedGetHeaders(
 }
 
 /**
+ * Optional fetch tuning for {@link fetchRemoteObject}. Currently exposes only
+ * a response-body byte cap; additional knobs may be added without breaking
+ * existing callers because the parameter itself is optional.
+ */
+export interface FetchRemoteObjectOptions {
+  /**
+   * Maximum number of bytes the axios client will accept in the response
+   * body. When the response exceeds this size axios aborts and the helper
+   * returns null. Defaults to axios's library default (effectively
+   * unbounded) when omitted. The AP follow-backfill worker passes a
+   * 1 MiB cap to stay within the documented page-size budget.
+   */
+  maxContentLength?: number;
+}
+
+/**
  * Fetches a remote ActivityPub object by URI.
  *
  * This function performs an HTTP GET request to retrieve an ActivityPub object
@@ -104,6 +120,7 @@ async function buildSignedGetHeaders(
  * @param uri - The URI of the remote ActivityPub object to fetch
  * @param signingCalendar - Optional local calendar whose actor keypair signs
  *   the outbound GET. When omitted, the request is sent unsigned.
+ * @param options - Optional fetch tuning (currently a response-body byte cap).
  * @returns The parsed JSON object, or null if the fetch fails
  *
  * @example
@@ -111,16 +128,18 @@ async function buildSignedGetHeaders(
  * // Unsigned (legacy callers)
  * const event = await fetchRemoteObject('https://remote.example/events/123');
  *
- * // Signed (Mastodon-compatible outbox pulls)
- * const event = await fetchRemoteObject(
- *   'https://remote.example/users/alice/outbox',
+ * // Signed (Mastodon-compatible outbox pulls) with a 1 MiB body cap
+ * const page = await fetchRemoteObject(
+ *   'https://remote.example/users/alice/outbox?page=true',
  *   followingCalendar,
+ *   { maxContentLength: 1_048_576 },
  * );
  * ```
  */
 export async function fetchRemoteObject(
   uri: string,
   signingCalendar?: Calendar,
+  options?: FetchRemoteObjectOptions,
 ): Promise<Record<string, unknown> | null> {
   try {
     // SECURITY: Validate that the URL does not point to a private IP address
@@ -152,11 +171,19 @@ export async function fetchRemoteObject(
       headers.Date = signedHeaders.Date;
     }
 
-    const response = await axios.get(uri, {
+    const axiosConfig: Record<string, unknown> = {
       headers,
       timeout: REMOTE_OBJECT_FETCH_TIMEOUT_MS,
       maxRedirects: 0,
-    });
+    };
+    if (options?.maxContentLength !== undefined) {
+      axiosConfig.maxContentLength = options.maxContentLength;
+      // axios's `maxBodyLength` guards request bodies (irrelevant for GETs)
+      // while `maxContentLength` guards response bodies; we set the latter
+      // here. Documented for future maintainers who confuse the two.
+    }
+
+    const response = await axios.get(uri, axiosConfig);
 
     if (response.status !== 200) {
       logger.error({ uri, status: response.status }, 'Failed to fetch remote object');

--- a/src/server/activitypub/index.ts
+++ b/src/server/activitypub/index.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'stream';
 import CalendarInterface from '../calendar/interface';
 import AccountsInterface from '../accounts/interface';
 import ModerationInterface from '../moderation/interface';
+import HousekeepingInterface from '../housekeeping/interface';
 
 /**
  * ActivityPub domain entry point
@@ -16,18 +17,21 @@ export default class ActivityPubDomain {
   private readonly calendarInterface: CalendarInterface;
   private readonly accountsInterface: AccountsInterface;
   private readonly moderationInterface?: ModerationInterface;
+  private readonly housekeepingInterface: HousekeepingInterface;
   private readonly eventBus: EventEmitter;
 
   constructor(
     eventBus: EventEmitter,
     calendarInterface: CalendarInterface,
     accountsInterface: AccountsInterface,
+    housekeepingInterface: HousekeepingInterface,
     moderationInterface?: ModerationInterface,
   ) {
     this.eventBus = eventBus;
     this.calendarInterface = calendarInterface;
     this.accountsInterface = accountsInterface;
     this.moderationInterface = moderationInterface;
+    this.housekeepingInterface = housekeepingInterface;
     this.interface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface, moderationInterface);
   }
 
@@ -41,7 +45,7 @@ export default class ActivityPubDomain {
   }
 
   public installEventHandlers() {
-    new ActivityPubEventHandlers(this.interface, this.calendarInterface).install(this.eventBus);
+    new ActivityPubEventHandlers(this.interface, this.calendarInterface, this.housekeepingInterface).install(this.eventBus);
   }
 
 }

--- a/src/server/activitypub/service/backfill.ts
+++ b/src/server/activitypub/service/backfill.ts
@@ -1,0 +1,516 @@
+/**
+ * ActivityPub follow-backfill worker service.
+ *
+ * Pulls a remote calendar's outbox after a confirmed Accept(Follow) and
+ * routes the historical Create(Event), Announce, and Delete activities
+ * through the same inbox path that handles live federation traffic. This
+ * lets a new follower see backlog without the source instance having to
+ * re-broadcast everything.
+ *
+ * Trust posture
+ * -------------
+ * The inbox path's normal trust invariants come from middleware-verified
+ * HTTP signatures on inbound POSTs. Outbox-pulled activities have no such
+ * envelope, so this worker performs the equivalent checks itself before
+ * handing each activity off to `processInboxMessage`:
+ *   1. The activity's `actor` URL shares an origin with the outbox URL.
+ *   2. For `Create(Event)`: `object.attributedTo` matches the activity's
+ *      actor (no third-party "I created their event" forgery).
+ *   3. For `Announce`: the actor matches the followed source.
+ *   4. Loop guard: drop activities whose `object.attributedTo` resolves to
+ *      the local follower's own actor URL. This prevents a misconfigured
+ *      remote outbox from re-importing our own events back into our calendar.
+ *
+ * Two-pass Delete handling
+ * ------------------------
+ * Within a single page, a `Delete` is allowed to suppress earlier `Create`
+ * or `Announce` activities for the same `ap_id` even though the inbox path
+ * would otherwise process them in arrival order. This handles the common
+ * case where a creator publishes an event and tombstones it within the
+ * same paging window — without the suppression the worker would briefly
+ * write an EventObject row and then race the delete to remove it. Across
+ * pages, the same idempotency emerges naturally from the existing inbox
+ * Delete handler plus the unique constraint on `ap_event_object.ap_id`,
+ * so we only need the in-page short-circuit here.
+ *
+ * Hard caps
+ * ---------
+ * `MAX_OUTBOX_PAGES = 50` and `MAX_PAGE_BYTES = 1_048_576` bound the worst
+ * case: a misbehaving peer cannot exhaust the worker by serving an
+ * unbounded `next` chain or by returning a multi-megabyte page. Reaching
+ * the page cap emits one warn-level log line; pages larger than the byte
+ * cap are dropped silently by the underlying axios client (which returns
+ * null up here).
+ *
+ * Rate limiting
+ * -------------
+ * A shared {@link SyncRateLimiter} (60 acquisitions per minute, keyed by
+ * source hostname) gates the outbound requests. The limiter is a
+ * module-scope singleton so multiple concurrent backfill jobs against the
+ * same host share one budget.
+ */
+
+import { EventEmitter } from 'events';
+
+import { ActivityPubFollowAcceptedPayload } from '@/server/activitypub/events/types';
+import { ActivityPubInboxMessageEntity, FollowingCalendarEntity } from '@/server/activitypub/entity/activitypub';
+import ActivityPubInterface from '@/server/activitypub/interface';
+import AccountsInterface from '@/server/accounts/interface';
+import CalendarInterface from '@/server/calendar/interface';
+import { ActivityPubActor } from '@/server/activitypub/model/base';
+import { fetchRemoteObject } from '@/server/activitypub/helper/remote-fetch';
+import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
+import { createLogger } from '@/server/common/helper/logger';
+import { logError } from '@/server/common/helper/error-logger';
+import { SyncRateLimiter } from '@/server/common/helper/rate-limiter';
+
+const logger = createLogger('activitypub.backfill');
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/** Hard cap on the number of outbox pages a single backfill will walk. */
+export const MAX_OUTBOX_PAGES = 50;
+
+/** Per-page response-body byte cap enforced on every outbound GET. */
+export const MAX_PAGE_BYTES = 1_048_576;
+
+/** Per-host outbound request budget for outbox pulls. */
+const RATE_LIMIT_PER_MINUTE = 60;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Module-scope singletons
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared limiter keyed by source hostname. A module-scope singleton lets
+ * multiple concurrent backfill jobs against the same host share one budget,
+ * which matches the published "60 req/min per source" contract rather than
+ * "60 req/min per job".
+ *
+ * Exported for test reset only — production code paths must not reach in
+ * here directly.
+ */
+export const backfillRateLimiter = new SyncRateLimiter({
+  limit: RATE_LIMIT_PER_MINUTE,
+  windowMs: RATE_LIMIT_WINDOW_MS,
+});
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies the backfill service needs from the host process. Defaults are
+ * supplied by the production constructor so the worker entry point can hand
+ * the service a fresh event bus without wiring every collaborator manually;
+ * tests inject mocks here to exercise the trust/pagination/cap logic without
+ * standing up a real federation context.
+ */
+export interface BackfillDependencies {
+  activityPubInterface: ActivityPubInterface;
+  calendarInterface: CalendarInterface;
+  /** Limiter override for tests. Production code uses the module-scope singleton. */
+  rateLimiter?: SyncRateLimiter;
+  /** Fetcher override for tests. Production code uses fetchRemoteObject. */
+  fetcher?: typeof fetchRemoteObject;
+}
+
+/**
+ * Worker entry point. Walks the remote outbox identified by `payload`,
+ * routes surviving Create/Announce/Delete activities through the inbox
+ * pipeline, and returns once pagination completes or a hard stop fires
+ * (cap reached, follow row removed mid-run, rate limit exhausted).
+ *
+ * Designed to be invoked from `worker.ts`'s `activitypub:follow:backfill`
+ * job subscription; the export remains the service primitive so tests do
+ * not need to spin up pg-boss.
+ */
+export class FollowBackfillService {
+  private readonly activityPubInterface: ActivityPubInterface;
+  private readonly calendarInterface: CalendarInterface;
+  private readonly rateLimiter: SyncRateLimiter;
+  private readonly fetcher: typeof fetchRemoteObject;
+
+  constructor(deps: BackfillDependencies) {
+    this.activityPubInterface = deps.activityPubInterface;
+    this.calendarInterface = deps.calendarInterface;
+    this.rateLimiter = deps.rateLimiter ?? backfillRateLimiter;
+    this.fetcher = deps.fetcher ?? fetchRemoteObject;
+  }
+
+  /**
+   * Run a single backfill job to completion. Never throws for "expected"
+   * conditions (follow removed, source unreachable, malformed page, cap
+   * reached) — those exit cleanly so pg-boss does not loop on a
+   * permanently-broken peer. Catastrophic infrastructure failures (DB
+   * unavailable while loading the follow row) propagate so the worker
+   * surfaces them in logs and the job retries.
+   */
+  async runBackfill(payload: ActivityPubFollowAcceptedPayload): Promise<void> {
+    const { followingCalendarId, sourceActorUri } = payload;
+
+    // 1. Verify the follow row still exists at job start. The Accept that
+    // triggered this job could be racing an unfollow; if the user is no
+    // longer following, dropping their backfill is the right answer.
+    const followRow = await FollowingCalendarEntity.findByPk(followingCalendarId);
+    if (!followRow) {
+      logger.info({ followingCalendarId, sourceActorUri }, 'follow row missing at job start; skipping backfill');
+      return;
+    }
+
+    const calendar = await this.calendarInterface.getCalendar(followRow.calendar_id);
+    if (!calendar) {
+      logger.warn({ followingCalendarId, sourceActorUri, calendarId: followRow.calendar_id }, 'follower calendar missing; skipping backfill');
+      return;
+    }
+
+    const localActorUri = ActivityPubActor.actorUrl(calendar);
+
+    // 2. Fetch the source actor profile so we read the *current* outbox URL
+    // rather than whatever URL the federation handshake cached. Validate
+    // first because the source URI is attacker-influenced (came in via
+    // Accept(Follow)).
+    if (!(await this.assertUrlPublic(sourceActorUri))) {
+      return;
+    }
+    if (!(await this.acquireRateBudget(sourceActorUri))) {
+      return;
+    }
+    const actorProfile = await this.fetcher(sourceActorUri, calendar, { maxContentLength: MAX_PAGE_BYTES });
+    if (!actorProfile) {
+      logger.info({ sourceActorUri, followingCalendarId }, 'source actor profile fetch returned null; aborting backfill');
+      return;
+    }
+
+    const outboxUrl = typeof actorProfile.outbox === 'string' ? actorProfile.outbox : null;
+    if (!outboxUrl) {
+      logger.info({ sourceActorUri, followingCalendarId }, 'source actor profile has no outbox URL; aborting backfill');
+      return;
+    }
+
+    // 3. Walk the outbox. Most servers return an OrderedCollection whose
+    // `first` link points at the first page; a few hand back an
+    // OrderedCollectionPage directly. Handle both shapes.
+    if (!(await this.assertUrlPublic(outboxUrl))) {
+      return;
+    }
+    if (!(await this.acquireRateBudget(outboxUrl))) {
+      return;
+    }
+    const outbox = await this.fetcher(outboxUrl, calendar, { maxContentLength: MAX_PAGE_BYTES });
+    if (!outbox) {
+      logger.info({ outboxUrl, followingCalendarId }, 'outbox fetch returned null; aborting backfill');
+      return;
+    }
+
+    let currentPage: Record<string, unknown> | null;
+    if (outbox.type === 'OrderedCollectionPage') {
+      currentPage = outbox;
+    }
+    else if (typeof outbox.first === 'string') {
+      if (!(await this.assertUrlPublic(outbox.first))) {
+        return;
+      }
+      if (!(await this.acquireRateBudget(outbox.first))) {
+        return;
+      }
+      currentPage = await this.fetcher(outbox.first, calendar, { maxContentLength: MAX_PAGE_BYTES });
+    }
+    else {
+      logger.info({ outboxUrl, followingCalendarId }, 'outbox has no first page link; nothing to backfill');
+      return;
+    }
+
+    let pagesWalked = 0;
+    while (currentPage && pagesWalked < MAX_OUTBOX_PAGES) {
+      pagesWalked++;
+
+      const items = Array.isArray(currentPage.orderedItems) ? currentPage.orderedItems : [];
+      await this.processPage(items as unknown[], {
+        calendar,
+        localActorUri,
+        sourceActorUri,
+        outboxUrl,
+        followingCalendarId,
+      });
+
+      // Re-verify the follow row at every page boundary. A user unfollowing
+      // mid-backfill should stop us from continuing to drag down their
+      // event history.
+      const stillFollowing = await FollowingCalendarEntity.findByPk(followingCalendarId);
+      if (!stillFollowing) {
+        logger.info({ followingCalendarId, sourceActorUri }, 'follow row removed during backfill; stopping pagination');
+        return;
+      }
+
+      const nextUrl = typeof currentPage.next === 'string' ? currentPage.next : null;
+      if (!nextUrl) {
+        return;
+      }
+      if (!(await this.assertUrlPublic(nextUrl))) {
+        return;
+      }
+      if (!(await this.acquireRateBudget(nextUrl))) {
+        return;
+      }
+      currentPage = await this.fetcher(nextUrl, calendar, { maxContentLength: MAX_PAGE_BYTES });
+    }
+
+    if (pagesWalked >= MAX_OUTBOX_PAGES) {
+      logger.warn(
+        { followingCalendarId, sourceActorUri, pagesWalked, cap: MAX_OUTBOX_PAGES },
+        'backfill truncated at page cap',
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------
+
+  /**
+   * Validates a URL via the shared SSRF helper. Returns false (with a log
+   * line) on failure rather than throwing so the caller can short-circuit
+   * the pagination loop without surfacing the throw to pg-boss.
+   */
+  private async assertUrlPublic(url: string): Promise<boolean> {
+    try {
+      await validateUrlNotPrivate(url);
+      return true;
+    }
+    catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      logger.warn({ url, reason }, 'backfill refusing fetch: URL failed SSRF validation');
+      return false;
+    }
+  }
+
+  /**
+   * Reserves one slot in the per-host budget. Returns false (with a log
+   * line) when the source is over the cap; callers should exit cleanly.
+   */
+  private async acquireRateBudget(url: string): Promise<boolean> {
+    let host: string;
+    try {
+      host = new URL(url).hostname;
+    }
+    catch {
+      return true;
+    }
+    if (!this.rateLimiter.tryAcquire(host)) {
+      logger.warn({ host }, 'backfill paused: per-host rate limit exhausted');
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Two-pass walk of a single outbox page. Pass 1 enumerates items and
+   * collects the set of `ap_id`s that are tombstoned in the same page;
+   * Pass 2 runs the trust gates and routes the surviving Create/Announce/
+   * Delete activities through `processInboxMessage`.
+   */
+  private async processPage(
+    items: unknown[],
+    ctx: {
+      calendar: { id: string };
+      localActorUri: string;
+      sourceActorUri: string;
+      outboxUrl: string;
+      followingCalendarId: string;
+    },
+  ): Promise<void> {
+    // Pass 1: collect the set of object IDs that are deleted within this
+    // same page. A page-local Delete suppresses any earlier Create/Announce
+    // for the same `ap_id` in the same page so we never write a row we
+    // would immediately tombstone.
+    const inPageDeletes = new Set<string>();
+    for (const raw of items) {
+      if (!raw || typeof raw !== 'object') continue;
+      const activity = raw as Record<string, unknown>;
+      if (activity.type !== 'Delete') continue;
+      const objectId = extractObjectId(activity.object);
+      if (objectId) {
+        inPageDeletes.add(objectId);
+      }
+    }
+
+    // Pass 2: route each surviving activity through the inbox path.
+    for (const raw of items) {
+      if (!raw || typeof raw !== 'object') continue;
+      const activity = raw as Record<string, unknown>;
+
+      const type = typeof activity.type === 'string' ? activity.type : '';
+
+      // Type filter — Update is an explicit skip (the inbox path mutates
+      // EventEntity in place and we already have whatever state the source
+      // sent us via Create). Anything outside the documented set is ignored
+      // silently.
+      if (type !== 'Create' && type !== 'Announce' && type !== 'Delete') {
+        continue;
+      }
+
+      // In-page Delete suppression — only applies to Create/Announce.
+      if (type !== 'Delete') {
+        const objectId = extractObjectId(activity.object);
+        if (objectId && inPageDeletes.has(objectId)) {
+          continue;
+        }
+      }
+
+      // Trust re-validation — outbox activities have no signature envelope.
+      if (!passesTrustGates(activity, type, ctx)) {
+        continue;
+      }
+
+      await this.routeActivity(activity, type, ctx);
+    }
+  }
+
+  /**
+   * Constructs a synthetic ActivityPubInboxMessageEntity for the activity
+   * and hands it to `processInboxMessage`. The entity is built in memory
+   * (not saved) — the inbox path tolerates this because it only reads the
+   * `message` JSON, the `type`, and the `calendar_id`; the persisted
+   * processed_time/processed_status writes that the live inbox path does
+   * would be redundant here because the activity is not coming in via the
+   * stored-inbox queue.
+   *
+   * Errors are caught per-activity so one malformed entry does not abort
+   * the rest of the page.
+   */
+  private async routeActivity(
+    activity: Record<string, unknown>,
+    type: string,
+    ctx: {
+      calendar: { id: string };
+      followingCalendarId: string;
+    },
+  ): Promise<void> {
+    const apId = typeof activity.id === 'string' ? activity.id : `backfill:${ctx.followingCalendarId}:${Date.now()}:${Math.random()}`;
+
+    const synthetic = ActivityPubInboxMessageEntity.build({
+      id: apId,
+      calendar_id: ctx.calendar.id,
+      type,
+      message: activity,
+    });
+    // Stub the persistence hook the live inbox path normally calls at the
+    // end of processing. The synthetic message is not persisted, so the
+    // default `update` would throw; replacing it with a no-op keeps the
+    // inbox handler's bookkeeping write inert.
+    (synthetic as unknown as { update: (..._args: unknown[]) => Promise<void> }).update = async () => undefined;
+
+    try {
+      await this.activityPubInterface.processInboxMessage(synthetic);
+    }
+    catch (error) {
+      logError(error, `[ActivityPub backfill] inbox routing failed for ${type} ${apId}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the AP object id from a Create/Announce/Delete `object` field,
+ * which may be either a bare IRI string or an embedded object with an `id`.
+ */
+export function extractObjectId(objectField: unknown): string | null {
+  if (typeof objectField === 'string') {
+    return objectField;
+  }
+  if (objectField && typeof objectField === 'object' && typeof (objectField as Record<string, unknown>).id === 'string') {
+    return (objectField as Record<string, string>).id;
+  }
+  return null;
+}
+
+/**
+ * Trust gate. Returns false (and logs) when an activity fails any of the
+ * four checks documented at the top of this file. Pure so the unit tests
+ * can poke at every branch without mocking the worker.
+ */
+export function passesTrustGates(
+  activity: Record<string, unknown>,
+  type: string,
+  ctx: { localActorUri: string; sourceActorUri: string; outboxUrl: string },
+): boolean {
+  const actor = typeof activity.actor === 'string' ? activity.actor : null;
+  if (!actor) {
+    return false;
+  }
+
+  let actorOrigin: string;
+  let outboxOrigin: string;
+  let sourceOrigin: string;
+  try {
+    actorOrigin = new URL(actor).origin;
+    outboxOrigin = new URL(ctx.outboxUrl).origin;
+    sourceOrigin = new URL(ctx.sourceActorUri).origin;
+  }
+  catch {
+    return false;
+  }
+
+  // Gate 1: actor origin matches outbox origin.
+  if (actorOrigin !== outboxOrigin) {
+    logger.info({ actor, outboxUrl: ctx.outboxUrl }, 'backfill drop: actor origin mismatch');
+    return false;
+  }
+
+  // Gate 3 (covers Announce): actor matches the followed source.
+  if (type === 'Announce' && actor !== ctx.sourceActorUri && actorOrigin !== sourceOrigin) {
+    // For Announce we accept a same-origin actor as a peer of the source
+    // since the federation contract is that the source is announcing its
+    // own activity; a strict equality would reject legitimate alternates
+    // (alias actor URIs, capitalisation) that share an origin.
+    logger.info({ actor, sourceActorUri: ctx.sourceActorUri }, 'backfill drop: Announce actor not from source origin');
+    return false;
+  }
+
+  // Gate 2 (Create) + Gate 4 (loop guard): inspect the embedded object.
+  const obj = activity.object;
+  if (obj && typeof obj === 'object') {
+    const objRecord = obj as Record<string, unknown>;
+    const attributedTo = typeof objRecord.attributedTo === 'string' ? objRecord.attributedTo : null;
+
+    if (type === 'Create' && attributedTo && attributedTo !== actor) {
+      logger.info({ actor, attributedTo }, 'backfill drop: Create attributedTo does not match actor');
+      return false;
+    }
+
+    if (attributedTo && attributedTo === ctx.localActorUri) {
+      logger.info({ attributedTo, localActorUri: ctx.localActorUri }, 'backfill drop: loop guard tripped (object attributedTo == local actor)');
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Worker registration helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a FollowBackfillService instance suitable for the worker process.
+ * Used by `worker.ts`'s job subscription so the wiring lives in the
+ * service module rather than leaking into the worker entry point.
+ */
+export function createFollowBackfillService(
+  eventBus: EventEmitter,
+  calendarInterface: CalendarInterface,
+  accountsInterface: AccountsInterface,
+): FollowBackfillService {
+  const activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
+  return new FollowBackfillService({
+    activityPubInterface,
+    calendarInterface,
+  });
+}

--- a/src/server/activitypub/service/backfill.ts
+++ b/src/server/activitypub/service/backfill.ts
@@ -147,14 +147,22 @@ export class FollowBackfillService {
    * surfaces them in logs and the job retries.
    */
   async runBackfill(payload: ActivityPubFollowAcceptedPayload): Promise<void> {
-    const { followingCalendarId, sourceActorUri } = payload;
+    const { followingCalendarId, calendarActorId, sourceActorUri } = payload;
 
     // 1. Verify the follow row still exists at job start. The Accept that
     // triggered this job could be racing an unfollow; if the user is no
     // longer following, dropping their backfill is the right answer.
-    const followRow = await FollowingCalendarEntity.findByPk(followingCalendarId);
+    // The payload's `followingCalendarId` is the local Calendar's id
+    // (FollowingCalendarEntity.calendar_id, not the row PK); combined with
+    // calendarActorId it uniquely identifies the follow relationship.
+    const followRow = await FollowingCalendarEntity.findOne({
+      where: {
+        calendar_id: followingCalendarId,
+        calendar_actor_id: calendarActorId,
+      },
+    });
     if (!followRow) {
-      logger.info({ followingCalendarId }, 'follow row missing at job start; skipping backfill');
+      logger.info({ followingCalendarId, calendarActorId }, 'follow row missing at job start; skipping backfill');
       return;
     }
 
@@ -237,9 +245,14 @@ export class FollowBackfillService {
       // Re-verify the follow row at every page boundary. A user unfollowing
       // mid-backfill should stop us from continuing to drag down their
       // event history.
-      const stillFollowing = await FollowingCalendarEntity.findByPk(followingCalendarId);
+      const stillFollowing = await FollowingCalendarEntity.findOne({
+        where: {
+          calendar_id: followingCalendarId,
+          calendar_actor_id: calendarActorId,
+        },
+      });
       if (!stillFollowing) {
-        logger.info({ followingCalendarId }, 'follow row removed during backfill; stopping pagination');
+        logger.info({ followingCalendarId, calendarActorId }, 'follow row removed during backfill; stopping pagination');
         return;
       }
 

--- a/src/server/activitypub/service/backfill.ts
+++ b/src/server/activitypub/service/backfill.ts
@@ -50,12 +50,9 @@
  * same host share one budget.
  */
 
-import { EventEmitter } from 'events';
-
 import { ActivityPubFollowAcceptedPayload } from '@/server/activitypub/events/types';
 import { ActivityPubInboxMessageEntity, FollowingCalendarEntity } from '@/server/activitypub/entity/activitypub';
 import ActivityPubInterface from '@/server/activitypub/interface';
-import AccountsInterface from '@/server/accounts/interface';
 import CalendarInterface from '@/server/calendar/interface';
 import { ActivityPubActor } from '@/server/activitypub/model/base';
 import { fetchRemoteObject } from '@/server/activitypub/helper/remote-fetch';
@@ -157,7 +154,7 @@ export class FollowBackfillService {
     // longer following, dropping their backfill is the right answer.
     const followRow = await FollowingCalendarEntity.findByPk(followingCalendarId);
     if (!followRow) {
-      logger.info({ followingCalendarId, sourceActorUri }, 'follow row missing at job start; skipping backfill');
+      logger.info({ followingCalendarId }, 'follow row missing at job start; skipping backfill');
       return;
     }
 
@@ -181,13 +178,13 @@ export class FollowBackfillService {
     }
     const actorProfile = await this.fetcher(sourceActorUri, calendar, { maxContentLength: MAX_PAGE_BYTES });
     if (!actorProfile) {
-      logger.info({ sourceActorUri, followingCalendarId }, 'source actor profile fetch returned null; aborting backfill');
+      logger.info({ followingCalendarId }, 'source actor profile fetch returned null; aborting backfill');
       return;
     }
 
     const outboxUrl = typeof actorProfile.outbox === 'string' ? actorProfile.outbox : null;
     if (!outboxUrl) {
-      logger.info({ sourceActorUri, followingCalendarId }, 'source actor profile has no outbox URL; aborting backfill');
+      logger.info({ followingCalendarId }, 'source actor profile has no outbox URL; aborting backfill');
       return;
     }
 
@@ -242,7 +239,7 @@ export class FollowBackfillService {
       // event history.
       const stillFollowing = await FollowingCalendarEntity.findByPk(followingCalendarId);
       if (!stillFollowing) {
-        logger.info({ followingCalendarId, sourceActorUri }, 'follow row removed during backfill; stopping pagination');
+        logger.info({ followingCalendarId }, 'follow row removed during backfill; stopping pagination');
         return;
       }
 
@@ -460,7 +457,7 @@ export function passesTrustGates(
 
   // Gate 1: actor origin matches outbox origin.
   if (actorOrigin !== outboxOrigin) {
-    logger.info({ actor, outboxUrl: ctx.outboxUrl }, 'backfill drop: actor origin mismatch');
+    logger.debug({ actor, outboxUrl: ctx.outboxUrl }, 'backfill drop: actor origin mismatch');
     return false;
   }
 
@@ -470,7 +467,7 @@ export function passesTrustGates(
     // since the federation contract is that the source is announcing its
     // own activity; a strict equality would reject legitimate alternates
     // (alias actor URIs, capitalisation) that share an origin.
-    logger.info({ actor, sourceActorUri: ctx.sourceActorUri }, 'backfill drop: Announce actor not from source origin');
+    logger.debug({ actor, sourceActorUri: ctx.sourceActorUri }, 'backfill drop: Announce actor not from source origin');
     return false;
   }
 
@@ -481,12 +478,12 @@ export function passesTrustGates(
     const attributedTo = typeof objRecord.attributedTo === 'string' ? objRecord.attributedTo : null;
 
     if (type === 'Create' && attributedTo && attributedTo !== actor) {
-      logger.info({ actor, attributedTo }, 'backfill drop: Create attributedTo does not match actor');
+      logger.debug({ actor, attributedTo }, 'backfill drop: Create attributedTo does not match actor');
       return false;
     }
 
     if (attributedTo && attributedTo === ctx.localActorUri) {
-      logger.info({ attributedTo, localActorUri: ctx.localActorUri }, 'backfill drop: loop guard tripped (object attributedTo == local actor)');
+      logger.debug({ attributedTo, localActorUri: ctx.localActorUri }, 'backfill drop: loop guard tripped (object attributedTo == local actor)');
       return false;
     }
   }
@@ -494,23 +491,3 @@ export function passesTrustGates(
   return true;
 }
 
-// ---------------------------------------------------------------------------
-// Worker registration helper
-// ---------------------------------------------------------------------------
-
-/**
- * Builds a FollowBackfillService instance suitable for the worker process.
- * Used by `worker.ts`'s job subscription so the wiring lives in the
- * service module rather than leaking into the worker entry point.
- */
-export function createFollowBackfillService(
-  eventBus: EventEmitter,
-  calendarInterface: CalendarInterface,
-  accountsInterface: AccountsInterface,
-): FollowBackfillService {
-  const activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
-  return new FollowBackfillService({
-    activityPubInterface,
-    calendarInterface,
-  });
-}

--- a/src/server/activitypub/service/calendar_actor.ts
+++ b/src/server/activitypub/service/calendar_actor.ts
@@ -138,15 +138,31 @@ export default class CalendarActorService {
   }
 
   /**
-   * Signs an ActivityPub activity with HTTP signatures
+   * Signs an ActivityPub HTTP request with HTTP signatures.
+   *
+   * Supports both POST (outbound activity delivery, body + digest) and GET
+   * (outbound fetch of a remote object, no body). The `method` parameter
+   * controls the `(request-target)` pseudo-header verb in the signing
+   * string; it defaults to `'post'` to preserve existing caller behavior.
+   * For GET requests, callers must omit `digest` (there is no body to
+   * digest).
    *
    * @param actorUri - The actor URI performing the activity
-   * @param activity - The ActivityPub activity object
-   * @param targetUrl - The target URL (inbox) the activity is being sent to
+   * @param activity - The ActivityPub activity object (unused for GETs but
+   *   kept in the signature for parity with the POST signing path)
+   * @param targetUrl - The target URL the request will be sent to
    * @param digest - Optional Digest header value to include in the signature
+   * @param method - HTTP method for the request-target pseudo-header
+   *   (default `'post'`)
    * @returns Promise resolving to HttpSignature object
    */
-  async signActivity(actorUri: string, activity: any, targetUrl: string, digest?: string): Promise<HttpSignature> {
+  async signActivity(
+    actorUri: string,
+    activity: any,
+    targetUrl: string,
+    digest?: string,
+    method: 'get' | 'post' = 'post',
+  ): Promise<HttpSignature> {
     // Retrieve actor with private key
     const actor = await this.getActorByUri(actorUri);
     if (!actor) {
@@ -165,8 +181,10 @@ export default class CalendarActorService {
     // Generate date header
     const date = new Date().toUTCString();
 
-    // Create signing string
-    const requestTarget = `post ${path}`;
+    // Create signing string. The (request-target) verb must match the actual
+    // HTTP method; receivers reconstruct the signing string from the live
+    // request and a mismatch makes the signature invalid.
+    const requestTarget = `${method} ${path}`;
     const signingStringParts = [
       `(request-target): ${requestTarget}`,
       `host: ${host}`,

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -16,7 +16,8 @@ import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
 import { ActivityPubInboxMessageEntity, EventActivityEntity, FollowerCalendarEntity, FollowingCalendarEntity, RepostDismissalEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
 import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
-import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
+import { CalendarActor, CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
+import { ActivityPubFollowAcceptedPayload } from "@/server/activitypub/events/types";
 import RemoteCalendarService from "@/server/activitypub/service/remote_calendar";
 import { EventObject } from "@/server/activitypub/model/object/event";
 import { NoteObject } from "@/server/activitypub/model/object/note";
@@ -1641,6 +1642,35 @@ class ProcessInboxService {
     }
   }
   /**
+   * Emit `activitypub:follow:accepted` for a confirmed follow whose target
+   * is a remote CalendarActor. The AP-domain handler picks this up and
+   * enqueues a `activitypub:follow:backfill` job so the worker can pull
+   * the remote calendar's event history.
+   *
+   * This is a defensive guard: the only callers reach this with a
+   * `remoteCalendar` retrieved via `remoteCalendarService.getByActorUri`,
+   * which only returns CalendarActors with `actor_type === 'remote'`.
+   * Checking actorType here keeps the contract explicit and protects
+   * future callers from accidentally emitting for local-target follows
+   * (where no backfill is needed).
+   *
+   * @param followingRecord - The matched FollowingCalendarEntity row.
+   * @param remoteCalendar - The CalendarActor we are following (target).
+   */
+  private emitFollowAccepted(followingRecord: FollowingCalendarEntity, remoteCalendar: CalendarActor): void {
+    if (remoteCalendar.actorType !== 'remote') {
+      return;
+    }
+
+    const payload: ActivityPubFollowAcceptedPayload = {
+      followingCalendarId: followingRecord.calendar_id,
+      calendarActorId: followingRecord.calendar_actor_id,
+      sourceActorUri: remoteCalendar.actorUri,
+    };
+    this.eventBus.emit('activitypub:follow:accepted', payload);
+  }
+
+  /**
    * Processes an Accept activity received in response to a Follow or Flag request.
    * For Follow: Confirms the follow relationship on the initiating side.
    * For Flag: Updates the forward_status to 'acknowledged' on the forwarded report.
@@ -1729,6 +1759,12 @@ class ProcessInboxService {
 
           if (followingRecord) {
             logger.info(`Follow relationship confirmed for calendar ${calendar.id} via string URI Accept from ${message.actor}`);
+            // Emit follow-accepted event so the AP-domain handler can enqueue
+            // a backfill job for this remote source. Only fires when the
+            // target is remote-typed; getByActorUri returns only remote
+            // CalendarActorEntities, so reaching this point already implies
+            // a remote target.
+            this.emitFollowAccepted(followingRecord, remoteCalendar);
             return;
           }
         }
@@ -1769,6 +1805,12 @@ class ProcessInboxService {
         // In the future, we could add a "confirmed" status field
         // For now, the existence of the record means it's active
         logger.info(`Follow relationship confirmed for calendar ${calendar.id} following ${followActivity.object}`);
+        // Emit follow-accepted event so the AP-domain handler can enqueue
+        // a backfill job for the remote source. remoteCalendar comes from
+        // remoteCalendarService.getByActorUri, which only returns
+        // remote-typed CalendarActorEntities — local-target follows would
+        // not match here and therefore never reach this emit.
+        this.emitFollowAccepted(followingRecord, remoteCalendar);
       }
       else {
         logger.warn(`No FollowingCalendarEntity found for ${followActivity.object}, Accept may be for unknown follow`);

--- a/src/server/activitypub/test/account_created_event.test.ts
+++ b/src/server/activitypub/test/account_created_event.test.ts
@@ -10,6 +10,7 @@ import UserActorService from '@/server/activitypub/service/user_actor';
 import { UserActorEntity } from '@/server/activitypub/entity/user_actor';
 import { AccountEntity } from '@/server/common/entity/account';
 import db from '@/server/common/entity/db';
+import { stubHousekeepingInterface } from '@/server/activitypub/test/helper/housekeeping-stub';
 
 describe('ActivityPub account.created event handler', () => {
   let sandbox: sinon.SinonSandbox;
@@ -21,7 +22,7 @@ describe('ActivityPub account.created event handler', () => {
     sandbox = sinon.createSandbox();
     eventBus = new EventEmitter();
     activityPubInterface = new ActivityPubInterface(eventBus);
-    eventHandlers = new ActivityPubEventHandlers(activityPubInterface, new CalendarInterface(eventBus));
+    eventHandlers = new ActivityPubEventHandlers(activityPubInterface, new CalendarInterface(eventBus), stubHousekeepingInterface());
     eventHandlers.install(eventBus);
 
     // Sync database for test

--- a/src/server/activitypub/test/events.test.ts
+++ b/src/server/activitypub/test/events.test.ts
@@ -15,6 +15,7 @@ import { Calendar } from '@/common/model/calendar';
 import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { EventLocation, EventLocationContent, EventLocationSpace, EventLocationSpaceContent } from '@/common/model/location';
 import { setupActivityPubSchema, teardownActivityPubSchema } from '@/server/common/test/helpers/database';
+import { stubHousekeepingInterface } from '@/server/activitypub/test/helper/housekeeping-stub';
 
 describe('inbox event listener', () => {
   let service: ActivityPubInterface;
@@ -25,7 +26,7 @@ describe('inbox event listener', () => {
   beforeEach (() => {
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     eventHandler.install(eventBus);
   });
 
@@ -75,7 +76,7 @@ describe('outbox event listener', () => {
   beforeEach (() => {
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     eventHandler.install(eventBus);
   });
 
@@ -133,7 +134,7 @@ describe('handleEventUpdated guard', () => {
   beforeEach (() => {
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    eventHandler = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     eventHandler.install(eventBus);
   });
 
@@ -230,7 +231,7 @@ describe('handleEventCreated', () => {
     sandbox = sinon.createSandbox();
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     handlers.install(eventBus);
   });
 
@@ -370,7 +371,7 @@ describe('handleEventDeleted', () => {
   beforeEach(() => {
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     handlers.install(eventBus);
   });
 
@@ -551,5 +552,77 @@ describe('AP serialize → parse round-trip (Place + Space + multilingual conten
     expect(restored.location.originUri).toBe(apObject['pavillion:place'].id);
     expect(restored.space.originUri).toBe(apObject['pavillion:space'].id);
     expect(restored.space.originUri.startsWith(`${restored.location.originUri}/spaces/`)).toBe(true);
+  });
+});
+
+describe('handleFollowAccepted', () => {
+  // The handler turns the in-domain `activitypub:follow:accepted` event into a
+  // `activitypub:follow:backfill` job published through the housekeeping
+  // interface. The handler runs on the EventEmitter bus, so its async errors
+  // would otherwise surface as unhandled `error` events that crash the Node
+  // process — the swallow-and-log path is verified explicitly below.
+  let service: ActivityPubInterface;
+  let handlers: ActivityPubEventHandlers;
+  let eventBus: EventEmitter;
+  let sandbox: sinon.SinonSandbox;
+  let housekeeping: { publishJob: sinon.SinonStub };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    service = new ActivityPubInterface(eventBus);
+    housekeeping = { publishJob: sinon.stub().resolves() };
+    handlers = new ActivityPubEventHandlers(
+      service,
+      new CalendarInterface(eventBus),
+      housekeeping as any,
+    );
+    handlers.install(eventBus);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('publishes a activitypub:follow:backfill job with the full payload when activitypub:follow:accepted fires', async () => {
+    const payload = {
+      followingCalendarId: 'local-cal-id',
+      calendarActorId: 'remote-actor-id',
+      sourceActorUri: 'https://remote.federation.test/calendars/source',
+    };
+
+    eventBus.emit('activitypub:follow:accepted', payload);
+
+    // Allow the async handler to settle. EventEmitter dispatches listeners
+    // synchronously but our handler awaits publishJob; one microtask flush
+    // is enough for the stub call to register.
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(housekeeping.publishJob.calledOnce).toBe(true);
+    expect(housekeeping.publishJob.firstCall.args[0]).toBe('activitypub:follow:backfill');
+    expect(housekeeping.publishJob.firstCall.args[1]).toEqual(payload);
+  });
+
+  it('swallows publish errors so the EventEmitter does not surface them as an unhandled error event', async () => {
+    // EventEmitter routes unhandled rejections from listeners to its `error`
+    // event; with no listener, Node terminates the process. This test pins
+    // the catch-and-log behaviour so a transient pg-boss outage during a
+    // follow-accept burst cannot crash the web process.
+    housekeeping.publishJob.rejects(new Error('pg-boss connection refused'));
+
+    let unhandled = false;
+    eventBus.on('error', () => { unhandled = true; });
+
+    const payload = {
+      followingCalendarId: 'local-cal-id',
+      calendarActorId: 'remote-actor-id',
+      sourceActorUri: 'https://remote.federation.test/calendars/source',
+    };
+
+    eventBus.emit('activitypub:follow:accepted', payload);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(housekeeping.publishJob.calledOnce).toBe(true);
+    expect(unhandled).toBe(false);
   });
 });

--- a/src/server/activitypub/test/helper/housekeeping-stub.ts
+++ b/src/server/activitypub/test/helper/housekeeping-stub.ts
@@ -1,0 +1,16 @@
+import HousekeepingInterface from '@/server/housekeeping/interface';
+
+/**
+ * Returns a minimal HousekeepingInterface stand-in for AP unit tests that
+ * construct `ActivityPubEventHandlers`. The real housekeeping dependency is
+ * required by the handler constructor (DEC-003 — cross-domain calls go
+ * through interfaces, not service imports) but most tests only care that
+ * `publishJob` does not crash. Tests that exercise the actual publish path
+ * should stub `publishJob` directly with sinon.
+ */
+export function stubHousekeepingInterface(): HousekeepingInterface {
+  const stub = {
+    publishJob: async () => undefined,
+  };
+  return stub as unknown as HousekeepingInterface;
+}

--- a/src/server/activitypub/test/helper/remote-fetch.test.ts
+++ b/src/server/activitypub/test/helper/remote-fetch.test.ts
@@ -83,6 +83,32 @@ describe('fetchRemoteObject', () => {
     expect(callArgs.maxRedirects).toBe(0);
   });
 
+  it('should forward maxContentLength to axios when the option is provided', async () => {
+    axiosGetStub.resolves({
+      status: 200,
+      data: { type: 'Note' },
+    });
+
+    await fetchRemoteObject(
+      'https://remote.example/notes/456',
+      undefined,
+      { maxContentLength: 512_000 },
+    );
+
+    expect(axiosGetStub.firstCall.args[1].maxContentLength).toBe(512_000);
+  });
+
+  it('should omit maxContentLength from axios config when the option is not provided', async () => {
+    axiosGetStub.resolves({
+      status: 200,
+      data: { type: 'Note' },
+    });
+
+    await fetchRemoteObject('https://remote.example/notes/456');
+
+    expect(axiosGetStub.firstCall.args[1].maxContentLength).toBeUndefined();
+  });
+
   it('should return null when HTTP response is not 200', async () => {
     axiosGetStub.resolves({
       status: 404,

--- a/src/server/activitypub/test/helper/remote-fetch.test.ts
+++ b/src/server/activitypub/test/helper/remote-fetch.test.ts
@@ -3,6 +3,8 @@ import axios from 'axios';
 import sinon from 'sinon';
 import { fetchRemoteObject } from '@/server/activitypub/helper/remote-fetch';
 import { REMOTE_OBJECT_FETCH_TIMEOUT_MS } from '@/server/common/constants';
+import { Calendar } from '@/common/model/calendar';
+import CalendarActorService from '@/server/activitypub/service/calendar_actor';
 
 describe('fetchRemoteObject', () => {
   let sandbox: sinon.SinonSandbox = sinon.createSandbox();
@@ -245,6 +247,130 @@ describe('fetchRemoteObject', () => {
 
       expect(result).not.toBeNull();
       expect(axiosGetStub.called).toBe(true);
+    });
+  });
+
+  describe('Signed GET path', () => {
+    const SIGNING_CALENDAR_ID = 'signing-calendar-id';
+    const SIGNING_CALENDAR_URLNAME = 'community-events';
+    const SIGNING_ACTOR_URI = 'https://local.test/calendars/community-events';
+    const TARGET_URI = 'https://remote.example/users/alice/outbox';
+    const MOCK_SIGNATURE = 'mock-signature-base64-value';
+    const MOCK_DATE = 'Wed, 13 May 2026 12:00:00 GMT';
+
+    function makeSigningCalendar(): Calendar {
+      return new Calendar(SIGNING_CALENDAR_ID, SIGNING_CALENDAR_URLNAME);
+    }
+
+    function stubActorLookupAndSigning() {
+      sandbox.stub(CalendarActorService.prototype, 'getActorByCalendarId').resolves({
+        id: 'actor-id-123',
+        calendarId: SIGNING_CALENDAR_ID,
+        actorUri: SIGNING_ACTOR_URI,
+        publicKey: 'PUBLIC_KEY_PEM',
+        privateKey: 'PRIVATE_KEY_PEM',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+      const signStub = sandbox.stub(CalendarActorService.prototype, 'signActivity').resolves({
+        keyId: `${SIGNING_ACTOR_URI}#main-key`,
+        signature: MOCK_SIGNATURE,
+        algorithm: 'rsa-sha256',
+        headers: '(request-target) host date',
+        date: MOCK_DATE,
+      });
+      return signStub;
+    }
+
+    it('attaches an HTTP Signature header when a signing calendar is provided', async () => {
+      const signStub = stubActorLookupAndSigning();
+      axiosGetStub.resolves({ status: 200, data: { type: 'OrderedCollection' } });
+
+      const result = await fetchRemoteObject(TARGET_URI, makeSigningCalendar());
+
+      expect(result).toEqual({ type: 'OrderedCollection' });
+      expect(axiosGetStub.calledOnce).toBe(true);
+      const callArgs = axiosGetStub.firstCall.args[1];
+      const signatureHeader = callArgs.headers.Signature as string;
+      expect(signatureHeader).toBeDefined();
+      // Signature header must reference the calendar actor's keyId, the
+      // signing algorithm, the headers list including (request-target), and
+      // the base64 signature value.
+      expect(signatureHeader).toContain(`keyId="${SIGNING_ACTOR_URI}#main-key"`);
+      expect(signatureHeader).toContain('algorithm="rsa-sha256"');
+      expect(signatureHeader).toContain('headers="(request-target) host date"');
+      expect(signatureHeader).toContain(`signature="${MOCK_SIGNATURE}"`);
+      expect(callArgs.headers.Date).toBe(MOCK_DATE);
+
+      // signActivity must be invoked with method='get' and no digest so the
+      // (request-target) pseudo-header reflects the actual HTTP verb.
+      expect(signStub.calledOnce).toBe(true);
+      const signCallArgs = signStub.firstCall.args;
+      expect(signCallArgs[0]).toBe(SIGNING_ACTOR_URI); // actorUri
+      expect(signCallArgs[2]).toBe(TARGET_URI);        // targetUrl
+      expect(signCallArgs[3]).toBeUndefined();          // digest omitted for GET
+      expect(signCallArgs[4]).toBe('get');              // method
+    });
+
+    it('preserves Accept and User-Agent headers alongside signature headers', async () => {
+      stubActorLookupAndSigning();
+      axiosGetStub.resolves({ status: 200, data: { type: 'OrderedCollection' } });
+
+      await fetchRemoteObject(TARGET_URI, makeSigningCalendar());
+
+      const callArgs = axiosGetStub.firstCall.args[1];
+      expect(callArgs.headers['Accept']).toBe('application/activity+json');
+      expect(callArgs.headers['User-Agent']).toBe('Pavillion ActivityPub Server');
+    });
+
+    it('returns null and skips the HTTP request when the calendar has no actor', async () => {
+      sandbox.stub(CalendarActorService.prototype, 'getActorByCalendarId').resolves(null);
+
+      const result = await fetchRemoteObject(TARGET_URI, makeSigningCalendar());
+
+      // Fail-closed: when signing was requested but cannot be performed, we
+      // must not send an unsigned GET (which signature-requiring peers
+      // would reject anyway).
+      expect(result).toBeNull();
+      expect(axiosGetStub.called).toBe(false);
+    });
+
+    it('returns null and skips the HTTP request when signing throws', async () => {
+      sandbox.stub(CalendarActorService.prototype, 'getActorByCalendarId').resolves({
+        id: 'actor-id-123',
+        calendarId: SIGNING_CALENDAR_ID,
+        actorUri: SIGNING_ACTOR_URI,
+        publicKey: 'PUBLIC_KEY_PEM',
+        privateKey: 'PRIVATE_KEY_PEM',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+      sandbox.stub(CalendarActorService.prototype, 'signActivity').rejects(new Error('no private key'));
+
+      const result = await fetchRemoteObject(TARGET_URI, makeSigningCalendar());
+
+      expect(result).toBeNull();
+      expect(axiosGetStub.called).toBe(false);
+    });
+
+    it('does NOT attach signature headers when no signing calendar is provided', async () => {
+      // Stub signing primitives so a leak through to them would still be
+      // observable; assert they are never called.
+      const actorStub = sandbox.stub(CalendarActorService.prototype, 'getActorByCalendarId');
+      const signStub = sandbox.stub(CalendarActorService.prototype, 'signActivity');
+      axiosGetStub.resolves({ status: 200, data: { type: 'Event' } });
+
+      await fetchRemoteObject(TARGET_URI);
+
+      const callArgs = axiosGetStub.firstCall.args[1];
+      expect(callArgs.headers.Signature).toBeUndefined();
+      expect(callArgs.headers.Date).toBeUndefined();
+      // Existing Accept/User-Agent headers are still present.
+      expect(callArgs.headers['Accept']).toBe('application/activity+json');
+      expect(callArgs.headers['User-Agent']).toBe('Pavillion ActivityPub Server');
+      // Signing primitives must not be invoked in the unsigned path.
+      expect(actorStub.called).toBe(false);
+      expect(signStub.called).toBe(false);
     });
   });
 });

--- a/src/server/activitypub/test/integration/follow-backfill.test.ts
+++ b/src/server/activitypub/test/integration/follow-backfill.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Integration test for the follow-backfill worker.
+ *
+ * Pins the end-to-end path: a synthetic remote outbox served across two
+ * pages -> the worker's pagination + trust + routing logic -> the real
+ * inbox `processCreateEvent` -> `EventObjectEntity` + `EventEntity` rows ->
+ * `getEventsFromFollowedSources` returning the new events on the follower
+ * calendar's feed.
+ *
+ * The HTTP boundary (`fetchRemoteObject`) is mocked at the module level
+ * because real federation requires DNS, TLS, and a peer running an outbox;
+ * everything from the worker downward runs against real services and real
+ * SQLite-backed entities. This matches the bead's "exercising real HTTP-
+ * shape parsing" requirement: the worker parses real AP collection /
+ * collection-page payloads and threads them through the real inbox
+ * pipeline.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+import AccountService from '@/server/accounts/service/account';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountsInterface from '@/server/accounts/interface';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import ActivityPubInterface from '@/server/activitypub/interface';
+import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
+import { FollowingCalendarEntity } from '@/server/activitypub/entity/activitypub';
+import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
+
+// Mock the remote-fetch helper so both the backfill worker and the inbox
+// `actorOwnsObject` check observe the same scripted federation peer.
+vi.mock('@/server/activitypub/helper/remote-fetch', () => ({
+  fetchRemoteObject: vi.fn(),
+}));
+
+import { fetchRemoteObject } from '@/server/activitypub/helper/remote-fetch';
+import { FollowBackfillService } from '@/server/activitypub/service/backfill';
+import { SyncRateLimiter } from '@/server/common/helper/rate-limiter';
+
+const REMOTE_HOST = 'remote.federation.test';
+const REMOTE_ACTOR_URI = `https://${REMOTE_HOST}/calendars/sourcecal`;
+const REMOTE_OUTBOX_URI = `https://${REMOTE_HOST}/calendars/sourcecal/outbox`;
+const REMOTE_OUTBOX_PAGE_1 = `${REMOTE_OUTBOX_URI}?page=true`;
+const REMOTE_OUTBOX_PAGE_2 = `${REMOTE_OUTBOX_URI}?page=true&p=2`;
+
+function eventApId(slug: string): string {
+  return `https://${REMOTE_HOST}/events/${slug}`;
+}
+
+function createActivity(slug: string, name: string): Record<string, unknown> {
+  const eventId = eventApId(slug);
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    id: `${REMOTE_ACTOR_URI}/activities/${slug}`,
+    type: 'Create',
+    actor: REMOTE_ACTOR_URI,
+    object: {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Event',
+      id: eventId,
+      attributedTo: REMOTE_ACTOR_URI,
+      content: {
+        en: {
+          name,
+          description: `Synthetic event ${slug} from backfill source`,
+        },
+      },
+      schedules: [
+        {
+          startDate: '2026-06-01',
+          endDate: '2026-06-01',
+          startTime: '10:00',
+          endTime: '11:00',
+        },
+      ],
+    },
+  };
+}
+
+describe('Follow backfill integration', () => {
+  let env: TestEnvironment;
+  let eventBus: EventEmitter;
+  let calendarInterface: CalendarInterface;
+  let accountsInterface: AccountsInterface;
+  let activityPubInterface: ActivityPubInterface;
+  let backfillService: FollowBackfillService;
+
+  let followerAccount: Account;
+  let followerCalendar: Calendar;
+  let followingId: string;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    accountsInterface = new AccountsInterface(eventBus, configurationInterface, setupInterface);
+    calendarInterface = new CalendarInterface(eventBus, accountsInterface, configurationInterface);
+    activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const accountInfo = await accountService._setupAccount('backfillfollower@pavillion.dev', 'testpassword');
+    followerAccount = accountInfo.account;
+    followerCalendar = await calendarInterface.createCalendar(followerAccount, 'backfillfollower');
+
+    backfillService = new FollowBackfillService({
+      activityPubInterface,
+      calendarInterface,
+      // Tight per-test budget for test determinism; far above what we need.
+      rateLimiter: new SyncRateLimiter({ limit: 100, windowMs: 60_000 }),
+    });
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  beforeEach(async () => {
+    // Reset the mock; each test scripts its own peer.
+    vi.mocked(fetchRemoteObject).mockReset();
+
+    // Drop any prior follow rows / event objects / remote actor rows so the
+    // unique constraint on calendar_actor.actor_uri does not trip on the
+    // second test in the file.
+    await FollowingCalendarEntity.destroy({ where: {} });
+    await EventObjectEntity.destroy({ where: {} });
+    await CalendarActorEntity.destroy({ where: { actor_type: 'remote' } });
+
+    // Seed a remote CalendarActor + Following row so the worker can resolve
+    // the source from the payload it receives off the job queue.
+    const calendarActor = await CalendarActorEntity.create({
+      id: uuidv4(),
+      actor_type: 'remote',
+      calendar_id: null,
+      actor_uri: REMOTE_ACTOR_URI,
+      remote_domain: REMOTE_HOST,
+      private_key: null,
+    });
+    followingId = uuidv4();
+    await FollowingCalendarEntity.create({
+      id: followingId,
+      calendar_actor_id: calendarActor.id,
+      calendar_id: followerCalendar.id,
+      auto_repost_originals: false,
+      auto_repost_reposts: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('walks a two-page outbox and lands events on the follower feed', async () => {
+    const ev1 = createActivity('one', 'Backfill Event One');
+    const ev2 = createActivity('two', 'Backfill Event Two');
+    const ev3 = createActivity('three', 'Backfill Event Three');
+
+    vi.mocked(fetchRemoteObject).mockImplementation(async (uri: string) => {
+      switch (uri) {
+        case REMOTE_ACTOR_URI:
+          return { id: REMOTE_ACTOR_URI, type: 'Group', outbox: REMOTE_OUTBOX_URI };
+        case REMOTE_OUTBOX_URI:
+          return {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollection',
+            id: REMOTE_OUTBOX_URI,
+            first: REMOTE_OUTBOX_PAGE_1,
+          };
+        case REMOTE_OUTBOX_PAGE_1:
+          return {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollectionPage',
+            id: REMOTE_OUTBOX_PAGE_1,
+            partOf: REMOTE_OUTBOX_URI,
+            orderedItems: [ev1, ev2],
+            next: REMOTE_OUTBOX_PAGE_2,
+          };
+        case REMOTE_OUTBOX_PAGE_2:
+          return {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollectionPage',
+            id: REMOTE_OUTBOX_PAGE_2,
+            partOf: REMOTE_OUTBOX_URI,
+            orderedItems: [ev3],
+          };
+        case eventApId('one'):
+          return { id: eventApId('one'), type: 'Event', attributedTo: REMOTE_ACTOR_URI };
+        case eventApId('two'):
+          return { id: eventApId('two'), type: 'Event', attributedTo: REMOTE_ACTOR_URI };
+        case eventApId('three'):
+          return { id: eventApId('three'), type: 'Event', attributedTo: REMOTE_ACTOR_URI };
+        default:
+          return null;
+      }
+    });
+
+    await backfillService.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'irrelevant-for-worker',
+      sourceActorUri: REMOTE_ACTOR_URI,
+    });
+
+    // EventObject rows landed for all three events. The unique constraint
+    // on `ap_event_object.ap_id` is the inbox handler's idempotency anchor
+    // (DEC-008 dismissals + auto-repost suppression run through the same
+    // entity), so this is the load-bearing assertion for "backfill landed
+    // the events".
+    const objects = await EventObjectEntity.findAll({
+      where: { attributed_to: REMOTE_ACTOR_URI },
+    });
+    const apIds = objects.map(o => o.ap_id).sort();
+    expect(apIds).toEqual([
+      eventApId('one'),
+      eventApId('three'),
+      eventApId('two'),
+    ]);
+
+    // The events are reachable via the same feed query the API renders.
+    // We assert presence by event-id linkage (EventObjectEntity -> EventEntity)
+    // rather than by content-name lookup because the test calendar uses
+    // SQLite literal joins and the simplest stable surface is the row link.
+    const feed = await calendarInterface.getEventsFromFollowedSources(followerCalendar);
+    const feedEventIds = new Set(feed.map((e: { id: string }) => e.id));
+    for (const obj of objects) {
+      expect(feedEventIds.has(obj.event_id)).toBe(true);
+    }
+  });
+
+  it('respects in-page Delete: a Create + Delete for the same ap_id in one page yields no event row', async () => {
+    const apId = eventApId('ephemeral');
+    const create = createActivity('ephemeral', 'Ephemeral Event');
+    const del = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `${REMOTE_ACTOR_URI}/activities/ephemeral-delete`,
+      type: 'Delete',
+      actor: REMOTE_ACTOR_URI,
+      object: apId,
+    };
+
+    vi.mocked(fetchRemoteObject).mockImplementation(async (uri: string) => {
+      switch (uri) {
+        case REMOTE_ACTOR_URI:
+          return { id: REMOTE_ACTOR_URI, type: 'Group', outbox: REMOTE_OUTBOX_URI };
+        case REMOTE_OUTBOX_URI:
+          return {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            type: 'OrderedCollectionPage',
+            id: REMOTE_OUTBOX_URI,
+            orderedItems: [create, del],
+          };
+        default:
+          return null;
+      }
+    });
+
+    await backfillService.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'irrelevant',
+      sourceActorUri: REMOTE_ACTOR_URI,
+    });
+
+    const objects = await EventObjectEntity.findAll({ where: { ap_id: apId } });
+    expect(objects.length).toBe(0);
+  });
+});

--- a/src/server/activitypub/test/integration/follow-backfill.test.ts
+++ b/src/server/activitypub/test/integration/follow-backfill.test.ts
@@ -93,7 +93,7 @@ describe('Follow backfill integration', () => {
 
   let followerAccount: Account;
   let followerCalendar: Calendar;
-  let followingId: string;
+  let calendarActorId: string;
 
   beforeAll(async () => {
     env = new TestEnvironment();
@@ -144,9 +144,9 @@ describe('Follow backfill integration', () => {
       remote_domain: REMOTE_HOST,
       private_key: null,
     });
-    followingId = uuidv4();
+    calendarActorId = calendarActor.id;
     await FollowingCalendarEntity.create({
-      id: followingId,
+      id: uuidv4(),
       calendar_actor_id: calendarActor.id,
       calendar_id: followerCalendar.id,
       auto_repost_originals: false,
@@ -203,8 +203,8 @@ describe('Follow backfill integration', () => {
     });
 
     await backfillService.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'irrelevant-for-worker',
+      followingCalendarId: followerCalendar.id,
+      calendarActorId,
       sourceActorUri: REMOTE_ACTOR_URI,
     });
 
@@ -262,8 +262,8 @@ describe('Follow backfill integration', () => {
     });
 
     await backfillService.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'irrelevant',
+      followingCalendarId: followerCalendar.id,
+      calendarActorId,
       sourceActorUri: REMOTE_ACTOR_URI,
     });
 

--- a/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
+++ b/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
@@ -49,6 +49,7 @@ import SetupInterface from '@/server/setup/interface';
 import EmailInterface from '@/server/email/interface';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import ActivityPubEventHandlers from '@/server/activitypub/events';
+import { stubHousekeepingInterface } from '@/server/activitypub/test/helper/housekeeping-stub';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
 import CalendarActorService from '@/server/activitypub/service/calendar_actor';
@@ -214,7 +215,7 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     // Now install the ActivityPub event handlers so that a subsequent
     // calendarInterface.createEvent triggers handleEventCreated, which in turn
     // runs the unified outbox dispatch path against the fixtures we just built.
-    new ActivityPubEventHandlers(apInterface, calendarInterface).install(eventBus);
+    new ActivityPubEventHandlers(apInterface, calendarInterface, stubHousekeepingInterface()).install(eventBus);
   });
 
   afterAll(async () => {

--- a/src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts
+++ b/src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts
@@ -17,6 +17,7 @@ import {
   EventLocationSpace,
   EventLocationSpaceContent,
 } from '@/common/model/location';
+import { stubHousekeepingInterface } from '@/server/activitypub/test/helper/housekeeping-stub';
 
 /**
  * Federation regression test for the Place + Spaces atomic-save model.
@@ -46,7 +47,7 @@ describe('Place+Spaces atomic save: federation regression', () => {
     sandbox = sinon.createSandbox();
     eventBus = new EventEmitter();
     service = new ActivityPubInterface(eventBus);
-    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus));
+    handlers = new ActivityPubEventHandlers(service, new CalendarInterface(eventBus), stubHousekeepingInterface());
     handlers.install(eventBus);
   });
 

--- a/src/server/activitypub/test/service/backfill.test.ts
+++ b/src/server/activitypub/test/service/backfill.test.ts
@@ -1,0 +1,721 @@
+/**
+ * Unit tests for FollowBackfillService.
+ *
+ * These tests stand up the real ActivityPub ephemeral schema so we can
+ * assert against row state for FollowingCalendarEntity (re-verification at
+ * page boundaries) and seed CalendarEntity/CalendarActorEntity rows the
+ * worker resolves at job start. The downstream `processInboxMessage` call
+ * is stubbed on the ActivityPubInterface — the inbox-side behaviour
+ * (idempotency, DEC-008 dismissals, auto-repost policy gates) is owned by
+ * existing inbox tests and exercised end-to-end by the integration test.
+ *
+ * Each test asserts on observable worker behaviour: which URLs were
+ * fetched, which activities reached processInboxMessage, how the trust
+ * gates and two-pass Delete logic filtered the stream.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import sinon from 'sinon';
+import { v4 as uuidv4 } from 'uuid';
+
+import db from '@/server/common/entity/db';
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEntity } from '@/server/calendar/entity/calendar';
+import { CalendarActorEntity } from '@/server/activitypub/entity/calendar_actor';
+import { FollowingCalendarEntity, ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
+import {
+  setupActivityPubSchema,
+  teardownActivityPubSchema,
+} from '@/server/common/test/helpers/database';
+
+// Mock the SSRF helper at the module boundary. We assert on call counts so
+// the worker is provably calling it before every fetch.
+vi.mock('@/server/common/helper/ip-validation', () => ({
+  validateUrlNotPrivate: vi.fn(),
+  isPrivateIP: vi.fn(),
+  resolvesToPrivateIP: vi.fn(),
+}));
+
+import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
+import {
+  FollowBackfillService,
+  MAX_OUTBOX_PAGES,
+  MAX_PAGE_BYTES,
+  passesTrustGates,
+  extractObjectId,
+} from '@/server/activitypub/service/backfill';
+import { SyncRateLimiter } from '@/server/common/helper/rate-limiter';
+
+const REMOTE_HOST = 'remote.federation.test';
+const SOURCE_ACTOR_URI = `https://${REMOTE_HOST}/calendars/source`;
+const SOURCE_OUTBOX_URI = `https://${REMOTE_HOST}/calendars/source/outbox`;
+const SOURCE_OUTBOX_PAGE_URI = `${SOURCE_OUTBOX_URI}?page=true`;
+
+function buildEventActivity(opts: {
+  id: string;
+  type?: 'Create' | 'Update' | 'Announce' | 'Delete';
+  actor?: string;
+  attributedTo?: string;
+}): Record<string, unknown> {
+  const type = opts.type ?? 'Create';
+  const actor = opts.actor ?? SOURCE_ACTOR_URI;
+  if (type === 'Delete') {
+    return {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `${actor}/activities/${opts.id}-delete`,
+      type: 'Delete',
+      actor,
+      object: opts.id,
+    };
+  }
+  if (type === 'Announce') {
+    return {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `${actor}/activities/${opts.id}-announce`,
+      type: 'Announce',
+      actor,
+      object: opts.id,
+    };
+  }
+  return {
+    '@context': 'https://www.w3.org/ns/activitystreams',
+    id: `${actor}/activities/${opts.id}`,
+    type,
+    actor,
+    object: {
+      id: opts.id,
+      type: 'Event',
+      attributedTo: opts.attributedTo ?? actor,
+    },
+  };
+}
+
+function makeFetcher(responses: Map<string, Record<string, unknown> | null>) {
+  const calls: { url: string }[] = [];
+  const fetcher = vi.fn(async (url: string) => {
+    calls.push({ url });
+    if (!responses.has(url)) {
+      return null;
+    }
+    return responses.get(url) ?? null;
+  });
+  return { fetcher, calls };
+}
+
+describe('FollowBackfillService.runBackfill', () => {
+  let sandbox: sinon.SinonSandbox;
+  let calendarId: string;
+  let followingId: string;
+  let followerCalendar: Calendar;
+  let processInboxStub: sinon.SinonStub;
+  let activityPubInterfaceStub: { processInboxMessage: sinon.SinonStub };
+  let calendarInterfaceStub: { getCalendar: sinon.SinonStub };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    await setupActivityPubSchema();
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    // Seed the local follower calendar so ActivityPubActor.actorUrl can build
+    // a stable loop-guard URL for it.
+    calendarId = uuidv4();
+    await CalendarEntity.create({
+      id: calendarId,
+      url_name: 'localfollower',
+      languages: 'en',
+    });
+    // Seed a remote CalendarActor row to mirror the AP discovery side.
+    const calendarActor = await CalendarActorEntity.create({
+      id: uuidv4(),
+      actor_type: 'remote',
+      calendar_id: null,
+      actor_uri: SOURCE_ACTOR_URI,
+      remote_domain: REMOTE_HOST,
+      private_key: null,
+    });
+    followingId = uuidv4();
+    await FollowingCalendarEntity.create({
+      id: followingId,
+      calendar_actor_id: calendarActor.id,
+      calendar_id: calendarId,
+      auto_repost_originals: false,
+      auto_repost_reposts: false,
+    });
+
+    followerCalendar = new Calendar(calendarId, 'localfollower');
+    // Pin the local actor URL so the loop-guard test below is deterministic.
+    Object.defineProperty(followerCalendar, 'id', { value: calendarId });
+
+    processInboxStub = sandbox.stub().resolves();
+    activityPubInterfaceStub = { processInboxMessage: processInboxStub };
+    calendarInterfaceStub = {
+      getCalendar: sandbox.stub().resolves(followerCalendar),
+    };
+
+    (validateUrlNotPrivate as unknown as sinon.SinonStub & ((url: string) => Promise<boolean>));
+    vi.mocked(validateUrlNotPrivate).mockReset();
+    vi.mocked(validateUrlNotPrivate).mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+    await db.query('PRAGMA foreign_keys = ON');
+    vi.clearAllMocks();
+  });
+
+  function buildService(opts: {
+    responses: Map<string, Record<string, unknown> | null>;
+    rateLimiter?: SyncRateLimiter;
+  }) {
+    const { fetcher, calls } = makeFetcher(opts.responses);
+    const service = new FollowBackfillService({
+      activityPubInterface: activityPubInterfaceStub as never,
+      calendarInterface: calendarInterfaceStub as never,
+      rateLimiter: opts.rateLimiter ?? new SyncRateLimiter({ limit: 60, windowMs: 60_000 }),
+      fetcher: fetcher as never,
+    });
+    return { service, fetcher, calls };
+  }
+
+  it('happy path: pulls events from outbox and routes each through processInboxMessage', async () => {
+    const event1 = buildEventActivity({ id: `https://${REMOTE_HOST}/events/1` });
+    const event2 = buildEventActivity({ id: `https://${REMOTE_HOST}/events/2` });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollection',
+      id: SOURCE_OUTBOX_URI,
+      first: SOURCE_OUTBOX_PAGE_URI,
+    });
+    responses.set(SOURCE_OUTBOX_PAGE_URI, {
+      type: 'OrderedCollectionPage',
+      id: SOURCE_OUTBOX_PAGE_URI,
+      orderedItems: [event1, event2],
+    });
+
+    const { service } = buildService({ responses });
+
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(2);
+    const routedTypes = processInboxStub.getCalls().map(c => (c.args[0] as ActivityPubInboxMessageEntity).type);
+    expect(routedTypes).toEqual(['Create', 'Create']);
+  });
+
+  it('handles outbox that returns OrderedCollectionPage directly without a first link', async () => {
+    const event = buildEventActivity({ id: `https://${REMOTE_HOST}/events/direct` });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      id: SOURCE_OUTBOX_URI,
+      orderedItems: [event],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(1);
+  });
+
+  it('two-pass within-page Delete suppresses earlier Create for the same ap_id', async () => {
+    const apId = `https://${REMOTE_HOST}/events/ephemeral`;
+    const create = buildEventActivity({ id: apId, type: 'Create' });
+    const del = buildEventActivity({ id: apId, type: 'Delete' });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      id: SOURCE_OUTBOX_URI,
+      orderedItems: [create, del],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // The Create is suppressed; only the Delete is routed.
+    expect(processInboxStub.callCount).toBe(1);
+    expect((processInboxStub.firstCall.args[0] as ActivityPubInboxMessageEntity).type).toBe('Delete');
+  });
+
+  it('cross-page Delete-after-Create routes both activities (idempotency owned by inbox handler)', async () => {
+    const apId = `https://${REMOTE_HOST}/events/cross-page`;
+    const create = buildEventActivity({ id: apId, type: 'Create' });
+    const del = buildEventActivity({ id: apId, type: 'Delete' });
+
+    const page2Url = `${SOURCE_OUTBOX_PAGE_URI}&page=2`;
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollection',
+      first: SOURCE_OUTBOX_PAGE_URI,
+    });
+    responses.set(SOURCE_OUTBOX_PAGE_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [create],
+      next: page2Url,
+    });
+    responses.set(page2Url, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [del],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(2);
+    const types = processInboxStub.getCalls().map(c => (c.args[0] as ActivityPubInboxMessageEntity).type);
+    expect(types).toEqual(['Create', 'Delete']);
+  });
+
+  it('skips Update activities entirely', async () => {
+    const apId = `https://${REMOTE_HOST}/events/upd`;
+    const update = buildEventActivity({ id: apId, type: 'Update' });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [update],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('drops Create when activity.actor origin mismatches outbox origin (trust gate 1)', async () => {
+    const evil = buildEventActivity({
+      id: `https://${REMOTE_HOST}/events/forged`,
+      actor: 'https://evil.example.com/users/mallory',
+    });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [evil],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('drops Create when object.attributedTo does not match actor (trust gate 2)', async () => {
+    const bad = buildEventActivity({
+      id: `https://${REMOTE_HOST}/events/badattrib`,
+      attributedTo: 'https://elsewhere.example.com/calendars/other',
+    });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [bad],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('loop guard: drops activity whose object.attributedTo matches the local actor URL', async () => {
+    // The local actor URI is derived from the followerCalendar via the
+    // pinned local domain. We construct a Create whose attributedTo points
+    // back at the local actor — that's the loop-guard trip case.
+    const localActorUri = `https://${REMOTE_HOST}/calendars/source`;
+    // To trip the loop guard, we make the *follower* actor URL equal to the
+    // outbox source and forge an attributedTo into that. We use the
+    // sourceActorUri as the local actor URL since ActivityPubActor.actorUrl
+    // builds from config + urlName; for this assertion the simplest path is
+    // to fabricate an attributedTo and assert via the pure helper.
+    const attributedTo = localActorUri;
+
+    // Use the pure helper directly here to keep this test independent of
+    // config-driven domain resolution.
+    const result = passesTrustGates(
+      {
+        type: 'Create',
+        actor: SOURCE_ACTOR_URI,
+        object: { id: 'x', attributedTo },
+      },
+      'Create',
+      {
+        localActorUri,
+        sourceActorUri: SOURCE_ACTOR_URI,
+        outboxUrl: SOURCE_OUTBOX_URI,
+      },
+    );
+    expect(result).toBe(false);
+  });
+
+  it('re-running the backfill produces the same routed call set (idempotency owned by inbox handler)', async () => {
+    const event = buildEventActivity({ id: `https://${REMOTE_HOST}/events/idem` });
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event],
+    });
+
+    const { service } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // The worker hands the same activity to processInboxMessage on both
+    // runs. Idempotency at the row level is the inbox handler's
+    // responsibility (unique constraint on ap_event_object.ap_id +
+    // findOrCreate); the worker's job is to deliver the activities every
+    // time it runs.
+    expect(processInboxStub.callCount).toBe(2);
+  });
+
+  it('truncates pagination at MAX_OUTBOX_PAGES and emits one warn-level log', async () => {
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollection',
+      first: `${SOURCE_OUTBOX_PAGE_URI}&p=1`,
+    });
+    // Build 60 pages, each linking to the next; the worker should stop at
+    // MAX_OUTBOX_PAGES regardless.
+    for (let i = 1; i <= MAX_OUTBOX_PAGES + 10; i++) {
+      const url = `${SOURCE_OUTBOX_PAGE_URI}&p=${i}`;
+      const next = `${SOURCE_OUTBOX_PAGE_URI}&p=${i + 1}`;
+      responses.set(url, {
+        type: 'OrderedCollectionPage',
+        orderedItems: [],
+        next,
+      });
+    }
+
+    const { service, calls } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // 1 actor profile + 1 collection summary + 1 "first" page fetch +
+    // (MAX_OUTBOX_PAGES - 1) "next" page fetches walked from the first.
+    // The loop walks at most MAX_OUTBOX_PAGES pages.
+    expect(calls.length).toBeLessThanOrEqual(3 + MAX_OUTBOX_PAGES);
+    // No activities to route in this synthetic stream.
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('mid-pagination unfollow: removes FollowingCalendarEntity between pages and exits cleanly', async () => {
+    const event1 = buildEventActivity({ id: `https://${REMOTE_HOST}/events/a` });
+    const event2 = buildEventActivity({ id: `https://${REMOTE_HOST}/events/b` });
+    const page2Url = `${SOURCE_OUTBOX_PAGE_URI}&p=2`;
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollection',
+      first: SOURCE_OUTBOX_PAGE_URI,
+    });
+    responses.set(SOURCE_OUTBOX_PAGE_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event1],
+      next: page2Url,
+    });
+    responses.set(page2Url, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event2],
+    });
+
+    const { service } = buildService({ responses });
+    // Side-effect: drop the follow row after the first inbox call so the
+    // page-boundary re-check trips.
+    processInboxStub.callsFake(async () => {
+      await FollowingCalendarEntity.destroy({ where: { id: followingId } });
+    });
+
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // Only the first page is processed; the second page is never fetched.
+    expect(processInboxStub.callCount).toBe(1);
+  });
+
+  it('SSRF: refuses fetch when outbox URL fails private-IP validation', async () => {
+    vi.mocked(validateUrlNotPrivate).mockImplementation(async (url: string) => {
+      if (url === SOURCE_OUTBOX_URI) {
+        throw new Error('Hostname remote.federation.test resolves to a private IP address');
+      }
+      return true;
+    });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [buildEventActivity({ id: 'should-never-fetch' })],
+    });
+
+    const { service, calls } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // The actor URI passes (returns true), the outbox throws — fetcher is
+    // called for the actor profile only, never for the rejected outbox URL.
+    const fetchedUrls = calls.map(c => c.url);
+    expect(fetchedUrls).not.toContain(SOURCE_OUTBOX_URI);
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('SSRF: refuses fetch when a next-page URL fails private-IP validation', async () => {
+    const page2Url = `${SOURCE_OUTBOX_PAGE_URI}&p=2`;
+    vi.mocked(validateUrlNotPrivate).mockImplementation(async (url: string) => {
+      if (url === page2Url) {
+        throw new Error('SSRF: page2 rejected');
+      }
+      return true;
+    });
+
+    const event1 = buildEventActivity({ id: `https://${REMOTE_HOST}/events/p1` });
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollection',
+      first: SOURCE_OUTBOX_PAGE_URI,
+    });
+    responses.set(SOURCE_OUTBOX_PAGE_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event1],
+      next: page2Url,
+    });
+
+    const { service, calls } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    expect(calls.map(c => c.url)).not.toContain(page2Url);
+    expect(processInboxStub.callCount).toBe(1);
+  });
+
+  it('every fetcher call receives the follower calendar and a 1 MiB content cap (signed-GET + size guard)', async () => {
+    const event = buildEventActivity({ id: `https://${REMOTE_HOST}/events/sign` });
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event],
+    });
+
+    const { service, fetcher } = buildService({ responses });
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // Every outbound call carries (url, signingCalendar, { maxContentLength: MAX_PAGE_BYTES }).
+    const calls = (fetcher as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call[1]).toBeDefined();
+      expect((call[1] as Calendar).id).toBe(calendarId);
+      expect(call[2]).toEqual({ maxContentLength: MAX_PAGE_BYTES });
+    }
+  });
+
+  it('rate limiter: per-host cap exhaustion stops pagination cleanly', async () => {
+    const event = buildEventActivity({ id: `https://${REMOTE_HOST}/events/cap` });
+    const responses = new Map<string, Record<string, unknown> | null>();
+    responses.set(SOURCE_ACTOR_URI, { id: SOURCE_ACTOR_URI, outbox: SOURCE_OUTBOX_URI });
+    responses.set(SOURCE_OUTBOX_URI, {
+      type: 'OrderedCollectionPage',
+      orderedItems: [event],
+    });
+
+    // Limiter with a single slot per host — the actor-profile fetch
+    // consumes it and the outbox fetch is refused.
+    const tight = new SyncRateLimiter({ limit: 1, windowMs: 60_000 });
+    const { service, calls } = buildService({ responses, rateLimiter: tight });
+
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // Only the actor profile fetched; outbox refused.
+    expect(calls.length).toBe(1);
+    expect(processInboxStub.callCount).toBe(0);
+  });
+
+  it('exits cleanly when follow row is missing at job start', async () => {
+    await FollowingCalendarEntity.destroy({ where: { id: followingId } });
+
+    const responses = new Map<string, Record<string, unknown> | null>();
+    const { service, calls } = buildService({ responses });
+
+    await service.runBackfill({
+      followingCalendarId: followingId,
+      calendarActorId: 'unused',
+      sourceActorUri: SOURCE_ACTOR_URI,
+    });
+
+    // No fetch issued; no inbox routing.
+    expect(calls.length).toBe(0);
+    expect(processInboxStub.callCount).toBe(0);
+  });
+});
+
+describe('passesTrustGates (pure helper)', () => {
+  const ctx = {
+    localActorUri: 'https://local.example.com/calendars/me',
+    sourceActorUri: 'https://remote.example.com/calendars/source',
+    outboxUrl: 'https://remote.example.com/calendars/source/outbox',
+  };
+
+  it('accepts a well-formed Create from the source', () => {
+    const result = passesTrustGates(
+      {
+        type: 'Create',
+        actor: 'https://remote.example.com/calendars/source',
+        object: {
+          id: 'https://remote.example.com/events/1',
+          attributedTo: 'https://remote.example.com/calendars/source',
+        },
+      },
+      'Create',
+      ctx,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('rejects missing actor', () => {
+    expect(passesTrustGates({ type: 'Create', object: {} }, 'Create', ctx)).toBe(false);
+  });
+
+  it('rejects when the activity actor is on a different origin than the outbox', () => {
+    expect(
+      passesTrustGates(
+        { type: 'Create', actor: 'https://attacker.example/users/m', object: {} },
+        'Create',
+        ctx,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects Create whose attributedTo does not equal actor', () => {
+    expect(
+      passesTrustGates(
+        {
+          type: 'Create',
+          actor: 'https://remote.example.com/calendars/source',
+          object: { attributedTo: 'https://remote.example.com/users/someone-else' },
+        },
+        'Create',
+        ctx,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects Announce with mismatched source origin', () => {
+    expect(
+      passesTrustGates(
+        {
+          type: 'Announce',
+          actor: 'https://remote.example.com/calendars/peer',
+          object: 'https://other.example.com/events/1',
+        },
+        'Announce',
+        {
+          ...ctx,
+          sourceActorUri: 'https://elsewhere.example.com/calendars/source',
+          outboxUrl: 'https://remote.example.com/calendars/peer/outbox',
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects when object.attributedTo equals the local follower actor', () => {
+    expect(
+      passesTrustGates(
+        {
+          type: 'Create',
+          actor: 'https://remote.example.com/calendars/source',
+          object: {
+            attributedTo: 'https://local.example.com/calendars/me',
+          },
+        },
+        'Create',
+        ctx,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('extractObjectId (pure helper)', () => {
+  it('returns string IRI when object is a bare string', () => {
+    expect(extractObjectId('https://x.example/1')).toBe('https://x.example/1');
+  });
+
+  it('returns id when object is an embedded record', () => {
+    expect(extractObjectId({ id: 'https://x.example/2', type: 'Event' })).toBe('https://x.example/2');
+  });
+
+  it('returns null when object is null/undefined/empty', () => {
+    expect(extractObjectId(null)).toBe(null);
+    expect(extractObjectId(undefined)).toBe(null);
+    expect(extractObjectId({})).toBe(null);
+    expect(extractObjectId(42 as unknown)).toBe(null);
+  });
+});

--- a/src/server/activitypub/test/service/backfill.test.ts
+++ b/src/server/activitypub/test/service/backfill.test.ts
@@ -36,6 +36,27 @@ vi.mock('@/server/common/helper/ip-validation', () => ({
   resolvesToPrivateIP: vi.fn(),
 }));
 
+// Mock the logger helper so the cap test can assert on a single warn-level
+// emission when MAX_OUTBOX_PAGES is reached. createLogger returns a stable
+// fake logger whose methods are vi.fn spies; tests reset them in beforeEach.
+// vi.hoisted is required because vi.mock factories are hoisted above
+// top-level statements and would otherwise see an undefined reference.
+const { loggerSpies } = vi.hoisted(() => {
+  const spies = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  };
+  spies.child.mockReturnValue(spies);
+  return { loggerSpies: spies };
+});
+vi.mock('@/server/common/helper/logger', () => ({
+  createLogger: () => loggerSpies,
+  default: loggerSpies,
+}));
+
 import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
 import {
   FollowBackfillService,
@@ -446,6 +467,21 @@ describe('FollowBackfillService.runBackfill', () => {
     expect(calls.length).toBeLessThanOrEqual(3 + MAX_OUTBOX_PAGES);
     // No activities to route in this synthetic stream.
     expect(processInboxStub.callCount).toBe(0);
+
+    // Acceptance criterion: reaching MAX_OUTBOX_PAGES emits exactly one
+    // warn-level log line carrying the structured fields the operator
+    // would need to triage a runaway outbox (pages walked, the cap).
+    const capWarnCalls = loggerSpies.warn.mock.calls.filter(
+      ([fields, message]) =>
+        typeof message === 'string'
+        && message.includes('backfill truncated at page cap'),
+    );
+    expect(capWarnCalls).toHaveLength(1);
+    expect(capWarnCalls[0][0]).toMatchObject({
+      pagesWalked: MAX_OUTBOX_PAGES,
+      cap: MAX_OUTBOX_PAGES,
+      followingCalendarId: followingId,
+    });
   });
 
   it('mid-pagination unfollow: removes FollowingCalendarEntity between pages and exits cleanly', async () => {

--- a/src/server/activitypub/test/service/backfill.test.ts
+++ b/src/server/activitypub/test/service/backfill.test.ts
@@ -126,6 +126,7 @@ function makeFetcher(responses: Map<string, Record<string, unknown> | null>) {
 describe('FollowBackfillService.runBackfill', () => {
   let sandbox: sinon.SinonSandbox;
   let calendarId: string;
+  let calendarActorId: string;
   let followingId: string;
   let followerCalendar: Calendar;
   let processInboxStub: sinon.SinonStub;
@@ -154,6 +155,7 @@ describe('FollowBackfillService.runBackfill', () => {
       remote_domain: REMOTE_HOST,
       private_key: null,
     });
+    calendarActorId = calendarActor.id;
     followingId = uuidv4();
     await FollowingCalendarEntity.create({
       id: followingId,
@@ -219,8 +221,8 @@ describe('FollowBackfillService.runBackfill', () => {
     const { service } = buildService({ responses });
 
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -242,8 +244,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -265,8 +267,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -299,8 +301,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -322,8 +324,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -345,8 +347,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -368,8 +370,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -417,13 +419,13 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -456,8 +458,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service, calls } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -480,7 +482,7 @@ describe('FollowBackfillService.runBackfill', () => {
     expect(capWarnCalls[0][0]).toMatchObject({
       pagesWalked: MAX_OUTBOX_PAGES,
       cap: MAX_OUTBOX_PAGES,
-      followingCalendarId: followingId,
+      followingCalendarId: calendarId,
     });
   });
 
@@ -513,8 +515,8 @@ describe('FollowBackfillService.runBackfill', () => {
     });
 
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -539,8 +541,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service, calls } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -575,8 +577,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service, calls } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -595,8 +597,8 @@ describe('FollowBackfillService.runBackfill', () => {
 
     const { service, fetcher } = buildService({ responses });
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -625,8 +627,8 @@ describe('FollowBackfillService.runBackfill', () => {
     const { service, calls } = buildService({ responses, rateLimiter: tight });
 
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 
@@ -642,8 +644,8 @@ describe('FollowBackfillService.runBackfill', () => {
     const { service, calls } = buildService({ responses });
 
     await service.runBackfill({
-      followingCalendarId: followingId,
-      calendarActorId: 'unused',
+      followingCalendarId: calendarId,
+      calendarActorId,
       sourceActorUri: SOURCE_ACTOR_URI,
     });
 

--- a/src/server/activitypub/test/service/inbox.test.ts
+++ b/src/server/activitypub/test/service/inbox.test.ts
@@ -1914,4 +1914,36 @@ describe('processAcceptActivity — activitypub:follow:accepted emission', () =>
 
     expect(emitted).toHaveLength(0);
   });
+
+  it('emits activitypub:follow:accepted on the string-URI Accept branch when hostnames match and a FollowingCalendarEntity is matched', async () => {
+    // The string-URI Accept branch fires when a peer sends `Accept` whose
+    // `object` is the IRI of our outbound Follow rather than an inline Follow
+    // object. The branch matches the FollowingCalendarEntity via
+    // remoteCalendarService.getByActorUri(message.actor) — by symmetry the
+    // emission must fire here too so backfill can run regardless of which
+    // peer shape we received.
+    sandbox.stub(service.remoteCalendarService, 'getByActorUri').resolves(mockRemoteCalendarActor as any);
+    sandbox.stub(FollowingCalendarEntity, 'findOne').resolves(mockFollowingRecord as any);
+
+    const emitted: any[] = [];
+    eventBus.on('activitypub:follow:accepted', (payload) => emitted.push(payload));
+
+    // Object is a URI on the SAME host as message.actor — required for the
+    // branch's hostname-match guard, mirroring the production wire shape
+    // where a remote instance echoes our follow IRI back inside the Accept.
+    const localFollowIri = 'https://remote.federation.test/activities/follow-123';
+    const raw = createMockAcceptActivity(REMOTE_CALENDAR_ACTOR_URL, { __unused: true });
+    raw.object = localFollowIri;
+    const stringUriAccept = AcceptActivity.fromObject(raw as Record<string, any>) as AcceptActivity;
+
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: TEST_CALENDAR_URL_NAME });
+    await service.processAcceptActivity(calendar, stringUriAccept);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toEqual({
+      followingCalendarId: TEST_CALENDAR_ID,
+      calendarActorId: REMOTE_CALENDAR_ACTOR_ID,
+      sourceActorUri: REMOTE_CALENDAR_ACTOR_URL,
+    });
+  });
 });

--- a/src/server/activitypub/test/service/inbox.test.ts
+++ b/src/server/activitypub/test/service/inbox.test.ts
@@ -36,7 +36,9 @@ import {
   createMockDeleteActivity,
   createMockAnnounceActivity,
   createMockUndoActivity,
+  createMockAcceptActivity,
 } from '@/server/activitypub/test/helpers/fedify-mock';
+import AcceptActivity from '@/server/activitypub/model/action/accept';
 
 
 // Mock the remote-fetch module at the top level for vitest
@@ -1790,5 +1792,126 @@ describe('AP Object ID URI Scheme Validation', () => {
 
     expect(result).toBeNull();
     expect(mockLogActivityRejection).toHaveBeenCalledOnce();
+  });
+});
+
+describe('processAcceptActivity — activitypub:follow:accepted emission', () => {
+  let service: ProcessInboxService;
+  let eventBus: EventEmitter;
+  let sandbox: sinon.SinonSandbox;
+
+  const TEST_CALENDAR_ID = 'test-calendar-id';
+  const TEST_CALENDAR_URL_NAME = 'testcalendar';
+  const REMOTE_CALENDAR_ACTOR_URL = 'https://remote.federation.test/calendars/events';
+  const REMOTE_CALENDAR_ACTOR_ID = 'remote-actor-uuid';
+  const FOLLOWING_ROW_ID = 'following-row-uuid';
+
+  // A mock CalendarActor returned by remoteCalendarService.getByActorUri.
+  // actorType: 'remote' mirrors what getByActorUri can return — it filters
+  // by actor_type='remote' so this is the realistic shape.
+  const mockRemoteCalendarActor = {
+    id: REMOTE_CALENDAR_ACTOR_ID,
+    actorUri: REMOTE_CALENDAR_ACTOR_URL,
+    actorType: 'remote' as const,
+    calendarId: null,
+    remoteCalendarId: null,
+    remoteDisplayName: null,
+    remoteDomain: 'remote.federation.test',
+    inboxUrl: null,
+    sharedInboxUrl: null,
+    lastFetched: null,
+    publicKey: null,
+    privateKey: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockFollowingRecord = {
+    id: FOLLOWING_ROW_ID,
+    calendar_actor_id: REMOTE_CALENDAR_ACTOR_ID,
+    calendar_id: TEST_CALENDAR_ID,
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    const calendarInterface = new CalendarInterface(eventBus);
+    service = new ProcessInboxService(eventBus, calendarInterface);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /**
+   * Builds an AcceptActivity wrapping an inline Follow whose `object` is the
+   * remote actor URL we follow. This mirrors a remote instance confirming a
+   * Follow we sent.
+   */
+  function buildInlineFollowAccept(): AcceptActivity {
+    const followObject = {
+      type: 'Follow',
+      actor: `https://local.federation.test/calendars/${TEST_CALENDAR_URL_NAME}`,
+      object: REMOTE_CALENDAR_ACTOR_URL,
+    };
+    const raw = createMockAcceptActivity(REMOTE_CALENDAR_ACTOR_URL, followObject);
+    return AcceptActivity.fromObject(raw as Record<string, any>) as AcceptActivity;
+  }
+
+  it('emits activitypub:follow:accepted with the expected payload when a remote-target FollowingCalendarEntity matches', async () => {
+    sandbox.stub(service.remoteCalendarService, 'getByActorUri').resolves(mockRemoteCalendarActor as any);
+    sandbox.stub(FollowingCalendarEntity, 'findOne').resolves(mockFollowingRecord as any);
+
+    const emitted: any[] = [];
+    eventBus.on('activitypub:follow:accepted', (payload) => emitted.push(payload));
+
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: TEST_CALENDAR_URL_NAME });
+    await service.processAcceptActivity(calendar, buildInlineFollowAccept());
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toEqual({
+      followingCalendarId: TEST_CALENDAR_ID,
+      calendarActorId: REMOTE_CALENDAR_ACTOR_ID,
+      sourceActorUri: REMOTE_CALENDAR_ACTOR_URL,
+    });
+  });
+
+  it('does NOT emit when no FollowingCalendarEntity matches the Accept(Follow)', async () => {
+    sandbox.stub(service.remoteCalendarService, 'getByActorUri').resolves(mockRemoteCalendarActor as any);
+    // No following row exists for this calendar/actor pair.
+    sandbox.stub(FollowingCalendarEntity, 'findOne').resolves(null);
+
+    const emitted: any[] = [];
+    eventBus.on('activitypub:follow:accepted', (payload) => emitted.push(payload));
+
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: TEST_CALENDAR_URL_NAME });
+    await service.processAcceptActivity(calendar, buildInlineFollowAccept());
+
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('does NOT emit when the matched CalendarActor is local-typed (backfill is only meaningful for remote sources)', async () => {
+    // Defensive guard: even if a FollowingCalendarEntity were somehow keyed
+    // to a local CalendarActor, emitFollowAccepted's actorType check should
+    // suppress emission. Today getByActorUri only returns remote actors, so
+    // this codepath is reached only when the contract is violated upstream;
+    // the test pins that behaviour.
+    const localCalendarActor = {
+      ...mockRemoteCalendarActor,
+      actorType: 'local' as const,
+      calendarId: 'local-calendar-id',
+      remoteDomain: null,
+    };
+
+    sandbox.stub(service.remoteCalendarService, 'getByActorUri').resolves(localCalendarActor as any);
+    sandbox.stub(FollowingCalendarEntity, 'findOne').resolves(mockFollowingRecord as any);
+
+    const emitted: any[] = [];
+    eventBus.on('activitypub:follow:accepted', (payload) => emitted.push(payload));
+
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: TEST_CALENDAR_URL_NAME });
+    await service.processAcceptActivity(calendar, buildInlineFollowAccept());
+
+    expect(emitted).toHaveLength(0);
   });
 });

--- a/src/server/calendar/service/import/sync.ts
+++ b/src/server/calendar/service/import/sync.ts
@@ -72,18 +72,23 @@ import {
 import { mapVEvent, type MapperOutput } from '@/server/calendar/service/import/mapper';
 import db from '@/server/common/entity/db';
 import { createLogger } from '@/server/common/helper/logger';
+import {
+  SyncRateLimiter,
+  SYNC_PER_SOURCE_HOURLY_LIMIT,
+} from '@/server/common/helper/rate-limiter';
 
 const logger = createLogger('calendar.import.sync');
+
+// Re-export the limiter and its hourly cap so existing call sites (tests,
+// API wiring) keep importing from the sync orchestrator while the
+// implementation lives in the shared common helper. The AP follow-backfill
+// worker (pv-cug3.4) imports the limiter directly from
+// `@/server/common/helper/rate-limiter`.
+export { SyncRateLimiter, SYNC_PER_SOURCE_HOURLY_LIMIT };
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/** Maximum Sync-Now calls allowed per source in a sliding 1-hour window. */
-export const SYNC_PER_SOURCE_HOURLY_LIMIT = 4;
-
-/** Milliseconds per hour — the rate-limit window. */
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
 /** Retention cap for ImportRun rows per source. */
 export const IMPORT_RUN_RETENTION = 50;
@@ -129,47 +134,6 @@ export interface SyncResult {
 export interface SyncInput {
   account: Account;
   importSourceId: string;
-}
-
-// ---------------------------------------------------------------------------
-// Rate limiter — per-source sliding window, in-memory
-// ---------------------------------------------------------------------------
-
-/**
- * Process-local sliding-window counter keyed by importSourceId. The window is
- * 1 hour; the cap is {@link SYNC_PER_SOURCE_HOURLY_LIMIT}. Entries expire
- * lazily on check.
- *
- * An in-memory cap is sufficient for v1 (single-instance deployment is the
- * common case; distributed operators will add Redis-backed limits in a later
- * bead — see complexity-playbook YAGNI).
- */
-export class SyncRateLimiter {
-  private timestamps: Map<string, number[]> = new Map();
-
-  /**
-   * Records a Sync Now attempt. Returns true if the call is allowed.
-   */
-  tryAcquire(sourceId: string, now: number = Date.now()): boolean {
-    const cutoff = now - RATE_LIMIT_WINDOW_MS;
-    const existing = this.timestamps.get(sourceId) ?? [];
-    // Drop stale entries.
-    const fresh = existing.filter(t => t > cutoff);
-    if (fresh.length >= SYNC_PER_SOURCE_HOURLY_LIMIT) {
-      this.timestamps.set(sourceId, fresh);
-      return false;
-    }
-    fresh.push(now);
-    this.timestamps.set(sourceId, fresh);
-    return true;
-  }
-
-  /**
-   * Clear recorded timestamps. Intended for tests.
-   */
-  reset(): void {
-    this.timestamps.clear();
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/common/helper/rate-limiter.ts
+++ b/src/server/common/helper/rate-limiter.ts
@@ -2,8 +2,9 @@
  * Shared in-memory sliding-window rate limiter.
  *
  * Process-local sliding-window counter keyed by arbitrary string. The window
- * is 1 hour; the cap is {@link SYNC_PER_SOURCE_HOURLY_LIMIT}. Entries expire
- * lazily on check.
+ * and cap are configurable per instance via the constructor; the default
+ * settings preserve the original ICS-sync contract (1 hour window, 4
+ * acquisitions per key) so existing callers do not need to change.
  *
  * Lives in `src/server/common/helper/` rather than inside any single domain so
  * that multiple domains (ICS import, ActivityPub follow-backfill, ...) can
@@ -15,29 +16,51 @@
  * bead — see complexity-playbook YAGNI).
  */
 
-/** Maximum acquisitions allowed per key in a sliding 1-hour window. */
+/** Default cap: maximum acquisitions allowed per key in the configured window. */
 export const SYNC_PER_SOURCE_HOURLY_LIMIT = 4;
 
-/** Milliseconds per hour — the rate-limit window. */
-const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+/** Default window: milliseconds per hour. */
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
 
 /**
- * Process-local sliding-window counter keyed by arbitrary string. The window
- * is 1 hour; the cap is {@link SYNC_PER_SOURCE_HOURLY_LIMIT}. Entries expire
- * lazily on check.
+ * Options controlling the limiter's window and cap. Either or both may be
+ * omitted to inherit the ICS-sync defaults.
+ */
+export interface SyncRateLimiterOptions {
+  /** Maximum acquisitions allowed per key inside `windowMs`. */
+  limit?: number;
+  /** Sliding window in milliseconds. */
+  windowMs?: number;
+}
+
+/**
+ * Process-local sliding-window counter keyed by arbitrary string. Entries
+ * expire lazily on check.
+ *
+ * Construct with no arguments for the legacy ICS-sync defaults (4 per hour),
+ * or pass an options object to use a different window/cap — for example, the
+ * ActivityPub follow-backfill worker uses `{ limit: 60, windowMs: 60_000 }`
+ * to enforce a 60 req/min per-source cap.
  */
 export class SyncRateLimiter {
   private timestamps: Map<string, number[]> = new Map();
+  private readonly limit: number;
+  private readonly windowMs: number;
+
+  constructor(options: SyncRateLimiterOptions = {}) {
+    this.limit = options.limit ?? SYNC_PER_SOURCE_HOURLY_LIMIT;
+    this.windowMs = options.windowMs ?? DEFAULT_RATE_LIMIT_WINDOW_MS;
+  }
 
   /**
    * Records an acquisition attempt. Returns true if the call is allowed.
    */
   tryAcquire(sourceId: string, now: number = Date.now()): boolean {
-    const cutoff = now - RATE_LIMIT_WINDOW_MS;
+    const cutoff = now - this.windowMs;
     const existing = this.timestamps.get(sourceId) ?? [];
     // Drop stale entries.
     const fresh = existing.filter(t => t > cutoff);
-    if (fresh.length >= SYNC_PER_SOURCE_HOURLY_LIMIT) {
+    if (fresh.length >= this.limit) {
       this.timestamps.set(sourceId, fresh);
       return false;
     }

--- a/src/server/common/helper/rate-limiter.ts
+++ b/src/server/common/helper/rate-limiter.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared in-memory sliding-window rate limiter.
+ *
+ * Process-local sliding-window counter keyed by arbitrary string. The window
+ * is 1 hour; the cap is {@link SYNC_PER_SOURCE_HOURLY_LIMIT}. Entries expire
+ * lazily on check.
+ *
+ * Lives in `src/server/common/helper/` rather than inside any single domain so
+ * that multiple domains (ICS import, ActivityPub follow-backfill, ...) can
+ * share one implementation without cross-domain imports violating
+ * domain-structure standards.
+ *
+ * An in-memory cap is sufficient for v1 (single-instance deployment is the
+ * common case; distributed operators will add Redis-backed limits in a later
+ * bead — see complexity-playbook YAGNI).
+ */
+
+/** Maximum acquisitions allowed per key in a sliding 1-hour window. */
+export const SYNC_PER_SOURCE_HOURLY_LIMIT = 4;
+
+/** Milliseconds per hour — the rate-limit window. */
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Process-local sliding-window counter keyed by arbitrary string. The window
+ * is 1 hour; the cap is {@link SYNC_PER_SOURCE_HOURLY_LIMIT}. Entries expire
+ * lazily on check.
+ */
+export class SyncRateLimiter {
+  private timestamps: Map<string, number[]> = new Map();
+
+  /**
+   * Records an acquisition attempt. Returns true if the call is allowed.
+   */
+  tryAcquire(sourceId: string, now: number = Date.now()): boolean {
+    const cutoff = now - RATE_LIMIT_WINDOW_MS;
+    const existing = this.timestamps.get(sourceId) ?? [];
+    // Drop stale entries.
+    const fresh = existing.filter(t => t > cutoff);
+    if (fresh.length >= SYNC_PER_SOURCE_HOURLY_LIMIT) {
+      this.timestamps.set(sourceId, fresh);
+      return false;
+    }
+    fresh.push(now);
+    this.timestamps.set(sourceId, fresh);
+    return true;
+  }
+
+  /**
+   * Clear recorded timestamps. Intended for tests.
+   */
+  reset(): void {
+    this.timestamps.clear();
+  }
+}

--- a/src/server/housekeeping/index.ts
+++ b/src/server/housekeeping/index.ts
@@ -2,8 +2,10 @@ import { Application } from 'express';
 import { EventEmitter } from 'events';
 import HousekeepingInterface from './interface';
 import HousekeepingStatusRoutes from './api/v1/status';
+import JobQueueService from './service/job-queue';
 import EmailInterface from '@/server/email/interface';
 import AccountsInterface from '@/server/accounts/interface';
+import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('housekeeping');
@@ -19,6 +21,7 @@ const logger = createLogger('housekeeping');
 export default class HousekeepingDomain {
   public readonly interface: HousekeepingInterface;
   private readonly eventBus: EventEmitter;
+  private jobQueueService: JobQueueService | null = null;
 
   constructor(
     eventBus: EventEmitter,
@@ -31,13 +34,21 @@ export default class HousekeepingDomain {
 
   /**
    * Initializes the housekeeping domain.
-   * Sets up API routes and event handlers.
+   *
+   * Sets up API routes, event handlers, and a publish-only JobQueueService
+   * so other domains can enqueue background jobs through
+   * `HousekeepingInterface.publishJob`. The actual job consumers run in the
+   * separate worker process (`src/server/worker.ts`).
+   *
+   * In sqlite test mode `JobQueueService.start()` is a no-op so the wire-up
+   * still completes without a live pg-boss server.
    *
    * @param app - Express application instance
    */
-  public initialize(app: Application): void {
+  public async initialize(app: Application): Promise<void> {
     this.installAPI(app);
     this.installEventHandlers();
+    await this.installJobPublisher();
   }
 
   /**
@@ -59,5 +70,27 @@ export default class HousekeepingDomain {
   public installEventHandlers(): void {
     // Event handlers will be implemented as needed
     logger.info('Event handlers initialized');
+  }
+
+  /**
+   * Starts a publish-only pg-boss connection and wires it into the interface
+   * so other domains can publish jobs. The worker process owns its own
+   * separate JobQueueService instance for consumption; this one is publisher-
+   * only and never calls subscribe(). If pg-boss fails to start (e.g. the
+   * database is briefly unreachable on boot) we log and continue — calls to
+   * `publishJob` will then throw a clear wiring error rather than silently
+   * dropping jobs.
+   */
+  private async installJobPublisher(): Promise<void> {
+    try {
+      this.jobQueueService = new JobQueueService();
+      await this.jobQueueService.start();
+      this.interface.setJobQueueService(this.jobQueueService);
+      logger.info('Job publisher wired into housekeeping interface');
+    }
+    catch (error) {
+      logError(error, '[Housekeeping] Failed to start job publisher; publishJob will throw until restart');
+      this.jobQueueService = null;
+    }
   }
 }

--- a/src/server/housekeeping/interface/index.ts
+++ b/src/server/housekeeping/interface/index.ts
@@ -5,6 +5,7 @@ import AccountsInterface from '@/server/accounts/interface';
 import BackupService from '@/server/housekeeping/service/backup';
 import StorageService from '@/server/housekeeping/service/storage';
 import DiskMonitorService from '@/server/housekeeping/service/disk-monitor';
+import JobQueueService from '@/server/housekeeping/service/job-queue';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';
 import { createLogger } from '@/server/common/helper/logger';
 
@@ -45,6 +46,7 @@ export default class HousekeepingInterface {
   private backupService: BackupService;
   private storageService: StorageService;
   private diskMonitor: DiskMonitorService;
+  private jobQueueService: JobQueueService | null = null;
 
   constructor(emailInterface: EmailInterface, accountsInterface: AccountsInterface) {
     this.emailInterface = emailInterface;
@@ -52,6 +54,39 @@ export default class HousekeepingInterface {
     this.backupService = new BackupService();
     this.storageService = new StorageService();
     this.diskMonitor = new DiskMonitorService();
+  }
+
+  /**
+   * Wires a started JobQueueService into the interface so other domains can
+   * publish background jobs through `publishJob`. Set once by
+   * `HousekeepingDomain.initialize()` in the web process. Worker and CLI
+   * processes own their own JobQueueService directly and do not call this.
+   */
+  setJobQueueService(queue: JobQueueService): void {
+    this.jobQueueService = queue;
+  }
+
+  /**
+   * Publishes a background job through the housekeeping-owned pg-boss queue.
+   * Other domains call this rather than importing JobQueueService directly,
+   * keeping the queue infrastructure encapsulated inside the housekeeping
+   * domain (DEC-003 domain boundary).
+   *
+   * @param jobName - pg-boss queue name (e.g. `activitypub:follow:backfill`)
+   * @param data - JSON-serialisable job payload
+   * @throws Error if the queue has not been wired in via setJobQueueService.
+   *   In production this should never happen — `HousekeepingDomain.initialize`
+   *   wires the queue before AP handlers can fire. The throw exists so
+   *   miswiring fails loudly rather than silently dropping jobs.
+   */
+  async publishJob<T = any>(jobName: string, data: T): Promise<void> {
+    if (!this.jobQueueService) {
+      throw new Error(
+        `HousekeepingInterface.publishJob('${jobName}') called before a JobQueueService was wired in. ` +
+        'This indicates a server-startup ordering bug — housekeeping must initialize before any domain that publishes jobs.',
+      );
+    }
+    await this.jobQueueService.publish(jobName, data);
   }
 
   /**

--- a/src/server/housekeeping/service/job-queue.ts
+++ b/src/server/housekeeping/service/job-queue.ts
@@ -47,6 +47,7 @@ export default class JobQueueService {
   private boss: PgBoss | null = null;
   private connectionString: string;
   private started: boolean = false;
+  private isSqliteDialect: boolean;
 
   /**
    * Creates a new JobQueueService instance.
@@ -55,6 +56,7 @@ export default class JobQueueService {
    */
   constructor(dbConfig?: DatabaseConfig) {
     const actualConfig = dbConfig || config.get<DatabaseConfig>('database');
+    this.isSqliteDialect = actualConfig.dialect === 'sqlite';
     this.connectionString = this.buildConnectionString(actualConfig);
   }
 
@@ -88,9 +90,24 @@ export default class JobQueueService {
    * Starts the pg-boss connection.
    * Must be called before using other methods.
    *
-   * @throws Error if connection fails
+   * In sqlite mode (used by unit/integration tests) the pg-boss server is
+   * unreachable. The service still flips its `started` flag so callers can
+   * publish without throwing; publish becomes a logged no-op in that mode.
+   *
+   * @throws Error if connection fails (postgres mode only)
    */
   async start(): Promise<void> {
+    // sqlite-mode test environments don't run a pg-boss server. Mark started
+    // so publish() returns a logged no-op instead of throwing, mirroring the
+    // graceful path already used by ensureQueue() for the same case. Checked
+    // against the constructor-time dialect so tests that pass an explicit
+    // postgres dbConfig continue to exercise the real start path.
+    if (this.isSqliteDialect) {
+      this.started = true;
+      logger.info('pg-boss start skipped (sqlite dialect)');
+      return;
+    }
+
     try {
       this.boss = new PgBoss(this.connectionString);
 
@@ -130,8 +147,16 @@ export default class JobQueueService {
    * @throws Error if service not started
    */
   async publish<T = any>(jobName: string, data: T): Promise<string | null> {
-    if (!this.started || !this.boss) {
+    if (!this.started) {
       throw new Error('JobQueueService not started. Call start() first.');
+    }
+
+    // sqlite-mode test environments don't run a pg-boss server. start() flips
+    // `started` but leaves `boss` null; publish becomes a logged no-op so
+    // wire-up code paths exercised by unit/integration tests don't fail.
+    if (!this.boss) {
+      logger.info({ jobName }, 'Publish skipped (sqlite dialect)');
+      return null;
     }
 
     const jobId = await this.boss.send(jobName, data);

--- a/src/server/housekeeping/service/job-queue.ts
+++ b/src/server/housekeeping/service/job-queue.ts
@@ -242,7 +242,14 @@ export default class JobQueueService {
     // Ensure queue exists before subscribing
     await this.ensureQueue(jobName);
 
-    await this.boss.work(jobName, { includeMetadata: true }, async (job: any) => {
+    // pg-boss v10+ delivers jobs as an array regardless of batchSize. The
+    // default fetch size is 1, so we unwrap the first element here and keep
+    // each handler invocation single-job.
+    await this.boss.work(jobName, { includeMetadata: true }, async (jobs: any) => {
+      const job = Array.isArray(jobs) ? jobs[0] : jobs;
+      if (!job) {
+        return;
+      }
       try {
         logger.info({ jobName, jobId: job.id }, 'Processing job');
         await handler(job.data, { retryCount: job.retryCount, retryLimit: job.retryLimit });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -318,8 +318,17 @@ const initPavillionServer = async (app: express.Application, port: number): Prom
   // Wire moderation interface into calendar domain for admin-scoped cross-domain decoration
   calendarDomain.interface.setModerationInterface(moderationDomain.interface);
 
-  // Initialize ActivityPub domain with ModerationInterface for instance blocking
-  const activityPubDomain = new ActivityPubDomain(eventBus, calendarDomain.interface, accountsDomain.interface, moderationDomain.interface);
+  // Initialize housekeeping domain before ActivityPub. AP event handlers
+  // publish background jobs (e.g. activitypub:follow:backfill) through the
+  // housekeeping-owned pg-boss queue; this construction order ensures the
+  // queue is wired in before any AP handler can fire. `initialize` is async
+  // because it starts a pg-boss connection (sqlite test mode no-ops).
+  const housekeepingDomain = new HousekeepingDomain(eventBus, emailDomain.interface, accountsDomain.interface);
+  await housekeepingDomain.initialize(app);
+
+  // Initialize ActivityPub domain with HousekeepingInterface (job publishing)
+  // and ModerationInterface (instance blocking).
+  const activityPubDomain = new ActivityPubDomain(eventBus, calendarDomain.interface, accountsDomain.interface, housekeepingDomain.interface, moderationDomain.interface);
   activityPubDomain.initialize(app);
 
   // Wire AP interface into calendar domain for cross-domain queries
@@ -346,10 +355,6 @@ const initPavillionServer = async (app: express.Application, port: number): Prom
   // to resolve the circular dependency (MediaDomain needs CalendarInterface,
   // CalendarInterface needs MediaInterface for media ownership checks).
   calendarDomain.interface.setMediaInterface(mediaDomain.interface);
-
-  // Initialize housekeeping domain (for automated server maintenance)
-  const housekeepingDomain = new HousekeepingDomain(eventBus, emailDomain.interface, accountsDomain.interface);
-  housekeepingDomain.initialize(app);
 
   // Register global error handler (MUST be after all routes and middleware)
   app.use(globalErrorHandler);

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -14,6 +14,8 @@ import CalendarInterface from '@/server/calendar/interface';
 import IpCleanupService from '@/server/moderation/service/ip-cleanup';
 import NotificationService from '@/server/notifications/service/notification';
 import ActivityPubInterface from '@/server/activitypub/interface';
+import { FollowBackfillService } from '@/server/activitypub/service/backfill';
+import { ActivityPubFollowAcceptedPayload } from '@/server/activitypub/events/types';
 import { BackupCreateError } from '@/common/exceptions/housekeeping';
 import { createLogger } from '@/server/common/helper/logger';
 
@@ -72,6 +74,10 @@ async function registerJobHandlers(queue: JobQueueService): Promise<void> {
   const eventBus = new EventEmitter();
   const calendarInterface = new CalendarInterface(eventBus);
   const activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
+  const followBackfillService = new FollowBackfillService({
+    activityPubInterface,
+    calendarInterface,
+  });
 
   // Manual backup job handler (triggered via API/CLI)
   await queue.subscribe('backup:create', async (data: any, meta) => {
@@ -217,6 +223,27 @@ async function registerJobHandlers(queue: JobQueueService): Promise<void> {
       }
       catch (error) {
         logger.error({ err: error }, 'Inbox cleanup failed');
+        throw error;
+      }
+    },
+  );
+
+  // ActivityPub follow-backfill job handler. Published by
+  // ActivityPubEventHandlers#handleFollowAccepted whenever a remote
+  // Accept(Follow) confirms a follow the local instance initiated.
+  await queue.subscribe(
+    'activitypub:follow:backfill',
+    async (data: ActivityPubFollowAcceptedPayload) => {
+      logger.info(
+        { followingCalendarId: data?.followingCalendarId, sourceActorUri: data?.sourceActorUri },
+        'Executing activitypub:follow:backfill job',
+      );
+      try {
+        await followBackfillService.runBackfill(data);
+        logger.info({ followingCalendarId: data?.followingCalendarId }, 'activitypub:follow:backfill job completed');
+      }
+      catch (error) {
+        logger.error({ err: error, followingCalendarId: data?.followingCalendarId }, 'activitypub:follow:backfill job failed');
         throw error;
       }
     },

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -235,7 +235,7 @@ async function registerJobHandlers(queue: JobQueueService): Promise<void> {
     'activitypub:follow:backfill',
     async (data: ActivityPubFollowAcceptedPayload) => {
       logger.info(
-        { followingCalendarId: data?.followingCalendarId, sourceActorUri: data?.sourceActorUri },
+        { followingCalendarId: data?.followingCalendarId },
         'Executing activitypub:follow:backfill job',
       );
       try {

--- a/tests/e2e/federation/follow-backfill.spec.ts
+++ b/tests/e2e/federation/follow-backfill.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Follow Backfill Tests (pv-cug3)
+ *
+ * These tests verify that when a Pavillion calendar follows a remote calendar,
+ * the follower's feed surfaces the source calendar's existing event history —
+ * not just events the source Announces after the follow lands.
+ *
+ * Backfill flow exercised here:
+ * 1. Source calendar (Alice on Alpha) creates N public events.
+ * 2. Follower calendar (Bob on Beta) follows Alice.
+ * 3. Alpha sends Accept(Follow); Beta's processAcceptActivity emits
+ *    activitypub:follow:accepted, which the AP-domain handler turns into an
+ *    activitypub:follow:backfill pg-boss job (pv-cug3.3).
+ * 4. The worker (pv-cug3.4) signs an outbound GET to Alice's outbox
+ *    (pv-cug3.1), paginates through the OrderedCollection, routes each
+ *    surviving Create activity through ActivityPubInterface.processInboxMessage,
+ *    and respects existing dismissal/policy gates.
+ * 5. Bob's feed surfaces all N pre-existing events.
+ *
+ * Idempotency: unfollowing and re-following triggers a second Accept(Follow)
+ * and a second backfill job; the unique constraints on ap_event_object.ap_id
+ * and (event_id, calendar_id) on ap_shared_event ensure no duplicate rows.
+ *
+ * Prerequisites:
+ * - Federation environment running: npm run federation:start
+ * - /etc/hosts entries for alpha.federation.local and beta.federation.local
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  formatRemoteCalendarId,
+  generateCalendarName,
+} from './helpers/instances';
+import {
+  getToken,
+  createCalendar,
+  createEvent,
+  followCalendar,
+  unfollowCalendar,
+  getFeed,
+  getFollows,
+} from './helpers/api';
+
+const BACKFILL_DRAIN_MS = 15_000;
+const FOLLOW_PROCESS_MS = 3_000;
+
+test.describe('Follow Backfill', () => {
+  let aliceToken: string;
+  let bobToken: string;
+
+  test.beforeAll(async () => {
+    aliceToken = await getToken(
+      INSTANCE_ALPHA,
+      INSTANCE_ALPHA.adminEmail,
+      INSTANCE_ALPHA.adminPassword,
+    );
+
+    bobToken = await getToken(
+      INSTANCE_BETA,
+      INSTANCE_BETA.adminEmail,
+      INSTANCE_BETA.adminPassword,
+    );
+  });
+
+  test('Backfill surfaces pre-existing source events in follower feed', async () => {
+    const aliceCalendar = await createCalendar(INSTANCE_ALPHA, aliceToken, {
+      urlName: generateCalendarName('abf'),
+      content: {
+        en: { name: 'Alice Backfill Source' },
+      },
+    });
+
+    const eventTitles: string[] = [];
+    const baseTimestamp = Date.now();
+
+    for (let i = 0; i < 5; i++) {
+      const title = `Backfill Pre-Follow Event ${baseTimestamp}-${i}`;
+      eventTitles.push(title);
+
+      const startMonth = (3 + i).toString().padStart(2, '0');
+      await createEvent(INSTANCE_ALPHA, aliceToken, {
+        calendarId: aliceCalendar.id,
+        content: {
+          en: {
+            title,
+            description: `Pre-existing event ${i} created before any follow`,
+          },
+        },
+        startTime: `2025-${startMonth}-15T14:00:00Z`,
+        endTime: `2025-${startMonth}-15T16:00:00Z`,
+      });
+    }
+
+    const bobCalendar = await createCalendar(INSTANCE_BETA, bobToken, {
+      urlName: generateCalendarName('bbf'),
+      content: {
+        en: { name: 'Bob Backfill Follower' },
+      },
+    });
+
+    const aliceCalendarRemoteId = formatRemoteCalendarId(aliceCalendar.urlName, INSTANCE_ALPHA);
+
+    await followCalendar(INSTANCE_BETA, bobToken, bobCalendar.id, aliceCalendarRemoteId);
+
+    await new Promise(resolve => setTimeout(resolve, FOLLOW_PROCESS_MS + BACKFILL_DRAIN_MS));
+
+    const feed = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
+
+    for (const title of eventTitles) {
+      const eventInFeed = feed.events.find(e => e.content?.en?.title === title);
+      expect(eventInFeed, `expected backfilled event "${title}" in follower feed`).toBeDefined();
+    }
+  });
+
+  test('Re-following does not create duplicate backfill rows', async () => {
+    const aliceCalendar = await createCalendar(INSTANCE_ALPHA, aliceToken, {
+      urlName: generateCalendarName('abi'),
+      content: {
+        en: { name: 'Alice Backfill Idempotency Source' },
+      },
+    });
+
+    const eventTitles: string[] = [];
+    const baseTimestamp = Date.now();
+
+    for (let i = 0; i < 3; i++) {
+      const title = `Backfill Idempotency Event ${baseTimestamp}-${i}`;
+      eventTitles.push(title);
+
+      const startMonth = (3 + i).toString().padStart(2, '0');
+      await createEvent(INSTANCE_ALPHA, aliceToken, {
+        calendarId: aliceCalendar.id,
+        content: {
+          en: {
+            title,
+            description: `Idempotency-check event ${i}`,
+          },
+        },
+        startTime: `2025-${startMonth}-20T10:00:00Z`,
+        endTime: `2025-${startMonth}-20T12:00:00Z`,
+      });
+    }
+
+    const bobCalendar = await createCalendar(INSTANCE_BETA, bobToken, {
+      urlName: generateCalendarName('bbi'),
+      content: {
+        en: { name: 'Bob Backfill Idempotency Follower' },
+      },
+    });
+
+    const aliceCalendarRemoteId = formatRemoteCalendarId(aliceCalendar.urlName, INSTANCE_ALPHA);
+
+    await followCalendar(INSTANCE_BETA, bobToken, bobCalendar.id, aliceCalendarRemoteId);
+    await new Promise(resolve => setTimeout(resolve, FOLLOW_PROCESS_MS + BACKFILL_DRAIN_MS));
+
+    const feedAfterFirst = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
+    const firstRunCounts = new Map<string, number>();
+    for (const title of eventTitles) {
+      const count = feedAfterFirst.events.filter(e => e.content?.en?.title === title).length;
+      expect(count, `expected exactly one feed row for "${title}" after first backfill`).toBe(1);
+      firstRunCounts.set(title, count);
+    }
+
+    const followsBeforeUnfollow = await getFollows(INSTANCE_BETA, bobToken, bobCalendar.id);
+    const aliceFollow = followsBeforeUnfollow.find(
+      f => f.calendarActorId === aliceCalendarRemoteId ||
+           f.calendarActorId?.includes(aliceCalendar.urlName),
+    );
+    expect(aliceFollow, 'expected follow row before unfollow').toBeDefined();
+
+    await unfollowCalendar(INSTANCE_BETA, bobToken, aliceFollow!.id, bobCalendar.id);
+    await new Promise(resolve => setTimeout(resolve, FOLLOW_PROCESS_MS));
+
+    await followCalendar(INSTANCE_BETA, bobToken, bobCalendar.id, aliceCalendarRemoteId);
+    await new Promise(resolve => setTimeout(resolve, FOLLOW_PROCESS_MS + BACKFILL_DRAIN_MS));
+
+    const feedAfterSecond = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
+    for (const title of eventTitles) {
+      const count = feedAfterSecond.events.filter(e => e.content?.en?.title === title).length;
+      expect(count, `expected exactly one feed row for "${title}" after re-follow (no duplicates)`).toBe(1);
+    }
+  });
+});

--- a/tests/e2e/federation/follow-backfill.spec.ts
+++ b/tests/e2e/federation/follow-backfill.spec.ts
@@ -109,8 +109,8 @@ test.describe('Follow Backfill', () => {
     const feed = await getFeed(INSTANCE_BETA, bobToken, bobCalendar.id);
 
     for (const title of eventTitles) {
-      const eventInFeed = feed.events.find(e => e.content?.en?.title === title);
-      expect(eventInFeed, `expected backfilled event "${title}" in follower feed`).toBeDefined();
+      const count = feed.events.filter(e => e.content?.en?.title === title).length;
+      expect(count, `expected exactly one feed row for "${title}" after initial backfill`).toBe(1);
     }
   });
 
@@ -166,11 +166,11 @@ test.describe('Follow Backfill', () => {
     const followsBeforeUnfollow = await getFollows(INSTANCE_BETA, bobToken, bobCalendar.id);
     const aliceFollow = followsBeforeUnfollow.find(
       f => f.calendarActorId === aliceCalendarRemoteId ||
-           f.calendarActorId?.includes(aliceCalendar.urlName),
+           f.calendarActorId.includes(aliceCalendar.urlName),
     );
     expect(aliceFollow, 'expected follow row before unfollow').toBeDefined();
 
-    await unfollowCalendar(INSTANCE_BETA, bobToken, aliceFollow!.id, bobCalendar.id);
+    await unfollowCalendar(INSTANCE_BETA, bobToken, aliceFollow!.id, bobCalendar.id, aliceCalendarRemoteId);
     await new Promise(resolve => setTimeout(resolve, FOLLOW_PROCESS_MS));
 
     await followCalendar(INSTANCE_BETA, bobToken, bobCalendar.id, aliceCalendarRemoteId);


### PR DESCRIPTION
## Motivation

When a Pavillion calendar follows a remote calendar, the follower previously saw only events the source `Announce`d after the follow landed — a freshly-followed remote calendar appeared empty until it published a new event. Local follows did not have this gap because `EventService.getEventsFromFollowedSources()` joins `ap_following` directly against `EventEntity.calendar_id`; the remote-only gap was that Pavillion never reached out to a remote actor's outbox after WebFinger resolution.

This closes that gap so following a calendar immediately reveals what's on that calendar, anchored by DEC-001 (community discovery via federation).

## Approach

Five-step pipeline split across federation, infrastructure, and worker layers:

1. **Signed outbound GETs** in `fetchRemoteObject` — Mastodon 4+ requires signed GETs on outbox endpoints. `signActivity` gained an optional `method: 'get' | 'post'` argument (defaults to `'post'` so all existing POST callers are unchanged), and `fetchRemoteObject` accepts an optional `signingCalendar`. Fail-closed on signing failure (skip the request rather than send unsigned).
2. **Shared rate limiter** — extracted `SyncRateLimiter` from `calendar/service/import/sync.ts` to `common/helper/rate-limiter.ts` and parameterized its constructor with `{ limit, windowMs }` so ICS sync keeps its 4/hour default while the new worker uses 60/min keyed by source hostname. `sync.ts` re-exports the symbols for backward compatibility.
3. **Trigger** — `processAcceptActivity` now emits `activitypub:follow:accepted` when the matched `FollowingCalendarEntity` has a remote-type target. An AP-domain handler publishes an `activitypub:follow:backfill` pg-boss job and returns synchronously before any HTTP work. Job publishing routes through a new `HousekeepingInterface.publishJob` method (DEC-003 — no direct service imports across domains). `HousekeepingDomain.initialize` is now async and constructs a publish-only `JobQueueService` in the web process; `server.ts` was reordered to construct `HousekeepingDomain` before `ActivityPubDomain`.
4. **Worker** (`activitypub/service/backfill.ts`) — paginates the remote outbox (`MAX_OUTBOX_PAGES = 50`, `MAX_PAGE_BYTES = 1_048_576`, warn-log on cap), calls `validateUrlNotPrivate` on the outbox URL and every `next` link before fetching, signs every outbound GET, two-passes each page so within-page Delete suppresses Create, re-validates trust (actor-origin match, attributedTo match, loop guard) before routing, and routes `Create(Event)`/`Announce`/`Delete` through `ActivityPubInterface.processInboxMessage` via synthetic `ActivityPubInboxMessageEntity` records. `Update` is skipped. Trust re-validation lives in `backfill.ts`, not in `processInboxMessage`, because outbox-pulled activities carry no HTTP-signature envelope. DEC-008 sticky dismissals and `auto_repost_*` policy flags are inherited for free via the unified inbox routing.
5. **Federation E2E** — two-instance Playwright spec exercising happy-path (5 pre-existing events surface in follower feed after Accept+backfill) and idempotency (unfollow → re-follow produces no duplicates, asserted by feed count).

## Validation

- Lint: 0 errors (277 pre-existing warnings baseline).
- Unit tests: 7918 pass / 0 fail. Includes 25 new cases in `backfill.test.ts` covering happy path, two-pass Delete, trust failures (origin/attributedTo/loop guard), Update skip, idempotency, SSRF rejection on outbox + next-page URLs, signed-GET assertion, page-cap truncation with warn-log, mid-pagination unfollow, and per-host rate limiting.
- Integration tests: 599 pass / 5 skipped. Includes 2 new cases in `follow-backfill.test.ts` exercising real outbox pagination across `OrderedCollection` → `first` → `OrderedCollectionPage` and a within-page Delete suppression scenario.
- Build: PASS (frontend + widget SDK).
- E2E (single-instance): PASS for everything not pre-existing. Four pre-existing baseline failures (workers=2 port race in admin-moderation/calendar-validation/settings-modals; missing federation TLS certs in import-sources) confirmed unrelated to this PR.
- Federation E2E (`tests/e2e/federation/follow-backfill.spec.ts`): spec authored and lint-clean, but **not run end-to-end here** because the Docker federation harness is not started in this worktree and TLS certs are not generated. Run `npm run federation:start` then `npm run test:federation` to validate.

Per-bead audits cycled through security, complexity, consistency, testing, and privacy auditors with one FAIL→retry on the event-emission bead (originally imported `JobQueueService` directly; fixed to route through `HousekeepingInterface` with a required, non-optional wire). Final cross-bead integration verifier and architecture auditor both PASS.