### PR TITLE
test: add VSR screen-reader test foundation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@fedify/fedify": "^1.10.0",
+        "@guidepup/virtual-screen-reader": "^0.32.1",
         "@playwright/test": "^1.55.1",
         "@stylistic/eslint-plugin": "^4.2.0",
         "@types/cls-hooked": "^4.3.9",
@@ -2267,6 +2268,28 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -2277,9 +2300,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3334,6 +3357,22 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@guidepup/virtual-screen-reader": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@guidepup/virtual-screen-reader/-/virtual-screen-reader-0.32.1.tgz",
+      "integrity": "sha512-QoxyFmIkE4em+Up0VJ+cchpVndHbwMGUztbTWasNbjWfxT28Sf5XYq3U+ueM1sENk7AV4+0N7ahoYxjcFVAo8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/user-event": "^14.6.1",
+        "dom-accessibility-api": "^0.7.0",
+        "html-aria": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -5499,6 +5538,47 @@
         "eslint": ">=9.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5541,6 +5621,13 @@
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -7007,6 +7094,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -8609,6 +8706,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.7.1.tgz",
+      "integrity": "sha512-vdnCeZD+3wZ+8h8xXL/ZtBlvvoobOFyPzSiIfO6sGOZDqjFx4aLMAjZhl4rawj5xYz3UwP6Tgvyh0iH4IOCVnQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -10367,6 +10471,13 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
+    "node_modules/html-aria": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/html-aria/-/html-aria-0.5.3.tgz",
+      "integrity": "sha512-2SkCacsjXJu0e6D5vLSHlLs7KEdPZ7pIJqLh9EFedPqrAaywthe7jJWQ+PjEyB7bpmWMMOsBJuV4WlYd9WRiug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -12031,6 +12142,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -13990,6 +14111,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -14241,6 +14400,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@fedify/fedify": "^1.10.0",
+    "@guidepup/virtual-screen-reader": "^0.32.1",
     "@playwright/test": "^1.55.1",
     "@stylistic/eslint-plugin": "^4.2.0",
     "@types/cls-hooked": "^4.3.9",

--- a/src/common/test-utils/screen-reader.ts
+++ b/src/common/test-utils/screen-reader.ts
@@ -1,0 +1,348 @@
+/**
+ * Screen Reader Test Helper
+ *
+ * Thin wrappers around `@guidepup/virtual-screen-reader` for use in two
+ * complementary test contexts:
+ *
+ *  - `screenReader(element)`    — Vitest (happy-dom / jsdom), drives VSR
+ *                                  against a `wrapper.element` from
+ *                                  `@vue/test-utils`.
+ *  - `pageScreenReader(page)`   — Playwright, injects VSR into the page
+ *                                  context via `addInitScript` and drives
+ *                                  it through `page.evaluate()`.
+ *
+ * Both surfaces expose the same five primitives:
+ *
+ *   - `walk(): Promise<string[]>`      Walk the document from the start,
+ *                                      collecting every spoken phrase.
+ *   - `next(): Promise<void>`          Move to the next accessibility node.
+ *   - `previous(): Promise<void>`      Move to the previous accessibility
+ *                                      node.
+ *   - `lastPhrase(): Promise<string>`  Return the most recently spoken
+ *                                      phrase.
+ *   - `act(): Promise<void>`           Activate the currently focused
+ *                                      element (analogous to pressing the
+ *                                      screen reader's primary action key).
+ *
+ * Locale lock: both variants force `i18next` to `'en'` before walking and
+ * restore the previous language on teardown (via the returned `stop()`).
+ * Individual tests do not need to manage locale.
+ *
+ * Design reference:
+ *   `docs/superpowers/specs/2026-05-13-screen-reader-testing-design.md`
+ *   § Architecture, § Phase 1.
+ *
+ * happy-dom note: as of `@guidepup/virtual-screen-reader@0.32` and
+ * `happy-dom@15`, the Vitest variant runs under the project's default
+ * happy-dom environment — the Phase 1 spike confirmed VSR walks the
+ * accessibility tree of mounted Vue components without an environment
+ * swap. If a future VSR or happy-dom upgrade regresses, the per-file
+ * escape hatch is to add `// @vitest-environment jsdom` to the affected
+ * test file (jsdom is already in `devDependencies`).
+ */
+
+import { readFileSync } from 'fs';
+import { createRequire } from 'module';
+import { dirname, join } from 'path';
+import { virtual } from '@guidepup/virtual-screen-reader';
+import i18next from 'i18next';
+import type { Page } from '@playwright/test';
+
+// The Vitest/Node test runners load this module as ESM, so `require` is
+// not a global. `createRequire` provides a CJS-style resolver bound to
+// this module's URL — used only by the Playwright variant to locate the
+// VSR browser bundle on disk.
+const req = createRequire(import.meta.url);
+
+/**
+ * The shared screen-reader API surface. Both `screenReader()` and
+ * `pageScreenReader()` return objects conforming to this shape, so tests
+ * authored against the Vitest variant translate directly to Playwright
+ * (and vice versa).
+ */
+export interface ScreenReaderHandle {
+  /**
+   * Walk the document from the current position to the end, returning the
+   * full spoken-phrase log accumulated during the walk.
+   */
+  walk(): Promise<string[]>;
+  /** Move forward one accessibility node. */
+  next(): Promise<void>;
+  /** Move backward one accessibility node. */
+  previous(): Promise<void>;
+  /** The most recently spoken phrase (e.g. after `next()` or `act()`). */
+  lastPhrase(): Promise<string>;
+  /** Activate the currently focused element. */
+  act(): Promise<void>;
+  /** Stop the virtual SR and restore the previous i18next language. */
+  stop(): Promise<void>;
+}
+
+const LOCALE = 'en';
+
+/**
+ * Lock i18next to English for the duration of a screen-reader test. Returns
+ * a restore function that resets the previous language.
+ *
+ * Vitest tests typically have i18next initialized via `mountComponent`'s
+ * call to `initI18Next()`. Playwright tests do not initialize i18next in
+ * the *test process* (the browser context's i18next is a separate runtime
+ * managed by the application). When `i18next.isInitialized` is false the
+ * lock is a no-op — the page-side locale must be controlled by the test
+ * (cookie, URL, or UI interaction).
+ */
+async function lockLocale(): Promise<() => Promise<void>> {
+  if (!i18next.isInitialized) {
+    return async () => { /* nothing to restore */ };
+  }
+  const previous = i18next.language;
+  if (previous !== LOCALE) {
+    await i18next.changeLanguage(LOCALE);
+  }
+  return async () => {
+    if (previous && previous !== LOCALE) {
+      await i18next.changeLanguage(previous);
+    }
+  };
+}
+
+/**
+ * Create a virtual screen reader bound to a DOM element (typically a
+ * Vue Test Utils `wrapper.element`).
+ *
+ * The helper starts the virtual SR against the supplied container, forces
+ * the i18next locale to `'en'`, and exposes the shared primitive API. Call
+ * `stop()` on the returned handle in your test teardown to release the
+ * virtual SR and restore the previous locale.
+ */
+export async function screenReader(element: Node): Promise<ScreenReaderHandle> {
+  const restoreLocale = await lockLocale();
+  await virtual.start({ container: element });
+
+  return {
+    async walk() {
+      await virtual.clearSpokenPhraseLog();
+      // Walk forward, stopping at the "end of document" sentinel (which
+      // VSR emits when the container is the full document) or when the
+      // active node returns to the starting node (which is what happens
+      // when VSR is bound to a sub-tree — it cycles instead of emitting
+      // a terminal phrase). Capped to defeat runaway loops in case a
+      // future VSR release changes its traversal semantics.
+      const startNode = virtual.activeNode;
+      const maxSteps = 2000;
+      for (let i = 0; i < maxSteps; i++) {
+        await virtual.next();
+        const last = await virtual.lastSpokenPhrase();
+        if (last === 'end of document') {
+          break;
+        }
+        if (i > 0 && virtual.activeNode === startNode) {
+          break;
+        }
+      }
+      return virtual.spokenPhraseLog();
+    },
+    async next() {
+      await virtual.next();
+    },
+    async previous() {
+      await virtual.previous();
+    },
+    async lastPhrase() {
+      return virtual.lastSpokenPhrase();
+    },
+    async act() {
+      await virtual.act();
+    },
+    async stop() {
+      await virtual.stop();
+      await restoreLocale();
+    },
+  };
+}
+
+/**
+ * Resolve the path to the VSR browser ESM bundle, then read it once and
+ * wrap it as a plain script that exposes `window.virtual` and
+ * `window.Virtual`. The bundle ships as an ES module (`export { ... }`),
+ * which `page.addScriptTag` won't load as a regular `<script>`; wrapping
+ * it in a `<script type="module">` plus a side-effect to publish the
+ * exports onto `window` is the most portable way to drive VSR from
+ * Playwright without requiring the test page to ship VSR itself.
+ *
+ * The bundle source path is resolved against the CJS entry's directory,
+ * which works in both ESM-loaded and CJS-loaded test runners.
+ */
+function buildPlaywrightInjection(): string {
+  const cjsEntry = req.resolve('@guidepup/virtual-screen-reader');
+  const browserBundle = join(dirname(cjsEntry), '..', 'esm', 'index.browser.js');
+  const source = readFileSync(browserBundle, 'utf8');
+  // The bundle ends with `export { Uo as Virtual, X$ as virtual };`.
+  // Rewrite to publish onto `window` and drop the `export` statement so
+  // the script can be evaluated as a plain script (or module) in the page
+  // context.
+  return source.replace(
+    /export\s*\{\s*([^}]+)\s*\}\s*;?\s*$/m,
+    (_match, exports) => {
+      const pairs = (exports as string).split(',').map(s => s.trim());
+      const assignments: string[] = [];
+      for (const pair of pairs) {
+        const m = /^(\S+)\s+as\s+(\S+)$/.exec(pair);
+        if (m) {
+          assignments.push(`window.${m[2]} = ${m[1]};`);
+        }
+        else {
+          assignments.push(`window.${pair} = ${pair};`);
+        }
+      }
+      return assignments.join('\n');
+    },
+  );
+}
+
+/**
+ * Verify that `addInitScript` injection succeeded — i.e. `window.virtual`
+ * is defined in the page context. Throws a descriptive error if not, so a
+ * future change to VSR's bundle export format surfaces immediately rather
+ * than producing a confusing `undefined` failure downstream.
+ */
+async function assertVsrInjected(page: Page): Promise<void> {
+  const ok = await page.evaluate(() => typeof (window as { virtual?: unknown }).virtual !== 'undefined');
+  if (!ok) {
+    throw new Error(
+      'VSR injection failed: window.virtual is not defined. '
+      + 'The @guidepup/virtual-screen-reader bundle export format may have changed; '
+      + 'inspect buildPlaywrightInjection() in src/common/test-utils/screen-reader.ts.',
+    );
+  }
+}
+
+/**
+ * Lazily start the virtual SR against the current page document.
+ *
+ * The handle is attached once via `addInitScript`, which fires on every
+ * navigation. Each navigation produces a fresh document with `window.virtual`
+ * present but no active session — so the first method call after attachment
+ * (or after a navigation) must call `virtual.start()` against the new
+ * document. The `__pavillion_vsr_active` flag on `window` is reset by every
+ * navigation, which is exactly the signal we want.
+ */
+async function ensureStarted(page: Page): Promise<void> {
+  await assertVsrInjected(page);
+  await page.evaluate(async () => {
+    const w = window as unknown as {
+      virtual: { start: (opts: { container: Node }) => Promise<void> };
+      __pavillion_vsr_active?: boolean;
+    };
+    if (!w.__pavillion_vsr_active) {
+      await w.virtual.start({ container: document.body });
+      w.__pavillion_vsr_active = true;
+    }
+  });
+}
+
+/**
+ * Create a virtual screen reader bound to a Playwright `Page`.
+ *
+ * Injects `@guidepup/virtual-screen-reader` into the page context via
+ * `addInitScript` (so it survives navigations), then drives it through
+ * `page.evaluate()`. The locale lock applies to the *test process*
+ * i18next instance, not the page's; the page-side locale must be managed
+ * by the test itself (e.g. via UI interaction or the locale cookie).
+ *
+ * Usage pattern: call `pageScreenReader(page)` *before* navigating to the
+ * target route so the init script is in place for the page's first load.
+ * The virtual SR session is started lazily on first method call and
+ * automatically re-started after every navigation, so callers do not need
+ * to track session lifecycle across page transitions.
+ *
+ * If `pageScreenReader(page)` is called on an already-loaded page, the
+ * page is reloaded so the init script can attach VSR; the lazy start then
+ * binds the session to the reloaded document.
+ */
+export async function pageScreenReader(page: Page): Promise<ScreenReaderHandle> {
+  const restoreLocale = await lockLocale();
+
+  // Inject VSR into every navigation context as `window.virtual` /
+  // `window.Virtual`. addInitScript only fires on subsequent loads, so
+  // reload if a non-blank page is already open. The about:blank case
+  // (helper attached before first navigation) is the recommended flow
+  // and requires no reload.
+  const injection = buildPlaywrightInjection();
+  await page.addInitScript(injection);
+
+  if (page.url() !== 'about:blank') {
+    await page.reload();
+    // Verify the injection actually landed on the reloaded page. For the
+    // about:blank case we defer this check to the first method call,
+    // which is the earliest point a meaningful document exists.
+    await assertVsrInjected(page);
+  }
+
+  return {
+    async walk() {
+      await ensureStarted(page);
+      return page.evaluate(async () => {
+        const v = (window as unknown as {
+          virtual: {
+            activeNode: Node | null;
+            clearSpokenPhraseLog: () => Promise<void>;
+            lastSpokenPhrase: () => Promise<string>;
+            next: () => Promise<void>;
+            spokenPhraseLog: () => Promise<string[]>;
+          };
+        }).virtual;
+        await v.clearSpokenPhraseLog();
+        const startNode = v.activeNode;
+        const maxSteps = 2000;
+        for (let i = 0; i < maxSteps; i++) {
+          await v.next();
+          const last = await v.lastSpokenPhrase();
+          if (last === 'end of document') break;
+          if (i > 0 && v.activeNode === startNode) break;
+        }
+        return v.spokenPhraseLog();
+      });
+    },
+    async next() {
+      await ensureStarted(page);
+      await page.evaluate(async () => {
+        await (window as unknown as { virtual: { next: () => Promise<void> } }).virtual.next();
+      });
+    },
+    async previous() {
+      await ensureStarted(page);
+      await page.evaluate(async () => {
+        await (window as unknown as { virtual: { previous: () => Promise<void> } }).virtual.previous();
+      });
+    },
+    async lastPhrase() {
+      await ensureStarted(page);
+      return page.evaluate(async () => {
+        return (window as unknown as { virtual: { lastSpokenPhrase: () => Promise<string> } }).virtual.lastSpokenPhrase();
+      });
+    },
+    async act() {
+      await ensureStarted(page);
+      await page.evaluate(async () => {
+        await (window as unknown as { virtual: { act: () => Promise<void> } }).virtual.act();
+      });
+    },
+    async stop() {
+      // Only stop if a session was actually started — if the caller
+      // attached the helper but never invoked a method, there is nothing
+      // to tear down on the page side.
+      await page.evaluate(async () => {
+        const w = window as unknown as {
+          virtual?: { stop: () => Promise<void> };
+          __pavillion_vsr_active?: boolean;
+        };
+        if (w.__pavillion_vsr_active && w.virtual) {
+          await w.virtual.stop();
+          w.__pavillion_vsr_active = false;
+        }
+      });
+      await restoreLocale();
+    },
+  };
+}

--- a/src/common/test/test-utils/screen-reader.test.ts
+++ b/src/common/test/test-utils/screen-reader.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createMemoryHistory, createRouter, Router } from 'vue-router';
+import { RouteRecordRaw } from 'vue-router';
+import { mountComponent } from '@/client/test/lib/vue';
+import ToggleSwitch from '@/client/components/common/toggle_switch.vue';
+import { screenReader, type ScreenReaderHandle } from '@/common/test-utils/screen-reader';
+
+/**
+ * Smoke test for the Vitest variant of the screen-reader helper.
+ *
+ * Scope: verifies that `screenReader(element)` can attach to a real Vue
+ * component's rendered DOM under happy-dom and return a non-empty spoken-
+ * phrase log via `walk()`. This is intentionally minimal — exhaustive
+ * announcement coverage is the Phase 2 corpus's job, not this file's.
+ */
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: {}, name: 'home' },
+];
+
+describe('screen-reader helper (Vitest variant)', () => {
+  let sr: ScreenReaderHandle | undefined;
+
+  afterEach(async () => {
+    if (sr) {
+      await sr.stop();
+      sr = undefined;
+    }
+  });
+
+  it('walks a rendered component and returns a non-empty spoken-phrase log', async () => {
+    const router: Router = createRouter({
+      history: createMemoryHistory(),
+      routes,
+    });
+
+    const wrapper = mountComponent(ToggleSwitch, router, {
+      props: {
+        modelValue: true,
+        label: 'Notifications',
+        id: 'notifications-toggle',
+      },
+    });
+
+    sr = await screenReader(wrapper.element as unknown as Node);
+    const phrases = await sr.walk();
+
+    expect(Array.isArray(phrases)).toBe(true);
+    expect(phrases.length).toBeGreaterThan(0);
+    // Sanity-check: the label or the switch role should appear somewhere
+    // in the walk. Exact phrasing is the Phase 2 corpus's concern; here
+    // we only care that VSR successfully traversed the rendered DOM.
+    const joined = phrases.join(' | ');
+    expect(joined.toLowerCase()).toMatch(/switch|notifications/);
+  });
+
+  it('reports the last spoken phrase after walking', async () => {
+    const router: Router = createRouter({
+      history: createMemoryHistory(),
+      routes,
+    });
+
+    const wrapper = mountComponent(ToggleSwitch, router, {
+      props: {
+        modelValue: false,
+        label: 'Notifications',
+        id: 'notifications-toggle',
+      },
+    });
+
+    sr = await screenReader(wrapper.element as unknown as Node);
+    await sr.walk();
+    const last = await sr.lastPhrase();
+
+    expect(typeof last).toBe('string');
+    expect(last.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/a11y/screen-reader.smoke.spec.ts
+++ b/tests/e2e/a11y/screen-reader.smoke.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { startTestServer, TestEnvironment } from '../helpers/test-server';
+import { pageScreenReader } from '../helpers/screen-reader';
+
+/**
+ * Smoke test for the Playwright variant of the screen-reader helper.
+ *
+ * Scope: confirms `pageScreenReader(page)` can attach to a live page,
+ * walk it, and return a non-empty last-spoken phrase. This is the Phase 1
+ * deliverable from the screen-reader testing design — it verifies the
+ * helper itself works. The Phase 2 test corpus (announcement contracts
+ * for specific flows) is a separate epic.
+ */
+
+let env: TestEnvironment;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Screen Reader Helper (Playwright variant)', () => {
+  test.beforeAll(async () => {
+    env = await startTestServer();
+  });
+
+  test.afterAll(async () => {
+    if (env?.cleanup) {
+      await env.cleanup();
+    }
+  });
+
+  test('attaches to a live page and reports a non-empty last spoken phrase', async ({ page }) => {
+    // Attach the helper before navigating so `addInitScript` is in place
+    // for the page's first load and no internal reload is needed. Login
+    // route is anonymous-accessible and has stable accessible primitives
+    // (heading, email/password fields, submit button), making it a
+    // low-risk smoke target.
+    const sr = await pageScreenReader(page);
+    try {
+      await page.goto(env.baseURL + '/auth/login');
+      await sr.next();
+      const phrase = await sr.lastPhrase();
+      expect(typeof phrase).toBe('string');
+      expect(phrase.length).toBeGreaterThan(0);
+    }
+    finally {
+      await sr.stop();
+    }
+  });
+});

--- a/tests/e2e/helpers/screen-reader.ts
+++ b/tests/e2e/helpers/screen-reader.ts
@@ -1,0 +1,13 @@
+/**
+ * Thin re-export of the Playwright screen-reader helper for use from e2e
+ * specs. Establishes `tests/e2e/helpers/screen-reader.ts` as the canonical
+ * import path so individual specs do not reach into `src/common/test-utils/`
+ * via deep relative paths. The implementation lives in
+ * `src/common/test-utils/screen-reader.ts` and is shared with the Vitest
+ * variant.
+ *
+ * Design reference:
+ *   `docs/superpowers/specs/2026-05-13-screen-reader-testing-design.md`
+ *   § Phase 2 (helpers/screen-reader.ts).
+ */
+export { pageScreenReader, type ScreenReaderHandle } from '../../../src/common/test-utils/screen-reader';


### PR DESCRIPTION
## Motivation

Phase 1 of the screen-reader testing rollout. Establishes the shared foundation that lets future accessibility tests drive a virtual screen reader against both Vue components (Vitest) and live pages (Playwright) through one identical API. Subsequent phases extend the `accessibility-auditor` agent to consult the helper and ship the actual a11y test corpus.

## Approach

`src/common/test-utils/screen-reader.ts` exports two functions, both returning the same `ScreenReaderHandle` (`walk`, `next`, `previous`, `lastPhrase`, `act`, `stop`):

- `screenReader(element)` — drives `@guidepup/virtual-screen-reader` against a `wrapper.element` under happy-dom.
- `pageScreenReader(page)` — injects the VSR browser ESM bundle via `page.addInitScript`, then lazily starts a session per document (tracked by a `__pavillion_vsr_active` window flag so navigations within a single test re-bind cleanly), exposing the same API through `page.evaluate`.

Both variants centralize the i18next locale lock so individual tests don't need to manage language state. `assertVsrInjected` guards against silent injection failures if a future VSR release changes its ESM export format.

`tests/e2e/helpers/screen-reader.ts` is a thin re-export so e2e specs import `../helpers/screen-reader` rather than reaching into `src/` directly. The Vitest test file uses the existing `@/` alias; the e2e helper does not because the alias is `src/`-scoped in `tsconfig.json` (a follow-up chore tracks extending the alias to `tests/`).

Two smoke tests confirm both surfaces work — one Vitest against `ToggleSwitch`, one Playwright walking `/auth/login`. They are not part of the future a11y test corpus; they verify only the helper itself.

## Validation

- `npm run lint` — 0 errors, warning count unchanged from baseline.
- `npm run test:unit` — 7913 passed.
- `npm run test:integration` — 599 passed (5 skipped).
- `npm run build` — clean.
- `npm run test:e2e` — 133 passed, including the new smoke spec. Two pre-existing baseline failures observed (`admin-moderation` flaky `loginAsAdmin` server-startup timeout; `import-sources` missing local federation TLS cert that is gitignored and produced by `docker/federation/ssl/generate-certs.sh`). Both confirmed unrelated to this branch's changes by independent attribution analysis.