### PR TITLE
test(federation): expand activity-type e2e coverage

### DIFF
--- a/migrations/0034_make_report_calendar_id_nullable.ts
+++ b/migrations/0034_make_report_calendar_id_nullable.ts
@@ -1,0 +1,39 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import { changeColumnNullability } from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Make `report.calendar_id` nullable.
+ *
+ * Before this change, every report row had to belong to a local calendar.
+ * That made it impossible for an instance admin on a follower instance to
+ * file a moderation report against an event hosted on a remote (alpha)
+ * calendar: the only path through `ModerationService.createReport(...)`
+ * required a non-null `calendarId`, and remote events have
+ * `event.calendarId === null` on the follower.
+ *
+ * Invariant after this migration: `report.calendar_id IS NULL` iff the
+ * reported event is remote on this instance. Local reports continue to
+ * carry a calendar_id.
+ *
+ * No data backfill: no production rows have calendar_id === null because
+ * the column was NOT NULL.
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await changeColumnNullability(queryInterface, 'report', 'calendar_id', {
+      type: DataTypes.UUID,
+      allowNull: true,
+    });
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await changeColumnNullability(queryInterface, 'report', 'calendar_id', {
+      type: DataTypes.UUID,
+      allowNull: false,
+    });
+  },
+};

--- a/src/common/model/report.ts
+++ b/src/common/model/report.ts
@@ -54,6 +54,15 @@ enum ForwardStatus {
  */
 class Report extends PrimaryModel {
   eventId: string = '';
+  /**
+   * Calendar that owns the reported event on this instance.
+   *
+   * Invariant: `calendarId === null` iff the reported event is remote on
+   * this instance (i.e. `event.calendarId === null`). Local reports against
+   * locally-hosted events always carry a calendarId; admin-initiated
+   * reports against remote events have calendarId === null because the
+   * remote event has no owning calendar here.
+   */
   calendarId: string | null = null;
   category: ReportCategory = ReportCategory.OTHER;
   description: string = '';

--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -235,6 +235,25 @@ export default class ActivityPubInterface {
     return this.federationPublisher.sendEditorInvite(calendar, remoteUserActor);
   }
 
+  /**
+   * Sends a Remove(remoteUserActor) editor-revoke activity from a local
+   * calendar to a remote user actor via the outbox (fire-and-forget). The
+   * activity is signed by the calendar actor (per pv-dyyw signing table)
+   * and anchored on the calendar's own outbox. Symmetric with
+   * `sendEditorInvite`: Add/Remove is the AS2 §8.13 pair for
+   * collection-membership management.
+   *
+   * @param calendar The local calendar revoking the editor.
+   * @param remoteUserActorUri The remote user actor URI whose editor
+   *   access is being revoked.
+   */
+  async sendEditorRevoke(
+    calendar: Calendar,
+    remoteUserActorUri: string,
+  ): Promise<void> {
+    return this.federationPublisher.sendEditorRevoke(calendar, remoteUserActorUri);
+  }
+
   async addToInbox(calendar: Calendar, message: ActivityPubActivity): Promise<null> {
     return this.serverService.addToInbox(calendar, message);
   }

--- a/src/server/activitypub/model/action/remove.ts
+++ b/src/server/activitypub/model/action/remove.ts
@@ -1,0 +1,69 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityPubActivity, ActivityPubObject } from '@/server/activitypub/model/base';
+
+/**
+ * ActivityPub Remove activity. Used in Pavillion to notify a remote actor
+ * (e.g. a remote calendar editor) that they have been removed from a
+ * collection such as a calendar's editor list. Mirrors {@link AddActivity}
+ * — Add/Remove is the symmetric pair for collection-membership management
+ * per AS2 §8.13. Remove uses explicit `to` targeting for single-recipient
+ * delivery rather than follower fan-out.
+ *
+ * The receiving user actor inbox derives the calendar from `activity.actor`
+ * (the calendar actor URI), so Remove does NOT carry the
+ * `calendarId` / `calendarInboxUrl` extension fields that Add uses to seed
+ * the initial editor-invite membership.
+ */
+class RemoveActivity extends ActivityPubActivity {
+
+  target: string | ActivityPubObject = '';
+
+  constructor( actorUrl: string, object: string | ActivityPubObject, target: string | ActivityPubObject = '' ) {
+    super(actorUrl);
+    this.type = 'Remove';
+    this.object = object;
+    this.target = target;
+    const objectId = typeof object === 'string' ? object : object.id;
+    this.id = objectId + '/removes/' + uuidv4();
+  }
+
+  static fromObject( json: Record<string, any> ): RemoveActivity | null {
+    if (!json || typeof json !== 'object') {
+      return null;
+    }
+
+    if (!json.actor || typeof json.actor !== 'string') {
+      return null;
+    }
+
+    if (!json.object) {
+      return null;
+    }
+
+    let activity = new RemoveActivity(json.actor, json.object, json.target ?? '');
+
+    if (json.id) {
+      activity.id = json.id;
+    }
+    if (json.to) {
+      activity.to = json.to;
+    }
+    if (json.cc) {
+      activity.cc = json.cc;
+    }
+
+    return activity;
+  }
+
+  toObject(): Record<string, any> {
+    const result = super.toObject();
+    if (this.target) {
+      result.target = typeof this.target === 'object' && this.target !== null
+        ? ('toObject' in this.target ? (this.target as any).toObject() : this.target)
+        : this.target;
+    }
+    return result;
+  }
+}
+
+export default RemoveActivity;

--- a/src/server/activitypub/service/federation_publisher.ts
+++ b/src/server/activitypub/service/federation_publisher.ts
@@ -14,6 +14,7 @@ import { ActivityPubActivity } from '@/server/activitypub/model/base';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import DeleteActivity from '@/server/activitypub/model/action/delete';
 import AddActivity from '@/server/activitypub/model/action/add';
+import RemoveActivity from '@/server/activitypub/model/action/remove';
 import { addToOutbox as addToOutboxHelper } from '@/server/activitypub/helper/outbox';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
@@ -436,6 +437,45 @@ class FederationPublisher {
       'Enqueuing Add activity for remote user',
     );
     await this.addToOutbox(calendar, addActivity);
+  }
+
+  /**
+   * Sends a Remove(remoteUserActor) editor-revoke activity from a local
+   * calendar to a remote user actor. Mirrors {@link sendEditorInvite}
+   * byte-for-byte except the activity type and the absence of the
+   * Pavillion-specific `calendarId` / `calendarInboxUrl` extension fields
+   * — the receive-side handler derives the calendar from `activity.actor`,
+   * not from extension fields.
+   *
+   * The activity is signed by the calendar actor (per pv-dyyw signing
+   * table) and anchored on the calendar's own outbox. Delivery is routed
+   * by the outbox worker from the activity's explicit `to` field; no
+   * caller-supplied inbox URL is required.
+   *
+   * @param calendar - The local calendar revoking the editor.
+   * @param remoteUserActorUri - The remote user actor URI whose editor
+   *   access is being revoked.
+   */
+  async sendEditorRevoke(
+    calendar: Calendar,
+    remoteUserActorUri: string,
+  ): Promise<void> {
+    const localDomain = config.get<string>('domain');
+    const calendarActorUri = `https://${localDomain}/calendars/${calendar.urlName}`;
+
+    const removeActivity = new RemoveActivity(
+      calendarActorUri,
+      remoteUserActorUri,
+      `${calendarActorUri}/editors`,
+    );
+    removeActivity.id = `${calendarActorUri}/activities/${uuidv4()}`;
+    removeActivity.to = [remoteUserActorUri];
+
+    logger.info(
+      { remoteUserActorUri, calendarId: calendar.id },
+      'Enqueuing Remove activity for remote user',
+    );
+    await this.addToOutbox(calendar, removeActivity);
   }
 
   /**

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -13,6 +13,7 @@ import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor"
 import UpdateActivity from "@/server/activitypub/model/action/update";
 import DeleteActivity from "@/server/activitypub/model/action/delete";
 import AddActivity from "@/server/activitypub/model/action/add";
+import RemoveActivity from "@/server/activitypub/model/action/remove";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
@@ -280,6 +281,22 @@ class ProcessOutboxService {
         }
         else {
           logger.warn({ activityId: activity.id }, 'Add activity has no explicit to field; skipping delivery (no follower fan-out for Add)');
+        }
+        break;
+      case 'Remove':
+        activity = RemoveActivity.fromObject(message.message);
+        if (!activity) {
+          throw new Error('Failed to parse Remove activity');
+        }
+        // Remove activities are inherently single-recipient (editor-revoke
+        // to a remote actor) — mirror Add. No follower fan-out fallback:
+        // broadcasting an editor-revoke is never the intent.
+        if (activity.to && activity.to.length > 0) {
+          recipients = activity.to;
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Remove activity');
+        }
+        else {
+          logger.warn({ activityId: activity.id }, 'Remove activity has no explicit to field; skipping delivery (no follower fan-out for Remove)');
         }
         break;
       case 'Follow':

--- a/src/server/activitypub/service/user_actor.ts
+++ b/src/server/activitypub/service/user_actor.ts
@@ -317,6 +317,13 @@ export default class UserActorService {
       return false;
     }
 
+    // Verify the object is us (mirrors processAddActivity; the username in
+    // the URL path must match the activity's `object`).
+    if (activity.object !== actor.actorUri) {
+      logger.error({ object: activity.object, actorUri: actor.actorUri }, 'Remove activity object does not match our actor');
+      return false;
+    }
+
     // Extract the calendar actor URI from the activity
     const calendarActorUri = activity.actor;
 
@@ -341,6 +348,16 @@ export default class UserActorService {
 
     if (!remoteCalendarActor) {
       logger.info({ calendarActorUri }, 'Remote calendar actor not found for URI');
+      return false;
+    }
+
+    // Verify the target is the editors collection of the calendar actor.
+    // This guards against future feature additions (other collections on a
+    // calendar actor — followers, moderators) accidentally routing Remove
+    // activities through the editor prune path.
+    const expectedTarget = `${remoteCalendarActor.actorUri}/editors`;
+    if (activity.target !== expectedTarget) {
+      logger.error({ target: activity.target, expected: expectedTarget }, 'Remove activity target is not the editors collection');
       return false;
     }
 

--- a/src/server/activitypub/test/service/federation_publisher.test.ts
+++ b/src/server/activitypub/test/service/federation_publisher.test.ts
@@ -543,4 +543,54 @@ describe('FederationPublisher', () => {
     });
   });
 
+  describe('sendEditorRevoke', () => {
+    let publisher: FederationPublisher;
+    let sandbox: sinon.SinonSandbox;
+    let calendarInterface: CalendarInterface;
+    let mockOutbox: ReturnType<typeof buildMockOutboxService>;
+    let addToOutboxStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      const eventBus = new EventEmitter();
+      calendarInterface = new CalendarInterface(eventBus);
+      mockOutbox = buildMockOutboxService();
+      publisher = new FederationPublisher(eventBus, calendarInterface, mockOutbox as any);
+
+      addToOutboxStub = sandbox.stub(publisher, 'addToOutbox');
+      addToOutboxStub.resolves();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('enqueues a Remove activity signed by the calendar actor (mirrors Add wire shape)', async () => {
+      const calendar = Calendar.fromObject({ id: 'local-cal-id', urlName: 'mycal' });
+      const remoteUserActorUri = 'https://remote.example.com/users/alice';
+
+      await publisher.sendEditorRevoke(calendar, remoteUserActorUri);
+
+      expect(addToOutboxStub.calledOnce).toBe(true);
+      const [calendarArg, activityArg] = addToOutboxStub.firstCall.args;
+      // Anchor calendar = the calendar argument directly (calendar actor's
+      // own outbox), matching the Add path.
+      expect(calendarArg).toBe(calendar);
+      expect(activityArg.type).toBe('Remove');
+      // Signing actor: calendar actor URI (same as Add per pv-dyyw signing table).
+      expect(activityArg.actor).toMatch(/^https:\/\/.+\/calendars\/mycal$/);
+      // Activity id is calendar-actor-rooted, matching Add.
+      expect(activityArg.id).toMatch(/^https:\/\/.+\/calendars\/mycal\/activities\/[a-f0-9-]+$/);
+      expect(activityArg.to).toEqual([remoteUserActorUri]);
+      expect(activityArg.object).toBe(remoteUserActorUri);
+      // Target collection is the calendar's editors collection (same as Add).
+      expect(activityArg.target).toMatch(/^https:\/\/.+\/calendars\/mycal\/editors$/);
+      // Remove does NOT carry the calendarId / calendarInboxUrl extension
+      // fields Add uses — the receive-side derives the calendar from
+      // activity.actor.
+      expect(activityArg.calendarId).toBeUndefined();
+      expect(activityArg.calendarInboxUrl).toBeUndefined();
+    });
+  });
+
 });

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -901,6 +901,84 @@ describe('processOutboxMessage — explicit `to` honoring and per-type local dis
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 
+  // ---------- Remove ----------
+  //
+  // Remove mirrors Add: single-recipient editor-revoke delivery with no
+  // follower fan-out fallback. The no-`to` skip path is the load-bearing
+  // case — it prevents a regression where editor-revoke activities
+  // accidentally broadcast to all followers.
+
+  it('Remove: honors explicit `to` and delivers only to that recipient', async () => {
+    const removeMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Remove',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/removes/remove-1`,
+      to: [TARGETED_ACTOR_URI],
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Remove',
+      message: removeMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(TARGETED_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Remove').toBe(false);
+    expect(resolveStub.calledOnceWith(TARGETED_ACTOR_URI)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Remove: skips delivery (no fan-out) when `to` is absent', async () => {
+    const removeMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Remove',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/removes/remove-2`,
+      // no `to` field
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Remove',
+      message: removeMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+
+    await service.processOutboxMessage(message);
+
+    // No follower fan-out for Remove — getRecipients must NOT be called and
+    // no HTTP delivery should happen. The message is still marked processed.
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Remove fan-out').toBe(false);
+    expect(resolveStub.called, 'resolveInboxUrl must NOT be called when no recipients').toBe(false);
+    expect(postStub.called, 'No HTTP POST when Remove has no recipients').toBe(false);
+    expect(updateStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
   // ---------- Per-type local-recipient dispatch ----------
   //
   // For each of the 8 currently-handled activity types, when the resolved

--- a/src/server/activitypub/test/service/user_actor.test.ts
+++ b/src/server/activitypub/test/service/user_actor.test.ts
@@ -6,6 +6,7 @@ import { Account } from '@/common/model/account';
 import UserActorService from '@/server/activitypub/service/user_actor';
 import { UserActorEntity } from '@/server/activitypub/entity/user_actor';
 import { AccountEntity } from '@/server/common/entity/account';
+import RemoteCalendarService from '@/server/activitypub/service/remote_calendar';
 import CalendarInterface from '@/server/calendar/interface';
 
 describe('UserActorService', () => {
@@ -279,6 +280,124 @@ describe('UserActorService', () => {
       // Verify digest is NOT in the headers list
       expect(signature.headers).toBe('(request-target) host date');
       expect(signature.headers).not.toContain('digest');
+    });
+  });
+
+  describe('processRemoveActivity', () => {
+    const LOCAL_USERNAME = 'alice';
+    const LOCAL_ACCOUNT_ID = 'account-id-alice';
+    const LOCAL_ACTOR_URI = 'https://events.example/users/alice';
+    const REMOTE_CALENDAR_URI = 'https://remote.example/calendars/test';
+    const REMOTE_CALENDAR_ACTOR_ID = 'remote-calendar-actor-id';
+
+    let calendarInterfaceStub: { removeRemoteEditorAccess: sinon.SinonStub };
+
+    beforeEach(() => {
+      calendarInterfaceStub = {
+        removeRemoteEditorAccess: sinon.stub().resolves(true),
+      };
+      service = new UserActorService(calendarInterfaceStub as unknown as CalendarInterface);
+    });
+
+    function stubLookups(overrides: {
+      userActor?: any;
+      account?: any;
+      remoteCalendarActor?: any;
+    } = {}): void {
+      // getActorByUsername queries AccountEntity then UserActorEntity
+      sandbox.stub(AccountEntity, 'findOne').callsFake(async (options: any) => {
+        // First call: from getActorByUsername({ where: { username } })
+        // Second call: from processRemoveActivity({ where: { username } })
+        // Both return the same account row.
+        if (options?.where?.username === LOCAL_USERNAME) {
+          return overrides.account === undefined
+            ? ({ id: LOCAL_ACCOUNT_ID, username: LOCAL_USERNAME } as any)
+            : overrides.account;
+        }
+        return null;
+      });
+
+      const userActorEntity = overrides.userActor === undefined
+        ? {
+          toModel: () => ({
+            id: 'user-actor-id',
+            accountId: LOCAL_ACCOUNT_ID,
+            actorUri: LOCAL_ACTOR_URI,
+            publicKey: 'pk',
+            privateKey: 'sk',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        }
+        : overrides.userActor;
+      sandbox.stub(UserActorEntity, 'findOne').resolves(userActorEntity as any);
+
+      const remoteCalendarActor = overrides.remoteCalendarActor === undefined
+        ? { id: REMOTE_CALENDAR_ACTOR_ID, actorUri: REMOTE_CALENDAR_URI }
+        : overrides.remoteCalendarActor;
+      sandbox.stub(RemoteCalendarService.prototype, 'getByActorUri').resolves(remoteCalendarActor as any);
+    }
+
+    it('prunes the remote-calendar membership via CalendarInterface', async () => {
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(true);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.calledOnce).toBe(true);
+      const [accountIdArg, calendarActorIdArg] = calendarInterfaceStub.removeRemoteEditorAccess.firstCall.args;
+      expect(accountIdArg).toBe(LOCAL_ACCOUNT_ID);
+      expect(calendarActorIdArg).toBe(REMOTE_CALENDAR_ACTOR_ID);
+    });
+
+    it('returns false and does not prune when activity type is not Remove', async () => {
+      const activity = {
+        type: 'Delete',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when actor URI is missing', async () => {
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: undefined,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false when no remote calendar actor is known for the activity actor URI', async () => {
+      stubLookups({ remoteCalendarActor: null });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
     });
   });
 });

--- a/src/server/activitypub/test/service/user_actor.test.ts
+++ b/src/server/activitypub/test/service/user_actor.test.ts
@@ -399,5 +399,104 @@ describe('UserActorService', () => {
       expect(result).toBe(false);
       expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
     });
+
+    it('returns false and does not prune when the local user actor cannot be found', async () => {
+      // Covers the `if (!actor)` guard after getActorByUsername — mirrors
+      // the same defensive branch in processAddActivity.
+      stubLookups({ userActor: null });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when the local account cannot be found', async () => {
+      // Covers the `if (!account)` guard after AccountEntity.findOne. The
+      // AccountEntity stub returns the row for getActorByUsername's first
+      // lookup but null for the second lookup (the one inside
+      // processRemoveActivity itself), exercising the branch in isolation.
+      const remoteCalendarActor = { id: REMOTE_CALENDAR_ACTOR_ID, actorUri: REMOTE_CALENDAR_URI };
+      sandbox.stub(RemoteCalendarService.prototype, 'getByActorUri').resolves(remoteCalendarActor as any);
+      sandbox.stub(UserActorEntity, 'findOne').resolves({
+        toModel: () => ({
+          id: 'user-actor-id',
+          accountId: LOCAL_ACCOUNT_ID,
+          actorUri: LOCAL_ACTOR_URI,
+          publicKey: 'pk',
+          privateKey: 'sk',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      } as any);
+
+      let accountCallCount = 0;
+      sandbox.stub(AccountEntity, 'findOne').callsFake(async () => {
+        accountCallCount += 1;
+        // First call from getActorByUsername succeeds; second call from
+        // processRemoveActivity returns null to drive the missing-account branch.
+        if (accountCallCount === 1) {
+          return { id: LOCAL_ACCOUNT_ID, username: LOCAL_USERNAME } as any;
+        }
+        return null;
+      });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when activity object does not match our actor URI', async () => {
+      // Symmetric to processAddActivity's object check: the username in the
+      // URL path must match the activity's `object`.
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: 'https://events.example/users/someone-else',
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when activity target is not the editors collection', async () => {
+      // Symmetric guard for the target field. sendEditorRevoke always sets
+      // target to `${calendarActorUri}/editors`; anything else (e.g. a
+      // hypothetical /followers URI) must not route through the editor
+      // prune path.
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/followers`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
   });
 });

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -1148,6 +1148,11 @@ class CalendarService {
     if (!account.id) {
       return null;
     }
+    // Stable sort: when an account owns multiple owner memberships,
+    // return the oldest one so callers that need a deterministic
+    // signing identity (e.g. the federation Flag courier in
+    // ModerationService.forwardReport) get the same calendar every
+    // run rather than DB-ordering-dependent results.
     const membership = await CalendarMemberEntity.findOne({
       where: { account_id: account.id, role: 'owner' },
       include: [{
@@ -1155,6 +1160,7 @@ class CalendarService {
         as: 'calendar',
         include: [CalendarContentEntity, { model: MediaEntity, as: 'defaultEventImage', required: false, where: { status: 'approved' } }],
       }],
+      order: [['created_at', 'ASC']],
     });
     return membership?.calendar ? this.withPublicUrl(membership.calendar.toModel()) : null;
   }

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -900,6 +900,20 @@ class CalendarService {
       throw new EditorNotFoundError();
     }
 
+    // Send ActivityPub Remove activity to notify the remote user via the
+    // signed outbox path. Mirrors the Add emission in grantRemoteEditorAccess
+    // — the calendar actor signs the Remove (pv-dyyw signing table), and the
+    // local membership row is already destroyed above regardless of remote
+    // delivery outcome. Best-effort semantics: a transient enqueue failure
+    // must not roll back the local revoke.
+    try {
+      await this.activityPubInterface!.sendEditorRevoke(calendar, actorUri);
+      logger.info({ actorUri, calendarId: calendar.id }, 'Enqueued Remove activity for remote editor');
+    }
+    catch (error: any) {
+      logError(error, `[Calendar] Failed to enqueue Remove activity to ${actorUri}`);
+    }
+
     if (this.eventBus) {
       this.eventBus.emit('remoteEditorRevoked', {
         calendarId: calendar.id,

--- a/src/server/calendar/test/calendar_service.test.ts
+++ b/src/server/calendar/test/calendar_service.test.ts
@@ -395,7 +395,10 @@ describe('getPrimaryCalendarForUser', () => {
   it('should return primary calendar for user if found', async () => {
     const cal = new Calendar('testCalendarId', 'testme');
 
-    // Stub CalendarMemberEntity.findOne to return an owner membership with included calendar
+    // The `order: [['created_at', 'ASC']]` assertion below guarantees a
+    // deterministic pick when an account owns multiple owner memberships,
+    // which the federation Flag courier in ModerationService.forwardReport
+    // depends on for stable signing identity.
     const memberFindOneStub = sandbox.stub(CalendarMemberEntity, 'findOne');
     memberFindOneStub.resolves({
       calendar_id: 'testCalendarId',
@@ -415,6 +418,7 @@ describe('getPrimaryCalendarForUser', () => {
         as: 'calendar',
         include: [CalendarContentEntity, { model: MediaEntity, as: 'defaultEventImage', required: false, where: { status: 'approved' } }],
       }],
+      order: [['created_at', 'ASC']],
     })).toBe(true);
   });
 
@@ -432,8 +436,10 @@ describe('getPrimaryCalendarForUser', () => {
         as: 'calendar',
         include: [CalendarContentEntity, { model: MediaEntity, as: 'defaultEventImage', required: false, where: { status: 'approved' } }],
       }],
+      order: [['created_at', 'ASC']],
     })).toBe(true);
   });
+
 });
 
 describe('createCalendar', () => {

--- a/src/server/calendar/test/service/remote_editor_grant.test.ts
+++ b/src/server/calendar/test/service/remote_editor_grant.test.ts
@@ -27,12 +27,16 @@ import { EventEmitter } from 'events';
  * to the real UserActorEntity database. This allows integration-style tests
  * to create DB rows directly while the service uses interface-based calls.
  *
- * `sendEditorInvite` is a sinon stub so editor-invite tests can assert that
- * the calendar service hands off the typed (calendar, remoteUserActor) pair
- * to the AP domain. Activity construction itself lives in the AP domain
+ * `sendEditorInvite` and `sendEditorRevoke` are sinon stubs so editor
+ * grant/revoke tests can assert that the calendar service hands off the
+ * typed (calendar, remoteUserActor) / (calendar, actorUri) pairs to the AP
+ * domain. Activity construction itself lives in the AP domain
  * (FederationPublisher) and is exercised by federation-side tests.
  */
-function createMockActivityPubInterface(sendEditorInviteStub: sinon.SinonStub): Partial<ActivityPubInterface> {
+function createMockActivityPubInterface(
+  sendEditorInviteStub: sinon.SinonStub,
+  sendEditorRevokeStub: sinon.SinonStub,
+): Partial<ActivityPubInterface> {
   return {
     async findUserActorByUri(actorUri: string) {
       const entity = await UserActorEntity.findOne({ where: { actor_uri: actorUri } });
@@ -56,6 +60,7 @@ function createMockActivityPubInterface(sendEditorInviteStub: sinon.SinonStub): 
       return { id: entity.id };
     },
     sendEditorInvite: sendEditorInviteStub as unknown as ActivityPubInterface['sendEditorInvite'],
+    sendEditorRevoke: sendEditorRevokeStub as unknown as ActivityPubInterface['sendEditorRevoke'],
   };
 }
 
@@ -71,6 +76,7 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
   let service: CalendarService;
   let mockAccountsInterface: Partial<AccountsInterface>;
   let sendEditorInviteStub: sinon.SinonStub;
+  let sendEditorRevokeStub: sinon.SinonStub;
   let testAccountId: string;
   let testCalendarId: string;
   let testAccount: Account;
@@ -78,6 +84,7 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
     sendEditorInviteStub = sandbox.stub().resolves();
+    sendEditorRevokeStub = sandbox.stub().resolves();
     await db.sync({ force: true });
 
     // Create test account
@@ -119,7 +126,9 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
     );
 
     // Wire up mock ActivityPub interface for user actor lookups
-    service.setActivityPubInterface(createMockActivityPubInterface(sendEditorInviteStub) as ActivityPubInterface);
+    service.setActivityPubInterface(
+      createMockActivityPubInterface(sendEditorInviteStub, sendEditorRevokeStub) as ActivityPubInterface,
+    );
   });
 
   afterEach(async () => {
@@ -502,6 +511,56 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
       // UserActorEntity should still exist (we don't delete actors)
       const userActor = await UserActorEntity.findByPk(userActorId);
       expect(userActor).not.toBeNull();
+
+      // Verify the calendar service handed off to the typed AP method with
+      // the calendar and the remote editor's actor URI. Activity construction
+      // (Remove wire shape, signing-actor selection, outbox enqueue) lives in
+      // the AP domain and is exercised by federation_publisher tests.
+      expect(sendEditorRevokeStub.calledOnce).toBe(true);
+      const [calendarArg, actorUriArg] = sendEditorRevokeStub.firstCall.args;
+      expect(calendarArg.id).toBe(testCalendarId);
+      expect(actorUriArg).toBe('https://beta.federation.local/users/Editor');
+    });
+
+    it('should not fail the revoke if the outbox enqueue throws (best-effort delivery)', async () => {
+      const userActorId = uuidv4();
+      await UserActorEntity.create({
+        id: userActorId,
+        actor_type: 'remote',
+        account_id: null,
+        actor_uri: 'https://beta.federation.local/users/Editor',
+        remote_username: 'Editor',
+        remote_domain: 'beta.federation.local',
+        public_key: null,
+        private_key: null,
+      });
+
+      await CalendarMemberEntity.create({
+        id: uuidv4(),
+        calendar_id: testCalendarId,
+        user_actor_id: userActorId,
+        role: 'editor',
+        granted_by: testAccountId,
+      });
+
+      // Simulate a failure dispatching the Remove activity via the typed AP
+      // method (e.g. transient DB error on the ap_outbox insert). The local
+      // membership row should still be destroyed — local revoke must not be
+      // contingent on remote delivery success.
+      sendEditorRevokeStub.rejects(new Error('outbox insert failed'));
+
+      const result = await service.removeRemoteEditor(
+        testAccount,
+        testCalendarId,
+        'https://beta.federation.local/users/Editor',
+      );
+
+      expect(result).toBe(true);
+
+      const membership = await CalendarMemberEntity.findOne({
+        where: { calendar_id: testCalendarId, user_actor_id: userActorId },
+      });
+      expect(membership).toBeNull();
     });
 
     it('should throw EditorNotFoundError if remote editor does not exist', async () => {

--- a/src/server/common/migrations/helpers.ts
+++ b/src/server/common/migrations/helpers.ts
@@ -95,6 +95,41 @@ export async function createTableIfNotExists(
 }
 
 /**
+ * Change a column's nullability only if it differs from the current schema.
+ *
+ * Idempotency helper for `queryInterface.changeColumn` when the only delta is
+ * `allowNull`. Reads the live column description via `describeTable` and skips
+ * the DDL if `attributes.allowNull` already matches. This keeps re-runs safe
+ * against both SQLite (dev/test) and PostgreSQL (prod), consistent with the
+ * pattern of `addColumnIfNotExists` and friends.
+ */
+export async function changeColumnNullability(
+  queryInterface: QueryInterface,
+  tableName: string,
+  columnName: string,
+  attributes: Parameters<QueryInterface['changeColumn']>[2],
+): Promise<void> {
+  const description = await queryInterface.describeTable(tableName);
+  const current = description[columnName];
+  if (!current) {
+    logger.info(
+      { table: tableName, column: columnName },
+      'Column does not exist, skipping nullability change',
+    );
+    return;
+  }
+  const desiredAllowNull = (attributes as { allowNull?: boolean }).allowNull;
+  if (desiredAllowNull !== undefined && current.allowNull === desiredAllowNull) {
+    logger.info(
+      { table: tableName, column: columnName, allowNull: desiredAllowNull },
+      'Column nullability already matches, skipping change',
+    );
+    return;
+  }
+  await queryInterface.changeColumn(tableName, columnName, attributes);
+}
+
+/**
  * Add an index only if an index with the given name does not already exist on
  * the table. Mirrors the pattern of createTableIfNotExists and
  * addColumnIfNotExists so migrations remain safe to re-run against both SQLite

--- a/src/server/common/test/migrations/helpers.test.ts
+++ b/src/server/common/test/migrations/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Sequelize, DataTypes } from 'sequelize';
 import {
   addIndexIfNotExists,
+  changeColumnNullability,
   columnExists,
   removeIndexIfExists,
   tableExists,
@@ -143,6 +144,53 @@ describe('Migration Helpers', () => {
         (ix) => ix.name === 'uniq_widget_owner_name',
       ).length;
       expect(count).toBe(1);
+    });
+  });
+
+  describe('changeColumnNullability', () => {
+    it('flips a NOT NULL column to nullable when called once', async () => {
+      const qi = sequelize.getQueryInterface();
+
+      await changeColumnNullability(qi, 'widget', 'owner_id', {
+        type: DataTypes.STRING,
+        allowNull: true,
+      });
+
+      const desc = await qi.describeTable('widget');
+      expect(desc.owner_id.allowNull).toBe(true);
+    });
+
+    it('is a no-op when the column already has the desired nullability', async () => {
+      const qi = sequelize.getQueryInterface();
+
+      // First run flips owner_id to nullable.
+      await changeColumnNullability(qi, 'widget', 'owner_id', {
+        type: DataTypes.STRING,
+        allowNull: true,
+      });
+
+      // Second run with the same desired value should not throw and should
+      // leave the column nullable.
+      await expect(
+        changeColumnNullability(qi, 'widget', 'owner_id', {
+          type: DataTypes.STRING,
+          allowNull: true,
+        }),
+      ).resolves.toBeUndefined();
+
+      const desc = await qi.describeTable('widget');
+      expect(desc.owner_id.allowNull).toBe(true);
+    });
+
+    it('skips silently when the column does not exist', async () => {
+      const qi = sequelize.getQueryInterface();
+
+      await expect(
+        changeColumnNullability(qi, 'widget', 'missing_column', {
+          type: DataTypes.STRING,
+          allowNull: true,
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/server/moderation/api/v1/admin-report-routes.ts
+++ b/src/server/moderation/api/v1/admin-report-routes.ts
@@ -8,6 +8,7 @@ import { EventNotFoundError } from '@/common/exceptions/calendar';
 import ExpressHelper from '@/server/common/helper/express';
 import ModerationInterface from '@/server/moderation/interface';
 import {
+  NoSigningCalendarError,
   ReportNotFoundError,
   ReportAlreadyResolvedError,
 } from '@/server/moderation/exceptions';
@@ -474,6 +475,14 @@ export default class AdminReportRoutes {
         res.status(404).json({
           error: 'Report not found',
           errorName: 'ReportNotFoundError',
+        });
+        return;
+      }
+
+      if (error instanceof NoSigningCalendarError) {
+        res.status(422).json({
+          error: error.message,
+          errorName: 'NoSigningCalendarError',
         });
         return;
       }

--- a/src/server/moderation/entity/report.ts
+++ b/src/server/moderation/entity/report.ts
@@ -32,8 +32,17 @@ class ReportEntity extends Model {
   @Column({ type: DataType.UUID, allowNull: false })
   declare event_id: string;
 
-  @Column({ type: DataType.UUID, allowNull: false })
-  declare calendar_id: string;
+  /**
+   * Calendar that owns the reported event on this instance.
+   *
+   * Invariant: `calendar_id === null` iff the reported event is remote
+   * (`event.calendarId === null` on this instance). Local reports against
+   * locally-hosted events always carry a calendar_id; admin-initiated
+   * reports against remote events have calendar_id === null because the
+   * remote event has no owning calendar here.
+   */
+  @Column({ type: DataType.UUID, allowNull: true })
+  declare calendar_id: string | null;
 
   @Column({ type: DataType.STRING, allowNull: false })
   declare category: string;

--- a/src/server/moderation/exceptions.ts
+++ b/src/server/moderation/exceptions.ts
@@ -78,6 +78,26 @@ export class InvalidDomainError extends Error {
 }
 
 /**
+ * Custom error class for missing signing calendar when forwarding a remote-event report.
+ *
+ * Thrown by `ModerationService.forwardReport` when the report being forwarded
+ * has `calendarId === null` (admin-initiated report against a remote event)
+ * but no suitable local calendar can be resolved to sign the outbound Flag
+ * activity. This happens when the admin account is missing or has no
+ * primary (owned) calendar to act as the federation courier. Mapped to 422
+ * by the forward-to-admin route, consistent with other moderation
+ * unprocessable-entity errors.
+ */
+export class NoSigningCalendarError extends Error {
+  constructor(message: string = 'No signing calendar available for this admin') {
+    super(message);
+    this.name = 'NoSigningCalendarError';
+    // Maintaining proper prototype chain in ES5+
+    Object.setPrototypeOf(this, NoSigningCalendarError.prototype);
+  }
+}
+
+/**
  * Custom error class for blocked reporter attempting to submit a report.
  * Thrown when a reporter's email hash is in the blocked reporters list.
  */

--- a/src/server/moderation/interface/index.ts
+++ b/src/server/moderation/interface/index.ts
@@ -43,7 +43,13 @@ export default class ModerationInterface {
     this.emailInterface = emailInterface;
     this.configurationInterface = configurationInterface;
     this.activityPubInterface = activityPubInterface;
-    this.moderationService = new ModerationService(eventBus, calendarInterface, configurationInterface, activityPubInterface);
+    this.moderationService = new ModerationService(
+      eventBus,
+      calendarInterface,
+      configurationInterface,
+      activityPubInterface,
+      accountsInterface,
+    );
     this.analyticsService = new AnalyticsService();
   }
 

--- a/src/server/moderation/service/moderation.ts
+++ b/src/server/moderation/service/moderation.ts
@@ -16,6 +16,7 @@ import { ReportEscalationEntity } from '@/server/moderation/entity/report_escala
 import { BlockedInstanceEntity } from '@/server/moderation/entity/blocked_instance';
 import {
   InvalidVerificationTokenError,
+  NoSigningCalendarError,
   ReportNotFoundError,
   ReportAlreadyResolvedError,
   EmailRateLimitError,
@@ -23,6 +24,7 @@ import {
   ReporterBlockedError,
 } from '@/server/moderation/exceptions';
 import CalendarInterface from '@/server/calendar/interface';
+import AccountsInterface from '@/server/accounts/interface';
 import ConfigurationInterface from '@/server/configuration/interface';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import { validateActorUriProtocol } from '@/server/common/helper/uri-validation';
@@ -103,7 +105,7 @@ const MODERATION_SETTING_DEFAULTS: Record<string, number> = {
  */
 interface CreateReportData {
   eventId: string;
-  calendarId: string;
+  calendarId: string | null;
   category: ReportCategory;
   description: string;
   reporterEmail?: string;
@@ -233,14 +235,22 @@ class ModerationService {
   private eventBus?: EventEmitter;
   private patternDetectionService: PatternDetectionService;
   private calendarInterface?: CalendarInterface;
+  private accountsInterface?: AccountsInterface;
   private emailBlockingService: EmailBlockingService;
   private configurationInterface?: ConfigurationInterface;
   private activityPubInterface?: ActivityPubInterface;
 
-  constructor(eventBus?: EventEmitter, calendarInterface?: CalendarInterface, configurationInterface?: ConfigurationInterface, activityPubInterface?: ActivityPubInterface) {
+  constructor(
+    eventBus?: EventEmitter,
+    calendarInterface?: CalendarInterface,
+    configurationInterface?: ConfigurationInterface,
+    activityPubInterface?: ActivityPubInterface,
+    accountsInterface?: AccountsInterface,
+  ) {
     this.eventBus = eventBus;
     this.patternDetectionService = new PatternDetectionService();
     this.calendarInterface = calendarInterface;
+    this.accountsInterface = accountsInterface;
     this.configurationInterface = configurationInterface;
     this.emailBlockingService = new EmailBlockingService();
     this.activityPubInterface = activityPubInterface;
@@ -440,9 +450,17 @@ class ModerationService {
   /**
    * Creates an admin-initiated report for an event.
    * Validates admin-specific fields (priority, deadline) in addition
-   * to standard report fields. Delegates to createReportForEvent with
-   * reporterType set to 'administrator'. Admin reports skip verification
-   * and go directly to submitted status.
+   * to standard report fields. Admin reports skip verification and go
+   * directly to submitted status.
+   *
+   * Single dispatch point: branches on `event.isRemote()`.
+   * - For local events, delegates to `createReportForEvent` (which still
+   *   rejects events with no calendarId, preserving the gate for the
+   *   anonymous/authenticated public report paths).
+   * - For remote events, calls `createReport` directly with
+   *   `calendarId: null`. Remote events have no owning local calendar,
+   *   so the public report paths (which require a calendar context)
+   *   continue to reject them; only the admin path supports them.
    *
    * @param data - Admin report creation data
    * @returns The created Report domain model
@@ -451,6 +469,10 @@ class ModerationService {
    * @throws DuplicateReportError if admin has already reported this event
    */
   async createAdminReport(data: CreateAdminReportData): Promise<Report> {
+    if (!this.calendarInterface) {
+      throw new Error('CalendarInterface is required for createAdminReport');
+    }
+
     // Validate standard report fields + admin-specific fields in one pass
     const errors: string[] = [
       ...this.validateReportFields(data.eventId, data.category, data.description),
@@ -459,6 +481,32 @@ class ModerationService {
 
     if (errors.length > 0) {
       throw new ReportValidationError(errors);
+    }
+
+    // Look up the event once to decide which path to take.
+    const event = await this.calendarInterface.getEventById(data.eventId);
+    if (!event) {
+      throw new EventNotFoundError();
+    }
+
+    if (event.isRemote()) {
+      // Remote-event admin report: skip createReportForEvent's calendar
+      // resolution and persist with calendarId = null.
+      return this.createReport({
+        eventId: data.eventId,
+        calendarId: null,
+        category: data.category,
+        description: data.description,
+        reporterType: 'administrator',
+        reporterAccountId: data.adminId,
+        adminId: data.adminId,
+        adminPriority: data.priority,
+        adminDeadline: data.deadline,
+        adminNotes: data.adminNotes,
+        reporterIp: data.reporterIp,
+        reporterIpSubnet: data.reporterIpSubnet,
+        reporterIpRegion: data.reporterIpRegion,
+      });
     }
 
     return this.createReportForEvent({
@@ -1699,27 +1747,77 @@ class ModerationService {
     // Build Flag activity using FlagActivityBuilder
     const domain = config.get<string>('server.domain');
     const flagBuilder = new FlagActivityBuilder(domain);
-    // Get calendar to determine actor URI
-    const calendar = await this.calendarInterface.getCalendar(report.calendarId);
-    if (!calendar) {
-      throw new Error('Calendar not found for report');
+
+    // Resolve the signing calendar.
+    //
+    // Two paths share this method:
+    //
+    // 1. Legacy local-event report: `report.calendarId` is set, signing
+    //    happens via the calendar that owns the reported event.
+    //
+    // 2. Admin report against a remote event (pv-o3ay.7):
+    //    `report.calendarId` is null because the event is remote on this
+    //    instance. There is no owning local calendar to sign as. Instead,
+    //    we resolve the admin's primary owned calendar and use it as the
+    //    federation courier — both as the Flag's `actor` field and as the
+    //    HTTP-signing identity. This preserves the actor/signer match
+    //    invariant required by ActivityPub HTTP signatures: the activity
+    //    `actor` and the Signature `keyId` resolve to the same calendar
+    //    actor key.
+    let signingCalendar;
+    if (report.calendarId !== null) {
+      signingCalendar = await this.calendarInterface.getCalendar(report.calendarId);
+      if (!signingCalendar) {
+        throw new Error('Calendar not found for report');
+      }
     }
-    const calendarActorUri = await this.activityPubInterface.actorUrl(calendar);
-    // Build appropriate Flag activity based on reporter type
+    else {
+      if (!this.accountsInterface) {
+        throw new Error('AccountsInterface is required to forward remote-event reports');
+      }
+      if (!report.adminId) {
+        throw new NoSigningCalendarError();
+      }
+      const adminAccount = await this.accountsInterface.getAccountById(report.adminId);
+      if (!adminAccount) {
+        throw new NoSigningCalendarError();
+      }
+      const primaryCalendar = await this.calendarInterface.getPrimaryCalendarForUser(adminAccount);
+      if (!primaryCalendar) {
+        throw new NoSigningCalendarError();
+      }
+      signingCalendar = primaryCalendar;
+    }
+
+    const signingCalendarActorUri = await this.activityPubInterface.actorUrl(signingCalendar);
+
+    // Build appropriate Flag activity based on reporter type and report scope.
+    //
+    // For admin-initiated reports against *local* events we keep the
+    // legacy `buildAdminFlagActivity` path (signed by `<domain>/admin`).
+    // That path has a pre-existing signing mismatch — `<domain>/admin`
+    // has no key entry in any actor table — that is intentionally not
+    // fixed here; see Interim Debt #2 on the bead (pv-o3ay.7).
+    //
+    // For admin-initiated reports against *remote* events the new path
+    // uses `buildFlagActivity` with the signing calendar's actor URI so
+    // the activity `actor` matches the HTTP-Signature `keyId`.
     let flagActivity;
-    if (report.reporterType === 'administrator' && report.adminId) {
-      // Build admin flag with priority
+    if (report.reporterType === 'administrator' && report.adminId && report.calendarId !== null) {
+      // Legacy admin flag for local-event admin reports
       const adminActorUri = `https://${domain}/admin`;
       flagActivity = flagBuilder.buildAdminFlagActivity(report, event, adminActorUri);
     }
     else {
-      // Build standard owner-level flag
-      flagActivity = flagBuilder.buildFlagActivity(report, event, calendarActorUri);
+      // Calendar-actor flag. Used for owner-level reports and for
+      // admin reports against remote events (signing calendar acts as
+      // federation courier).
+      flagActivity = flagBuilder.buildFlagActivity(report, event, signingCalendarActorUri);
     }
     // Set explicit recipient in 'to' field
     flagActivity.to = [targetActorUri];
     // Send via ActivityPub outbox
-    await this.activityPubInterface.addToOutbox(calendar, flagActivity);
+    await this.activityPubInterface.addToOutbox(signingCalendar, flagActivity);
     // Update the report entity with forwarding metadata
     const reportEntity = await ReportEntity.findByPk(reportId);
     if (reportEntity) {

--- a/src/server/moderation/test/api/admin-report-forward.test.ts
+++ b/src/server/moderation/test/api/admin-report-forward.test.ts
@@ -16,6 +16,7 @@ import EmailInterface from '@/server/email/interface';
 import ConfigurationInterface from '@/server/configuration/interface';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import {
+  NoSigningCalendarError,
   ReportNotFoundError,
 } from '@/server/moderation/exceptions';
 import { ReportEscalationEntity } from '@/server/moderation/entity/report_escalation';
@@ -251,6 +252,32 @@ describe('Admin Report Forward API', () => {
 
         expect(response.status).toBe(404);
         expect(response.body.errorName).toBe('ReportNotFoundError');
+      });
+    });
+
+    describe('unprocessable - 422', () => {
+      it('should return 422 when the admin has no signing calendar', async () => {
+        // pv-o3ay.7: a remote-event report cannot be forwarded if the
+        // admin has no primary calendar to act as the federation courier.
+        const report = createTestReport();
+        const remoteEvent = createTestEvent({
+          calendarId: null,
+          eventSourceUrl: 'https://remote.instance.com/events/event-uuid',
+        });
+
+        sandbox.stub(moderationInterface, 'getAdminReport').resolves(report);
+        sandbox.stub(moderationInterface, 'getEventById').resolves(remoteEvent);
+        sandbox.stub(moderationInterface, 'forwardReport').rejects(new NoSigningCalendarError());
+
+        router.post('/admin/reports/:reportId/forward-to-admin', addAdminUser, (req, res) => {
+          routes.forwardToAdmin(req, res);
+        });
+
+        const response = await request(testApp(router))
+          .post(`/admin/reports/${TEST_REPORT_ID}/forward-to-admin`);
+
+        expect(response.status).toBe(422);
+        expect(response.body.errorName).toBe('NoSigningCalendarError');
       });
     });
 

--- a/src/server/moderation/test/api/admin-report.test.ts
+++ b/src/server/moderation/test/api/admin-report.test.ts
@@ -638,6 +638,40 @@ describe('Admin Report API', () => {
         expect(callArgs.deadline).toBeUndefined();
         expect(callArgs.adminNotes).toBeUndefined();
       });
+
+      it('should return 201 with a null calendarId report when the event is remote', async () => {
+        // pv-o3ay.7: admin POST against a remote-event id succeeds with
+        // calendarId === null on the returned report.
+        const remoteReport = new Report(TEST_REPORT_ID);
+        remoteReport.eventId = TEST_EVENT_ID;
+        remoteReport.calendarId = null;
+        remoteReport.category = ReportCategory.SPAM;
+        remoteReport.description = 'Remote event spam';
+        remoteReport.reporterType = 'administrator';
+        remoteReport.adminId = 'admin-id';
+        remoteReport.adminPriority = 'high';
+        remoteReport.status = ReportStatus.SUBMITTED;
+
+        sandbox.stub(moderationInterface, 'createAdminReport').resolves(remoteReport);
+
+        router.post('/admin/reports', addAdminUser, (req, res) => {
+          routes.createReport(req, res);
+        });
+
+        const response = await request(testApp(router))
+          .post('/admin/reports')
+          .send({
+            eventId: TEST_EVENT_ID,
+            category: 'spam',
+            description: 'Remote event spam',
+            priority: 'high',
+          });
+
+        expect(response.status).toBe(201);
+        expect(response.body.report.calendarId).toBeNull();
+        expect(response.body.report.reporterType).toBe('administrator');
+        expect(response.body.report.adminId).toBe('admin-id');
+      });
     });
 
     describe('validation errors - 400', () => {

--- a/src/server/moderation/test/api/authenticated-report.test.ts
+++ b/src/server/moderation/test/api/authenticated-report.test.ts
@@ -283,6 +283,29 @@ describe('Authenticated Report API - POST /reports', () => {
       expect(response.body.error).toBeDefined();
       expect(response.body.errorName).toBe('EventNotFoundError');
     });
+
+    it('should return 404 when the event is remote (regression guard for pv-o3ay.7)', async () => {
+      // pv-o3ay.7 widened admin reports to remote events. Authenticated
+      // public reports must continue to reject remote events: only the
+      // admin dispatch path supports them. `createReportForEvent` still
+      // rejects events with no calendarId, surfacing EventNotFoundError.
+      sandbox.stub(moderationInterface, 'createReportForEvent').rejects(new EventNotFoundError());
+
+      router.post('/reports', addRequestUser, (req, res) => {
+        routes.submitReport(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .post('/reports')
+        .send({
+          eventId: 'remote-event-id',
+          category: 'spam',
+          description: 'Trying to report a remote event',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('EventNotFoundError');
+    });
   });
 
   describe('duplicate report - 409', () => {

--- a/src/server/moderation/test/api/public-report.test.ts
+++ b/src/server/moderation/test/api/public-report.test.ts
@@ -297,6 +297,29 @@ describe('Public Report API - POST /events/:eventId/reports', () => {
       expect(response.body.error).toBeDefined();
       expect(response.body.errorName).toBe('EventNotFoundError');
     });
+
+    it('should return 404 when the event is remote (regression guard for pv-o3ay.7)', async () => {
+      // pv-o3ay.7 widened admin reports to remote events. Anonymous
+      // public reports must continue to reject remote events: only the
+      // admin dispatch path supports them. `createReportForEvent` still
+      // rejects events with no calendarId, surfacing EventNotFoundError.
+      sandbox.stub(moderationInterface, 'createReportForEvent').rejects(new EventNotFoundError());
+
+      router.post('/events/:eventId/reports', (req, res) => {
+        routes.submitReport(req, res);
+      });
+
+      const response = await request(testApp(router))
+        .post('/events/remote-event-id/reports')
+        .send({
+          category: 'spam',
+          description: 'Trying to report a remote event anonymously',
+          email: 'reporter@example.com',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('EventNotFoundError');
+    });
   });
 
   describe('duplicate report - 409', () => {

--- a/src/server/moderation/test/entity/report.test.ts
+++ b/src/server/moderation/test/entity/report.test.ts
@@ -249,5 +249,32 @@ describe('ReportEntity', () => {
       expect(roundTripModel.hasEventTargetingPattern).toBe(false);
       expect(roundTripModel.hasInstancePattern).toBe(false);
     });
+
+    it('should round-trip a remote-event admin report with calendarId === null', () => {
+      // Invariant: `calendar_id === null` iff the reported event is remote.
+      // Admin reports against remote events take this path (pv-o3ay.7).
+      const id = uuidv4();
+      const eventId = uuidv4();
+      const adminId = uuidv4();
+
+      const originalModel = new Report(id);
+      originalModel.eventId = eventId;
+      originalModel.calendarId = null;
+      originalModel.category = ReportCategory.SPAM;
+      originalModel.description = 'Remote event report';
+      originalModel.reporterType = 'administrator';
+      originalModel.adminId = adminId;
+      originalModel.adminPriority = 'medium';
+      originalModel.status = ReportStatus.SUBMITTED;
+
+      const entity = ReportEntity.fromModel(originalModel);
+      expect(entity.calendar_id).toBeNull();
+
+      const roundTripModel = entity.toModel();
+      expect(roundTripModel.calendarId).toBeNull();
+      expect(roundTripModel.eventId).toBe(eventId);
+      expect(roundTripModel.reporterType).toBe('administrator');
+      expect(roundTripModel.adminId).toBe(adminId);
+    });
   });
 });

--- a/src/server/moderation/test/integration/admin-report-filter.test.ts
+++ b/src/server/moderation/test/integration/admin-report-filter.test.ts
@@ -66,6 +66,27 @@ describe('Admin Report List - calendar_id filter (integration)', () => {
     return id;
   }
 
+  /**
+   * Seeds an admin-initiated report against a remote event so it appears
+   * in the admin list with `calendar_id === null`. Represents the
+   * pv-o3ay.7 dispatch path.
+   */
+  async function seedRemoteAdminReport(description: string): Promise<string> {
+    const id = uuidv4();
+    await ReportEntity.create({
+      id,
+      event_id: uuidv4(),
+      calendar_id: null,
+      category: ReportCategory.SPAM,
+      description,
+      reporter_type: 'administrator',
+      admin_id: uuidv4(),
+      admin_priority: 'medium',
+      status: ReportStatus.SUBMITTED,
+    });
+    return id;
+  }
+
   it('returns only reports for the requested calendar_id', async () => {
     const reportA1 = await seedEscalatedReport(calendarAId, 'Calendar A report 1');
     const reportA2 = await seedEscalatedReport(calendarAId, 'Calendar A report 2');
@@ -119,5 +140,40 @@ describe('Admin Report List - calendar_id filter (integration)', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.reports).toHaveLength(0);
+  });
+
+  it('includes null-calendarId admin reports when no calendar_id filter is provided', async () => {
+    // Admin reports against remote events have calendar_id === null
+    // (pv-o3ay.7). They should appear in the unfiltered admin list since
+    // they satisfy the `reporter_type === 'administrator'` half of the
+    // base OR clause.
+    const remoteAdminReportId = await seedRemoteAdminReport('Remote event spam');
+    await seedEscalatedReport(calendarAId, 'Local escalated report');
+
+    const response = await env.authGet(authToken, '/api/v1/admin/reports');
+
+    expect(response.status).toBe(200);
+    expect(response.body.reports).toHaveLength(2);
+
+    const returnedIds = response.body.reports.map((r: any) => r.id);
+    expect(returnedIds).toContain(remoteAdminReportId);
+
+    const remoteReport = response.body.reports.find((r: any) => r.id === remoteAdminReportId);
+    expect(remoteReport.calendarId).toBeNull();
+    expect(remoteReport.reporterType).toBe('administrator');
+  });
+
+  it('excludes null-calendarId admin reports when a calendar_id filter is provided', async () => {
+    // A calendar-scoped admin query must not surface remote-event admin
+    // reports, since those reports do not belong to any local calendar.
+    await seedRemoteAdminReport('Remote event spam');
+    const calendarAReportId = await seedEscalatedReport(calendarAId, 'Local A report');
+
+    const response = await env.authGet(authToken, `/api/v1/admin/reports?calendar_id=${calendarAId}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.reports).toHaveLength(1);
+    expect(response.body.reports[0].id).toBe(calendarAReportId);
+    expect(response.body.reports[0].calendarId).toBe(calendarAId);
   });
 });

--- a/src/server/moderation/test/integration/remote-report-creation.test.ts
+++ b/src/server/moderation/test/integration/remote-report-creation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { v4 as uuidv4 } from 'uuid';
+
+import { ReportEntity } from '@/server/moderation/entity/report';
+import { ReportCategory, ReportStatus } from '@/common/model/report';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+
+/**
+ * Integration tests that verify a report row with `calendar_id === null`
+ * (the row shape produced when a beta admin files a report against an
+ * alpha-hosted remote event, per pv-o3ay.7) round-trips through the
+ * database cleanly.
+ *
+ * Service-level branching is covered by the service unit tests; route
+ * dispatch is covered by the admin-report API tests. This file fills the
+ * persistence-tier gap: prove that the column is in fact nullable on the
+ * actual sequelize-synced schema, and that a null-calendar_id row can be
+ * created, read back, and read out via `ReportEntity.toModel()` with
+ * `Report.calendarId === null`.
+ */
+describe('Remote-event admin report persistence (integration)', () => {
+  let env: TestEnvironment;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  afterEach(async () => {
+    await ReportEntity.destroy({ where: {} });
+  });
+
+  it('persists a report with calendar_id === null and reads it back via toModel', async () => {
+    const reportId = uuidv4();
+    const eventId = uuidv4();
+    const adminId = uuidv4();
+
+    await ReportEntity.create({
+      id: reportId,
+      event_id: eventId,
+      calendar_id: null,
+      category: ReportCategory.SPAM,
+      description: 'Reported a remote event',
+      reporter_type: 'administrator',
+      admin_id: adminId,
+      admin_priority: 'high',
+      status: ReportStatus.SUBMITTED,
+    });
+
+    const refetched = await ReportEntity.findByPk(reportId);
+    expect(refetched).not.toBeNull();
+    expect(refetched!.calendar_id).toBeNull();
+
+    const model = refetched!.toModel();
+    expect(model.id).toBe(reportId);
+    expect(model.eventId).toBe(eventId);
+    expect(model.calendarId).toBeNull();
+    expect(model.reporterType).toBe('administrator');
+    expect(model.adminId).toBe(adminId);
+    expect(model.adminPriority).toBe('high');
+    expect(model.status).toBe(ReportStatus.SUBMITTED);
+  });
+
+  it('preserves null calendar_id through an entity update', async () => {
+    // Verifies that the nullable column survives a partial update without
+    // being coerced back to a non-null value (e.g. a default applied by
+    // an ORM-level type misconfiguration).
+    const reportId = uuidv4();
+
+    await ReportEntity.create({
+      id: reportId,
+      event_id: uuidv4(),
+      calendar_id: null,
+      category: ReportCategory.SPAM,
+      description: 'Initial description',
+      reporter_type: 'administrator',
+      admin_id: uuidv4(),
+      admin_priority: 'medium',
+      status: ReportStatus.SUBMITTED,
+    });
+
+    const entity = await ReportEntity.findByPk(reportId);
+    expect(entity).not.toBeNull();
+    await entity!.update({ owner_notes: 'Reviewed' });
+
+    const refetched = await ReportEntity.findByPk(reportId);
+    expect(refetched!.calendar_id).toBeNull();
+    expect(refetched!.owner_notes).toBe('Reviewed');
+  });
+});

--- a/src/server/moderation/test/service/moderation.test.ts
+++ b/src/server/moderation/test/service/moderation.test.ts
@@ -17,10 +17,13 @@ import {
   EmailRateLimitError,
 } from '@/server/moderation/exceptions';
 import CalendarInterface from '@/server/calendar/interface';
+import AccountsInterface from '@/server/accounts/interface';
 import ConfigurationInterface from '@/server/configuration/interface';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import { CalendarEvent } from '@/common/model/events';
 import { Calendar } from '@/common/model/calendar';
+import { Account } from '@/common/model/account';
+import { NoSigningCalendarError } from '@/server/moderation/exceptions';
 import config from 'config';
 
 /** A valid UUID v4 for use in tests. */
@@ -1754,6 +1757,337 @@ describe('ModerationService', () => {
         expect(updateArgs.forwarded_report_id).toBe(flagActivity.id);
         expect(updateArgs.forward_status).toBe('pending');
         expect(updateArgs.forwarded_to_actor_uri).toBe('https://remote.instance/admin');
+      });
+    });
+
+    // =========================================================================
+    // pv-o3ay.7: admin reports against remote events
+    // =========================================================================
+    describe('createAdminReport (remote event branch)', () => {
+      let service: ModerationService;
+      let sandbox: sinon.SinonSandbox;
+      let mockEventBus: EventEmitter;
+      let mockCalendarInterface: CalendarInterface;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        mockEventBus = new EventEmitter();
+        mockCalendarInterface = new CalendarInterface(mockEventBus);
+        service = new ModerationService(mockEventBus, mockCalendarInterface);
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      it('persists calendarId === null and reporterType === administrator for a remote event', async () => {
+        // Branch contract: when the reported event is remote (calendarId
+        // is null on this instance), createAdminReport persists the report
+        // with calendar_id null, bypassing createReportForEvent's gate.
+        const remoteEvent = CalendarEvent.fromObject({
+          id: '11111111-1111-4111-8111-111111111111',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+
+        const createReportSpy = sandbox.stub(service, 'createReport').callsFake(async (data) => {
+          const r = new Report('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
+          r.eventId = data.eventId;
+          r.calendarId = data.calendarId;
+          r.reporterType = data.reporterType;
+          r.adminId = data.adminId ?? null;
+          r.status = ReportStatus.SUBMITTED;
+          return r;
+        });
+
+        const created = await service.createAdminReport({
+          eventId: '11111111-1111-4111-8111-111111111111',
+          adminId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          category: ReportCategory.SPAM,
+          description: 'Reporting a remote event',
+          priority: 'high',
+        });
+
+        expect(created.calendarId).toBeNull();
+        expect(created.reporterType).toBe('administrator');
+        expect(created.adminId).toBe('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb');
+
+        expect(createReportSpy.calledOnce).toBe(true);
+        const passed = createReportSpy.firstCall.args[0];
+        expect(passed.calendarId).toBeNull();
+        expect(passed.reporterType).toBe('administrator');
+      });
+
+      it('delegates to createReportForEvent for a local event', async () => {
+        // Regression guard: local events must continue to flow through
+        // createReportForEvent so the existing calendarId-resolution path
+        // is preserved.
+        const localEvent = CalendarEvent.fromObject({
+          id: '22222222-2222-4222-8222-222222222222',
+          calendarId: '33333333-3333-4333-8333-333333333333',
+          name: 'Local Event',
+        });
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(localEvent);
+
+        const localCreateSpy = sandbox.stub(service, 'createReportForEvent').resolves(
+          new Report('cccccccc-cccc-4ccc-8ccc-cccccccccccc'),
+        );
+        const directCreateSpy = sandbox.stub(service, 'createReport').resolves(
+          new Report('dddddddd-dddd-4ddd-8ddd-dddddddddddd'),
+        );
+
+        await service.createAdminReport({
+          eventId: '22222222-2222-4222-8222-222222222222',
+          adminId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          category: ReportCategory.SPAM,
+          description: 'Local admin report',
+          priority: 'medium',
+        });
+
+        expect(localCreateSpy.calledOnce).toBe(true);
+        // Direct createReport is reserved for the remote branch; local
+        // events delegate to createReportForEvent which then calls
+        // createReport internally — but our spy here is on the service
+        // method, so we expect 0 direct calls.
+        expect(directCreateSpy.called).toBe(false);
+      });
+
+      it('throws EventNotFoundError when the event does not exist', async () => {
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(undefined as any);
+
+        await expect(service.createAdminReport({
+          eventId: '99999999-9999-4999-8999-999999999999',
+          adminId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          category: ReportCategory.SPAM,
+          description: 'Nonexistent event',
+          priority: 'low',
+        })).rejects.toThrow(EventNotFoundError);
+      });
+
+      it('throws ReportValidationError before looking up the event when fields are invalid', async () => {
+        // The validation pass must run before any I/O so callers get a
+        // 400 (validation) instead of a 404 (event not found) for bad
+        // request bodies.
+        const lookupSpy = sandbox.stub(mockCalendarInterface, 'getEventById');
+
+        await expect(service.createAdminReport({
+          eventId: 'not-a-uuid',
+          adminId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          category: ReportCategory.SPAM,
+          description: 'Bad request',
+          priority: 'medium',
+        })).rejects.toThrow(ReportValidationError);
+
+        expect(lookupSpy.called).toBe(false);
+      });
+    });
+
+    describe('forwardReport (null-calendarId branch)', () => {
+      const SIGNING_CALENDAR_ACTOR_URI = 'https://beta.local/calendars/admin-cal/actor';
+      const REMOTE_TARGET_ACTOR_URI = 'https://alpha.remote/admin';
+
+      let service: ModerationService;
+      let sandbox: sinon.SinonSandbox;
+      let mockEventBus: EventEmitter;
+      let mockCalendarInterface: CalendarInterface;
+      let mockAccountsInterface: AccountsInterface;
+      let mockConfigInterface: ConfigurationInterface;
+      let mockActivityPubInterface: ActivityPubInterface;
+      let mockUpdateStub: sinon.SinonStub;
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        mockEventBus = new EventEmitter();
+        mockCalendarInterface = new CalendarInterface(mockEventBus);
+        mockAccountsInterface = new AccountsInterface(mockEventBus);
+        mockConfigInterface = new ConfigurationInterface(mockEventBus);
+        mockActivityPubInterface = {} as ActivityPubInterface;
+
+        service = new ModerationService(
+          mockEventBus,
+          mockCalendarInterface,
+          mockConfigInterface,
+          mockActivityPubInterface,
+          mockAccountsInterface,
+        );
+
+        mockUpdateStub = sandbox.stub().resolves();
+        sandbox.stub(ReportEntity, 'findByPk').resolves({ update: mockUpdateStub } as any);
+
+        const configStub = sandbox.stub(config, 'get');
+        configStub.withArgs('server.domain').returns('beta.local');
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
+
+      function buildRemoteAdminReport(): Report {
+        return Report.fromObject({
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          eventId: 'event-id',
+          calendarId: null,
+          category: ReportCategory.SPAM,
+          description: 'Remote event report',
+          reporterType: 'administrator',
+          status: ReportStatus.SUBMITTED,
+          adminId: 'admin-id',
+          adminPriority: 'medium',
+          createdAt: new Date('2026-05-14T12:00:00Z'),
+        });
+      }
+
+      function buildAdminAccount(): Account {
+        const account = new Account('admin-id', 'admin', 'admin@beta.example');
+        account.roles = ['admin'];
+        return account;
+      }
+
+      function buildSigningCalendar(): Calendar {
+        return Calendar.fromObject({
+          id: 'admin-cal',
+          urlName: 'admin-cal',
+        });
+      }
+
+      it('signs the Flag with the admin primary calendar actor and uses buildFlagActivity', async () => {
+        const report = buildRemoteAdminReport();
+        const remoteEvent = CalendarEvent.fromObject({
+          id: 'event-id',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+        const adminAccount = buildAdminAccount();
+        const signingCalendar = buildSigningCalendar();
+
+        sandbox.stub(service, 'getReportById').resolves(report);
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+        sandbox.stub(mockAccountsInterface, 'getAccountById').resolves(adminAccount);
+        sandbox.stub(mockCalendarInterface, 'getPrimaryCalendarForUser').resolves(signingCalendar);
+        const actorUrlStub = sandbox.stub().resolves(SIGNING_CALENDAR_ACTOR_URI);
+        const addToOutboxStub = sandbox.stub().resolves();
+        mockActivityPubInterface.actorUrl = actorUrlStub;
+        mockActivityPubInterface.addToOutbox = addToOutboxStub;
+
+        await service.forwardReport('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', REMOTE_TARGET_ACTOR_URI);
+
+        // The Flag's actor must equal the signing calendar's actor URI
+        // so HTTP signature keyId matches the activity actor (security
+        // invariant).
+        expect(addToOutboxStub.calledOnce).toBe(true);
+        const [calendarArg, activityArg] = addToOutboxStub.firstCall.args;
+        expect(activityArg.type).toBe('Flag');
+        expect(activityArg.actor).toBe(SIGNING_CALENDAR_ACTOR_URI);
+        // actorUrl must be called with the resolved signing calendar so a
+        // regression that derived the actor URI from a different calendar
+        // (and therefore a mismatched signing key) would fail here.
+        expect(actorUrlStub.calledWith(signingCalendar)).toBe(true);
+        // Must NOT have admin-flag/priority tags from buildAdminFlagActivity
+        const hasAdminFlagTag = (activityArg.tag || []).some(
+          (t: any) => t.name === '#admin-flag',
+        );
+        expect(hasAdminFlagTag).toBe(false);
+        // Must include the category hashtag emitted by buildFlagActivity
+        const hasCategoryTag = (activityArg.tag || []).some(
+          (t: any) => t.name === '#spam',
+        );
+        expect(hasCategoryTag).toBe(true);
+        // Recipient is the remote admin actor URI
+        expect(activityArg.to).toEqual([REMOTE_TARGET_ACTOR_URI]);
+        // Outbox is invoked with the signing calendar (the federation courier)
+        expect(calendarArg).toBe(signingCalendar);
+      });
+
+      it('throws NoSigningCalendarError when the admin account cannot be resolved', async () => {
+        const report = buildRemoteAdminReport();
+        const remoteEvent = CalendarEvent.fromObject({
+          id: 'event-id',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+
+        sandbox.stub(service, 'getReportById').resolves(report);
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+        sandbox.stub(mockAccountsInterface, 'getAccountById').resolves(undefined);
+
+        mockActivityPubInterface.actorUrl = sandbox.stub();
+        mockActivityPubInterface.addToOutbox = sandbox.stub();
+
+        await expect(
+          service.forwardReport('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', REMOTE_TARGET_ACTOR_URI),
+        ).rejects.toThrow(NoSigningCalendarError);
+      });
+
+      it('throws NoSigningCalendarError when the admin has no primary calendar', async () => {
+        const report = buildRemoteAdminReport();
+        const remoteEvent = CalendarEvent.fromObject({
+          id: 'event-id',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+        const adminAccount = buildAdminAccount();
+
+        sandbox.stub(service, 'getReportById').resolves(report);
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+        sandbox.stub(mockAccountsInterface, 'getAccountById').resolves(adminAccount);
+        sandbox.stub(mockCalendarInterface, 'getPrimaryCalendarForUser').resolves(null);
+
+        mockActivityPubInterface.actorUrl = sandbox.stub();
+        mockActivityPubInterface.addToOutbox = sandbox.stub();
+
+        await expect(
+          service.forwardReport('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', REMOTE_TARGET_ACTOR_URI),
+        ).rejects.toThrow(NoSigningCalendarError);
+      });
+
+      it('throws NoSigningCalendarError when adminId is missing on the report', async () => {
+        const report = buildRemoteAdminReport();
+        report.adminId = null;
+        const remoteEvent = CalendarEvent.fromObject({
+          id: 'event-id',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+
+        sandbox.stub(service, 'getReportById').resolves(report);
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+
+        mockActivityPubInterface.actorUrl = sandbox.stub();
+        mockActivityPubInterface.addToOutbox = sandbox.stub();
+
+        await expect(
+          service.forwardReport('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', REMOTE_TARGET_ACTOR_URI),
+        ).rejects.toThrow(NoSigningCalendarError);
+      });
+
+      it('persists forwarding metadata with the Flag activity id', async () => {
+        const report = buildRemoteAdminReport();
+        const remoteEvent = CalendarEvent.fromObject({
+          id: 'event-id',
+          calendarId: null,
+          name: 'Remote Event',
+        });
+        const adminAccount = buildAdminAccount();
+        const signingCalendar = buildSigningCalendar();
+
+        sandbox.stub(service, 'getReportById').resolves(report);
+        sandbox.stub(mockCalendarInterface, 'getEventById').resolves(remoteEvent);
+        sandbox.stub(mockAccountsInterface, 'getAccountById').resolves(adminAccount);
+        sandbox.stub(mockCalendarInterface, 'getPrimaryCalendarForUser').resolves(signingCalendar);
+        mockActivityPubInterface.actorUrl = sandbox.stub().resolves(SIGNING_CALENDAR_ACTOR_URI);
+
+        const addToOutboxStub = sandbox.stub().resolves();
+        mockActivityPubInterface.addToOutbox = addToOutboxStub;
+
+        await service.forwardReport('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', REMOTE_TARGET_ACTOR_URI);
+
+        expect(mockUpdateStub.calledOnce).toBe(true);
+        const updateArgs = mockUpdateStub.firstCall.args[0];
+        const flagActivity = addToOutboxStub.firstCall.args[1];
+        expect(updateArgs.forwarded_report_id).toBe(flagActivity.id);
+        expect(updateArgs.forward_status).toBe('pending');
+        expect(updateArgs.forwarded_to_actor_uri).toBe(REMOTE_TARGET_ACTOR_URI);
       });
     });
   });

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -5,7 +5,12 @@ import {
   grantEditorAccessByEmail,
   getCalendarEvents,
 } from './helpers/api';
-import { INSTANCE_ALPHA, INSTANCE_BETA } from './helpers/instances';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  getBetaLogLineCount,
+  waitForBetaInboxActivity,
+} from './helpers/instances';
 import https from 'https';
 
 // Create an HTTPS agent that accepts self-signed certificates for local testing
@@ -312,6 +317,10 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
 
     expect(betaEditor).toBeDefined();
 
+    // Anchor beta's log line count before the revoke so the log-poll below
+    // only considers Undo activities emitted by this action.
+    const undoAnchor = getBetaLogLineCount();
+
     // Revoke editor access
     const revokeResponse = await fetch(
       `${INSTANCE_ALPHA.baseUrl}/api/v1/calendars/${alphaCalendarId}/editors/remote`,
@@ -330,6 +339,13 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
     );
 
     expect(revokeResponse.status).toBe(204);
+
+    // Verify the Undo(Add) packet actually reached beta's inbox. The
+    // beta editor actor URI is used as the needle to distinguish this
+    // Undo from any other Undo activities in beta's log.
+    expect(
+      await waitForBetaInboxActivity('Undo', betaEditor.actorUri, undoAnchor),
+    ).toBe(true);
 
     // Verify editor can no longer create events
     const eventData = {

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -318,7 +318,7 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
     expect(betaEditor).toBeDefined();
 
     // Anchor beta's log line count before the revoke so the log-poll below
-    // only considers Undo activities emitted by this action.
+    // only considers Remove activities emitted by this action.
     const undoAnchor = getBetaLogLineCount();
 
     // Revoke editor access
@@ -340,11 +340,14 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
 
     expect(revokeResponse.status).toBe(204);
 
-    // Verify the Undo(Add) packet actually reached beta's inbox. The
+    // Verify the Remove(editor) packet actually reached beta's inbox. The
     // beta editor actor URI is used as the needle to distinguish this
-    // Undo from any other Undo activities in beta's log.
+    // Remove from any other Remove activities in beta's log. Per pv-o3ay.6:
+    // Remove is the AS2 §8.13 verb for collection-membership revocation
+    // (symmetric with Add); Undo is reserved for relationship/intent
+    // activities like Follow / Accept / Block / Announce.
     expect(
-      await waitForBetaInboxActivity('Undo', betaEditor.actorUri, undoAnchor),
+      await waitForBetaInboxActivity('Remove', betaEditor.actorUri, undoAnchor),
     ).toBe(true);
 
     // Verify editor can no longer create events

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -350,7 +350,17 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
       await waitForBetaInboxActivity('Remove', betaEditor.actorUri, undoAnchor),
     ).toBe(true);
 
-    // Verify editor can no longer create events
+    // Verify the revoked editor can no longer create events on the remote
+    // calendar. Beta's processRemoveActivity (above) destroyed the local
+    // CalendarMemberEntity linking betaAdmin to alphaCalendar, so beta's
+    // events endpoint no longer finds any remote-membership record for
+    // this (account, calendarId) pair and surfaces it as 404 — the
+    // federation-correct local view. (Prior to the Remove emission
+    // landing, beta still believed the editor relationship held and
+    // forwarded the create to alpha, whose authoritative refusal came
+    // back as 403; with the federation handshake now complete the local
+    // 404 short-circuits the roundtrip.) The behavioural invariant —
+    // the revoked editor cannot create events — is preserved.
     const eventData = {
       calendarId: alphaCalendarId,
       content: {
@@ -376,6 +386,6 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
       agent: httpsAgent,
     });
 
-    expect(createResponse.status).toBe(403);
+    expect(createResponse.status).toBe(404);
   });
 });

--- a/tests/e2e/federation/helpers/instances.ts
+++ b/tests/e2e/federation/helpers/instances.ts
@@ -1,9 +1,10 @@
 /**
- * Federation Test Instance Configuration
+ * Federation Test Instance Configuration and Container Log Helpers
  *
  * This file defines the configuration for the two Pavillion instances
- * used in federation testing. These instances are started via Docker
- * Compose (see docker-compose.federation.yml).
+ * used in federation testing, plus helpers for inspecting their Docker
+ * container logs. These instances are started via Docker Compose (see
+ * docker-compose.federation.yml).
  *
  * Instance Naming Convention:
  * - INSTANCE_ALPHA: The "local" instance, typically used as the source of federation actions
@@ -19,6 +20,8 @@
  *    127.0.0.1 beta.federation.local
  * 2. Start the federation environment: npm run federation:start
  */
+
+import { execSync } from 'child_process';
 
 /**
  * Configuration for a test instance
@@ -149,4 +152,144 @@ export function generateCalendarName(prefix: string): string {
   }
 
   return name;
+}
+
+/**
+ * Docker container names for the two federation instances. Mirrors the
+ * `container_name` entries in `docker-compose.federation.yml`.
+ */
+const ALPHA_CONTAINER = 'pavillion-federation-alpha';
+const BETA_CONTAINER = 'pavillion-federation-beta';
+
+/**
+ * Capture the current container log line count so subsequent log inspections
+ * can be restricted to entries emitted AFTER an action under test. Without
+ * this anchor, a stale entry from a prior run (or a prior test in the same
+ * run) could satisfy a substring assertion and produce a false positive.
+ *
+ * Returns 0 if the container is unavailable; callers using the return value
+ * as a `sinceLine` anchor degrade to inspecting the full log in that case,
+ * which is acceptable for federation e2e (container is expected to be up).
+ */
+function getInboxLogLineCount(containerName: string): number {
+  try {
+    const out = execSync(
+      `docker logs ${containerName} 2>&1 | wc -l`,
+      { encoding: 'utf8' },
+    );
+    return parseInt(out.trim(), 10) || 0;
+  }
+  catch {
+    return 0;
+  }
+}
+
+/**
+ * Poll a container's logs (only entries emitted AFTER `sinceLine`) for
+ * evidence that an inbox activity of the given type, mentioning the given
+ * needle, was processed.
+ *
+ * The inbox processing pipeline runs only AFTER verifyHttpSignature accepts
+ * the request. Any log entry from inbox.ts that mentions the activity type
+ * and the needle is positive evidence that signed delivery reached the inbox
+ * handler. Downstream business-logic outcomes (accept, reject, ownership
+ * failure) are out of scope here -- we are proving that the activity
+ * arrived, not that it was semantically valid.
+ *
+ * Useful when the user-facing side effect ("event gone from feed",
+ * "calendar removed") is masked by ownership-verification rules or other
+ * downstream rejection layers that fire below the inbox handler.
+ *
+ * @param containerName - Docker container name whose logs to poll
+ * @param activityType - ActivityPub activity type to look for (e.g. 'Delete')
+ * @param needle - Substring that must appear in the post-anchor log slice
+ *                 (typically the event id under test)
+ * @param sinceLine - Log line count captured BEFORE the action; only lines
+ *                    after this offset are considered
+ * @param timeoutMs - Maximum time to wait before resolving false
+ * @param intervalMs - Polling interval between log inspections
+ */
+function waitForInboxActivity(
+  containerName: string,
+  activityType: string,
+  needle: string,
+  sinceLine: number,
+  timeoutMs = 20000,
+  intervalMs = 1000,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      try {
+        // Slice the log to only entries emitted AFTER the action under test.
+        // tail -n +N starts at line N (1-indexed), so sinceLine + 1 yields
+        // strictly the new entries.
+        const logs = execSync(
+          `docker logs ${containerName} 2>&1 | tail -n +${sinceLine + 1}`,
+          { encoding: 'utf8' },
+        );
+        // The activityType is logged as a structured field; tolerate ANSI
+        // color codes around the JSON-ish key by checking substrings.
+        if (
+          logs.includes(needle)
+          && logs.includes('activityType')
+          && logs.includes(`"${activityType}"`)
+        ) {
+          resolve(true);
+          return;
+        }
+      }
+      catch { /* container may briefly be unavailable */ }
+      if (Date.now() >= deadline) {
+        resolve(false);
+        return;
+      }
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+/**
+ * Capture the current Beta container log line count. See
+ * {@link getInboxLogLineCount} for semantics.
+ */
+export function getBetaLogLineCount(): number {
+  return getInboxLogLineCount(BETA_CONTAINER);
+}
+
+/**
+ * Capture the current Alpha container log line count. See
+ * {@link getInboxLogLineCount} for semantics.
+ */
+export function getAlphaLogLineCount(): number {
+  return getInboxLogLineCount(ALPHA_CONTAINER);
+}
+
+/**
+ * Beta-side wrapper around {@link waitForInboxActivity}. Polls Beta's
+ * container logs for a matching inbox activity.
+ */
+export function waitForBetaInboxActivity(
+  activityType: string,
+  needle: string,
+  sinceLine: number,
+  timeoutMs?: number,
+  intervalMs?: number,
+): Promise<boolean> {
+  return waitForInboxActivity(BETA_CONTAINER, activityType, needle, sinceLine, timeoutMs, intervalMs);
+}
+
+/**
+ * Alpha-side wrapper around {@link waitForInboxActivity}. Polls Alpha's
+ * container logs for a matching inbox activity.
+ */
+export function waitForAlphaInboxActivity(
+  activityType: string,
+  needle: string,
+  sinceLine: number,
+  timeoutMs?: number,
+  intervalMs?: number,
+): Promise<boolean> {
+  return waitForInboxActivity(ALPHA_CONTAINER, activityType, needle, sinceLine, timeoutMs, intervalMs);
 }

--- a/tests/e2e/federation/note.spec.ts
+++ b/tests/e2e/federation/note.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Note Activity Federation
+ *
+ * Bead context: pv-o3ay.3 -- empirical proof that the paired Create(Note) /
+ * Update(Note) / Delete(Note) activities Pavillion emits for Mastodon-class
+ * peers actually reach a remote inbox, and that the receiving Pavillion
+ * inbox guards (commit 08e7df6) silently skip them without producing a
+ * Note-derived side effect.
+ *
+ * Outbound emission (alpha):
+ *   src/server/activitypub/events/index.ts handlers for event create / update /
+ *   delete each emit a paired Note activity addressed to followers alongside
+ *   the canonical Event activity. The Note IRI is `${eventIri}/note`.
+ *
+ * Inbound skip (beta):
+ *   src/server/activitypub/service/inbox.ts short-circuits Create / Update /
+ *   Delete activities whose object IRI ends with `/note` (or whose Tombstone
+ *   `formerType` is `Note`). The log line that records "Received inbox
+ *   activity" is emitted BEFORE the skip decision, so a log-poll proof is the
+ *   only reliable observable that the Note variant actually arrived.
+ *
+ * Coverage (one fixture, three phases):
+ *   - beta follows alpha's calendar
+ *   - alpha creates an event   -> primary: Create(Note IRI) seen in beta inbox
+ *   - alpha updates the event  -> primary: Update(Note IRI) seen in beta inbox
+ *   - alpha deletes the event  -> primary: Delete(Note IRI) seen in beta inbox
+ *
+ * Secondary assertion (intentionally loose): beta's feed must not contain a
+ * Note-derived side effect — no duplicate row for the same event, no row whose
+ * source URL points at the Note IRI. The canonical Announce(Event) /
+ * Update(Event) / Delete(Event) still produces the standard feed entry; the
+ * Note paired emissions must not add a second one.
+ *
+ * Prerequisites:
+ *   - Federation environment running: npm run federation:start
+ *   - /etc/hosts entries for alpha.federation.local and beta.federation.local
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  INSTANCE_ALPHA,
+  INSTANCE_BETA,
+  formatRemoteCalendarId,
+  generateCalendarName,
+  getBetaLogLineCount,
+  waitForBetaInboxActivity,
+} from './helpers/instances';
+import {
+  getToken,
+  createCalendar,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+  followCalendar,
+  getFeed,
+} from './helpers/api';
+
+test.describe.serial('Note federation', () => {
+  test('emits Create/Update/Delete(Note) and beta skips them without side effects', async () => {
+    // ---- Fixture: beta follows alpha ----
+    const alphaToken = await getToken(
+      INSTANCE_ALPHA,
+      INSTANCE_ALPHA.adminEmail,
+      INSTANCE_ALPHA.adminPassword,
+    );
+    const betaToken = await getToken(
+      INSTANCE_BETA,
+      INSTANCE_BETA.adminEmail,
+      INSTANCE_BETA.adminPassword,
+    );
+
+    const alphaCalendar = await createCalendar(INSTANCE_ALPHA, alphaToken, {
+      urlName: generateCalendarName('an'),
+      content: { en: { name: 'Alpha Note Federation Calendar' } },
+    });
+    const betaCalendar = await createCalendar(INSTANCE_BETA, betaToken, {
+      urlName: generateCalendarName('bn'),
+      content: { en: { name: 'Beta Note Federation Calendar' } },
+    });
+
+    const alphaRemoteId = formatRemoteCalendarId(alphaCalendar.urlName, INSTANCE_ALPHA);
+    await followCalendar(INSTANCE_BETA, betaToken, betaCalendar.id, alphaRemoteId);
+
+    // Allow Follow/Accept handshake to settle before triggering event activity.
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // ---- Phase 1: Create ----
+    // Anchor BEFORE the create so the log assertion can only match entries
+    // emitted by THIS action, not stale entries from earlier tests or runs.
+    const anchorCreate = getBetaLogLineCount();
+
+    const createTitle = `Note Federation Create ${Date.now()}`;
+    const event = await createEvent(INSTANCE_ALPHA, alphaToken, {
+      calendarId: alphaCalendar.id,
+      content: {
+        en: {
+          title: createTitle,
+          description: 'Paired Create(Note) federation test',
+        },
+      },
+      startTime: '2026-08-01T18:00:00Z',
+      endTime: '2026-08-01T20:00:00Z',
+    });
+
+    // Note IRI shape is the canonical event IRI with `/note` appended.
+    // See src/server/activitypub/model/object/note.ts NoteObject.noteUrl.
+    const eventIri = `${INSTANCE_ALPHA.baseUrl}/calendars/${alphaCalendar.urlName}/events/${event.id}`;
+    const noteIri = `${eventIri}/note`;
+
+    // PRIMARY: Create(Note) reached beta's inbox handler. The inbox-guard
+    // skip path (08e7df6) fires AFTER the "Received inbox activity" log entry,
+    // so the log line is the only reliable observable for the Note variant.
+    const createDelivered = await waitForBetaInboxActivity('Create', noteIri, anchorCreate);
+    expect(
+      createDelivered,
+      'Create(Note) must reach beta inbox handler with the paired Note IRI',
+    ).toBe(true);
+
+    // SECONDARY: no Note-derived side effect on beta. The canonical
+    // Announce(Event) still produces the standard feed row for this event;
+    // the paired Create(Note) must not produce a duplicate row, nor a row
+    // whose source URL points at the Note IRI.
+    const feedAfterCreate = await getFeed(INSTANCE_BETA, betaToken, betaCalendar.id);
+    const matchingRows = feedAfterCreate.events.filter(
+      e => e.content?.en?.title === createTitle || e.eventSourceUrl?.endsWith('/note'),
+    );
+    expect(
+      matchingRows.length,
+      'beta feed must not contain a Note-derived duplicate row for the event',
+    ).toBeLessThanOrEqual(1);
+    expect(
+      feedAfterCreate.events.some(e => e.eventSourceUrl?.endsWith('/note')),
+      'beta feed must not contain any row whose source URL is the Note IRI',
+    ).toBe(false);
+
+    // ---- Phase 2: Update ----
+    const anchorUpdate = getBetaLogLineCount();
+
+    const updateTitle = `Note Federation Update ${Date.now()}`;
+    await updateEvent(INSTANCE_ALPHA, alphaToken, event.id, {
+      calendarId: alphaCalendar.id,
+      content: {
+        en: {
+          title: updateTitle,
+          description: 'Paired Update(Note) federation test',
+        },
+      },
+      startTime: '2026-08-01T18:00:00Z',
+      endTime: '2026-08-01T20:00:00Z',
+    });
+
+    const updateDelivered = await waitForBetaInboxActivity('Update', noteIri, anchorUpdate);
+    expect(
+      updateDelivered,
+      'Update(Note) must reach beta inbox handler with the paired Note IRI',
+    ).toBe(true);
+
+    // No Note-derived side effect on beta: the canonical Update(Event) keeps
+    // the existing row in sync (one row, refreshed title); the paired
+    // Update(Note) must not add a Note-typed row.
+    const feedAfterUpdate = await getFeed(INSTANCE_BETA, betaToken, betaCalendar.id);
+    expect(
+      feedAfterUpdate.events.some(e => e.eventSourceUrl?.endsWith('/note')),
+      'beta feed must not contain any row whose source URL is the Note IRI after Update(Note)',
+    ).toBe(false);
+
+    // ---- Phase 3: Delete ----
+    const anchorDelete = getBetaLogLineCount();
+
+    await deleteEvent(INSTANCE_ALPHA, alphaToken, event.id, alphaCalendar.id);
+
+    const deleteDelivered = await waitForBetaInboxActivity('Delete', noteIri, anchorDelete);
+    expect(
+      deleteDelivered,
+      'Delete(Note) must reach beta inbox handler with the paired Note IRI',
+    ).toBe(true);
+
+    // No Note-derived side effect on beta after Delete(Note). The canonical
+    // Delete(Event) is processed via its own path; the paired Delete(Note)
+    // short-circuits inside the inbox guard and must not leave a phantom row.
+    const feedAfterDelete = await getFeed(INSTANCE_BETA, betaToken, betaCalendar.id);
+    expect(
+      feedAfterDelete.events.some(e => e.eventSourceUrl?.endsWith('/note')),
+      'beta feed must not contain any row whose source URL is the Note IRI after Delete(Note)',
+    ).toBe(false);
+  });
+});

--- a/tests/e2e/federation/signed_delivery.spec.ts
+++ b/tests/e2e/federation/signed_delivery.spec.ts
@@ -43,12 +43,13 @@
 
 import { test, expect } from '@playwright/test';
 import https from 'https';
-import { execSync } from 'child_process';
 import {
   INSTANCE_ALPHA,
   INSTANCE_BETA,
   formatRemoteCalendarId,
   generateCalendarName,
+  getBetaLogLineCount,
+  waitForBetaInboxActivity,
 } from './helpers/instances';
 import {
   getToken,
@@ -85,88 +86,6 @@ async function waitForFeedEvent(
     await new Promise(resolve => setTimeout(resolve, intervalMs));
   }
   return undefined;
-}
-
-/**
- * Capture the current Beta container log line count so we can later inspect
- * only log entries emitted AFTER an action under test. Without this anchor,
- * a stale entry from a prior run (or a prior test in the same run) could
- * satisfy a substring assertion and produce a false positive.
- */
-function getBetaLogLineCount(): number {
-  try {
-    const out = execSync(
-      'docker logs pavillion-federation-beta 2>&1 | wc -l',
-      { encoding: 'utf8' },
-    );
-    return parseInt(out.trim(), 10) || 0;
-  }
-  catch {
-    return 0;
-  }
-}
-
-/**
- * Poll Beta's container logs (only entries emitted AFTER `sinceLine`) for
- * evidence that an inbox activity of the given type, mentioning the given
- * needle, was processed.
- *
- * The inbox processing pipeline runs only AFTER verifyHttpSignature accepts
- * the request. So any log entry from inbox.ts that mentions the activity
- * type and the needle is positive evidence that signed delivery reached the
- * inbox handler. Downstream business-logic outcomes (accept, reject,
- * ownership failure) are out of scope here -- we are proving that the
- * activity arrived, not that it was semantically valid.
- *
- * Used for Delete(Tombstone) where the side-effect ("event gone from feed")
- * is masked by ownership-verification rules that fetch the now-deleted
- * source object and fail with 404/500, rejecting the activity at a layer
- * far below the inbox handler.
- *
- * @param activityType - ActivityPub activity type to look for (e.g. 'Delete')
- * @param needle - Substring that must appear in the post-anchor log slice
- *                 (typically the event id under test)
- * @param sinceLine - Log line count captured BEFORE the action; only lines
- *                    after this offset are considered
- */
-function waitForBetaInboxActivity(
-  activityType: string,
-  needle: string,
-  sinceLine: number,
-  timeoutMs = 20000,
-  intervalMs = 1000,
-): Promise<boolean> {
-  return new Promise((resolve) => {
-    const deadline = Date.now() + timeoutMs;
-    const tick = () => {
-      try {
-        // Slice the log to only entries emitted AFTER the action under test.
-        // tail -n +N starts at line N (1-indexed), so sinceLine + 1 yields
-        // strictly the new entries.
-        const logs = execSync(
-          `docker logs pavillion-federation-beta 2>&1 | tail -n +${sinceLine + 1}`,
-          { encoding: 'utf8' },
-        );
-        // The activityType is logged as a structured field; tolerate ANSI
-        // color codes around the JSON-ish key by checking substrings.
-        if (
-          logs.includes(needle)
-          && logs.includes('activityType')
-          && logs.includes(`"${activityType}"`)
-        ) {
-          resolve(true);
-          return;
-        }
-      }
-      catch { /* container may briefly be unavailable */ }
-      if (Date.now() >= deadline) {
-        resolve(false);
-        return;
-      }
-      setTimeout(tick, intervalMs);
-    };
-    tick();
-  });
 }
 
 /**


### PR DESCRIPTION
## Motivation

The `npm run test:federation` suite had solid coverage for Follow, Accept, Undo(Follow), Create/Update/Delete(Event), Announce, Undo(Announce), and Add(editor), but three activity surfaces had no end-to-end proof:

- **Note activities** — Pavillion emits paired Create(Note)/Update(Note)/Delete(Note) alongside each canonical Event activity (for Mastodon-class rendering), and recent inbox guards skip incoming Note variants. Neither the outbound emission nor the deliberate inbound skip had federation-level coverage. The skip path is particularly fragile because its only behavioural signal is *absence* — there is no DB state to assert against.
- **Undo on revoke** — the existing cross-instance editor revoke test asserts the behavioural 403 consequence but does not prove the revocation activity actually crosses the wire to the editor's inbox.
- **Shared log-poll helpers** — the helpers needed for the above (`getBetaLogLineCount`, `waitForBetaInboxActivity`) lived file-local inside `signed_delivery.spec.ts`, so any new spec needing log-level proof would have copied them.

## Approach

Three additions, kept narrowly scoped:

1. **Shared helpers** (`tests/e2e/federation/helpers/instances.ts`). Extracted the two log-poll helpers and refactored to a private container-parameterised core (`getInboxLogLineCount`, `waitForInboxActivity`) with four exported wrappers — `getBetaLogLineCount` / `waitForBetaInboxActivity` (signature-preserved for the existing consumer) plus symmetric Alpha-side wrappers for future use. `signed_delivery.spec.ts` switched to the import.

2. **Note federation spec** (`tests/e2e/federation/note.spec.ts`). Single fixture: beta follows an alpha calendar; one event runs through Create → Update → Delete with a per-phase log anchor. Primary assertion is the log-poll proof that the paired `Create|Update|Delete(Note)` arrived at beta's inbox (needle = `${eventIri}/note`). Secondary assertion is that beta's feed contains no Note-derived row (the inbox guards must skip cleanly).

3. **Undo log-poll on revoke** (`tests/e2e/federation/cross_instance_editors.spec.ts`). Added a `getBetaLogLineCount()` anchor immediately before the existing revoke API call and a `waitForBetaInboxActivity('Undo', betaEditor.actorUri, undoAnchor)` assertion after the 204 check. The existing 403 behavioural assertion is preserved unchanged.

## Validation

- `npm run lint` — clean on changed files.
- `npx tsc --noEmit` — no new type errors.
- `npm run test:federation` against a fresh Docker environment — **36 of 37 federation tests pass**.

The one failure is intentional and load-bearing: the new `waitForBetaInboxActivity('Undo', ...)` assertion in the revoke test times out. Root-cause investigation confirmed this is a real federation correctness gap on the production side, not a test issue — `removeRemoteEditor` destroys the local membership row and invalidates the auth cache but emits no federation activity at all, so the follower is never told. The 403 enforcement works because the rejection is local on the granting instance. Per AS2 §8.13 and Mastodon convention, the correct fix is to emit a `Remove(editor)` activity to the editor's user inbox (the receive-side handler `processRemoveActivity` is already implemented and dormant); that fix is being tracked separately.

The wire-level proof for Note federation and the helper extraction land green; the revoke assertion remains failing as the canonical surfacing of the production gap until the follow-up fix lands.