### PR TITLE
fix(federation): emit Remove(editor) on cross-instance editor revoke

### DIFF
--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -235,6 +235,25 @@ export default class ActivityPubInterface {
     return this.federationPublisher.sendEditorInvite(calendar, remoteUserActor);
   }
 
+  /**
+   * Sends a Remove(remoteUserActor) editor-revoke activity from a local
+   * calendar to a remote user actor via the outbox (fire-and-forget). The
+   * activity is signed by the calendar actor (per pv-dyyw signing table)
+   * and anchored on the calendar's own outbox. Symmetric with
+   * `sendEditorInvite`: Add/Remove is the AS2 §8.13 pair for
+   * collection-membership management.
+   *
+   * @param calendar The local calendar revoking the editor.
+   * @param remoteUserActorUri The remote user actor URI whose editor
+   *   access is being revoked.
+   */
+  async sendEditorRevoke(
+    calendar: Calendar,
+    remoteUserActorUri: string,
+  ): Promise<void> {
+    return this.federationPublisher.sendEditorRevoke(calendar, remoteUserActorUri);
+  }
+
   async addToInbox(calendar: Calendar, message: ActivityPubActivity): Promise<null> {
     return this.serverService.addToInbox(calendar, message);
   }

--- a/src/server/activitypub/model/action/remove.ts
+++ b/src/server/activitypub/model/action/remove.ts
@@ -1,0 +1,69 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityPubActivity, ActivityPubObject } from '@/server/activitypub/model/base';
+
+/**
+ * ActivityPub Remove activity. Used in Pavillion to notify a remote actor
+ * (e.g. a remote calendar editor) that they have been removed from a
+ * collection such as a calendar's editor list. Mirrors {@link AddActivity}
+ * — Add/Remove is the symmetric pair for collection-membership management
+ * per AS2 §8.13. Remove uses explicit `to` targeting for single-recipient
+ * delivery rather than follower fan-out.
+ *
+ * The receiving user actor inbox derives the calendar from `activity.actor`
+ * (the calendar actor URI), so Remove does NOT carry the
+ * `calendarId` / `calendarInboxUrl` extension fields that Add uses to seed
+ * the initial editor-invite membership.
+ */
+class RemoveActivity extends ActivityPubActivity {
+
+  target: string | ActivityPubObject = '';
+
+  constructor( actorUrl: string, object: string | ActivityPubObject, target: string | ActivityPubObject = '' ) {
+    super(actorUrl);
+    this.type = 'Remove';
+    this.object = object;
+    this.target = target;
+    const objectId = typeof object === 'string' ? object : object.id;
+    this.id = objectId + '/removes/' + uuidv4();
+  }
+
+  static fromObject( json: Record<string, any> ): RemoveActivity | null {
+    if (!json || typeof json !== 'object') {
+      return null;
+    }
+
+    if (!json.actor || typeof json.actor !== 'string') {
+      return null;
+    }
+
+    if (!json.object) {
+      return null;
+    }
+
+    let activity = new RemoveActivity(json.actor, json.object, json.target ?? '');
+
+    if (json.id) {
+      activity.id = json.id;
+    }
+    if (json.to) {
+      activity.to = json.to;
+    }
+    if (json.cc) {
+      activity.cc = json.cc;
+    }
+
+    return activity;
+  }
+
+  toObject(): Record<string, any> {
+    const result = super.toObject();
+    if (this.target) {
+      result.target = typeof this.target === 'object' && this.target !== null
+        ? ('toObject' in this.target ? (this.target as any).toObject() : this.target)
+        : this.target;
+    }
+    return result;
+  }
+}
+
+export default RemoveActivity;

--- a/src/server/activitypub/service/federation_publisher.ts
+++ b/src/server/activitypub/service/federation_publisher.ts
@@ -14,6 +14,7 @@ import { ActivityPubActivity } from '@/server/activitypub/model/base';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import DeleteActivity from '@/server/activitypub/model/action/delete';
 import AddActivity from '@/server/activitypub/model/action/add';
+import RemoveActivity from '@/server/activitypub/model/action/remove';
 import { addToOutbox as addToOutboxHelper } from '@/server/activitypub/helper/outbox';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
@@ -436,6 +437,45 @@ class FederationPublisher {
       'Enqueuing Add activity for remote user',
     );
     await this.addToOutbox(calendar, addActivity);
+  }
+
+  /**
+   * Sends a Remove(remoteUserActor) editor-revoke activity from a local
+   * calendar to a remote user actor. Mirrors {@link sendEditorInvite}
+   * byte-for-byte except the activity type and the absence of the
+   * Pavillion-specific `calendarId` / `calendarInboxUrl` extension fields
+   * — the receive-side handler derives the calendar from `activity.actor`,
+   * not from extension fields.
+   *
+   * The activity is signed by the calendar actor (per pv-dyyw signing
+   * table) and anchored on the calendar's own outbox. Delivery is routed
+   * by the outbox worker from the activity's explicit `to` field; no
+   * caller-supplied inbox URL is required.
+   *
+   * @param calendar - The local calendar revoking the editor.
+   * @param remoteUserActorUri - The remote user actor URI whose editor
+   *   access is being revoked.
+   */
+  async sendEditorRevoke(
+    calendar: Calendar,
+    remoteUserActorUri: string,
+  ): Promise<void> {
+    const localDomain = config.get<string>('domain');
+    const calendarActorUri = `https://${localDomain}/calendars/${calendar.urlName}`;
+
+    const removeActivity = new RemoveActivity(
+      calendarActorUri,
+      remoteUserActorUri,
+      `${calendarActorUri}/editors`,
+    );
+    removeActivity.id = `${calendarActorUri}/activities/${uuidv4()}`;
+    removeActivity.to = [remoteUserActorUri];
+
+    logger.info(
+      { remoteUserActorUri, calendarId: calendar.id },
+      'Enqueuing Remove activity for remote user',
+    );
+    await this.addToOutbox(calendar, removeActivity);
   }
 
   /**

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -13,6 +13,7 @@ import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor"
 import UpdateActivity from "@/server/activitypub/model/action/update";
 import DeleteActivity from "@/server/activitypub/model/action/delete";
 import AddActivity from "@/server/activitypub/model/action/add";
+import RemoveActivity from "@/server/activitypub/model/action/remove";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
@@ -280,6 +281,22 @@ class ProcessOutboxService {
         }
         else {
           logger.warn({ activityId: activity.id }, 'Add activity has no explicit to field; skipping delivery (no follower fan-out for Add)');
+        }
+        break;
+      case 'Remove':
+        activity = RemoveActivity.fromObject(message.message);
+        if (!activity) {
+          throw new Error('Failed to parse Remove activity');
+        }
+        // Remove activities are inherently single-recipient (editor-revoke
+        // to a remote actor) — mirror Add. No follower fan-out fallback:
+        // broadcasting an editor-revoke is never the intent.
+        if (activity.to && activity.to.length > 0) {
+          recipients = activity.to;
+          logger.info({ recipientCount: recipients.length }, 'Using explicit recipients from to field for Remove activity');
+        }
+        else {
+          logger.warn({ activityId: activity.id }, 'Remove activity has no explicit to field; skipping delivery (no follower fan-out for Remove)');
         }
         break;
       case 'Follow':

--- a/src/server/activitypub/service/user_actor.ts
+++ b/src/server/activitypub/service/user_actor.ts
@@ -317,6 +317,13 @@ export default class UserActorService {
       return false;
     }
 
+    // Verify the object is us (mirrors processAddActivity; the username in
+    // the URL path must match the activity's `object`).
+    if (activity.object !== actor.actorUri) {
+      logger.error({ object: activity.object, actorUri: actor.actorUri }, 'Remove activity object does not match our actor');
+      return false;
+    }
+
     // Extract the calendar actor URI from the activity
     const calendarActorUri = activity.actor;
 
@@ -341,6 +348,16 @@ export default class UserActorService {
 
     if (!remoteCalendarActor) {
       logger.info({ calendarActorUri }, 'Remote calendar actor not found for URI');
+      return false;
+    }
+
+    // Verify the target is the editors collection of the calendar actor.
+    // This guards against future feature additions (other collections on a
+    // calendar actor — followers, moderators) accidentally routing Remove
+    // activities through the editor prune path.
+    const expectedTarget = `${remoteCalendarActor.actorUri}/editors`;
+    if (activity.target !== expectedTarget) {
+      logger.error({ target: activity.target, expected: expectedTarget }, 'Remove activity target is not the editors collection');
       return false;
     }
 

--- a/src/server/activitypub/test/service/federation_publisher.test.ts
+++ b/src/server/activitypub/test/service/federation_publisher.test.ts
@@ -543,4 +543,54 @@ describe('FederationPublisher', () => {
     });
   });
 
+  describe('sendEditorRevoke', () => {
+    let publisher: FederationPublisher;
+    let sandbox: sinon.SinonSandbox;
+    let calendarInterface: CalendarInterface;
+    let mockOutbox: ReturnType<typeof buildMockOutboxService>;
+    let addToOutboxStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      const eventBus = new EventEmitter();
+      calendarInterface = new CalendarInterface(eventBus);
+      mockOutbox = buildMockOutboxService();
+      publisher = new FederationPublisher(eventBus, calendarInterface, mockOutbox as any);
+
+      addToOutboxStub = sandbox.stub(publisher, 'addToOutbox');
+      addToOutboxStub.resolves();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('enqueues a Remove activity signed by the calendar actor (mirrors Add wire shape)', async () => {
+      const calendar = Calendar.fromObject({ id: 'local-cal-id', urlName: 'mycal' });
+      const remoteUserActorUri = 'https://remote.example.com/users/alice';
+
+      await publisher.sendEditorRevoke(calendar, remoteUserActorUri);
+
+      expect(addToOutboxStub.calledOnce).toBe(true);
+      const [calendarArg, activityArg] = addToOutboxStub.firstCall.args;
+      // Anchor calendar = the calendar argument directly (calendar actor's
+      // own outbox), matching the Add path.
+      expect(calendarArg).toBe(calendar);
+      expect(activityArg.type).toBe('Remove');
+      // Signing actor: calendar actor URI (same as Add per pv-dyyw signing table).
+      expect(activityArg.actor).toMatch(/^https:\/\/.+\/calendars\/mycal$/);
+      // Activity id is calendar-actor-rooted, matching Add.
+      expect(activityArg.id).toMatch(/^https:\/\/.+\/calendars\/mycal\/activities\/[a-f0-9-]+$/);
+      expect(activityArg.to).toEqual([remoteUserActorUri]);
+      expect(activityArg.object).toBe(remoteUserActorUri);
+      // Target collection is the calendar's editors collection (same as Add).
+      expect(activityArg.target).toMatch(/^https:\/\/.+\/calendars\/mycal\/editors$/);
+      // Remove does NOT carry the calendarId / calendarInboxUrl extension
+      // fields Add uses — the receive-side derives the calendar from
+      // activity.actor.
+      expect(activityArg.calendarId).toBeUndefined();
+      expect(activityArg.calendarInboxUrl).toBeUndefined();
+    });
+  });
+
 });

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -901,6 +901,84 @@ describe('processOutboxMessage — explicit `to` honoring and per-type local dis
     expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
   });
 
+  // ---------- Remove ----------
+  //
+  // Remove mirrors Add: single-recipient editor-revoke delivery with no
+  // follower fan-out fallback. The no-`to` skip path is the load-bearing
+  // case — it prevents a regression where editor-revoke activities
+  // accidentally broadcast to all followers.
+
+  it('Remove: honors explicit `to` and delivers only to that recipient', async () => {
+    const removeMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Remove',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/removes/remove-1`,
+      to: [TARGETED_ACTOR_URI],
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Remove',
+      message: removeMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(TARGETED_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Remove').toBe(false);
+    expect(resolveStub.calledOnceWith(TARGETED_ACTOR_URI)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Remove: skips delivery (no fan-out) when `to` is absent', async () => {
+    const removeMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Remove',
+      actor: LOCAL_ACTOR_URL,
+      object: TARGETED_ACTOR_URI,
+      target: `${LOCAL_ACTOR_URL}/editors`,
+      id: `${LOCAL_ACTOR_URL}/removes/remove-2`,
+      // no `to` field
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Remove',
+      message: removeMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+
+    await service.processOutboxMessage(message);
+
+    // No follower fan-out for Remove — getRecipients must NOT be called and
+    // no HTTP delivery should happen. The message is still marked processed.
+    expect(getRecipientsStub.called, 'getRecipients must NOT be called for Remove fan-out').toBe(false);
+    expect(resolveStub.called, 'resolveInboxUrl must NOT be called when no recipients').toBe(false);
+    expect(postStub.called, 'No HTTP POST when Remove has no recipients').toBe(false);
+    expect(updateStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
   // ---------- Per-type local-recipient dispatch ----------
   //
   // For each of the 8 currently-handled activity types, when the resolved

--- a/src/server/activitypub/test/service/user_actor.test.ts
+++ b/src/server/activitypub/test/service/user_actor.test.ts
@@ -6,6 +6,7 @@ import { Account } from '@/common/model/account';
 import UserActorService from '@/server/activitypub/service/user_actor';
 import { UserActorEntity } from '@/server/activitypub/entity/user_actor';
 import { AccountEntity } from '@/server/common/entity/account';
+import RemoteCalendarService from '@/server/activitypub/service/remote_calendar';
 import CalendarInterface from '@/server/calendar/interface';
 
 describe('UserActorService', () => {
@@ -279,6 +280,124 @@ describe('UserActorService', () => {
       // Verify digest is NOT in the headers list
       expect(signature.headers).toBe('(request-target) host date');
       expect(signature.headers).not.toContain('digest');
+    });
+  });
+
+  describe('processRemoveActivity', () => {
+    const LOCAL_USERNAME = 'alice';
+    const LOCAL_ACCOUNT_ID = 'account-id-alice';
+    const LOCAL_ACTOR_URI = 'https://events.example/users/alice';
+    const REMOTE_CALENDAR_URI = 'https://remote.example/calendars/test';
+    const REMOTE_CALENDAR_ACTOR_ID = 'remote-calendar-actor-id';
+
+    let calendarInterfaceStub: { removeRemoteEditorAccess: sinon.SinonStub };
+
+    beforeEach(() => {
+      calendarInterfaceStub = {
+        removeRemoteEditorAccess: sinon.stub().resolves(true),
+      };
+      service = new UserActorService(calendarInterfaceStub as unknown as CalendarInterface);
+    });
+
+    function stubLookups(overrides: {
+      userActor?: any;
+      account?: any;
+      remoteCalendarActor?: any;
+    } = {}): void {
+      // getActorByUsername queries AccountEntity then UserActorEntity
+      sandbox.stub(AccountEntity, 'findOne').callsFake(async (options: any) => {
+        // First call: from getActorByUsername({ where: { username } })
+        // Second call: from processRemoveActivity({ where: { username } })
+        // Both return the same account row.
+        if (options?.where?.username === LOCAL_USERNAME) {
+          return overrides.account === undefined
+            ? ({ id: LOCAL_ACCOUNT_ID, username: LOCAL_USERNAME } as any)
+            : overrides.account;
+        }
+        return null;
+      });
+
+      const userActorEntity = overrides.userActor === undefined
+        ? {
+          toModel: () => ({
+            id: 'user-actor-id',
+            accountId: LOCAL_ACCOUNT_ID,
+            actorUri: LOCAL_ACTOR_URI,
+            publicKey: 'pk',
+            privateKey: 'sk',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }),
+        }
+        : overrides.userActor;
+      sandbox.stub(UserActorEntity, 'findOne').resolves(userActorEntity as any);
+
+      const remoteCalendarActor = overrides.remoteCalendarActor === undefined
+        ? { id: REMOTE_CALENDAR_ACTOR_ID, actorUri: REMOTE_CALENDAR_URI }
+        : overrides.remoteCalendarActor;
+      sandbox.stub(RemoteCalendarService.prototype, 'getByActorUri').resolves(remoteCalendarActor as any);
+    }
+
+    it('prunes the remote-calendar membership via CalendarInterface', async () => {
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(true);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.calledOnce).toBe(true);
+      const [accountIdArg, calendarActorIdArg] = calendarInterfaceStub.removeRemoteEditorAccess.firstCall.args;
+      expect(accountIdArg).toBe(LOCAL_ACCOUNT_ID);
+      expect(calendarActorIdArg).toBe(REMOTE_CALENDAR_ACTOR_ID);
+    });
+
+    it('returns false and does not prune when activity type is not Remove', async () => {
+      const activity = {
+        type: 'Delete',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when actor URI is missing', async () => {
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: undefined,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false when no remote calendar actor is known for the activity actor URI', async () => {
+      stubLookups({ remoteCalendarActor: null });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
     });
   });
 });

--- a/src/server/activitypub/test/service/user_actor.test.ts
+++ b/src/server/activitypub/test/service/user_actor.test.ts
@@ -399,5 +399,104 @@ describe('UserActorService', () => {
       expect(result).toBe(false);
       expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
     });
+
+    it('returns false and does not prune when the local user actor cannot be found', async () => {
+      // Covers the `if (!actor)` guard after getActorByUsername — mirrors
+      // the same defensive branch in processAddActivity.
+      stubLookups({ userActor: null });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when the local account cannot be found', async () => {
+      // Covers the `if (!account)` guard after AccountEntity.findOne. The
+      // AccountEntity stub returns the row for getActorByUsername's first
+      // lookup but null for the second lookup (the one inside
+      // processRemoveActivity itself), exercising the branch in isolation.
+      const remoteCalendarActor = { id: REMOTE_CALENDAR_ACTOR_ID, actorUri: REMOTE_CALENDAR_URI };
+      sandbox.stub(RemoteCalendarService.prototype, 'getByActorUri').resolves(remoteCalendarActor as any);
+      sandbox.stub(UserActorEntity, 'findOne').resolves({
+        toModel: () => ({
+          id: 'user-actor-id',
+          accountId: LOCAL_ACCOUNT_ID,
+          actorUri: LOCAL_ACTOR_URI,
+          publicKey: 'pk',
+          privateKey: 'sk',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        }),
+      } as any);
+
+      let accountCallCount = 0;
+      sandbox.stub(AccountEntity, 'findOne').callsFake(async () => {
+        accountCallCount += 1;
+        // First call from getActorByUsername succeeds; second call from
+        // processRemoveActivity returns null to drive the missing-account branch.
+        if (accountCallCount === 1) {
+          return { id: LOCAL_ACCOUNT_ID, username: LOCAL_USERNAME } as any;
+        }
+        return null;
+      });
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when activity object does not match our actor URI', async () => {
+      // Symmetric to processAddActivity's object check: the username in the
+      // URL path must match the activity's `object`.
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: 'https://events.example/users/someone-else',
+        target: `${REMOTE_CALENDAR_URI}/editors`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
+
+    it('returns false and does not prune when activity target is not the editors collection', async () => {
+      // Symmetric guard for the target field. sendEditorRevoke always sets
+      // target to `${calendarActorUri}/editors`; anything else (e.g. a
+      // hypothetical /followers URI) must not route through the editor
+      // prune path.
+      stubLookups();
+
+      const activity = {
+        type: 'Remove',
+        actor: REMOTE_CALENDAR_URI,
+        object: LOCAL_ACTOR_URI,
+        target: `${REMOTE_CALENDAR_URI}/followers`,
+      };
+
+      const result = await service.processRemoveActivity(LOCAL_USERNAME, activity);
+
+      expect(result).toBe(false);
+      expect(calendarInterfaceStub.removeRemoteEditorAccess.called).toBe(false);
+    });
   });
 });

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -900,6 +900,20 @@ class CalendarService {
       throw new EditorNotFoundError();
     }
 
+    // Send ActivityPub Remove activity to notify the remote user via the
+    // signed outbox path. Mirrors the Add emission in grantRemoteEditorAccess
+    // — the calendar actor signs the Remove (pv-dyyw signing table), and the
+    // local membership row is already destroyed above regardless of remote
+    // delivery outcome. Best-effort semantics: a transient enqueue failure
+    // must not roll back the local revoke.
+    try {
+      await this.activityPubInterface!.sendEditorRevoke(calendar, actorUri);
+      logger.info({ actorUri, calendarId: calendar.id }, 'Enqueued Remove activity for remote editor');
+    }
+    catch (error: any) {
+      logError(error, `[Calendar] Failed to enqueue Remove activity to ${actorUri}`);
+    }
+
     if (this.eventBus) {
       this.eventBus.emit('remoteEditorRevoked', {
         calendarId: calendar.id,

--- a/src/server/calendar/test/service/remote_editor_grant.test.ts
+++ b/src/server/calendar/test/service/remote_editor_grant.test.ts
@@ -27,12 +27,16 @@ import { EventEmitter } from 'events';
  * to the real UserActorEntity database. This allows integration-style tests
  * to create DB rows directly while the service uses interface-based calls.
  *
- * `sendEditorInvite` is a sinon stub so editor-invite tests can assert that
- * the calendar service hands off the typed (calendar, remoteUserActor) pair
- * to the AP domain. Activity construction itself lives in the AP domain
+ * `sendEditorInvite` and `sendEditorRevoke` are sinon stubs so editor
+ * grant/revoke tests can assert that the calendar service hands off the
+ * typed (calendar, remoteUserActor) / (calendar, actorUri) pairs to the AP
+ * domain. Activity construction itself lives in the AP domain
  * (FederationPublisher) and is exercised by federation-side tests.
  */
-function createMockActivityPubInterface(sendEditorInviteStub: sinon.SinonStub): Partial<ActivityPubInterface> {
+function createMockActivityPubInterface(
+  sendEditorInviteStub: sinon.SinonStub,
+  sendEditorRevokeStub: sinon.SinonStub,
+): Partial<ActivityPubInterface> {
   return {
     async findUserActorByUri(actorUri: string) {
       const entity = await UserActorEntity.findOne({ where: { actor_uri: actorUri } });
@@ -56,6 +60,7 @@ function createMockActivityPubInterface(sendEditorInviteStub: sinon.SinonStub): 
       return { id: entity.id };
     },
     sendEditorInvite: sendEditorInviteStub as unknown as ActivityPubInterface['sendEditorInvite'],
+    sendEditorRevoke: sendEditorRevokeStub as unknown as ActivityPubInterface['sendEditorRevoke'],
   };
 }
 
@@ -71,6 +76,7 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
   let service: CalendarService;
   let mockAccountsInterface: Partial<AccountsInterface>;
   let sendEditorInviteStub: sinon.SinonStub;
+  let sendEditorRevokeStub: sinon.SinonStub;
   let testAccountId: string;
   let testCalendarId: string;
   let testAccount: Account;
@@ -78,6 +84,7 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
     sendEditorInviteStub = sandbox.stub().resolves();
+    sendEditorRevokeStub = sandbox.stub().resolves();
     await db.sync({ force: true });
 
     // Create test account
@@ -119,7 +126,9 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
     );
 
     // Wire up mock ActivityPub interface for user actor lookups
-    service.setActivityPubInterface(createMockActivityPubInterface(sendEditorInviteStub) as ActivityPubInterface);
+    service.setActivityPubInterface(
+      createMockActivityPubInterface(sendEditorInviteStub, sendEditorRevokeStub) as ActivityPubInterface,
+    );
   });
 
   afterEach(async () => {
@@ -502,6 +511,56 @@ describe('CalendarService.grantEditAccessByEmail - Remote Editors', () => {
       // UserActorEntity should still exist (we don't delete actors)
       const userActor = await UserActorEntity.findByPk(userActorId);
       expect(userActor).not.toBeNull();
+
+      // Verify the calendar service handed off to the typed AP method with
+      // the calendar and the remote editor's actor URI. Activity construction
+      // (Remove wire shape, signing-actor selection, outbox enqueue) lives in
+      // the AP domain and is exercised by federation_publisher tests.
+      expect(sendEditorRevokeStub.calledOnce).toBe(true);
+      const [calendarArg, actorUriArg] = sendEditorRevokeStub.firstCall.args;
+      expect(calendarArg.id).toBe(testCalendarId);
+      expect(actorUriArg).toBe('https://beta.federation.local/users/Editor');
+    });
+
+    it('should not fail the revoke if the outbox enqueue throws (best-effort delivery)', async () => {
+      const userActorId = uuidv4();
+      await UserActorEntity.create({
+        id: userActorId,
+        actor_type: 'remote',
+        account_id: null,
+        actor_uri: 'https://beta.federation.local/users/Editor',
+        remote_username: 'Editor',
+        remote_domain: 'beta.federation.local',
+        public_key: null,
+        private_key: null,
+      });
+
+      await CalendarMemberEntity.create({
+        id: uuidv4(),
+        calendar_id: testCalendarId,
+        user_actor_id: userActorId,
+        role: 'editor',
+        granted_by: testAccountId,
+      });
+
+      // Simulate a failure dispatching the Remove activity via the typed AP
+      // method (e.g. transient DB error on the ap_outbox insert). The local
+      // membership row should still be destroyed — local revoke must not be
+      // contingent on remote delivery success.
+      sendEditorRevokeStub.rejects(new Error('outbox insert failed'));
+
+      const result = await service.removeRemoteEditor(
+        testAccount,
+        testCalendarId,
+        'https://beta.federation.local/users/Editor',
+      );
+
+      expect(result).toBe(true);
+
+      const membership = await CalendarMemberEntity.findOne({
+        where: { calendar_id: testCalendarId, user_actor_id: userActorId },
+      });
+      expect(membership).toBeNull();
     });
 
     it('should throw EditorNotFoundError if remote editor does not exist', async () => {

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -318,7 +318,7 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
     expect(betaEditor).toBeDefined();
 
     // Anchor beta's log line count before the revoke so the log-poll below
-    // only considers Undo activities emitted by this action.
+    // only considers Remove activities emitted by this action.
     const undoAnchor = getBetaLogLineCount();
 
     // Revoke editor access
@@ -340,11 +340,14 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
 
     expect(revokeResponse.status).toBe(204);
 
-    // Verify the Undo(Add) packet actually reached beta's inbox. The
+    // Verify the Remove(editor) packet actually reached beta's inbox. The
     // beta editor actor URI is used as the needle to distinguish this
-    // Undo from any other Undo activities in beta's log.
+    // Remove from any other Remove activities in beta's log. Per pv-o3ay.6:
+    // Remove is the AS2 §8.13 verb for collection-membership revocation
+    // (symmetric with Add); Undo is reserved for relationship/intent
+    // activities like Follow / Accept / Block / Announce.
     expect(
-      await waitForBetaInboxActivity('Undo', betaEditor.actorUri, undoAnchor),
+      await waitForBetaInboxActivity('Remove', betaEditor.actorUri, undoAnchor),
     ).toBe(true);
 
     // Verify editor can no longer create events

--- a/tests/e2e/federation/cross_instance_editors.spec.ts
+++ b/tests/e2e/federation/cross_instance_editors.spec.ts
@@ -350,7 +350,17 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
       await waitForBetaInboxActivity('Remove', betaEditor.actorUri, undoAnchor),
     ).toBe(true);
 
-    // Verify editor can no longer create events
+    // Verify the revoked editor can no longer create events on the remote
+    // calendar. Beta's processRemoveActivity (above) destroyed the local
+    // CalendarMemberEntity linking betaAdmin to alphaCalendar, so beta's
+    // events endpoint no longer finds any remote-membership record for
+    // this (account, calendarId) pair and surfaces it as 404 — the
+    // federation-correct local view. (Prior to the Remove emission
+    // landing, beta still believed the editor relationship held and
+    // forwarded the create to alpha, whose authoritative refusal came
+    // back as 403; with the federation handshake now complete the local
+    // 404 short-circuits the roundtrip.) The behavioural invariant —
+    // the revoked editor cannot create events — is preserved.
     const eventData = {
       calendarId: alphaCalendarId,
       content: {
@@ -376,6 +386,6 @@ test.describe.serial('Cross-Instance Editor Collaboration', () => {
       agent: httpsAgent,
     });
 
-    expect(createResponse.status).toBe(403);
+    expect(createResponse.status).toBe(404);
   });
 });


### PR DESCRIPTION
> Stacked on top of #313. Once #313 merges, the base will retarget to `main`.

## Motivation

#313 added a wire-level log-poll assertion to the cross-instance editor revoke test, which surfaced a real federation correctness gap: `removeRemoteEditor` destroyed the local membership row and invalidated the auth cache but emitted **no federation activity at all**. Followers were never told the editor was revoked. The 403 enforcement on subsequent edit attempts only worked because the granting instance rejected locally — not because the federation handshake completed.

This was asymmetric with the grant path, which dispatches an `Add(editor)` activity to the editor's user inbox via `sendEditorInvite`. The receive-side handler `processRemoveActivity` was already implemented and routed but dormant: no producer emitted the matching `Remove`.

Per AS2 §8.13 and Mastodon convention, Add/Remove is the symmetric pair for collection-membership management; Undo is reserved for relationship/intent activities (Follow, Accept, Block, Announce). The right fix is to emit `Remove(editor)`, not `Undo(Add)`. Choosing `Undo(Add)` would also have required net-new persistence (storing sent Add activity ids) since the user-inbox path does not persist activities.

## Approach

Three commits, narrowly scoped:

1. **`feat(federation): emit Remove(editor) activity on cross-instance editor revoke`** — adds a new `RemoveActivity` model mirroring `AddActivity` (no `calendarId`/`calendarInboxUrl` extension fields — the receive side derives the calendar from `activity.actor`), a `FederationPublisher.sendEditorRevoke(calendar, actorUri)` method mirroring `sendEditorInvite` byte-for-byte except for the activity type, a matching `ActivityPubInterface` entry, the outbox `case 'Remove'` dispatcher arm, and a best-effort try/catch wire-up in `removeRemoteEditor` mirroring the grant-side pattern. The e2e assertion at the revoke site changes from `'Undo'` to `'Remove'`. New unit tests cover `sendEditorRevoke` wire shape and `processRemoveActivity` happy/edge paths.

2. **`test(federation): add Remove(editor) receive-side symmetry checks and coverage`** — adds symmetric `activity.object !== actor.actorUri` and `activity.target !== ${calendarActorUri}/editors` defensive guards in `processRemoveActivity` (mirroring `processAddActivity`); adds the two outbox tests for `case 'Remove'` (with explicit `to`; with absent `to` skipping delivery rather than fan-out broadcasting); covers the previously-untested guard branches in `processRemoveActivity`. The no-fan-out outbox test prevents the worst-case regression: an editor-revoke accidentally broadcasting to every follower.

3. **`test(federation): expect 404 (not 403) on post-revoke create attempt`** — corrects the behavioural assertion in the revoke test. The pre-fix 403 was an artifact of incomplete federation: beta still believed it had editor access (no `Remove` had propagated), forwarded the create attempt to alpha, and alpha's authoritative refusal returned 403 via a federation roundtrip. With the handshake now complete, beta's `processRemoveActivity` prunes the local `CalendarMemberEntity`, so beta's create-event endpoint no longer finds a membership row for the (account, calendarId) pair and returns 404 locally without any roundtrip. The 404 is the federation-correct outcome and is IDOR-safe (beta does not distinguish "calendar exists but you are not an editor" from "no such calendar" for users with no membership row). The behavioural invariant the test guards — a revoked editor cannot create events — is preserved.

## Validation

- `npm run lint` — clean on changed files.
- Targeted vitest on `user_actor.test.ts`, `outbox.test.ts`, `federation_publisher.test.ts`, `remote_editor_grant.test.ts` — all pass; 107 tests including the new coverage.
- `npm run test:federation` against a fresh Docker environment — the previously-failing `cross_instance_editors.spec.ts` `'should allow owner to revoke cross-instance editor access'` now passes end-to-end (both the `waitForBetaInboxActivity('Remove', ...)` wire-level assertion and the new 404 behavioural assertion). The remaining federation failures are pre-existing 502 nginx infrastructure flakes (unchanged from runs on `main`, unrelated to these commits).