### PR TITLE
fix(client): use long-form layout on /policy page

### DIFF
--- a/src/client/components/logged_out/instance-policy.vue
+++ b/src/client/components/logged_out/instance-policy.vue
@@ -79,24 +79,44 @@ const backLink = computed<{ name: string; label: string }>(() => {
 </script>
 
 <template>
-  <div class="welcome-card">
-    <div class="welcome-card-main">
+  <article class="policy-page">
+    <header class="policy-page__header">
       <h2>{{ t('heading') }}</h2>
+    </header>
 
-      <article class="policy-content"
-               v-html="policyHtml" />
+    <div class="policy-page__body"
+         v-html="policyHtml" />
 
-      <router-link class="forgot"
-                   :to="{ name: backLink.name }">
-        {{ backLink.label }}
-      </router-link>
-    </div>
-  </div>
+    <router-link class="policy-page__back"
+                 :to="{ name: backLink.name }">
+      {{ backLink.label }}
+    </router-link>
+  </article>
 </template>
 
 <style scoped lang="scss">
-.policy-content {
-  margin-block-start: var(--pav-space-4);
+.policy-page {
+  width: 100%;
+  max-width: var(--pav-container-md);
+  margin-inline: auto;
+  padding-block: var(--pav-space-8);
+  color: var(--pav-text-primary);
+}
+
+.policy-page__header {
+  margin-block-end: var(--pav-space-8);
+  text-align: start;
+
+  h2 {
+    font-size: var(--pav-font-size-h2);
+    font-weight: var(--pav-font-weight-semibold);
+    color: var(--pav-text-primary);
+    line-height: 1.2;
+    margin: 0;
+  }
+}
+
+.policy-page__body {
   line-height: 1.6;
 
   :deep(h1),
@@ -105,6 +125,38 @@ const backLink = computed<{ name: string; label: string }>(() => {
   :deep(h4),
   :deep(h5),
   :deep(h6) {
+    font-weight: var(--pav-font-weight-semibold);
+    color: var(--pav-text-primary);
+    line-height: 1.3;
+    margin-block-start: var(--pav-space-8);
+    margin-block-end: var(--pav-space-3);
+  }
+
+  :deep(h1) {
+    font-size: var(--pav-font-size-h3);
+  }
+
+  :deep(h2) {
+    font-size: var(--pav-font-size-h4);
+  }
+
+  :deep(h3) {
+    font-size: var(--pav-font-size-h5);
+    margin-block-start: var(--pav-space-6);
+    margin-block-end: var(--pav-space-2);
+  }
+
+  :deep(h4) {
+    font-size: var(--pav-font-size-h6);
+    margin-block-start: var(--pav-space-6);
+    margin-block-end: var(--pav-space-2);
+  }
+
+  :deep(h5),
+  :deep(h6) {
+    font-size: var(--pav-font-size-base);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
     margin-block-start: var(--pav-space-6);
     margin-block-end: var(--pav-space-2);
   }
@@ -130,5 +182,31 @@ const backLink = computed<{ name: string; label: string }>(() => {
   :deep(li) {
     margin-block-end: var(--pav-space-2);
   }
+
+  :deep(a) {
+    color: var(--pav-color-brand-primary);
+    text-decoration: underline;
+  }
+
+  :deep(blockquote) {
+    border-inline-start: var(--pav-border-width-1) solid var(--pav-border-primary);
+    padding-inline-start: var(--pav-space-4);
+    margin-block-end: var(--pav-space-4);
+    color: var(--pav-color-text-secondary);
+  }
+
+  :deep(code) {
+    font-family: var(--pav-font-family-mono, monospace);
+    font-size: 0.9em;
+    background: var(--pav-surface-muted, var(--pav-surface-card));
+    padding: 0.125em 0.375em;
+    border-radius: var(--pav-border-radius-sm);
+  }
+}
+
+.policy-page__back {
+  display: inline-block;
+  margin-block-start: var(--pav-space-8);
+  color: var(--pav-color-brand-primary);
 }
 </style>

--- a/src/client/test/components/logged_out/instance-policy.test.ts
+++ b/src/client/test/components/logged_out/instance-policy.test.ts
@@ -67,7 +67,7 @@ describe('InstancePolicy fallback chain', () => {
       defaultLanguage: 'en',
     } });
 
-    const article = wrapper.find('article.policy-content');
+    const article = wrapper.find('.policy-page__body');
     expect(article.exists()).toBe(true);
 
     const heading = article.find('h2');
@@ -101,7 +101,7 @@ describe('InstancePolicy fallback chain', () => {
       defaultLanguage: 'en',
     } });
 
-    const article = wrapper.find('article.policy-content');
+    const article = wrapper.find('.policy-page__body');
     expect(article.exists()).toBe(true);
 
     const heading = article.find('h2');
@@ -117,7 +117,7 @@ describe('InstancePolicy fallback chain', () => {
       defaultLanguage: 'en',
     } });
 
-    const article = wrapper.find('article.policy-content');
+    const article = wrapper.find('.policy-page__body');
     expect(article.exists()).toBe(true);
     const emptyFallback = i18next.t('policy:empty_fallback');
     expect(article.text()).toContain(emptyFallback);
@@ -132,7 +132,7 @@ describe('InstancePolicy fallback chain', () => {
       defaultLanguage: 'en',
     } });
 
-    const article = wrapper.find('article.policy-content');
+    const article = wrapper.find('.policy-page__body');
     expect(article.exists()).toBe(true);
 
     // Safe content survives.
@@ -157,42 +157,42 @@ describe('InstancePolicy back link', () => {
 
   it('routes back to login when from=login', async () => {
     const { wrapper } = await mountInstancePolicy({ settings, policyPath: '/policy?from=login' });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/login');
     expect(link.text()).toContain('sign in');
   });
 
   it('routes back to register when from=register', async () => {
     const { wrapper } = await mountInstancePolicy({ settings, policyPath: '/policy?from=register' });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/auth/register');
     expect(link.text()).toContain('registration');
   });
 
   it('routes back to the application page when from=register-apply', async () => {
     const { wrapper } = await mountInstancePolicy({ settings, policyPath: '/policy?from=register-apply' });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/auth/apply');
     expect(link.text()).toContain('application');
   });
 
   it('routes back to settings when from=settings', async () => {
     const { wrapper } = await mountInstancePolicy({ settings, policyPath: '/policy?from=settings' });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/profile');
     expect(link.text()).toContain('settings');
   });
 
   it('falls back to settings when no source is given but the visitor is logged in', async () => {
     const { wrapper } = await mountInstancePolicy({ settings, isLoggedIn: true });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/profile');
     expect(link.text()).toContain('settings');
   });
 
   it('falls back to login when no source is given and the visitor is anonymous', async () => {
     const { wrapper } = await mountInstancePolicy({ settings });
-    const link = wrapper.find('a.forgot');
+    const link = wrapper.find('a.policy-page__back');
     expect(link.attributes('href')).toBe('/login');
     expect(link.text()).toContain('sign in');
   });


### PR DESCRIPTION
## Motivation

The `/policy` page was rendering inside the `.welcome-card` shell used by login and registration: a 448px column with `font-size: 36px; font-weight: 300; text-align: center` applied to every `h2` and `h3` inside. Long-form community-guidelines markdown rendered as an unreadable narrow strip with every heading level collapsed to the same visual treatment, making it impossible to scan the document structure.

## Approach

Replace the auth-card wrapper with a dedicated `.policy-page` long-form layout in `src/client/components/logged_out/instance-policy.vue`:

- Article-level wrapper sized to `--pav-container-md` (768px reading width), no card chrome.
- Page heading (`.policy-page__header h2`) styled at `--pav-font-size-h2`, left-aligned, semibold — and an explicit `text-align: start` to override the `.logged-out header { text-align: center }` rule that bleeds into nested `<header>` elements through descendant selector.
- Markdown body (`.policy-page__body`) sets explicit per-level typography for h1–h6 using the heading font-size tokens, all semibold and left-aligned, so the markdown's own structure shows through.
- Added rendering for `<a>`, `<blockquote>`, and `<code>` since those are in the markdown allowlist but were previously unstyled.

Component tests updated to point at the new `.policy-page__body` and `.policy-page__back` selectors instead of the old `article.policy-content` / `a.forgot`.

## Validation

- `npx vitest run src/client/test/components/logged_out/instance-policy.test.ts` — 10 tests pass (fallback chain, DOMPurify defense-in-depth, back-link routing).
- Build-guardian: lint, unit (7924), integration (602), and build all green. E2E failures present in the run were pre-existing infrastructure issues (server-startup connection refused on port 3100) unrelated to this change.
- Manual verification at 1440×900 and 375×812 with sample markdown spanning h1–h6, ul/ol lists, and paragraphs: heading hierarchy now visibly distinct at every level, column width readable on desktop, content reflows cleanly on mobile.