### PR TITLE
feat: add screen reader walk to accessibility-auditor

### DIFF
--- a/.claude/agents/accessibility-auditor.md
+++ b/.claude/agents/accessibility-auditor.md
@@ -116,7 +116,7 @@ for i in $(seq 1 30); do curl -s -o /dev/null -w "%{http_code}" http://localhost
 ```
 Note that you DID start it so you can stop it in Step 7.
 
-### Step 5: Keyboard Navigation Test
+### Step 5: Keyboard Navigation Test and Screen Reader Walk
 
 1. Navigate to the page containing the changed component
 2. Tab through all interactive elements — verify:
@@ -128,6 +128,48 @@ Note that you DID start it so you can stop it in Step 7.
    - Enter/Space activates buttons
    - Escape closes modals/dropdowns
    - Arrow keys navigate within composite widgets (tabs, menus)
+4. Screen Reader Walk-Through (VSR):
+
+   Inject `@guidepup/virtual-screen-reader` into the page and walk it. The Node-side helper at [`src/common/test-utils/screen-reader.ts`](../../src/common/test-utils/screen-reader.ts) is the contract definition (announcement shapes, locale lock at `'en'`, primitive API). Tests in `src/client/test/` and `tests/e2e/a11y/` use the helper directly via `screenReader(element)` / `pageScreenReader(page)`. From this agent, drive the same VSR runtime through `browser_evaluate` — if the helper grows setup/teardown invariants beyond the inline snippet below, mirror them here:
+
+   ```
+   browser_evaluate
+     function: |
+       async () => {
+         // VSR exposes a singleton on window.virtual when injected. If it's
+         // not present, the page wasn't started with addInitScript — the
+         // auditor runs against the live dev server where the helper isn't
+         // pre-injected, so fall back to importing it via dynamic import
+         // from the dev server's module graph.
+         if (!window.virtual) {
+           const mod = await import('@guidepup/virtual-screen-reader');
+           window.virtual = new mod.Virtual();
+         }
+         await window.virtual.start({ container: document.body });
+         const phrases = [];
+         while (!(await window.virtual.lastSpokenPhrase()).includes('end of document')) {
+           phrases.push(await window.virtual.lastSpokenPhrase());
+           await window.virtual.next();
+         }
+         return phrases;
+       }
+   ```
+
+   Capture the returned spoken-phrase log. For interactive checks (form submit, modal open, etc.) drive the page with `browser_click` / `browser_press_key`, then `browser_evaluate` `await window.virtual.lastSpokenPhrase()` to grab the new announcement.
+
+   Evaluate the log against these judgment-based check categories. **The log is evidence for your severity calls, not a pass/fail rule set** — flag deviations as Violations or Warnings, do not mechanize this into a check list.
+
+   | Check | What to look for |
+   |---|---|
+   | Role announcement | `<button>` announces as `button`; `role="switch"` announces as `switch, on/off`; `aria-expanded` announces as `expanded/collapsed` |
+   | Name presence | Every interactive element has a non-empty accessible name (no bare `button` with no label) |
+   | Order coherence | Walk-through matches visual reading order; heading levels are sequential (no skipping h2→h4) |
+   | Live region behavior | After activating a form submit or other live-region trigger, the alert/status text announces |
+   | Hidden noise | `aria-hidden` decorative content does not appear in the spoken log |
+
+   The expected announcement shapes for the project's common patterns are documented in `.claude/skills/frontend-accessibility/accessibility.md` § Expected Screen Reader Announcements. Compare your captured log against that table to surface deviations.
+
+   Locale is locked to `'en'` for the duration of the walk; do not attempt to verify announcements in other locales from this agent (that is out of scope for the auditor and belongs to dedicated tests).
 
 ### Step 6: Screen Reader Snapshot
 
@@ -173,6 +215,15 @@ For small changes (1-2 files), use a concise format. For larger changes (3+ file
 ### Warnings (should fix — degraded experience)
 - **Missing aria-expanded** — dropdown toggle doesn't announce state
 - **Hardcoded aria-label** — should use `t('key')` for i18n
+
+### Screen Reader Walk
+- Captured phrases (excerpt):
+  - "Page heading, heading level 1"
+  - "Save changes, button"
+  - "Email, edit"
+- Flagged deviations:
+  - **Role announcement** — toggle announces as `button` but template has `role="switch"`; check that `aria-checked` is bound
+  - **Hidden noise** — decorative icon announces "icon" — needs `aria-hidden="true"`
 
 ### Passed
 - Heading hierarchy: correct

--- a/.claude/skills/frontend-accessibility/accessibility.md
+++ b/.claude/skills/frontend-accessibility/accessibility.md
@@ -170,3 +170,24 @@ Use `role="alert"` and `aria-live="polite"` for error messages:
 
 - Add `required` attribute for native validation
 - Consider visual indicator (e.g., asterisk or border) for sighted users
+
+## Expected Screen Reader Announcements
+
+The patterns above produce specific announcement contracts when a real (or virtual) screen reader walks the page. The test helper at [`src/common/test-utils/screen-reader.ts`](../../../src/common/test-utils/screen-reader.ts) drives `@guidepup/virtual-screen-reader` against either a Vitest-mounted component (`screenReader(element)`) or a Playwright page (`pageScreenReader(page)`) and returns the same spoken-phrase log a real SR user would hear. The `accessibility-auditor` agent uses this helper during its per-PR walk-through and surfaces deviations as evidence in its severity reporting.
+
+The contracts below describe what each pattern should announce. Deviations indicate a problem in the underlying HTML/ARIA, not in the test.
+
+| Pattern | Expected announcement |
+|---|---|
+| `<button>Save</button>` | `Save, button` |
+| `<button role="switch" aria-checked="true">…` | `…, switch, on` (and `switch, off` when `aria-checked="false"`) |
+| `<button aria-expanded="true">…` | `…, expanded` (and `…, collapsed` when `aria-expanded="false"`) |
+| `<label for="id">Name</label><input id="id">` | `Name, edit` |
+| `<div role="alert" aria-live="polite">{{ error }}</div>` | The error text announces after the alert is rendered (live region update) |
+| `aria-hidden="true"` decorative icon | No announcement (the icon does not appear in the spoken log) |
+| `sr-only` label | Announced as part of the associated control's accessible name, never as a standalone phrase |
+
+### When to verify announcements
+
+- The auditor verifies announcements automatically during per-PR review (see `.claude/agents/accessibility-auditor.md` Step 5).
+- For load-bearing components, Phase 2 of the screen-reader testing rollout adds a small set of Vitest and Playwright tests using the same helper; see [`docs/superpowers/specs/2026-05-13-screen-reader-testing-design.md`](../../../docs/superpowers/specs/2026-05-13-screen-reader-testing-design.md) for the planned scope.


### PR DESCRIPTION
## Motivation

The `accessibility-auditor` agent has historically verified WCAG concerns through static template analysis (Step 2), focus styling (Step 3), keyboard navigation (Step 5), and an a11y-tree snapshot (Step 6). What it could not do was verify *what a screen reader actually announces* — the ARIA attribute might be present, but the spoken phrase could still be wrong (missing name, dropped role, decorative noise leaking through). This PR closes that gap by extending the auditor's existing Playwright walk with `@guidepup/virtual-screen-reader` (VSR), the foundation helper for which already shipped in #312.

This is half of Phase 1 of a planned 3-phase rollout. Phase 1 is the auditor enhancement; later phases (CI safety net + forcing function) are separate work.

## Approach

Two markdown files, no production code:

- **`.claude/agents/accessibility-auditor.md`** — Step 5 (now "Keyboard Navigation Test and Screen Reader Walk") gains a new subsection 4 that injects VSR into the live dev server via the agent's existing `browser_evaluate` MCP tool and captures the spoken-phrase log across the keyboard walk. A judgment-based check table covers role announcement, name presence, order coherence, live-region behavior, and hidden noise. The Reporting Format gains a "Screen Reader Walk" section sitting between Warnings and Passed, with example captured phrases and example flagged deviations. The auditor stays judgment-based — the log is *evidence* for severity calls, not a mechanized check list (Phase 2 will own the strict-assertion role).

- **`.claude/skills/frontend-accessibility/accessibility.md`** — new "Expected Screen Reader Announcements" reference section with an announcement-contract table for the project's common patterns (`<button>`, `role="switch"`, `aria-expanded`, labeled inputs, `role="alert"` live regions, `aria-hidden`, `sr-only`). Cross-references back to the auditor's Step 5 and to the shared helper.

The auditor uses MCP `browser_evaluate` rather than calling `pageScreenReader(page)` directly because the auditor doesn't hold a Playwright `Page` handle — it drives the browser through MCP tools. The injection pattern mirrors what the helper does internally (`addInitScript` + `page.evaluate`), so the runtime contract stays identical; a forward-reference comment in the agent file flags the inline snippet for review if the helper grows additional setup/teardown invariants.

Locale is locked to `'en'` for the duration of the walk; other-locale verification is explicitly deferred to Phase 2's dedicated tests.

## Validation

- **Lint**: 0 errors, 277 pre-existing warnings (baseline unchanged — no JS/TS files touched).
- **Architecture light pass**: PASS, with one LOW finding addressed inline (forward-reference comment now appears next to the inline VSR snippet so future divergence from the helper is caught).
- **Build-guardian**: green. The 1 unit + 1 integration + 5 e2e failures observed during this wave are all pre-existing baseline failures (recorded in project memory); none are attributable to these markdown-only changes.
- **Manual verification**: the auditor's two acceptance criteria — (1) a real-PR run produces a non-empty "Screen Reader Walk" section, and (2) regressing an `aria-label` makes the auditor surface the deviation citing spoken-phrase evidence — are manual checks that happen on the next real frontend PR review.

Phase 2 work is gated on Phase 1 being used on ≥3 real PRs before it begins.