### PR TITLE
feat(accounts): notify admins when account applications reach pending review

### DIFF
--- a/src/server/accounts/model/admin_application_notification_email.ts
+++ b/src/server/accounts/model/admin_application_notification_email.ts
@@ -1,0 +1,57 @@
+import config from 'config';
+import AccountApplication from '@/common/model/application';
+import { MailData } from '@/server/email/model/types';
+import { EmailMessage, compileTemplate } from '@/server/email/model/message';
+
+const textTemplate = compileTemplate('src/server/accounts', 'admin_application_notification_email.text.hbs');
+const htmlTemplate = compileTemplate('src/server/accounts', 'admin_application_notification_email.html.hbs');
+
+/**
+ * Email message notifying an instance administrator that an account
+ * application has been confirmed and is awaiting review in the admin queue.
+ *
+ * The applicant's free-text message is intentionally NOT reproduced in the
+ * email body — it may contain sensitive personal context that the applicant
+ * intends for the controlled in-app queue, not for admin mailboxes which
+ * sync to mobile devices and persist indefinitely. The applicant email is
+ * included so admins can recognize known correspondents at a glance, and the
+ * full message is reviewed in the admin applications queue (deep-linked from
+ * this email).
+ */
+class AdminApplicationNotificationEmail extends EmailMessage {
+  recipientEmail: string;
+  application: AccountApplication;
+
+  constructor(recipientEmail: string, application: AccountApplication) {
+    super('admin_application_notification_email', textTemplate, htmlTemplate);
+    this.recipientEmail = recipientEmail;
+    this.application = application;
+  }
+
+  /**
+   * Builds the admin-notify email payload.
+   *
+   * @param language - Language code for translations (e.g. 'en', 'fr')
+   * @returns Complete mail data ready for sending
+   */
+  buildMessage(language: string): MailData {
+    const appUrl = config.get<string>('domain');
+    const reviewUrl = appUrl + '/admin/applications';
+
+    const templateData = {
+      applicantEmail: this.application.email,
+      reviewUrl,
+      appUrl,
+      language,
+    };
+
+    return {
+      emailAddress: this.recipientEmail,
+      subject: this.renderSubject(language, {}),
+      textMessage: this.renderPlaintext(language, templateData),
+      htmlMessage: this.renderHtml(language, templateData),
+    };
+  }
+}
+
+export default AdminApplicationNotificationEmail;

--- a/src/server/accounts/model/admin_application_notification_email.ts
+++ b/src/server/accounts/model/admin_application_notification_email.ts
@@ -35,8 +35,8 @@ class AdminApplicationNotificationEmail extends EmailMessage {
    * @returns Complete mail data ready for sending
    */
   buildMessage(language: string): MailData {
-    const appUrl = config.get<string>('domain');
-    const reviewUrl = appUrl + '/admin/applications';
+    const appUrl = 'https://' + config.get<string>('domain');
+    const reviewUrl = appUrl + '/admin/accounts';
 
     const templateData = {
       applicantEmail: this.application.email,

--- a/src/server/accounts/service/account.ts
+++ b/src/server/accounts/service/account.ts
@@ -17,6 +17,7 @@ import ApplicationAcceptedEmail from '@/server/accounts/model/application_accept
 import ApplicationRejectedEmail from '@/server/accounts/model/application_rejected_email';
 import ApplicationAcknowledgmentEmail from '@/server/accounts/model/application_acknowledgment_email';
 import ApplicationConfirmationEmail from '@/server/accounts/model/application_confirmation_email';
+import AdminApplicationNotificationEmail from '@/server/accounts/model/admin_application_notification_email';
 import AccountAlreadyExistsEmail from '@/server/accounts/model/account_already_exists_email';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
@@ -397,6 +398,32 @@ export default class AccountService {
     // reflect pre-update values but are not surfaced to the recipient.
     const ackMessage = new ApplicationAcknowledgmentEmail(application.toModel());
     await this.emailInterface.sendEmail(ackMessage.buildMessage('en'));
+
+    // Notify instance administrators that an application has reached the
+    // `pending` review queue. The status flip already committed above, so any
+    // mail failure here cannot roll it back — wrap the whole loop in a
+    // best-effort try/catch (one swallow site, one log call). A failure on
+    // admin N means admins N+1..end miss this notification; the queue UI
+    // remains the source of truth and per-iteration isolation can be added
+    // later if observed-needed. The asymmetry with the applicant ack send
+    // above is intentional: the applicant ack is the primary user-facing
+    // signal of confirm success and should surface failures, whereas the
+    // admin notify is a side-effect that must not fail the confirm.
+    try {
+      const admins = await this.getAdmins();
+      for (const admin of admins) {
+        if (!admin.email) {
+          continue;
+        }
+        const adminEmail = new AdminApplicationNotificationEmail(admin.email, application.toModel());
+        await this.emailInterface.sendEmail(adminEmail.buildMessage(admin.language || 'en'));
+      }
+    }
+    catch (error) {
+      // Log application.id only — never the applicant email or message
+      // (privacy playbook: PII stays out of error logs).
+      logError(error, `[Accounts] Failed to notify admins of pending application ${application.id}`);
+    }
 
     return true;
   }

--- a/src/server/accounts/templates/admin_application_notification_email.html.hbs
+++ b/src/server/accounts/templates/admin_application_notification_email.html.hbs
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{t 'title'}}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background-color: #f8f9fa;
+            padding: 20px;
+            border-radius: 5px 5px 0 0;
+            border-bottom: 3px solid #4A90E2;
+        }
+        .content {
+            padding: 30px 20px;
+            background-color: #ffffff;
+        }
+        .info {
+            background-color: #e7f3ff;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 15px 0;
+            border-left: 4px solid #4A90E2;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #4A90E2;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 15px 0;
+            font-weight: bold;
+        }
+        .button:hover {
+            background-color: #357ABD;
+        }
+        .footer {
+            background-color: #f8f9fa;
+            padding: 20px;
+            border-radius: 0 0 5px 5px;
+            font-size: 12px;
+            color: #666;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{{t 'title'}}</h1>
+        </div>
+
+        <div class="content">
+            <p>{{t 'greeting'}}</p>
+
+            <p>{{t 'notification'}}</p>
+
+            <div class="info">
+                <strong>{{t 'applicant_email_label'}}</strong> {{applicantEmail}}
+            </div>
+
+            <p>{{t 'action_message'}}</p>
+
+            <p style="text-align: center;">
+                <a href="{{reviewUrl}}" class="button">
+                    {{t 'review_button'}}
+                </a>
+            </p>
+
+            <p>{{t 'copy_link_text'}}<br>
+            {{reviewUrl}}</p>
+
+            <p>{{t 'signature'}}<br>
+            {{t 'team_name'}}</p>
+        </div>
+
+        <div class="footer">
+            {{t 'footer_text'}}
+        </div>
+    </div>
+</body>
+</html>

--- a/src/server/accounts/templates/admin_application_notification_email.text.hbs
+++ b/src/server/accounts/templates/admin_application_notification_email.text.hbs
@@ -1,0 +1,18 @@
+{{t 'title'}}
+
+{{t 'greeting'}}
+
+{{t 'notification'}}
+
+{{t 'applicant_email_label'}} {{applicantEmail}}
+
+{{t 'action_message'}}
+
+{{t 'review_button'}}
+{{reviewUrl}}
+
+{{t 'signature'}}
+{{t 'team_name'}}
+
+----
+{{t 'footer_text'}}

--- a/src/server/accounts/test/admin_application_notification_email.test.ts
+++ b/src/server/accounts/test/admin_application_notification_email.test.ts
@@ -69,7 +69,7 @@ describe('AdminApplicationNotificationEmail', () => {
     const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
 
     const mailData = email.buildMessage('en');
-    const expectedReviewUrl = config.get<string>('domain') + '/admin/applications';
+    const expectedReviewUrl = 'https://' + config.get<string>('domain') + '/admin/accounts';
 
     expect(mailData.textMessage).toContain(applicantEmail);
     expect(mailData.htmlMessage).toContain(applicantEmail);

--- a/src/server/accounts/test/admin_application_notification_email.test.ts
+++ b/src/server/accounts/test/admin_application_notification_email.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import config from 'config';
+import i18next from 'i18next';
+
+import AccountApplication from '@/common/model/application';
+import AdminApplicationNotificationEmail from '@/server/accounts/model/admin_application_notification_email';
+import { initI18Next } from '@/server/common/test/lib/i18next';
+
+initI18Next();
+
+beforeAll(async () => {
+  // Eagerly load the email namespace so synchronous i18next.t() lookups
+  // (used by renderSubject) resolve translated content.
+  await i18next.loadLanguages(['en']);
+  await i18next.loadNamespaces('admin_application_notification_email');
+});
+
+/**
+ * Tests for AdminApplicationNotificationEmail model.
+ *
+ * Verifies the email model is constructed with the correct namespace,
+ * addresses the recipient admin, renders a subject + text + html body,
+ * and includes the applicant's email in the rendered body (the only
+ * applicant-identifying field in the message — the free-text message is
+ * intentionally omitted per the privacy decision in the bead notes).
+ */
+describe('AdminApplicationNotificationEmail', () => {
+  const applicantEmail = 'applicant@example.com';
+
+  function makeApplication(): AccountApplication {
+    return new AccountApplication('app-id', applicantEmail, 'sensitive message text');
+  }
+
+  it('constructs with the admin_application_notification_email namespace', () => {
+    const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
+
+    expect(email.namespace).toBe('admin_application_notification_email');
+  });
+
+  it('sets the recipient address to the admin email passed to the constructor', () => {
+    const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
+
+    const mailData = email.buildMessage('en');
+
+    expect(mailData.emailAddress).toBe('admin@example.com');
+  });
+
+  it('renders a non-empty subject line', () => {
+    const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
+
+    const mailData = email.buildMessage('en');
+
+    expect(mailData.subject).toBeTruthy();
+    expect(mailData.subject.length).toBeGreaterThan(0);
+  });
+
+  it('renders non-empty text and html bodies', () => {
+    const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
+
+    const mailData = email.buildMessage('en');
+
+    expect(mailData.textMessage).toBeDefined();
+    expect(mailData.textMessage.length).toBeGreaterThan(0);
+    expect(mailData.htmlMessage).toBeDefined();
+    expect(mailData.htmlMessage!.length).toBeGreaterThan(0);
+  });
+
+  it('includes the applicant email and a review deep link in the rendered body, and never the applicant free-text message', () => {
+    const email = new AdminApplicationNotificationEmail('admin@example.com', makeApplication());
+
+    const mailData = email.buildMessage('en');
+    const expectedReviewUrl = config.get<string>('domain') + '/admin/applications';
+
+    expect(mailData.textMessage).toContain(applicantEmail);
+    expect(mailData.htmlMessage).toContain(applicantEmail);
+    expect(mailData.textMessage).toContain(expectedReviewUrl);
+    expect(mailData.htmlMessage).toContain(expectedReviewUrl);
+
+    // Privacy invariant: the applicant's free-text message must never appear
+    // in the rendered output — admins read it from the in-app queue, not from
+    // their mailbox.
+    expect(mailData.textMessage).not.toContain('sensitive message text');
+    expect(mailData.htmlMessage).not.toContain('sensitive message text');
+  });
+});

--- a/src/server/accounts/test/integration/applications-integration.test.ts
+++ b/src/server/accounts/test/integration/applications-integration.test.ts
@@ -1,13 +1,19 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import request from 'supertest';
+import sinon from 'sinon';
 import { EventEmitter } from 'events';
 import { v4 as uuidv4 } from 'uuid';
 import { DateTime } from 'luxon';
 
-import { AccountApplicationEntity } from '@/server/common/entity/account';
+import {
+  AccountApplicationEntity,
+  AccountEntity,
+  AccountRoleEntity,
+} from '@/server/common/entity/account';
 import AccountService from '@/server/accounts/service/account';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
+import EmailInterface from '@/server/email/interface';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 
 /**
@@ -409,3 +415,170 @@ describe('Public POST /api/v1/applications anti-enumeration (integration)', () =
     });
   });
 });
+
+/**
+ * Integration tests for the admin-notify side-effect of
+ * `confirmAccountApplication`.
+ *
+ * When an applicant confirms their email, the status flips from
+ * `pending_confirmation` to `pending` and the applicant receives an
+ * acknowledgment email. This suite verifies the additional admin-notify
+ * fan-out: every admin returned by `AccountService.getAdmins()` receives an
+ * email, and the confirm response stays `true` regardless of admin-loop
+ * outcomes (zero admins, send failure mid-loop, etc.).
+ *
+ * Bead: pv-hne7
+ */
+describe('confirmAccountApplication admin-notify (integration)', () => {
+  let env: TestEnvironment;
+  let sandbox: sinon.SinonSandbox;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    // Provision a single admin account to exit setup mode so the public
+    // confirm endpoint responds on its own merits. This bootstrap admin is
+    // preserved across tests (the FK chain via account_secrets makes wholesale
+    // truncation noisy); per-test admin seeding controls which admin roles
+    // exist via the AccountRole table only.
+    const eventBus = new EventEmitter();
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+    await accountService._setupAccount('admin-notify-bootstrap@pavillion.dev', 'testpassword!1');
+  });
+
+  afterAll(async () => {
+    if (env) {
+      await env.cleanup();
+    }
+  });
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    await AccountApplicationEntity.destroy({ where: {}, truncate: true });
+    // Clear ALL admin roles (including the bootstrap admin's role). Each test
+    // re-adds the role assignments it needs. Account rows themselves are not
+    // truncated — the bootstrap row stays so the FK chain via
+    // account_secrets is preserved.
+    await AccountRoleEntity.destroy({ where: {}, truncate: true });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /** Seed a confirmation-pending application; returns the token. */
+  async function seedPendingConfirmation(): Promise<string> {
+    const token = `notify-token-${uuidv4()}`;
+    await AccountApplicationEntity.create({
+      id: uuidv4(),
+      email: `${uuidv4()}@example.com`,
+      message: 'integration applicant',
+      status: 'pending_confirmation',
+      status_timestamp: new Date(),
+      confirmation_token: token,
+      confirmation_token_expiration: DateTime.utc().plus({ days: 7 }).toJSDate(),
+    });
+    return token;
+  }
+
+  /** Create an account row with an optional role + language. */
+  async function seedAccount(
+    overrides: { role?: string; language?: string; email?: string } = {},
+  ): Promise<AccountEntity> {
+    const id = uuidv4();
+    const account = await AccountEntity.create({
+      id,
+      username: `user-${id}`,
+      email: overrides.email ?? `acct-${id}@example.com`,
+      language: overrides.language ?? 'en',
+    });
+    if (overrides.role) {
+      await AccountRoleEntity.create({ account_id: id, role: overrides.role });
+    }
+    return account;
+  }
+
+  it('fans out one admin-notify email per admin and skips non-admin accounts', async () => {
+    const admin1 = await seedAccount({ role: 'admin', email: 'admin1@example.com' });
+    const admin2 = await seedAccount({ role: 'admin', email: 'admin2@example.com' });
+    await seedAccount({ email: 'regular@example.com' }); // non-admin: must not receive
+    const sendStub = sandbox.stub(EmailInterface.prototype, 'sendEmail').resolves();
+    const token = await seedPendingConfirmation();
+
+    const response = await request(env.app).post(`/api/v1/applications/confirm/${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+
+    // 1 applicant ack + 2 admin notifies = 3 sends.
+    expect(sendStub.callCount).toBe(3);
+
+    const recipients = sendStub.getCalls().map(call => (call.args[0] as { emailAddress: string }).emailAddress);
+    expect(recipients).toContain(admin1.email);
+    expect(recipients).toContain(admin2.email);
+    expect(recipients).not.toContain('regular@example.com');
+  });
+
+  it('uses the admin account language when sending the admin-notify email', async () => {
+    await seedAccount({ role: 'admin', email: 'admin-fr@example.com', language: 'fr' });
+    const sendStub = sandbox.stub(EmailInterface.prototype, 'sendEmail').resolves();
+    const token = await seedPendingConfirmation();
+
+    const response = await request(env.app).post(`/api/v1/applications/confirm/${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+
+    // The admin send is the one addressed to admin-fr@example.com — find it
+    // and verify the MailData was built for 'fr'. The MailData itself does
+    // not carry a language field; we inspect the rendered subject to
+    // confirm the fr namespace was used. Since only EN translations exist
+    // today, fr falls back to EN, but the contract is that buildMessage(
+    // 'fr') is invoked, not buildMessage('en'). We capture the test by
+    // asserting the admin send completed (no language-fallback error) and
+    // by inspecting that the call to sendEmail was made with an email
+    // addressed to the fr admin (proving the loop reached the send).
+    const adminCall = sendStub.getCalls().find(
+      call => (call.args[0] as { emailAddress: string }).emailAddress === 'admin-fr@example.com',
+    );
+    expect(adminCall).toBeDefined();
+  });
+
+  it('returns success even when there are zero admins (loop is empty)', async () => {
+    // No admin role seeded — getAdmins() returns [].
+    const sendStub = sandbox.stub(EmailInterface.prototype, 'sendEmail').resolves();
+    const token = await seedPendingConfirmation();
+
+    const response = await request(env.app).post(`/api/v1/applications/confirm/${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+
+    // Only the applicant ack send fires — no admin notifies.
+    expect(sendStub.callCount).toBe(1);
+  });
+
+  it('returns success when an admin-notify send throws inside the loop', async () => {
+    await seedAccount({ role: 'admin', email: 'admin-fail@example.com' });
+    const sendStub = sandbox.stub(EmailInterface.prototype, 'sendEmail');
+    // First call (applicant ack) succeeds; second call (admin notify) throws.
+    sendStub.onFirstCall().resolves();
+    sendStub.onSecondCall().rejects(new Error('SMTP boom'));
+    const token = await seedPendingConfirmation();
+
+    const response = await request(env.app).post(`/api/v1/applications/confirm/${token}`);
+
+    // Confirm endpoint still reports success — admin-notify is a side effect
+    // and must not fail the confirm.
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+
+    // Both sends were attempted (applicant ack + admin notify); the loop
+    // failure was caught and swallowed.
+    expect(sendStub.callCount).toBe(2);
+  });
+});
+

--- a/src/server/locales/en/admin_application_notification_email.json
+++ b/src/server/locales/en/admin_application_notification_email.json
@@ -1,0 +1,13 @@
+{
+    "subject": "New account application awaiting review",
+    "title": "New Account Application",
+    "greeting": "Hello,",
+    "notification": "A new account application has been confirmed and is awaiting administrator review.",
+    "applicant_email_label": "Applicant email:",
+    "action_message": "Please review this application from the admin applications queue and take appropriate action.",
+    "review_button": "Review Applications",
+    "copy_link_text": "Or copy this link:",
+    "signature": "Thank you,",
+    "team_name": "The Pavillion Team",
+    "footer_text": "This is an automated message, please do not reply to this email."
+}


### PR DESCRIPTION
## Motivation

When a visitor submits an account application on an instance running in `apply` registration mode, only the applicant was notified (confirmation link, then post-confirmation acknowledgment). Instance administrators received no signal that an application had moved into the review queue — they had to poll `/admin/applications` to discover pending work. On a low-traffic instance, applications could sit unreviewed for days.

## Approach

Sends an admin-notify email inline from `confirmAccountApplication`, immediately after the existing applicant acknowledgment send. Reuses the existing `getAdmins()` query (no new query, no new event bus, no new domain handler) and mirrors the per-admin loop pattern from the moderation domain's auto-escalation notifier.

Key design choices:

- **Inline dispatch, not event bus.** The applicant ack is already sent inline from this method; admin notify follows the same pattern and stays co-located with its sibling notification.
- **Whole-loop try/catch.** Mail failures cannot roll back the status flip to `pending` (which has already committed). One swallow site, one log call.
- **Applicant free-text message excluded from the email body.** Applicants may include sensitive personal context in the optional message field; reproducing it across admin mailboxes (which sync to mobile and persist indefinitely) is the wrong disclosure surface. Admins read the message in the controlled in-app queue. The applicant email IS included in the body — admins routinely see applicant emails in moderation contexts.
- **Error logs contain `application.id` only** — never the applicant email or message.
- **Snake_case Handlebars templates** under `src/server/accounts/templates/`, matching the accounts domain convention (moderation uses kebab-case; the new files do not drift toward that).

## Validation

- **Lint:** 0 errors (277 pre-existing warnings, none from new files)
- **Unit tests:** 7929 passed, including 5 new tests for the `AdminApplicationNotificationEmail` model (namespace, recipient, subject + body render, applicant email present, free-text message asserted absent)
- **Integration tests:** 606 passed (5 skipped), including 4 new tests covering per-admin fan-out + non-admin skipped, language fallback, zero-admin success, and admin-loop throw resilience
- **Build:** clean
- **Per-bead audits (6, parallel):** consistency, security, privacy, i18n — PASS; complexity, testing — PASS WITH WARNINGS (one converging note that the language-fallback integration test verifies the loop reached the fr admin but does not directly assert `buildMessage('fr')` was invoked — only EN translations exist, so rendered output is identical either way; not a blocker per both auditors)
- **Architecture audit (light pass):** PASS — DEC-001 (community-control) strengthened, DEC-003 (intra-domain `this.getAdmins()`, no cross-domain interface needed) respected, DEC-004 (anti-enumeration) preserved (admin notify fires only after the confirmation token has de-anonymized the applicant)