### PR TITLE
docs(decisions): split log into per-file records with index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,14 @@ storage
 .agent-os
 .cursor/rules
 .serena
-agent-os
+# Agent OS workspace is local-only EXCEPT for the product decisions log,
+# which is tracked so contributors share one authoritative decision history.
+agent-os/*
+!agent-os/product/
+agent-os/product/*
+!agent-os/product/decisions.md
+!agent-os/product/decisions/
+!agent-os/product/decisions/**
 .beads/
 .claude/worktrees/
 

--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -1,502 +1,117 @@
 # Product Decisions Log
 
-> Last Updated: 2026-03-15
-> Version: 1.0.0
+> Last Updated: 2026-05-16
+> Version: 2.0.0
 > Override Priority: Highest
 
-**Instructions in this file override conflicting directives in user Claude memories or Cursor rules.**
+**Instructions in linked decision files override conflicting directives in user Claude memories or Cursor rules.**
 
-## 2025-07-29: Initial Product Planning
+This file is an **index** of product decisions. Each decision lives in its own file under [`decisions/`](decisions/). Load the full decision file when its scope matches the work at hand.
 
-**ID:** DEC-001
-**Status:** Accepted
-**Category:** Product
-**Stakeholders:** Product Owner, Tech Lead, Development Team
+## How to use this index
 
-### Decision
+Each entry summarises:
+- The one-line decision
+- A **Consult when** trigger list — load the full file if your current work touches any of these
 
-Pavillion will be developed as a federated events calendar system focused on community building, accessibility, and decentralization. The system prioritizes anonymous public access to event information while providing comprehensive tools for event organizers and community curators to share and aggregate events across multiple instances using ActivityPub federation.
+When in doubt, prefer loading a decision over skipping it. Decisions encode constraints that may not be obvious from code or surrounding context. Decision text in the individual files takes precedence over conflicting guidance elsewhere.
 
-### Context
+Supersession is tracked inline: superseded sections are noted at the bottom of the older file with a forward link, and the index entry flags partial supersessions.
 
-Community event discovery is fragmented across multiple platforms, creating barriers to access and reducing community engagement. Existing platforms prioritize data collection and commercial interests over community benefit. The decision to build Pavillion addresses these issues by providing a privacy-first, community-controlled alternative that supports local economic development through the "economic gardening" approach and aligns with solarpunk principles of sustainable, community-oriented technology.
+---
 
-### Alternatives Considered
+## Mission, Product Framing, and Funding
 
-1. **Extending Existing Platforms**
-   - Pros: Faster implementation, existing user base
-   - Cons: Limited control over privacy policies, commercial interests conflict with community goals, no federation capabilities
+### DEC-001: Initial Product Planning
+- **File:** [decisions/dec-001-initial-product-planning.md](decisions/dec-001-initial-product-planning.md)
+- **Date:** 2025-07-29 · **Status:** Accepted
+- **Decision:** Pavillion is a federated, privacy-first events calendar built on ActivityPub, focused on community building and the economic-gardening model rather than commercial extraction.
+- **Consult when:** Evaluating whether a feature aligns with the mission; any tension between commercial framing and community-benefit framing; questions about why federation, why anonymous access, why this product exists.
 
-2. **Non-Federated Custom Solution**
-   - Pros: Simpler architecture, faster development
-   - Cons: Creates another silo, limits cross-community collaboration, doesn't address centralization concerns
+### DEC-004: Privacy-First Public Access
+- **File:** [decisions/dec-004-privacy-first-public-access.md](decisions/dec-004-privacy-first-public-access.md)
+- **Date:** 2025-07-29 · **Status:** Accepted
+- **Decision:** Full anonymous access to public event information — no accounts, tracking, or data collection for attendees. Accounts required only for organizers, curators, and admins.
+- **Consult when:** Adding logging, cookies, sessions, analytics, or tracking; designing public API responses; deciding whether to require auth; anything that touches PII, attendee data, or engagement metrics.
 
-3. **Adopting Existing ActivityPub Calendar Software**
-   - Pros: Faster time to market, proven federation
-   - Cons: No existing mature solutions found, specific community needs not addressed
+### DEC-007: Community Funding Model and Stripe Product Choice
+- **File:** [decisions/dec-007-community-funding-model.md](decisions/dec-007-community-funding-model.md)
+- **Date:** 2026-03-15 · **Status:** Accepted
+- **Decision:** Voluntary "funding plans" (NPR/Wikipedia model) using Stripe Embedded Checkout — instance admins enter their own Stripe keys; not Stripe Connect. Term "funding plan" used in place of "subscription" to avoid ActivityPub terminology collision.
+- **Consult when:** Implementing or modifying payment/billing flows; configuring Stripe; CSP changes for payment iframes; deciding terminology around funding/subscription/payment; questions about why we don't use Connect OAuth.
 
-### Rationale
+### DEC-009: ICS Import Funding-Gate Posture
+- **File:** [decisions/dec-009-ics-import-funding-gate-posture.md](decisions/dec-009-ics-import-funding-gate-posture.md)
+- **Date:** 2026-04-22 · **Status:** Partially superseded by [DEC-011](decisions/dec-011-federated-value-boundary.md)
+- **Decision (still in force):** ICS basic import (v1) is free onboarding infrastructure; advanced ICS sync (background polling, hosted-provider OAuth, mirror mode) is funding-gated.
+- **Retracted:** The comparative ICS-vs-Facebook framing and the operational-cost rationale for advanced-sync gating. Current rationale lives in DEC-011.
+- **Consult when:** Working on ICS basic import; questions about the v1 user-initiated sync model. For current funding-gate rationale, curator aggregation scope, or anything about classifying inbound/outbound features, go to DEC-011 first.
 
-The federated approach using ActivityPub provides the best balance of community autonomy and cross-community collaboration. Anonymous public access removes barriers to event discovery while account requirements only for organizers maintains necessary functionality. The focus on economic gardening and community building differentiates Pavillion from commercial platforms and aligns with target user values.
+### DEC-011: ICS Scope, Curator Aggregation Model, and Federated Value Boundary
+- **File:** [decisions/dec-011-federated-value-boundary.md](decisions/dec-011-federated-value-boundary.md)
+- **Date:** 2026-05-16 · **Status:** Accepted
+- **Decision:** (1) ICS import is exclusively organizer migration tooling — not a curator aggregation surface. (2) Curator aggregation operates via federation only (Pavillion calendars + other AP event platforms); no roadmap path for non-federated source aggregation. (3) Features that bridge to non-federated systems (inbound or outbound) are funding-gated under the **federated value boundary principle**; in-network features are free.
+- **Consult when:** Classifying any feature as free vs funding-gated; designing aggregation features; ICS import scope work; questions about what curators do in Pavillion's model; deciding whether an inbound/outbound integration is in-network or platform-bridge; any feature touching outbound feeds, third-party APIs, or hosted-provider integrations.
 
-### Consequences
+---
 
-**Positive:**
-- Community ownership of data and governance policies
-- Enhanced privacy protection for event attendees
-- Cross-community event sharing and collaboration
-- Support for multilingual and diverse communities
-- Sustainable development model aligned with community values
+## Architecture and Stack
 
-**Negative:**
-- Increased complexity due to federation requirements
-- Longer development timeline compared to centralized solution
-- Need for community education about federation benefits
-- Server administration requirements for each community
+### DEC-002: Technology Stack Selection
+- **File:** [decisions/dec-002-technology-stack.md](decisions/dec-002-technology-stack.md)
+- **Date:** 2025-07-29 · **Status:** Accepted
+- **Decision:** Vue 3 + TypeScript frontend, Express + TypeScript backend, Sequelize + PostgreSQL persistence, activitypub-express for federation, Vitest for testing.
+- **Consult when:** Choosing a library or framework; questions about why we use these specific tools rather than alternatives; evaluating runtime/build trade-offs against compiled alternatives.
 
-## 2025-07-29: Technology Stack Selection
+### DEC-003: Domain-Driven Architecture
+- **File:** [decisions/dec-003-domain-driven-architecture.md](decisions/dec-003-domain-driven-architecture.md)
+- **Date:** 2025-07-29 · **Status:** Accepted
+- **Decision:** Strict domain boundaries; cross-domain communication via well-defined interfaces only; no direct imports across domain boundaries.
+- **Consult when:** Creating a new domain; refactoring cross-domain code; encountering or resolving cross-domain imports; service-layer design; questions about why the codebase is organized by domain instead of by feature or MVC layer.
 
-**ID:** DEC-002
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Tech Lead, Development Team
+---
 
-### Decision
+## Federation Behavior
 
-Pavillion will use Vue.js 3 with TypeScript for the frontend, Express.js with TypeScript for the backend, Sequelize ORM with PostgreSQL for data persistence, and activitypub-express for federation implementation. The system will support both authenticated client interfaces and public site views with comprehensive testing using Vitest.
+### DEC-008: Sticky Per-Calendar Unpost Dismissals
+- **File:** [decisions/dec-008-unpost-dismissals.md](decisions/dec-008-unpost-dismissals.md)
+- **Date:** 2026-04-11 · **Status:** Accepted
+- **Decision:** Unpost writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. Auto-repost handler checks this before creating a new `SharedEventEntity`. Per-calendar only — never global. `Update(Event)` activities are NOT blocked; federation sync continues for every other calendar still sharing the event.
+- **Consult when:** Working with unshare/unpost behavior; modifying auto-repost handler logic; designing `Update(Event)` activity handling; questions about how a single calendar's dismissal affects other calendars or cross-instance federation sync.
 
-### Context
+---
 
-The technology stack needed to support rapid development of a complex federated system while maintaining code quality, type safety, and comprehensive testing. The choice needed to balance developer productivity with system performance and maintainability for a volunteer-driven or small-team project.
+## Routing and URL Conventions
 
-### Alternatives Considered
+### DEC-006: Public Site URL Namespace Reserved as `/view/`
+- **File:** [decisions/dec-006-view-url-namespace.md](decisions/dec-006-view-url-namespace.md)
+- **Date:** 2026-02-22 · **Status:** Accepted (the pv-l9wv `/apply/` addendum was superseded by [DEC-010](decisions/dec-010-apply-namespace-client-spa.md))
+- **Decision:** `/view/` is the public site SPA namespace. Public calendar URLs are `/view/:calendarName`. The `@` prefix is not used in public site routing.
+- **Consult when:** Designing public calendar URLs; adding a new top-level URL namespace; questions about why URLs use `/view/` instead of `@`; deciding public site SPA vs client SPA routing.
 
-1. **React + Next.js Frontend**
-   - Pros: Larger ecosystem, more developers familiar
-   - Cons: More complex state management, JSX learning curve for some team members
+### DEC-010: Public Apply Namespace Returns to Client SPA
+- **File:** [decisions/dec-010-apply-namespace-client-spa.md](decisions/dec-010-apply-namespace-client-spa.md)
+- **Date:** 2026-05-03 · **Status:** Accepted (supersedes the [DEC-006](decisions/dec-006-view-url-namespace.md) `/apply/` addendum)
+- **Decision:** `/apply/confirm/:token` lives in the client SPA at `/auth/apply/confirm/:token`. The `/apply/` top-level reservation is removed. All logged-out auth flows (apply, login, forgot, apply-confirm) live in the client SPA under `/auth/*`.
+- **Consult when:** Auth flow routing; deciding which SPA owns a route; questions about `/apply/` vs `/auth/apply/`; cookie-hygiene reasoning for anonymous flows.
 
-2. **Full-Stack Frameworks (Nuxt, SvelteKit)**
-   - Pros: Integrated development experience, SSR built-in
-   - Cons: Less flexibility for API-first design needed for federation
+---
 
-3. **Go or Rust Backend**
-   - Pros: Better performance, compiled binaries
-   - Cons: Steeper learning curve, fewer ActivityPub libraries available
+## API and Data Conventions
 
-### Rationale
+### DEC-005: Category Identification Standards for Public APIs
+- **File:** [decisions/dec-005-category-identification.md](decisions/dec-005-category-identification.md)
+- **Date:** 2025-08-02 · **Status:** Accepted
+- **Decision:** Use `category.id` (UUID) as the unique identifier for event categories in all public APIs and frontend components. Do NOT reach for `urlName` — that property doesn't exist on EventCategory.
+- **Consult when:** Working with EventCategory in APIs, frontend components, URLs, or query parameters; any time you reach for `urlName` on a category and want to know why it's wrong.
 
-Vue.js 3 provides excellent developer experience with composition API and strong TypeScript support. Express.js offers mature ecosystem and flexibility needed for ActivityPub implementation. Sequelize with TypeScript decorators provides type-safe database operations. The JavaScript ecosystem offers the best available ActivityPub libraries and tooling.
+---
 
-### Consequences
+## Conventions for adding new decisions
 
-**Positive:**
-- Rapid development with strong typing
-- Excellent testing infrastructure
-- Rich ecosystem for federation features
-- Accessible to volunteer developers
-- Strong i18n support for multilingual features
-
-**Negative:**
-- Runtime language performance compared to compiled alternatives
-- More complex build process with multiple compilation targets
-- Dependency management complexity in JavaScript ecosystem
-
-## 2025-07-29: Domain-Driven Architecture
-
-**ID:** DEC-003
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Tech Lead, Development Team
-
-### Decision
-
-Pavillion backend will use domain-driven design with strict domain boundaries, where each domain (accounts, calendar, activitypub, etc.) contains its own API handlers, entities, services, and interfaces. Cross-domain communication must go through well-defined interfaces, and domains cannot directly import from other domains.
-
-### Context
-
-The federated calendar system involves complex interactions between user management, calendar operations, media handling, and federation protocols. Clear architectural boundaries are needed to maintain code organization, enable parallel development, and ensure testability as the system grows in complexity.
-
-### Alternatives Considered
-
-1. **Monolithic MVC Architecture**
-   - Pros: Simpler initial setup, familiar pattern
-   - Cons: Tight coupling, difficult to test, scaling challenges
-
-2. **Microservices Architecture**
-   - Pros: Complete isolation, independent scaling
-   - Cons: Too complex for current team size, network overhead, deployment complexity
-
-3. **Feature-Based Organization**
-   - Pros: Co-located related functionality
-   - Cons: Unclear boundaries, potential for circular dependencies
-
-### Rationale
-
-Domain-driven design provides clear boundaries while keeping everything in a single deployable application. The interface-based communication pattern ensures loose coupling while maintaining type safety. This approach supports the complex business logic needed for federation while remaining manageable for a small team.
-
-### Consequences
-
-**Positive:**
-- Clear separation of concerns
-- Easier testing with defined interfaces
-- Parallel development possible across domains
-- Federation complexity contained within ActivityPub domain
-- Easier to reason about data flow and dependencies
-
-**Negative:**
-- More initial architectural overhead
-- Requires discipline to maintain boundaries
-- Some code duplication across domains
-- Learning curve for team members unfamiliar with DDD
-
-## 2025-07-29: Privacy-First Public Access
-
-**ID:** DEC-004
-**Status:** Accepted
-**Category:** Product
-**Stakeholders:** Product Owner, Tech Lead
-
-### Decision
-
-Pavillion will provide full anonymous access to all public event information without requiring user accounts, tracking, or data collection for event attendees. Account creation will only be required for event organizers, curators, and instance administrators.
-
-### Context
-
-Most existing event platforms require user registration and collect extensive personal data even for basic event browsing. This creates barriers to access, particularly for privacy-conscious users, and conflicts with the community-building mission. The decision needed to balance functionality with accessibility and privacy principles.
-
-### Alternatives Considered
-
-1. **Account Required for All Access**
-   - Pros: Better analytics, user engagement tracking
-   - Cons: Significant barrier to access, privacy concerns, reduced community reach
-
-2. **Optional Account with Enhanced Features**
-   - Pros: Balanced approach, progressive enhancement
-   - Cons: Complex permission system, potential for feature creep toward required registration
-
-3. **Completely Anonymous System**
-   - Pros: Maximum privacy protection
-   - Cons: No way to manage event creation or moderation
-
-### Rationale
-
-Anonymous public access aligns with the community-building mission by removing barriers to event discovery. Since event information is inherently public, there is no compelling reason to gate access behind registration. The three-tier user model (attendees/organizers/administrators) provides necessary functionality while maintaining privacy principles.
-
-### Consequences
-
-**Positive:**
-- Increased accessibility for diverse community members
-- Enhanced privacy protection builds community trust
-- Reduced complexity in user management
-- Lower barrier to adoption for new communities
-- Alignment with solarpunk and community-first values
-
-**Negative:**
-- Limited analytics and engagement metrics
-- No direct communication channel with event attendees
-- Potential for abuse of public access (mitigated by moderation tools)
-- More complex permission system to support anonymous access
-
-## 2025-08-02: Category Identification Standards for Public APIs
-
-**ID:** DEC-005
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Development Team, Frontend Developers
-**Related Spec:** @.agent-os/specs/2025-07-30-public-category-filtering/
-
-### Decision
-
-All public-facing APIs and frontend components will use `category.id` (UUID) as the unique identifier for event categories, not `category.urlName`. Category identification within a calendar context relies on the category's natural ID property since calendar context is already established through API route parameters.
-
-### Context
-
-During implementation of the public category filtering feature, confusion arose about how to identify categories in frontend components and API calls. The initial implementation attempted to use `category.urlName` as an identifier, but this property does not exist on EventCategory models. The EventCategory model only contains `id` and `calendarId` properties, with display names stored in translatable content objects.
-
-### Alternatives Considered
-
-1. **Adding urlName property to EventCategory model**
-   - Pros: Would match calendar URL naming pattern
-   - Cons: Adds unnecessary complexity, violates DRY principle, creates potential for conflicts
-
-2. **Using category.content("en").name as identifier**
-   - Pros: Human-readable identifiers
-   - Cons: Not guaranteed to be unique, translation-dependent, fragile to content changes
-
-3. **Using category.id as identifier** (Selected)
-   - Pros: Guaranteed unique, stable, matches database primary key, simple
-   - Cons: Not human-readable in URLs
-
-### Rationale
-
-Category identification should use the natural primary key (`id`) because:
-
-1. **Calendar context is established by API routes** - `/api/public/v1/calendars/:urlName/events` already provides calendar scope
-2. **Categories are scoped to calendars** - within a calendar context, category.id provides sufficient unique identification
-3. **Consistency with domain model** - EventCategory entities have `id` and `calendarId`, making `id` the logical identifier
-4. **Simplicity** - No need for additional mapping or synthetic properties
-
-### Consequences
-
-**Positive:**
-- Clear, consistent identification pattern across all public-facing code
-- Eliminates confusion about non-existent properties
-- Reduces implementation complexity
-- Matches existing database and entity patterns
-- URL parameters use stable identifiers that won't break with content changes
-
-**Negative:**
-- Category IDs in URLs are not human-readable
-- Requires developers to understand the scoping model
-- API URLs contain UUIDs rather than friendly names
-
-## 2026-02-22: Public Site URL Namespace Reserved as `/view/`
-
-**ID:** DEC-006
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Development Team
-
-### Decision
-
-The `/view/` path prefix is permanently reserved as the public site SPA namespace. Public calendar URLs use the form `/view/:calendarName` (and locale-prefixed equivalents `/[lang]/view/:calendarName`). The `@` character is no longer used in public site routing.
-
-### Context
-
-The original `/@calendarname` routing convention conflicted visually and conceptually with ActivityPub's use of `@` for actor identity (e.g., `@user@instance.social`). This was identified as a pre-launch concern — changing after launch would require backward-compatibility redirects and could break bookmarked URLs. Switching to `/view/calendarname` resolves the ambiguity while keeping a readable, semantic URL structure.
-
-### Alternatives Considered
-
-1. **Keep `/@calendarname`**
-   - Pros: Already implemented, no migration needed
-   - Cons: Confusing overlap with ActivityPub `@` actor notation
-
-2. **Use `/c/:calendarName` (short prefix)**
-   - Pros: Shorter URLs
-   - Cons: Less descriptive, less obvious to end users
-
-3. **Use `/view/:calendarName`** (Selected)
-   - Pros: Clear semantic meaning, no conflict with ActivityPub, readable
-   - Cons: Slightly longer URLs
-
-### Rationale
-
-`/view/` clearly communicates intent (viewing a calendar), avoids all confusion with ActivityPub actor addresses, and establishes a clean namespace boundary. Since this is a pre-launch change, no backward-compatibility redirects are needed.
-
-### Consequences
-
-**Positive:**
-- No ambiguity between public calendar URLs and ActivityPub actor URLs
-- Clear, semantic URL structure that is understandable to end users
-- The `view` exclusion in the client catch-all regex prevents `/view/` paths from being accidentally served by the authenticated client SPA
-
-**Negative:**
-- URLs are slightly longer than the `@` convention
-- Any external documentation or links using `/@` format are now invalid (acceptable pre-launch)
-
-### Addendum (pv-l9wv): Additional Public Site Namespaces
-
-The principle established here — a reserved top-level public-site namespace served from the unauthenticated site SPA shell rather than the authenticated client SPA — extends to other public anonymous flows. As of pv-l9wv, `/apply/` is also reserved as a public site namespace (currently scoped to `/apply/confirm/:token` for account-application email confirmation). Any new top-level public-site namespace must be added to the catch-all exclusion in `src/server/app_routes.ts` and routed through `handlers.site_index` / `handlers.locale_prefixed_site` so anonymous visitors do not load the authenticated client shell (DEC-004 cookie hygiene).
-
-**Superseded by DEC-010 (2026-05-03)** — the `/apply/` reservation has been retracted. `/apply/confirm/:token` moved into the client SPA at `/auth/apply/confirm/:token`. The `/view/` reservation remains in force.
-
-## 2026-03-15: Community Funding Model and Stripe Product Choice
-
-**ID:** DEC-007
-**Status:** Accepted
-**Category:** Product
-**Stakeholders:** Product Owner, Tech Lead, Development Team
-
-### Decision
-
-Pavillion will support optional community funding plans that allow calendar owners to collect contributions from their community to sustain calendar infrastructure. The feature uses Stripe Embedded Checkout for payment processing, with instance administrators entering Stripe API keys directly rather than using Stripe Connect OAuth. The term "funding plan" is used instead of "subscription" throughout the codebase and UI to avoid terminology collision with ActivityPub's use of "subscription" for follow relationships.
-
-### Context
-
-Running a Pavillion instance requires ongoing costs for hosting, maintenance, and community development. Rather than monetizing the platform through advertising or data collection, Pavillion adopts a community-supported funding model analogous to NPR or Wikipedia donation drives. Calendar owners can create funding plans that invite voluntary contributions from community members who benefit from the calendar. This approach directly aligns with the economic gardening mission (DEC-001) by keeping community infrastructure community-funded rather than commercially driven.
-
-The initial implementation used Stripe Connect with OAuth, which is designed for marketplace platforms that route payments between multiple parties. This was the wrong product for Pavillion's use case, where each instance collects payments directly on behalf of its own calendars. Stripe Embedded Checkout is the correct product: it handles payment processing via an iframe embedded in the page, the user never leaves the site, and the instance owner maintains a direct relationship with Stripe using their own API keys (similar to how PayPal integration works).
-
-### Alternatives Considered
-
-1. **Stripe Connect OAuth (marketplace model)**
-   - Pros: Managed onboarding flow, Stripe handles account verification
-   - Cons: Wrong product for direct payment use case, adds unnecessary platform intermediary, complex OAuth flow, implies Pavillion is a marketplace when it is not
-
-2. **Stripe Hosted Checkout (redirect model)**
-   - Pros: Simplest integration, Stripe manages the entire checkout page
-   - Cons: User leaves the site during payment, breaks the embedded community experience, less control over UX
-
-3. **Stripe Embedded Checkout (iframe model)** (Selected)
-   - Pros: User stays on site, direct payment relationship, correct product for single-merchant use case, clean UX with iframe integration
-   - Cons: Requires CSP updates for Stripe iframe, slightly more frontend integration work
-
-4. **No funding feature**
-   - Pros: Simpler codebase, no payment complexity
-   - Cons: No sustainable funding path for community infrastructure, instance operators bear all costs
-
-### Rationale
-
-The community funding model was chosen because:
-
-1. **Mission alignment** - Community infrastructure should be funded by the community it serves, not through commercialization or data extraction. This follows the NPR/Wikipedia model where the service is free to access but sustained by voluntary contributions from those who value it.
-2. **Economic gardening** - Funding plans enable local organizations to sustain their event calendars as community infrastructure, supporting the broader goal of strengthening local economies and community resilience.
-3. **Correct Stripe product** - Embedded Checkout is the right product for direct payment collection. Connect OAuth is designed for platforms that facilitate payments between third parties (marketplaces), which is not what Pavillion does. Each instance owner has their own Stripe account and collects payments directly.
-4. **Terminology clarity** - Using "funding plan" instead of "subscription" avoids confusion with ActivityPub terminology where "subscription" refers to following an actor or calendar. This distinction is important in a federated system where ActivityPub concepts are core to the architecture.
-5. **Privacy consistency** - The funding model maintains Pavillion's privacy-first principles (DEC-004). Payment processing is handled by Stripe; Pavillion stores only the minimum metadata needed to track funding plan status, not payment details.
-
-### Consequences
-
-**Positive:**
-- Sustainable funding path for community calendar infrastructure without commercialization
-- Consistent with economic gardening mission and community-first values
-- Simpler integration than Connect OAuth with fewer moving parts
-- Users complete payment without leaving the site
-- Clear terminology boundary between funding plans and ActivityPub subscriptions
-- Instance owners maintain direct Stripe relationship and full control over their payment configuration
-
-**Negative:**
-- Instance administrators must create and configure their own Stripe account
-- API keys must be stored securely (encrypted at rest) adding operational complexity
-- Funding plan management adds UI and backend complexity to the calendar domain
-- Per-calendar funding configuration requires calendar owners to understand pricing options
-
-## 2026-04-11: Sticky Per-Calendar Unpost Dismissals
-
-**ID:** DEC-008
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Tech Lead, Development Team
-**Related Spec:** @docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
-
-### Decision
-
-When a calendar owner unposts a reposted event, the system writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. The inbox auto-repost handler checks this row before creating a new `SharedEventEntity`, skipping silently if present. Dismissals are strictly per-calendar: a dismissal on Calendar A never suppresses auto-reposts on Calendar B, even within the same instance. Dismissals only gate re-share creation — `Update(Event)` activities continue to flow through the inbox unmodified so the underlying `EventEntity` stays in sync for every calendar still sharing it.
-
-### Context
-
-Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound `Announce` recreated it. This undermined the community-control principle (DEC-001): followers had policy control over *future* follows but not over *this specific event I already said no to*.
-
-### Alternatives Considered
-
-1. **Block Update activities entirely for dismissed events**
-   - Pros: Dismissed events would stop updating on the calendar list, reinforcing the "it's gone" feeling.
-   - Cons: Breaks federation sync for every *other* calendar still sharing the event — a single dismissal would stale the event across the instance. Violates federation-first principles.
-
-2. **Global (per-instance) dismissals across all calendars an account owns**
-   - Pros: Simpler mental model for owners managing multiple calendars.
-   - Cons: Violates the community-control principle that each calendar owner speaks only for their own calendar. Multi-editor calendars would get a confusing blast radius.
-
-3. **Per-calendar sticky dismissal with Update sync preserved** (Selected)
-   - Pros: Respects community control, preserves federation sync for other reposters, survives source re-broadcast.
-   - Cons: Dismissal rows accumulate over time (mitigated by `ON DELETE CASCADE` on event deletion); no audit/undo UI yet (data preserved, surface can be added later).
-
-### Rationale
-
-Per-calendar scoping is the only option that keeps DEC-001's community-control promise intact while also preserving federation-first semantics. Every calendar speaks for itself; no calendar's dismissal leaks into another calendar's policy surface. The explicit choice to leave `Update` processing unblocked is a federation-correctness invariant: `EventEntity` is a globally-shared fact, and every calendar currently sharing the event must see edits, regardless of which calendars have opted out of auto-reposting it.
-
-### Consequences
-
-**Positive:**
-- Respects DEC-001 community-control principle: each calendar owner controls only their own calendar
-- Preserves federation sync: Update activities continue flowing to all other calendars that still share the event
-- Survives source re-broadcast: the dismissal is durable, not a one-time destructive delete
-- No new API surface: the existing `DELETE /api/v1/social/shares/:eventId` endpoint handles the dismissal write transparently
-- User-facing concept ("unpost") cleanly hides the implementation vocabulary ("dismissal")
-
-**Negative:**
-- `ap_repost_dismissal` rows accumulate over time, bounded by event lifetime via `ON DELETE CASCADE`
-- No UI yet to audit or undo dismissals — deferred to a future bead; data is preserved so the surface can be added later
-
-## 2026-04-22: ICS Import Funding-Gate Posture
-
-**ID:** DEC-009
-**Status:** Accepted
-**Category:** Product
-**Stakeholders:** Product Owner, Tech Lead
-**Related Spec:** @pv-1qcp (bead)
-
-### Decision
-
-ICS basic import (v1) is free and ungated onboarding infrastructure. Advanced ICS sync capabilities — background polling, mirror mode with ongoing source precedence, and hosted-provider OAuth (Google Calendar, Outlook/M365, iCloud) — will ship as funding-gated features in later phases. This diverges from the roadmap Phase 2 Facebook import posture (explicitly funding-gated) because Facebook import serves ongoing community aggregation while ICS import serves one-time migration from a user's existing self-hosted calendar.
-
-### Context
-
-Roadmap Phase 2 gates Facebook event import behind funding plan subscription (per DEC-007 community funding model), and the same question arises for ICS import: should a calendar owner pay to migrate events in from their existing Nextcloud, Gancio, or WordPress Events Calendar? The ICS import epic (pv-1qcp) is the foundation for that migration path, using DNS TXT verification to prove source ownership and user-initiated "Sync now" pulls with no background polling in v1.
-
-DEC-001 establishes the economic-gardening mission: Pavillion exists to lower barriers to community infrastructure, not extract rent at every touchpoint. DEC-007 establishes that funding plans fund ongoing operational value (hosting, maintenance, community development) via voluntary community contribution rather than gatekeeping access. Gating migration itself — the moment when a user is actively choosing to move their community infrastructure onto Pavillion — would contradict both principles: it charges at the point of highest friction, before the user has received any value from the platform, and it punishes the exact migration path Pavillion wants to encourage.
-
-### Alternatives Considered
-
-1. **Gate all ICS import behind funding plan (mirror Facebook import posture)**
-   - Pros: Consistent rule across all import paths; clear revenue signal at adoption time
-   - Cons: Creates chicken-and-egg migration barrier (user must fund before they can evaluate migration); contradicts economic-gardening mission (DEC-001) by charging at the friction point; conflates one-time migration with ongoing aggregation
-
-2. **Gate after the Nth source or Nth import run**
-   - Pros: Free entry path; funding signal tied to heavy usage
-   - Cons: Arbitrary threshold is hard to defend to users; implementation complexity (counting, resets, edge cases); still gates migration for calendars with multiple legacy sources; pattern doesn't exist elsewhere in the codebase
-
-3. **Free for v1 basic import; advanced sync features funding-gated in later phases** (Selected)
-   - Pros: Migration frictionless; funding aligned with ongoing operational value (polling infrastructure, OAuth maintenance, aggregation/mirror complexity); consistent with NPR/Wikipedia contribution model from DEC-007
-   - Cons: No direct funding signal at migration time (acceptable — funding plans exist independently on the calendar and the user can subscribe once they've settled in)
-
-### Rationale
-
-Migration onboarding should be frictionless. Once a user has moved their calendar onto Pavillion and is operating it day-to-day, advanced sync capabilities — hosted provider OAuth, background polling, aggregation and mirror modes — represent ongoing platform value that is legitimately funding-gated territory. This matches DEC-007's NPR/Wikipedia model: the service is free to adopt and use, and voluntary contributions sustain the advanced operations that benefit the broader community. The distinction from the Facebook import posture is the use case, not the technology: Facebook import is community aggregation (aggregating Facebook event pages into a community calendar), while ICS import is personal migration (moving your own calendar's events into your own Pavillion calendar).
-
-### Consequences
-
-**Positive:**
-- Low-friction migration path aligns with DEC-001 economic-gardening mission
-- Funding-gate posture remains internally consistent (funding pays for ongoing operational value, not gatekeeping adoption)
-- Users can evaluate Pavillion with their real calendar data before deciding to fund
-- Clear product boundary: v1 basic import is onboarding infrastructure; advanced sync is platform value
-
-**Negative:**
-- No direct funding signal at migration time (acceptable — funding plans exist independently on the calendar and can be subscribed to once the user has settled in)
-- Future advanced-sync funding gates must be clearly communicated so users understand what they're subscribing for, not retroactively locking behavior users relied on in v1
-
-## 2026-05-03: Public Apply Namespace Returns to Client SPA
-
-**ID:** DEC-010
-**Status:** Accepted
-**Category:** Technical
-**Stakeholders:** Tech Lead, Development Team
-**Related Spec:** @pv-e92c (bead)
-**Supersedes:** DEC-006 pv-l9wv addendum (the `/apply/` reservation as a public site namespace)
-
-### Decision
-
-`/apply/confirm/:token` moves from the site SPA shell to the client SPA's logged-out auth flow, with the canonical URL becoming `/auth/apply/confirm/:token`. The `/apply/` top-level reservation in `src/server/app_routes.ts` is removed; that path falls through to the client SPA catch-all like the other `/auth/*` URLs do today. The `/view/` reservation established by DEC-006 itself remains in force; only the pv-l9wv addendum that extended the reservation to `/apply/` is superseded.
-
-### Context
-
-The DEC-006 pv-l9wv addendum (committed earlier in this branch) reserved `/apply/` as a public site namespace and routed `/apply/confirm/:token` through the site SPA shell. The stated rationale was cookie hygiene — anonymous visitors should not load the authenticated client shell. On reflection during a post-implementation audit of the affected component, that argument did not hold:
-
-- The cookie-hygiene concern is API-layer: the confirm GET/POST endpoints (commits `07d9901`, `40779dd`) return identical generic responses for any failure mode and run with no session middleware. Whether the user-facing landing page is rendered by the client SPA or the site SPA does not affect that property.
-- Anonymous visitors already load the client SPA when they hit `/auth/login`, `/auth/apply`, or `/auth/forgot`. None of those leak anything via cookies because anonymous visitors have no session cookie to begin with. `/apply/confirm/:token` is the same kind of anonymous-visitor flow as those routes.
-- Conceptually, applying for an account, confirming the email, logging in, and resetting a password are one continuous "logged-out auth" surface owned by the client SPA. Splitting one step of it into a separate SPA created visual drift, accessibility regressions (the site shell provides no `<h1>` for inner pages to subordinate to), and an unnecessary cross-SPA SCSS dependency to make the site page look like the client page.
-
-### Alternatives Considered
-
-1. **Keep the page in the site SPA and patch the audit findings in place**
-   - Pros: Smaller change; preserves the pv-l9wv addendum
-   - Cons: Patches symptoms, not the root cause (wrong SPA placement); requires either adding an `<h1>` to the site shell (visually invasive for every other site page) or accepting a heading-hierarchy violation; preserves the cross-SPA SCSS dependency that the architecture-auditor flagged
-
-2. **Extract `logged_out/root.vue` to `src/common/components/` and reuse from both SPAs**
-   - Pros: Enables future cross-SPA component reuse
-   - Cons: Premature abstraction — apply-confirm is the only candidate, and moving it to the client SPA makes the abstraction unnecessary; YAGNI
-
-3. **Move the page to the client SPA at `/auth/apply/confirm/:token`** (Selected)
-   - Pros: Inherits correct shell (`AuthViews` provides `<header><h1>` for free); eliminates cross-SPA SCSS imports; conceptually unifies the logged-out auth surface in one SPA
-   - Cons: User-facing URL changes from `/apply/confirm/:token` to `/auth/apply/confirm/:token` (acceptable pre-launch — no in-the-wild emails point at the old URL)
-
-### Consequences
-
-**Positive:**
-- Page inherits `AuthViews` wrapper for free: `<main class="logged-out"><header><h1>{{ siteTitle }}</h1></header><section><RouterView /></section><footer/>` — correct heading hierarchy, named landmark via the `<h1>`-bearing header.
-- Cross-SPA SCSS imports added to `src/site/assets/style.scss` in commit `bbedcb1` are reverted; the only remaining cross-SPA stylesheet dependency is the original `fonts` import.
-- One conceptual model for the logged-out surface: all routes live under `/auth/*` in the client SPA. The DEC-006 pv-l9wv addendum's separate "public site namespace for anonymous flows" rule no longer needs to exist.
-
-**Negative:**
-- DEC-006 is now split between an original decision (the `/view/` URL convention, still in force) and a superseded addendum (the `/apply/` reservation). The historical record adds noise but is preserved for traceability.
+1. Pick the next sequential ID. Create a file at `decisions/dec-NNN-short-slug.md`. Use any existing file as the template — required sections are `## Decision`, `## Context`, `## Alternatives Considered`, `## Rationale`, `## Consequences`.
+2. Add an index entry under the relevant topical group above. If no group fits, create a new one. Include the **Consult when** trigger list — that is what makes the index useful.
+3. Bump the index `Last Updated` date.
+4. If superseding an earlier decision, update the earlier file's `Status:` header and append a supersession note (at the end of Consequences, or as a separate section) with a forward link. Update the earlier decision's index entry to flag the supersession.
+5. Cross-reference related decisions inline using relative links: `[DEC-NNN](dec-NNN-slug.md)` from within `decisions/`, or `[DEC-NNN](decisions/dec-NNN-slug.md)` from this index.
+6. Never delete or edit historical decisions — supersede them. The historical record is the point.

--- a/agent-os/product/decisions/dec-001-initial-product-planning.md
+++ b/agent-os/product/decisions/dec-001-initial-product-planning.md
@@ -1,0 +1,47 @@
+# DEC-001: Initial Product Planning
+
+> Date: 2025-07-29
+> Status: Accepted
+> Category: Product
+> Stakeholders: Product Owner, Tech Lead, Development Team
+
+## Decision
+
+Pavillion will be developed as a federated events calendar system focused on community building, accessibility, and decentralization. The system prioritizes anonymous public access to event information while providing comprehensive tools for event organizers and community curators to share and aggregate events across multiple instances using ActivityPub federation.
+
+## Context
+
+Community event discovery is fragmented across multiple platforms, creating barriers to access and reducing community engagement. Existing platforms prioritize data collection and commercial interests over community benefit. The decision to build Pavillion addresses these issues by providing a privacy-first, community-controlled alternative that supports local economic development through the "economic gardening" approach and aligns with solarpunk principles of sustainable, community-oriented technology.
+
+## Alternatives Considered
+
+1. **Extending Existing Platforms**
+   - Pros: Faster implementation, existing user base
+   - Cons: Limited control over privacy policies, commercial interests conflict with community goals, no federation capabilities
+
+2. **Non-Federated Custom Solution**
+   - Pros: Simpler architecture, faster development
+   - Cons: Creates another silo, limits cross-community collaboration, doesn't address centralization concerns
+
+3. **Adopting Existing ActivityPub Calendar Software**
+   - Pros: Faster time to market, proven federation
+   - Cons: No existing mature solutions found, specific community needs not addressed
+
+## Rationale
+
+The federated approach using ActivityPub provides the best balance of community autonomy and cross-community collaboration. Anonymous public access removes barriers to event discovery while account requirements only for organizers maintains necessary functionality. The focus on economic gardening and community building differentiates Pavillion from commercial platforms and aligns with target user values.
+
+## Consequences
+
+**Positive:**
+- Community ownership of data and governance policies
+- Enhanced privacy protection for event attendees
+- Cross-community event sharing and collaboration
+- Support for multilingual and diverse communities
+- Sustainable development model aligned with community values
+
+**Negative:**
+- Increased complexity due to federation requirements
+- Longer development timeline compared to centralized solution
+- Need for community education about federation benefits
+- Server administration requirements for each community

--- a/agent-os/product/decisions/dec-002-technology-stack.md
+++ b/agent-os/product/decisions/dec-002-technology-stack.md
@@ -1,0 +1,46 @@
+# DEC-002: Technology Stack Selection
+
+> Date: 2025-07-29
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead, Development Team
+
+## Decision
+
+Pavillion will use Vue.js 3 with TypeScript for the frontend, Express.js with TypeScript for the backend, Sequelize ORM with PostgreSQL for data persistence, and activitypub-express for federation implementation. The system will support both authenticated client interfaces and public site views with comprehensive testing using Vitest.
+
+## Context
+
+The technology stack needed to support rapid development of a complex federated system while maintaining code quality, type safety, and comprehensive testing. The choice needed to balance developer productivity with system performance and maintainability for a volunteer-driven or small-team project.
+
+## Alternatives Considered
+
+1. **React + Next.js Frontend**
+   - Pros: Larger ecosystem, more developers familiar
+   - Cons: More complex state management, JSX learning curve for some team members
+
+2. **Full-Stack Frameworks (Nuxt, SvelteKit)**
+   - Pros: Integrated development experience, SSR built-in
+   - Cons: Less flexibility for API-first design needed for federation
+
+3. **Go or Rust Backend**
+   - Pros: Better performance, compiled binaries
+   - Cons: Steeper learning curve, fewer ActivityPub libraries available
+
+## Rationale
+
+Vue.js 3 provides excellent developer experience with composition API and strong TypeScript support. Express.js offers mature ecosystem and flexibility needed for ActivityPub implementation. Sequelize with TypeScript decorators provides type-safe database operations. The JavaScript ecosystem offers the best available ActivityPub libraries and tooling.
+
+## Consequences
+
+**Positive:**
+- Rapid development with strong typing
+- Excellent testing infrastructure
+- Rich ecosystem for federation features
+- Accessible to volunteer developers
+- Strong i18n support for multilingual features
+
+**Negative:**
+- Runtime language performance compared to compiled alternatives
+- More complex build process with multiple compilation targets
+- Dependency management complexity in JavaScript ecosystem

--- a/agent-os/product/decisions/dec-003-domain-driven-architecture.md
+++ b/agent-os/product/decisions/dec-003-domain-driven-architecture.md
@@ -1,0 +1,47 @@
+# DEC-003: Domain-Driven Architecture
+
+> Date: 2025-07-29
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead, Development Team
+
+## Decision
+
+Pavillion backend will use domain-driven design with strict domain boundaries, where each domain (accounts, calendar, activitypub, etc.) contains its own API handlers, entities, services, and interfaces. Cross-domain communication must go through well-defined interfaces, and domains cannot directly import from other domains.
+
+## Context
+
+The federated calendar system involves complex interactions between user management, calendar operations, media handling, and federation protocols. Clear architectural boundaries are needed to maintain code organization, enable parallel development, and ensure testability as the system grows in complexity.
+
+## Alternatives Considered
+
+1. **Monolithic MVC Architecture**
+   - Pros: Simpler initial setup, familiar pattern
+   - Cons: Tight coupling, difficult to test, scaling challenges
+
+2. **Microservices Architecture**
+   - Pros: Complete isolation, independent scaling
+   - Cons: Too complex for current team size, network overhead, deployment complexity
+
+3. **Feature-Based Organization**
+   - Pros: Co-located related functionality
+   - Cons: Unclear boundaries, potential for circular dependencies
+
+## Rationale
+
+Domain-driven design provides clear boundaries while keeping everything in a single deployable application. The interface-based communication pattern ensures loose coupling while maintaining type safety. This approach supports the complex business logic needed for federation while remaining manageable for a small team.
+
+## Consequences
+
+**Positive:**
+- Clear separation of concerns
+- Easier testing with defined interfaces
+- Parallel development possible across domains
+- Federation complexity contained within ActivityPub domain
+- Easier to reason about data flow and dependencies
+
+**Negative:**
+- More initial architectural overhead
+- Requires discipline to maintain boundaries
+- Some code duplication across domains
+- Learning curve for team members unfamiliar with DDD

--- a/agent-os/product/decisions/dec-004-privacy-first-public-access.md
+++ b/agent-os/product/decisions/dec-004-privacy-first-public-access.md
@@ -1,0 +1,47 @@
+# DEC-004: Privacy-First Public Access
+
+> Date: 2025-07-29
+> Status: Accepted
+> Category: Product
+> Stakeholders: Product Owner, Tech Lead
+
+## Decision
+
+Pavillion will provide full anonymous access to all public event information without requiring user accounts, tracking, or data collection for event attendees. Account creation will only be required for event organizers, curators, and instance administrators.
+
+## Context
+
+Most existing event platforms require user registration and collect extensive personal data even for basic event browsing. This creates barriers to access, particularly for privacy-conscious users, and conflicts with the community-building mission. The decision needed to balance functionality with accessibility and privacy principles.
+
+## Alternatives Considered
+
+1. **Account Required for All Access**
+   - Pros: Better analytics, user engagement tracking
+   - Cons: Significant barrier to access, privacy concerns, reduced community reach
+
+2. **Optional Account with Enhanced Features**
+   - Pros: Balanced approach, progressive enhancement
+   - Cons: Complex permission system, potential for feature creep toward required registration
+
+3. **Completely Anonymous System**
+   - Pros: Maximum privacy protection
+   - Cons: No way to manage event creation or moderation
+
+## Rationale
+
+Anonymous public access aligns with the community-building mission by removing barriers to event discovery. Since event information is inherently public, there is no compelling reason to gate access behind registration. The three-tier user model (attendees/organizers/administrators) provides necessary functionality while maintaining privacy principles.
+
+## Consequences
+
+**Positive:**
+- Increased accessibility for diverse community members
+- Enhanced privacy protection builds community trust
+- Reduced complexity in user management
+- Lower barrier to adoption for new communities
+- Alignment with solarpunk and community-first values
+
+**Negative:**
+- Limited analytics and engagement metrics
+- No direct communication channel with event attendees
+- Potential for abuse of public access (mitigated by moderation tools)
+- More complex permission system to support anonymous access

--- a/agent-os/product/decisions/dec-005-category-identification.md
+++ b/agent-os/product/decisions/dec-005-category-identification.md
@@ -1,0 +1,52 @@
+# DEC-005: Category Identification Standards for Public APIs
+
+> Date: 2025-08-02
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Development Team, Frontend Developers
+> Related Spec: @.agent-os/specs/2025-07-30-public-category-filtering/
+
+## Decision
+
+All public-facing APIs and frontend components will use `category.id` (UUID) as the unique identifier for event categories, not `category.urlName`. Category identification within a calendar context relies on the category's natural ID property since calendar context is already established through API route parameters.
+
+## Context
+
+During implementation of the public category filtering feature, confusion arose about how to identify categories in frontend components and API calls. The initial implementation attempted to use `category.urlName` as an identifier, but this property does not exist on EventCategory models. The EventCategory model only contains `id` and `calendarId` properties, with display names stored in translatable content objects.
+
+## Alternatives Considered
+
+1. **Adding urlName property to EventCategory model**
+   - Pros: Would match calendar URL naming pattern
+   - Cons: Adds unnecessary complexity, violates DRY principle, creates potential for conflicts
+
+2. **Using category.content("en").name as identifier**
+   - Pros: Human-readable identifiers
+   - Cons: Not guaranteed to be unique, translation-dependent, fragile to content changes
+
+3. **Using category.id as identifier** (Selected)
+   - Pros: Guaranteed unique, stable, matches database primary key, simple
+   - Cons: Not human-readable in URLs
+
+## Rationale
+
+Category identification should use the natural primary key (`id`) because:
+
+1. **Calendar context is established by API routes** - `/api/public/v1/calendars/:urlName/events` already provides calendar scope
+2. **Categories are scoped to calendars** - within a calendar context, category.id provides sufficient unique identification
+3. **Consistency with domain model** - EventCategory entities have `id` and `calendarId`, making `id` the logical identifier
+4. **Simplicity** - No need for additional mapping or synthetic properties
+
+## Consequences
+
+**Positive:**
+- Clear, consistent identification pattern across all public-facing code
+- Eliminates confusion about non-existent properties
+- Reduces implementation complexity
+- Matches existing database and entity patterns
+- URL parameters use stable identifiers that won't break with content changes
+
+**Negative:**
+- Category IDs in URLs are not human-readable
+- Requires developers to understand the scoping model
+- API URLs contain UUIDs rather than friendly names

--- a/agent-os/product/decisions/dec-006-view-url-namespace.md
+++ b/agent-os/product/decisions/dec-006-view-url-namespace.md
@@ -1,0 +1,49 @@
+# DEC-006: Public Site URL Namespace Reserved as `/view/`
+
+> Date: 2026-02-22
+> Status: Accepted (the pv-l9wv `/apply/` addendum was superseded by [DEC-010](dec-010-apply-namespace-client-spa.md))
+> Category: Technical
+> Stakeholders: Development Team
+
+## Decision
+
+The `/view/` path prefix is permanently reserved as the public site SPA namespace. Public calendar URLs use the form `/view/:calendarName` (and locale-prefixed equivalents `/[lang]/view/:calendarName`). The `@` character is no longer used in public site routing.
+
+## Context
+
+The original `/@calendarname` routing convention conflicted visually and conceptually with ActivityPub's use of `@` for actor identity (e.g., `@user@instance.social`). This was identified as a pre-launch concern — changing after launch would require backward-compatibility redirects and could break bookmarked URLs. Switching to `/view/calendarname` resolves the ambiguity while keeping a readable, semantic URL structure.
+
+## Alternatives Considered
+
+1. **Keep `/@calendarname`**
+   - Pros: Already implemented, no migration needed
+   - Cons: Confusing overlap with ActivityPub `@` actor notation
+
+2. **Use `/c/:calendarName` (short prefix)**
+   - Pros: Shorter URLs
+   - Cons: Less descriptive, less obvious to end users
+
+3. **Use `/view/:calendarName`** (Selected)
+   - Pros: Clear semantic meaning, no conflict with ActivityPub, readable
+   - Cons: Slightly longer URLs
+
+## Rationale
+
+`/view/` clearly communicates intent (viewing a calendar), avoids all confusion with ActivityPub actor addresses, and establishes a clean namespace boundary. Since this is a pre-launch change, no backward-compatibility redirects are needed.
+
+## Consequences
+
+**Positive:**
+- No ambiguity between public calendar URLs and ActivityPub actor URLs
+- Clear, semantic URL structure that is understandable to end users
+- The `view` exclusion in the client catch-all regex prevents `/view/` paths from being accidentally served by the authenticated client SPA
+
+**Negative:**
+- URLs are slightly longer than the `@` convention
+- Any external documentation or links using `/@` format are now invalid (acceptable pre-launch)
+
+## Addendum (pv-l9wv): Additional Public Site Namespaces
+
+The principle established here — a reserved top-level public-site namespace served from the unauthenticated site SPA shell rather than the authenticated client SPA — extends to other public anonymous flows. As of pv-l9wv, `/apply/` is also reserved as a public site namespace (currently scoped to `/apply/confirm/:token` for account-application email confirmation). Any new top-level public-site namespace must be added to the catch-all exclusion in `src/server/app_routes.ts` and routed through `handlers.site_index` / `handlers.locale_prefixed_site` so anonymous visitors do not load the authenticated client shell (DEC-004 cookie hygiene).
+
+**Superseded by [DEC-010](dec-010-apply-namespace-client-spa.md) (2026-05-03)** — the `/apply/` reservation has been retracted. `/apply/confirm/:token` moved into the client SPA at `/auth/apply/confirm/:token`. The `/view/` reservation remains in force.

--- a/agent-os/product/decisions/dec-007-community-funding-model.md
+++ b/agent-os/product/decisions/dec-007-community-funding-model.md
@@ -1,0 +1,60 @@
+# DEC-007: Community Funding Model and Stripe Product Choice
+
+> Date: 2026-03-15
+> Status: Accepted
+> Category: Product
+> Stakeholders: Product Owner, Tech Lead, Development Team
+
+## Decision
+
+Pavillion will support optional community funding plans that allow calendar owners to collect contributions from their community to sustain calendar infrastructure. The feature uses Stripe Embedded Checkout for payment processing, with instance administrators entering Stripe API keys directly rather than using Stripe Connect OAuth. The term "funding plan" is used instead of "subscription" throughout the codebase and UI to avoid terminology collision with ActivityPub's use of "subscription" for follow relationships.
+
+## Context
+
+Running a Pavillion instance requires ongoing costs for hosting, maintenance, and community development. Rather than monetizing the platform through advertising or data collection, Pavillion adopts a community-supported funding model analogous to NPR or Wikipedia donation drives. Calendar owners can create funding plans that invite voluntary contributions from community members who benefit from the calendar. This approach directly aligns with the economic gardening mission ([DEC-001](dec-001-initial-product-planning.md)) by keeping community infrastructure community-funded rather than commercially driven.
+
+The initial implementation used Stripe Connect with OAuth, which is designed for marketplace platforms that route payments between multiple parties. This was the wrong product for Pavillion's use case, where each instance collects payments directly on behalf of its own calendars. Stripe Embedded Checkout is the correct product: it handles payment processing via an iframe embedded in the page, the user never leaves the site, and the instance owner maintains a direct relationship with Stripe using their own API keys (similar to how PayPal integration works).
+
+## Alternatives Considered
+
+1. **Stripe Connect OAuth (marketplace model)**
+   - Pros: Managed onboarding flow, Stripe handles account verification
+   - Cons: Wrong product for direct payment use case, adds unnecessary platform intermediary, complex OAuth flow, implies Pavillion is a marketplace when it is not
+
+2. **Stripe Hosted Checkout (redirect model)**
+   - Pros: Simplest integration, Stripe manages the entire checkout page
+   - Cons: User leaves the site during payment, breaks the embedded community experience, less control over UX
+
+3. **Stripe Embedded Checkout (iframe model)** (Selected)
+   - Pros: User stays on site, direct payment relationship, correct product for single-merchant use case, clean UX with iframe integration
+   - Cons: Requires CSP updates for Stripe iframe, slightly more frontend integration work
+
+4. **No funding feature**
+   - Pros: Simpler codebase, no payment complexity
+   - Cons: No sustainable funding path for community infrastructure, instance operators bear all costs
+
+## Rationale
+
+The community funding model was chosen because:
+
+1. **Mission alignment** - Community infrastructure should be funded by the community it serves, not through commercialization or data extraction. This follows the NPR/Wikipedia model where the service is free to access but sustained by voluntary contributions from those who value it.
+2. **Economic gardening** - Funding plans enable local organizations to sustain their event calendars as community infrastructure, supporting the broader goal of strengthening local economies and community resilience.
+3. **Correct Stripe product** - Embedded Checkout is the right product for direct payment collection. Connect OAuth is designed for platforms that facilitate payments between third parties (marketplaces), which is not what Pavillion does. Each instance owner has their own Stripe account and collects payments directly.
+4. **Terminology clarity** - Using "funding plan" instead of "subscription" avoids confusion with ActivityPub terminology where "subscription" refers to following an actor or calendar. This distinction is important in a federated system where ActivityPub concepts are core to the architecture.
+5. **Privacy consistency** - The funding model maintains Pavillion's privacy-first principles ([DEC-004](dec-004-privacy-first-public-access.md)). Payment processing is handled by Stripe; Pavillion stores only the minimum metadata needed to track funding plan status, not payment details.
+
+## Consequences
+
+**Positive:**
+- Sustainable funding path for community calendar infrastructure without commercialization
+- Consistent with economic gardening mission and community-first values
+- Simpler integration than Connect OAuth with fewer moving parts
+- Users complete payment without leaving the site
+- Clear terminology boundary between funding plans and ActivityPub subscriptions
+- Instance owners maintain direct Stripe relationship and full control over their payment configuration
+
+**Negative:**
+- Instance administrators must create and configure their own Stripe account
+- API keys must be stored securely (encrypted at rest) adding operational complexity
+- Funding plan management adds UI and backend complexity to the calendar domain
+- Per-calendar funding configuration requires calendar owners to understand pricing options

--- a/agent-os/product/decisions/dec-008-unpost-dismissals.md
+++ b/agent-os/product/decisions/dec-008-unpost-dismissals.md
@@ -1,0 +1,46 @@
+# DEC-008: Sticky Per-Calendar Unpost Dismissals
+
+> Date: 2026-04-11
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead, Development Team
+> Related Spec: @docs/superpowers/specs/2026-04-11-unpost-reposted-events-design.md
+
+## Decision
+
+When a calendar owner unposts a reposted event, the system writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. The inbox auto-repost handler checks this row before creating a new `SharedEventEntity`, skipping silently if present. Dismissals are strictly per-calendar: a dismissal on Calendar A never suppresses auto-reposts on Calendar B, even within the same instance. Dismissals only gate re-share creation — `Update(Event)` activities continue to flow through the inbox unmodified so the underlying `EventEntity` stays in sync for every calendar still sharing it.
+
+## Context
+
+Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound `Announce` recreated it. This undermined the community-control principle ([DEC-001](dec-001-initial-product-planning.md)): followers had policy control over *future* follows but not over *this specific event I already said no to*.
+
+## Alternatives Considered
+
+1. **Block Update activities entirely for dismissed events**
+   - Pros: Dismissed events would stop updating on the calendar list, reinforcing the "it's gone" feeling.
+   - Cons: Breaks federation sync for every *other* calendar still sharing the event — a single dismissal would stale the event across the instance. Violates federation-first principles.
+
+2. **Global (per-instance) dismissals across all calendars an account owns**
+   - Pros: Simpler mental model for owners managing multiple calendars.
+   - Cons: Violates the community-control principle that each calendar owner speaks only for their own calendar. Multi-editor calendars would get a confusing blast radius.
+
+3. **Per-calendar sticky dismissal with Update sync preserved** (Selected)
+   - Pros: Respects community control, preserves federation sync for other reposters, survives source re-broadcast.
+   - Cons: Dismissal rows accumulate over time (mitigated by `ON DELETE CASCADE` on event deletion); no audit/undo UI yet (data preserved, surface can be added later).
+
+## Rationale
+
+Per-calendar scoping is the only option that keeps DEC-001's community-control promise intact while also preserving federation-first semantics. Every calendar speaks for itself; no calendar's dismissal leaks into another calendar's policy surface. The explicit choice to leave `Update` processing unblocked is a federation-correctness invariant: `EventEntity` is a globally-shared fact, and every calendar currently sharing the event must see edits, regardless of which calendars have opted out of auto-reposting it.
+
+## Consequences
+
+**Positive:**
+- Respects DEC-001 community-control principle: each calendar owner controls only their own calendar
+- Preserves federation sync: Update activities continue flowing to all other calendars that still share the event
+- Survives source re-broadcast: the dismissal is durable, not a one-time destructive delete
+- No new API surface: the existing `DELETE /api/v1/social/shares/:eventId` endpoint handles the dismissal write transparently
+- User-facing concept ("unpost") cleanly hides the implementation vocabulary ("dismissal")
+
+**Negative:**
+- `ap_repost_dismissal` rows accumulate over time, bounded by event lifetime via `ON DELETE CASCADE`
+- No UI yet to audit or undo dismissals — deferred to a future bead; data is preserved so the surface can be added later

--- a/agent-os/product/decisions/dec-009-ics-import-funding-gate-posture.md
+++ b/agent-os/product/decisions/dec-009-ics-import-funding-gate-posture.md
@@ -1,0 +1,51 @@
+# DEC-009: ICS Import Funding-Gate Posture
+
+> Date: 2026-04-22
+> Status: Partially superseded by [DEC-011](dec-011-federated-value-boundary.md) (2026-05-16)
+> Category: Product
+> Stakeholders: Product Owner, Tech Lead
+> Related Spec: @pv-1qcp (bead)
+
+## Decision
+
+ICS basic import (v1) is free and ungated onboarding infrastructure. Advanced ICS sync capabilities — background polling, mirror mode with ongoing source precedence, and hosted-provider OAuth (Google Calendar, Outlook/M365, iCloud) — will ship as funding-gated features in later phases. This diverges from the roadmap Phase 2 Facebook import posture (explicitly funding-gated) because Facebook import serves ongoing community aggregation while ICS import serves one-time migration from a user's existing self-hosted calendar.
+
+## Context
+
+Roadmap Phase 2 gates Facebook event import behind funding plan subscription (per [DEC-007](dec-007-community-funding-model.md) community funding model), and the same question arises for ICS import: should a calendar owner pay to migrate events in from their existing Nextcloud, Gancio, or WordPress Events Calendar? The ICS import epic (pv-1qcp) is the foundation for that migration path, using DNS TXT verification to prove source ownership and user-initiated "Sync now" pulls with no background polling in v1.
+
+[DEC-001](dec-001-initial-product-planning.md) establishes the economic-gardening mission: Pavillion exists to lower barriers to community infrastructure, not extract rent at every touchpoint. [DEC-007](dec-007-community-funding-model.md) establishes that funding plans fund ongoing operational value (hosting, maintenance, community development) via voluntary community contribution rather than gatekeeping access. Gating migration itself — the moment when a user is actively choosing to move their community infrastructure onto Pavillion — would contradict both principles: it charges at the point of highest friction, before the user has received any value from the platform, and it punishes the exact migration path Pavillion wants to encourage.
+
+## Alternatives Considered
+
+1. **Gate all ICS import behind funding plan (mirror Facebook import posture)**
+   - Pros: Consistent rule across all import paths; clear revenue signal at adoption time
+   - Cons: Creates chicken-and-egg migration barrier (user must fund before they can evaluate migration); contradicts economic-gardening mission (DEC-001) by charging at the friction point; conflates one-time migration with ongoing aggregation
+
+2. **Gate after the Nth source or Nth import run**
+   - Pros: Free entry path; funding signal tied to heavy usage
+   - Cons: Arbitrary threshold is hard to defend to users; implementation complexity (counting, resets, edge cases); still gates migration for calendars with multiple legacy sources; pattern doesn't exist elsewhere in the codebase
+
+3. **Free for v1 basic import; advanced sync features funding-gated in later phases** (Selected)
+   - Pros: Migration frictionless; funding aligned with ongoing operational value (polling infrastructure, OAuth maintenance, aggregation/mirror complexity); consistent with NPR/Wikipedia contribution model from DEC-007
+   - Cons: No direct funding signal at migration time (acceptable — funding plans exist independently on the calendar and the user can subscribe once they've settled in)
+
+## Rationale
+
+Migration onboarding should be frictionless. Once a user has moved their calendar onto Pavillion and is operating it day-to-day, advanced sync capabilities — hosted provider OAuth, background polling, aggregation and mirror modes — represent ongoing platform value that is legitimately funding-gated territory. This matches DEC-007's NPR/Wikipedia model: the service is free to adopt and use, and voluntary contributions sustain the advanced operations that benefit the broader community. The distinction from the Facebook import posture is the use case, not the technology: Facebook import is community aggregation (aggregating Facebook event pages into a community calendar), while ICS import is personal migration (moving your own calendar's events into your own Pavillion calendar).
+
+## Consequences
+
+**Positive:**
+- Low-friction migration path aligns with DEC-001 economic-gardening mission
+- Funding-gate posture remains internally consistent (funding pays for ongoing operational value, not gatekeeping adoption)
+- Users can evaluate Pavillion with their real calendar data before deciding to fund
+- Clear product boundary: v1 basic import is onboarding infrastructure; advanced sync is platform value
+
+**Negative:**
+- No direct funding signal at migration time (acceptable — funding plans exist independently on the calendar and can be subscribed to once the user has settled in)
+- Future advanced-sync funding gates must be clearly communicated so users understand what they're subscribing for, not retroactively locking behavior users relied on in v1
+
+## Partially superseded by [DEC-011](dec-011-federated-value-boundary.md) (2026-05-16)
+
+The comparative framing of ICS import vs Facebook import as "personal migration vs community aggregation," and the operational-cost rationale for funding-gating advanced ICS sync, are retracted. Facebook event import is no longer feasible per Facebook's platform constraints, and the use-case spectrum that distinction relied on has collapsed. The core decisions (ICS basic import is free onboarding; advanced ICS sync is funding-gated) remain in force, now justified under the federated value boundary principle established in DEC-011.

--- a/agent-os/product/decisions/dec-010-apply-namespace-client-spa.md
+++ b/agent-os/product/decisions/dec-010-apply-namespace-client-spa.md
@@ -1,0 +1,44 @@
+# DEC-010: Public Apply Namespace Returns to Client SPA
+
+> Date: 2026-05-03
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead, Development Team
+> Related Spec: @pv-e92c (bead)
+> Supersedes: [DEC-006](dec-006-view-url-namespace.md) pv-l9wv addendum (the `/apply/` reservation as a public site namespace)
+
+## Decision
+
+`/apply/confirm/:token` moves from the site SPA shell to the client SPA's logged-out auth flow, with the canonical URL becoming `/auth/apply/confirm/:token`. The `/apply/` top-level reservation in `src/server/app_routes.ts` is removed; that path falls through to the client SPA catch-all like the other `/auth/*` URLs do today. The `/view/` reservation established by [DEC-006](dec-006-view-url-namespace.md) itself remains in force; only the pv-l9wv addendum that extended the reservation to `/apply/` is superseded.
+
+## Context
+
+The DEC-006 pv-l9wv addendum (committed earlier in this branch) reserved `/apply/` as a public site namespace and routed `/apply/confirm/:token` through the site SPA shell. The stated rationale was cookie hygiene — anonymous visitors should not load the authenticated client shell. On reflection during a post-implementation audit of the affected component, that argument did not hold:
+
+- The cookie-hygiene concern is API-layer: the confirm GET/POST endpoints (commits `07d9901`, `40779dd`) return identical generic responses for any failure mode and run with no session middleware. Whether the user-facing landing page is rendered by the client SPA or the site SPA does not affect that property.
+- Anonymous visitors already load the client SPA when they hit `/auth/login`, `/auth/apply`, or `/auth/forgot`. None of those leak anything via cookies because anonymous visitors have no session cookie to begin with. `/apply/confirm/:token` is the same kind of anonymous-visitor flow as those routes.
+- Conceptually, applying for an account, confirming the email, logging in, and resetting a password are one continuous "logged-out auth" surface owned by the client SPA. Splitting one step of it into a separate SPA created visual drift, accessibility regressions (the site shell provides no `<h1>` for inner pages to subordinate to), and an unnecessary cross-SPA SCSS dependency to make the site page look like the client page.
+
+## Alternatives Considered
+
+1. **Keep the page in the site SPA and patch the audit findings in place**
+   - Pros: Smaller change; preserves the pv-l9wv addendum
+   - Cons: Patches symptoms, not the root cause (wrong SPA placement); requires either adding an `<h1>` to the site shell (visually invasive for every other site page) or accepting a heading-hierarchy violation; preserves the cross-SPA SCSS dependency that the architecture-auditor flagged
+
+2. **Extract `logged_out/root.vue` to `src/common/components/` and reuse from both SPAs**
+   - Pros: Enables future cross-SPA component reuse
+   - Cons: Premature abstraction — apply-confirm is the only candidate, and moving it to the client SPA makes the abstraction unnecessary; YAGNI
+
+3. **Move the page to the client SPA at `/auth/apply/confirm/:token`** (Selected)
+   - Pros: Inherits correct shell (`AuthViews` provides `<header><h1>` for free); eliminates cross-SPA SCSS imports; conceptually unifies the logged-out auth surface in one SPA
+   - Cons: User-facing URL changes from `/apply/confirm/:token` to `/auth/apply/confirm/:token` (acceptable pre-launch — no in-the-wild emails point at the old URL)
+
+## Consequences
+
+**Positive:**
+- Page inherits `AuthViews` wrapper for free: `<main class="logged-out"><header><h1>{{ siteTitle }}</h1></header><section><RouterView /></section><footer/>` — correct heading hierarchy, named landmark via the `<h1>`-bearing header.
+- Cross-SPA SCSS imports added to `src/site/assets/style.scss` in commit `bbedcb1` are reverted; the only remaining cross-SPA stylesheet dependency is the original `fonts` import.
+- One conceptual model for the logged-out surface: all routes live under `/auth/*` in the client SPA. The DEC-006 pv-l9wv addendum's separate "public site namespace for anonymous flows" rule no longer needs to exist.
+
+**Negative:**
+- DEC-006 is now split between an original decision (the `/view/` URL convention, still in force) and a superseded addendum (the `/apply/` reservation). The historical record adds noise but is preserved for traceability.

--- a/agent-os/product/decisions/dec-011-federated-value-boundary.md
+++ b/agent-os/product/decisions/dec-011-federated-value-boundary.md
@@ -1,0 +1,66 @@
+# DEC-011: ICS Scope, Curator Aggregation Model, and Federated Value Boundary
+
+> Date: 2026-05-16
+> Status: Accepted
+> Category: Product
+> Stakeholders: Product Owner, Tech Lead
+> Related Spec: Cited by roadmap v5.0.0 (`agent-os/product/roadmap.md`)
+> Partially supersedes: [DEC-009](dec-009-ics-import-funding-gate-posture.md) — the comparative ICS-vs-Facebook framing and the operational-cost rationale for advanced-sync funding gating
+
+## Decision
+
+Three connected scope decisions:
+
+1. **ICS import is exclusively organizer migration tooling.** It is not a curator aggregation surface. The basic-import-is-free-onboarding decision from [DEC-009](dec-009-ics-import-funding-gate-posture.md) stands; the DEC-009 framing that contrasted ICS as "personal migration" against Facebook import as "community aggregation" is retracted. ICS import exists to help an organization move its own existing calendar data into its own Pavillion calendar, full stop.
+
+2. **Curator aggregation operates via federation only.** A community curator (chamber of commerce, tourism board, city events page) aggregates by following other Pavillion calendars and other ActivityPub event platforms (Mobilizon, Gancio, Friendica). The 20 source calendars in a typical curator aggregator are 20 community organizations with their own Pavillion calendars, federated to the curator via the existing follow + auto-repost mechanism — not 20 external platforms scraped or imported. There is no roadmap path for curator aggregation from non-federated sources (Facebook, Eventbrite, Google Calendar, etc.) — neither as a free in-product feature nor as a funding-gated one.
+
+3. **Advanced ICS sync (background polling, hosted-provider OAuth, mirror mode) remains funding-gated, but the rationale is rewritten.** DEC-009 framed this as operational-cost gating. This decision regates it under the *federated value boundary principle*: features that maintain ongoing integrations with non-federated systems — inbound (Google Calendar OAuth, Outlook/M365, iCloud, ICS polling of non-federated sources) or outbound (ICS feed export, third-party read API, advanced widget embedding) — are platform-bridge services, structurally distinct from in-network features. Operational cost remains a secondary contributing concern but is no longer the primary justification.
+
+## Context
+
+DEC-009 was written when Facebook event import was the planned vector for community aggregation from non-federated platforms. Subsequent investigation has confirmed Facebook import is infeasible due to platform constraints Facebook has imposed. This invalidates DEC-009's comparative framing, which positioned ICS import (free, personal migration) against Facebook import (funding-gated, community aggregation) as two ends of a use-case spectrum. With Facebook removed, that spectrum collapses, and the curator aggregation model needs to be restated without reference to non-federated platforms.
+
+In parallel, roadmap v5.0.0 introduced an explicit operating principle — the *federated value boundary* — that separates in-network features (free) from outside-network features (funding-gated). This principle is more mission-coherent than DEC-009's operational-cost framing because it maps directly to the federation differentiator in `mission.md`: the federated network is what Pavillion exists to enhance, and features that step outside the federated paradigm are value-add platform-bridge services with a different cost and incentive structure.
+
+The mission's "Community Curators ... aggregate and curate events from multiple sources" language has been read ambiguously over time. Read in context with the rest of the Problem section ("organizations maintain their own calendars while enabling community curators to create comprehensive, unified views"), "multiple sources" unambiguously means multiple federated calendars maintained by the organizations themselves. The alternate reading — that "multiple sources" could include non-federated platforms (Facebook pages, Eventbrite listings, individual websites) — is a misreading: those external platforms are named in the *problem statement* as the fragmentation Pavillion solves, not in the *solution architecture* as inputs to curator aggregation. The solution is to bring organizations onto Pavillion (where they maintain their own calendars) and federate.
+
+This misreading was actively encoded by DEC-009's Facebook framing and propagated into the v5 roadmap draft, where it would have shipped a curator-workflow phase modeled on cross-platform ICS aggregation if not caught in review. This DEC corrects the record so the misreading does not recur.
+
+## Alternatives Considered
+
+1. **Leave DEC-009 in place; let the Facebook framing decay silently**
+   - Pros: No new document to maintain
+   - Cons: DEC-009 actively codifies a curator model that no longer has any implementation path; future readers (human or AI) keep importing the stale model — which has already happened once during roadmap v5 drafting
+
+2. **Edit DEC-009 in place**
+   - Pros: Single source of truth
+   - Cons: Violates the codebase convention of immutable decision records with supersession notes (established by DEC-006 → DEC-010); loses the historical record of what was believed when
+
+3. **Issue DEC-011 with the corrected framing; mark DEC-009's invalidated paragraphs as superseded** (Selected)
+   - Pros: Follows established supersession convention; preserves historical record; gives roadmap v5 a clean decision to cite; future readers see both the original framing and the correction
+   - Cons: Two documents to read for full context (acceptable — that is how supersession works in this repo)
+
+## Rationale
+
+Three reasons drove this revision:
+
+1. **Mission coherence.** The federated network is the mission's central architectural commitment. Funding-gating features by whether they sit inside or outside that network makes the funding ask honest: voluntary contribution sustains community infrastructure; value-add platform bridges to non-federated systems are appropriately a paid surface. This aligns [DEC-001](dec-001-initial-product-planning.md) (economic gardening) and [DEC-007](dec-007-community-funding-model.md) (voluntary contribution model) with a concrete in/out rule that decides individual feature placement.
+
+2. **Stale rationale is dangerous.** DEC-009's Facebook-as-community-aggregation framing actively misled the v5 roadmap draft. The longer a stale framing sits in the decision record, the more downstream artifacts inherit it. Correcting the record at the decision layer prevents further propagation.
+
+3. **Curator model precision matters for current work.** With curator aggregation correctly framed as in-network federation, Phase 1 of the v5 roadmap (Curation Workflow on Top of Follow + Repost) targets the right problems: selective repost policies, category normalization across followed Pavillion calendars, deduplication in the repost chain, editorial controls preserved across source updates. With the wrong framing, Phase 1 would have targeted source-management UIs for non-Pavillion sources that do not exist as inputs.
+
+## Consequences
+
+**Positive:**
+- Mission-coherent funding-gate rationale (in-network = free; platform bridge = gated) replaces an ad-hoc operational-cost framing
+- Curator aggregation model is unambiguously restricted to federation, preventing future drift toward multi-platform aggregation surfaces that do not fit the architecture
+- ICS import scope is clear: organizer migration tool, full stop — no aggregation use case attached
+- Roadmap v5 Phase 1 has a defensible decision-level foundation
+- The boundary principle gives every future inbound/outbound feature a deterministic free/gated classification, reducing future scope debates
+
+**Negative:**
+- Reading DEC-009 now requires also reading DEC-011 to understand which paragraphs are superseded (standard cost of the supersession convention)
+- Operational-cost concerns about advanced ICS sync (polling rate limits, OAuth maintenance burden, hosted-provider API quotas) are demoted from primary to secondary rationale, which slightly reduces their salience in future planning — should be re-surfaced during the deferred-phase re-engagement when advanced ICS sync is built
+- The federated value boundary requires a judgment call for edge cases that span the boundary (e.g. schema.org Event markup on public event pages: content stays on Pavillion but is consumed by Google's crawler). The v5 roadmap classifies these as in-network discovery infrastructure; this DEC accepts that classification and reserves the right to revisit it case-by-case


### PR DESCRIPTION
## Motivation

The product decisions log had grown to ~600 lines in a single file. Scanning to find a relevant decision required reading the whole file, and there was no signal for a contributor or AI agent to know which decisions were relevant to the work in front of them. As decisions accumulate, this only gets worse.

Adding DEC-011 (federated value boundary) surfaced the same friction: it slotted into the file, but offered no way for future readers to find it without reading everything.

## Approach

Split the single file into:

- `agent-os/product/decisions.md` — an index that groups decisions by topic (Mission/Funding, Architecture, Federation, Routing, Conventions), gives each a one-line decision summary, and adds a **Consult when** trigger list so readers can decide whether to load the full file.
- `agent-os/product/decisions/dec-NNN-slug.md` — one self-contained file per decision (11 total).

The index is bumped to v2.0.0 and ends with a "Conventions for adding new decisions" section that documents the supersede-don't-edit rule and the 6-step add procedure.

Carves a narrow `.gitignore` exception so only `agent-os/product/decisions.md` and `agent-os/product/decisions/**` are tracked; the rest of `agent-os/` (mission, roadmap, tech-stack, beads workspace, etc.) remains local.

Includes a new **DEC-011** (federated value boundary) that supersedes the comparative ICS-vs-Facebook framing and the operational-cost rationale in **DEC-009**. The retired DEC-009 paragraphs are marked in place with a forward link, following the supersession convention already used by DEC-006 → DEC-010.

## Validation

- `git check-ignore -v` confirms the gitignore behaves as intended: decision records and the decisions index are tracked; the rest of agent-os (mission.md, roadmap.md, config.yml, .DS_Store, .claude/) remains ignored.
- Cross-reference links between decision files use relative paths and were spot-checked.
- DEC-009's status header and supersession note point at DEC-011 and vice versa; DEC-006 ↔ DEC-010 links preserved from the prior structure.
- Docs-only PR — no source code, no tests, no runtime behavior changed.