### PR TITLE
ci: bump deprecated Node 20 actions to Node 24 versions

### DIFF
--- a/.github/workflows/delete-merged-branches.yaml
+++ b/.github/workflows/delete-merged-branches.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Delete branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -26,13 +26,13 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'npm'

--- a/.github/workflows/manifest_lint.yaml
+++ b/.github/workflows/manifest_lint.yaml
@@ -6,7 +6,7 @@ jobs:
   manifest_lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run bash tests
         run: bash bin/test/run.sh
       - name: Check manifest wiring

--- a/.github/workflows/release_docker_images.yaml
+++ b/.github/workflows/release_docker_images.yaml
@@ -71,7 +71,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/run_federation_tests.yaml
+++ b/.github/workflows/run_federation_tests.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: federation-test-results
           path: |


### PR DESCRIPTION
## Motivation

GitHub deprecated the Node.js 20 runtime for JavaScript actions on 2025-09-19 and will force actions to Node 24 on 2026-06-02 (removing Node 20 entirely on 2026-09-16). The recent Node 22→24 LTS upgrade (#325) covered the main test workflows but left several workflow steps on action versions whose own runtime is still Node 20, producing warnings like:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4

## Approach

Bumped each remaining Node-20-pinned action to its current Node-24 release:

- \`manifest_lint.yaml\`: \`actions/checkout\` v4 → v6
- \`deploy_docs.yaml\`: \`actions/checkout\` v4 → v6, \`actions/setup-node\` v4 → v6
- \`run_federation_tests.yaml\`: \`actions/upload-artifact\` v4 → v5
- \`release_docker_images.yaml\`: \`actions/upload-artifact\` v4 → v5, \`actions/download-artifact\` v4 → v5
- \`delete-merged-branches.yaml\`: \`actions/github-script\` v7 → v8

No behavior changes — these are all backward-compatible major bumps where the only change is the runtime version the action itself executes on. The \`node-version-file: '.node-version'\` input to \`setup-node\` is unaffected; \`setup-node@v6\` still reads \`.node-version\` the same way.

## Validation

Verified with \`grep -rn "actions/" .github/workflows/\` that every \`actions/*\` reference now points at a Node-24-compatible major version. Application code is untouched, so the existing test suites are not affected. The workflows themselves will exercise the new versions when this PR's CI runs.