### PR TITLE
fix(housekeeping): hard-delete pruned backup rows

### DIFF
--- a/src/server/housekeeping/service/retention.ts
+++ b/src/server/housekeeping/service/retention.ts
@@ -83,7 +83,7 @@ export default class RetentionService {
   }
 
   /**
-   * Deletes a backup file from filesystem and updates metadata.
+   * Deletes a backup file from filesystem and removes its metadata row.
    *
    * @param backup - BackupEntity to delete
    */
@@ -91,21 +91,20 @@ export default class RetentionService {
     const fullPath = path.join(backup.storage_location, backup.filename);
 
     try {
-      // Delete file from filesystem
       if (fs.existsSync(fullPath)) {
         fs.unlinkSync(fullPath);
         logger.info({ filename: backup.filename }, 'Deleted backup file');
       }
       else {
-        logger.warn({ filename: backup.filename }, 'Backup file not found, skipping deletion');
+        logger.warn({ filename: backup.filename }, 'Backup file not found, skipping file deletion');
       }
 
-      // Update metadata to mark as deleted
-      await backup.update({
-        verified: false, // Mark as no longer verified since file is gone
-      });
+      // Hard-delete the metadata row. A backup whose file is gone has nothing
+      // left to represent; leaving a soft-deleted row behind inflates the
+      // dashboard's retention count, which queries every row in the category.
+      await backup.destroy();
 
-      logger.info({ backupId: backup.id }, 'Updated metadata for deleted backup');
+      logger.info({ backupId: backup.id }, 'Removed metadata for deleted backup');
     }
     catch (error) {
       logError(error, `[Housekeeping] Failed to delete backup ${backup.filename}`);

--- a/src/server/housekeeping/test/service/retention.test.ts
+++ b/src/server/housekeeping/test/service/retention.test.ts
@@ -56,14 +56,14 @@ describe('RetentionService', () => {
       // Verify that 3 oldest backups were deleted (indices 7, 8, 9)
       expect(fs.unlinkSync).toHaveBeenCalledTimes(3);
 
-      // Verify the update method was called for deleted backups
-      expect(dailyBackups[7].update).toHaveBeenCalled();
-      expect(dailyBackups[8].update).toHaveBeenCalled();
-      expect(dailyBackups[9].update).toHaveBeenCalled();
+      // Verify the metadata row was hard-deleted for each pruned backup
+      expect(dailyBackups[7].destroy).toHaveBeenCalled();
+      expect(dailyBackups[8].destroy).toHaveBeenCalled();
+      expect(dailyBackups[9].destroy).toHaveBeenCalled();
 
       // Verify newest 7 were not deleted (indices 0-6)
-      expect(dailyBackups[0].update).not.toHaveBeenCalled();
-      expect(dailyBackups[6].update).not.toHaveBeenCalled();
+      expect(dailyBackups[0].destroy).not.toHaveBeenCalled();
+      expect(dailyBackups[6].destroy).not.toHaveBeenCalled();
     });
 
     it('should keep only 4 most recent weekly backups', async () => {
@@ -108,12 +108,12 @@ describe('RetentionService', () => {
 
       // Verify that 2 oldest weekly backups were deleted (indices 4, 5)
       expect(fs.unlinkSync).toHaveBeenCalledTimes(2);
-      expect(weeklyBackups[4].update).toHaveBeenCalled();
-      expect(weeklyBackups[5].update).toHaveBeenCalled();
+      expect(weeklyBackups[4].destroy).toHaveBeenCalled();
+      expect(weeklyBackups[5].destroy).toHaveBeenCalled();
 
       // Verify newest 4 were not deleted (indices 0-3)
-      expect(weeklyBackups[0].update).not.toHaveBeenCalled();
-      expect(weeklyBackups[3].update).not.toHaveBeenCalled();
+      expect(weeklyBackups[0].destroy).not.toHaveBeenCalled();
+      expect(weeklyBackups[3].destroy).not.toHaveBeenCalled();
     });
 
     it('should keep only 6 most recent monthly backups', async () => {
@@ -148,12 +148,12 @@ describe('RetentionService', () => {
 
       // Verify that 2 oldest monthly backups were deleted (indices 6, 7)
       expect(fs.unlinkSync).toHaveBeenCalledTimes(2);
-      expect(monthlyBackups[6].update).toHaveBeenCalled();
-      expect(monthlyBackups[7].update).toHaveBeenCalled();
+      expect(monthlyBackups[6].destroy).toHaveBeenCalled();
+      expect(monthlyBackups[7].destroy).toHaveBeenCalled();
 
       // Verify newest 6 were not deleted (indices 0-5)
-      expect(monthlyBackups[0].update).not.toHaveBeenCalled();
-      expect(monthlyBackups[5].update).not.toHaveBeenCalled();
+      expect(monthlyBackups[0].destroy).not.toHaveBeenCalled();
+      expect(monthlyBackups[5].destroy).not.toHaveBeenCalled();
     });
 
     it('should delete correct files from filesystem', async () => {
@@ -223,8 +223,8 @@ describe('RetentionService', () => {
       // Should not throw even if file is missing
       await expect(service.enforceRetention()).resolves.not.toThrow();
 
-      // Should still update metadata for deleted backups (oldest one)
-      expect(backups[7].update).toHaveBeenCalled();
+      // Should still hard-delete metadata for pruned backups (oldest one)
+      expect(backups[7].destroy).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Motivation

The admin dashboard's System Status widget was reporting more daily backups than the configured retention limit (13 / 7 on staging, similar drift in production). The retention sweep itself was working — files were being deleted from disk on schedule — but the dashboard count kept climbing.

Root cause: `RetentionService.deleteBackup` unlinked the file but only flipped `verified=false` on the `BackupEntity` row. The dashboard's `getRetentionStats` counts every row in each category regardless of `verified`, so each prune left a tombstone that the widget kept counting.

## Approach

Replace `backup.update({ verified: false })` with `backup.destroy()` in `RetentionService.deleteBackup`. Once the file is gone there is nothing left for the metadata row to represent, and removing it keeps the dashboard count aligned with what the sweep actually retains.

Updated `retention.test.ts` to assert `destroy()` was called on each pruned backup instead of `update()`. The other unverified-row writer in the codebase (`BackupService.createBackup` recording a failed verification) is untouched — those are legitimate failure records, not tombstones, and the change here only affects the retention path.

Note: existing tombstone rows on staging and prod remain in the database. They will need a one-time `DELETE FROM backup_metadata WHERE verified = false;` (or a more careful filesystem-aware cleanup if any failed-creation rows are present) to bring those counts down immediately. New tombstones will not be created.

## Validation

- `npx vitest run src/server/housekeeping` — 121 tests pass across the 12 housekeeping test files, including the 6 retention tests with updated assertions.
- `npx eslint` on changed files — clean (one pre-existing unused-import warning in `retention.ts` is untouched and out of scope).