### PR TITLE
docs(instance-administrators): add scaffold and quickstart guide

### DIFF
--- a/bin/provision.sh
+++ b/bin/provision.sh
@@ -15,6 +15,8 @@
 #
 # Flags:
 #   --staging              Enable staging mode (webhook listener, auto-deploy)
+#   --standalone           Enable the bundled standalone Caddy reverse proxy
+#                          (writes COMPOSE_PROFILES=standalone to .env)
 #   --domain=<value>       Domain name for the instance (required when piped)
 #   --repo=<url>           Git repository URL (default: GitHub repo)
 #
@@ -51,6 +53,7 @@ DEPLOY_USER="pavillion"
 APP_DIR="/opt/pavillion"
 SSH_PORT=22
 STAGING_MODE=false
+STANDALONE_MODE=false
 DOMAIN=""
 REPO_URL="https://github.com/stephenhoward/pavillion.git"
 
@@ -435,12 +438,31 @@ clone_repo() {
 run_deploy() {
   print_step "Running bin/deploy.sh"
 
-  if [ -f "${APP_DIR}/bin/deploy.sh" ]; then
-    su - "${DEPLOY_USER}" -c "cd ${APP_DIR} && ./bin/deploy.sh --non-interactive --domain=${DOMAIN}"
-    print_success "Deploy script completed"
-  else
+  if [ ! -f "${APP_DIR}/bin/deploy.sh" ]; then
     print_error "bin/deploy.sh not found in ${APP_DIR}. Run deploy manually after cloning."
     return 1
+  fi
+
+  # Prepend COMPOSE_PROFILES so the docker compose calls inside deploy.sh pick
+  # up the bundled standalone Caddy. su - strips most env vars (login shell),
+  # so the prefix has to live on the command line itself, not the parent env.
+  local compose_profiles=""
+  if [ "$STANDALONE_MODE" = true ]; then
+    compose_profiles="COMPOSE_PROFILES=standalone "
+  fi
+
+  su - "${DEPLOY_USER}" -c "cd ${APP_DIR} && ${compose_profiles}./bin/deploy.sh --non-interactive --domain=${DOMAIN}"
+  print_success "Deploy script completed"
+
+  # Persist COMPOSE_PROFILES to .env so future docker compose calls (operator
+  # running 'docker compose ps', subsequent deploy.sh runs) also see it. .env
+  # is created during the install path above, so this append is safe to do
+  # after run_deploy succeeds.
+  if [ "$STANDALONE_MODE" = true ]; then
+    if ! grep -qE '^COMPOSE_PROFILES=' "${APP_DIR}/.env" 2>/dev/null; then
+      echo "COMPOSE_PROFILES=standalone" >> "${APP_DIR}/.env"
+      print_success "Persisted COMPOSE_PROFILES=standalone to ${APP_DIR}/.env"
+    fi
   fi
 }
 
@@ -555,6 +577,7 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --staging) STAGING_MODE=true ;;
+      --standalone) STANDALONE_MODE=true ;;
       --domain=*) DOMAIN="${arg#--domain=}" ;;
       --repo=*) REPO_URL="${arg#--repo=}" ;;
     esac

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,8 +49,80 @@ export default defineConfig({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Calendar owners', link: '/guides/calendar-owners/' },
+      { text: 'Instance administrators', link: '/guides/instance-administrators/' },
     ],
     sidebar: {
+      '/guides/instance-administrators/': [
+        {
+          text: 'For instance administrators',
+          link: '/guides/instance-administrators/',
+        },
+        {
+          text: 'Quickstart',
+          items: [
+            { text: 'From clean server to federating instance', link: '/guides/instance-administrators/quickstart' },
+          ],
+        },
+        {
+          text: 'Get an instance running',
+          items: [
+            { text: 'Install a Pavillion instance', link: '/guides/instance-administrators/installation' },
+            { text: 'Configure your instance', link: '/guides/instance-administrators/configuration' },
+            { text: 'Reverse proxy and TLS', link: '/guides/instance-administrators/reverse-proxy-and-tls' },
+            { text: 'Email', link: '/guides/instance-administrators/email' },
+            { text: 'Media storage', link: '/guides/instance-administrators/media-storage' },
+          ],
+        },
+        {
+          text: 'Shape your instance',
+          items: [
+            { text: 'What your instance is for', link: '/guides/instance-administrators/what-your-instance-is-for' },
+            { text: 'Who gets a calendar', link: '/guides/instance-administrators/who-gets-a-calendar' },
+            { text: 'A code of conduct for your instance', link: '/guides/instance-administrators/code-of-conduct' },
+          ],
+        },
+        {
+          text: 'Operate your instance',
+          items: [
+            { text: 'Monitoring and logs', link: '/guides/instance-administrators/monitoring-and-logs' },
+            { text: 'Backups', link: '/guides/instance-administrators/backups' },
+            { text: 'Upgrading', link: '/guides/instance-administrators/upgrading' },
+            { text: 'Rotating secrets', link: '/guides/instance-administrators/secret-rotation' },
+            { text: 'Troubleshooting', link: '/guides/instance-administrators/troubleshooting' },
+          ],
+        },
+        {
+          text: 'Federate with the network',
+          items: [
+            { text: 'How federation works, for admins', link: '/guides/instance-administrators/how-federation-works-for-admins' },
+            { text: 'Testing federation', link: '/guides/instance-administrators/testing-federation' },
+            { text: 'Federation policy', link: '/guides/instance-administrators/federation-policy' },
+            { text: 'Federation incidents', link: '/guides/instance-administrators/federation-incidents' },
+          ],
+        },
+        {
+          text: 'Moderate at the instance level',
+          items: [
+            { text: 'Moderation boundaries', link: '/guides/instance-administrators/moderation-boundaries' },
+            { text: 'Removing a calendar', link: '/guides/instance-administrators/removing-a-calendar' },
+            { text: 'Account operations', link: '/guides/instance-administrators/accounts' },
+          ],
+        },
+        {
+          text: 'Fund your instance',
+          items: [
+            { text: 'Setting up funding plans', link: '/guides/instance-administrators/funding-plans-setup' },
+            { text: 'Asking your community for money', link: '/guides/instance-administrators/asking-your-community-for-money' },
+          ],
+        },
+        {
+          text: 'Relationship with your community',
+          items: [
+            { text: 'Communicating with your calendar owners', link: '/guides/instance-administrators/communicating-with-calendar-owners' },
+            { text: 'Being a good admin', link: '/guides/instance-administrators/being-a-good-admin' },
+          ],
+        },
+      ],
       '/guides/calendar-owners/': [
         {
           text: 'For calendar owners',

--- a/docs/guides/instance-administrators/accounts.md
+++ b/docs/guides/instance-administrators/accounts.md
@@ -1,0 +1,18 @@
+---
+description: Admin-level account operations on Pavillion — suspending and reinstating accounts, deleting accounts, recovering a locked-out admin, helping a user back into a calendar they own.
+---
+
+# Account operations
+
+> Status: placeholder. This guide will be written before launch.
+
+The admin actions that touch accounts directly — not the content the account publishes, but the account itself. These are less frequent than calendar-level actions but the ones where mistakes are hardest to reverse.
+
+## Planned scope
+
+- Suspending an account: what it does, what the user sees, what their calendars do (this depends on product behavior to confirm), when to suspend vs. when to talk first
+- Reinstating a suspended account: the procedure and the conversation that should precede it
+- Deleting an account: the rare cases (user request, court order, account is purely abusive), what's recoverable, what isn't, the relationship between deleting an account and removing its calendars
+- Recovering a locked-out admin — the path back in when no admin can log in. The fallback procedure that has to exist for first-deployment day-two-disaster
+- Helping a calendar owner who's lost access to their own calendar: password reset paths, email-change paths, ownership-transfer paths if those exist
+- The "this user has a name collision with someone on another instance" question — federation makes this rarer than it is on centralized systems, but it does come up

--- a/docs/guides/instance-administrators/asking-your-community-for-money.md
+++ b/docs/guides/instance-administrators/asking-your-community-for-money.md
@@ -1,0 +1,19 @@
+---
+description: How to ask the community that uses your Pavillion instance for money — when, how often, how transparent, and how not to sound like a SaaS upsell.
+---
+
+# Asking your community for money
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion's funding model is public radio, not SaaS. The software supports voluntary contributions; the harder part is asking for them in a way that fits an anti-extractive community-funded platform. This guide is the organizer-judgment side of [funding plan setup](./funding-plans-setup).
+
+## Planned scope
+
+- Why ask at all: hosting, storage, your time, the infrastructure that lets people find each other's events. Naming this honestly does more for contributions than vagueness does
+- When to ask: not at signup (the "no friction to public access" promise is the whole point), not as a paywall, but at moments when the value is visible and the contribution is in proportion
+- How often: regular enough that contributions feel like part of how the instance runs, infrequent enough that nobody feels harassed. A drive a year is plausible; a banner that never goes away isn't
+- How transparent: publishing what it costs to run the instance, where the contributions go, what shortfall looks like. Public radio publishes its numbers, and that's why people contribute
+- The voice question: warmth, not desperation; gratitude, not entitlement; honesty about what contributions buy (continued operation) and what they don't (special treatment, more features, anything that resembles a tier)
+- The "what if I want to require contributions" question — you can't, and not just because the software won't let you. The free-public-access posture is a load-bearing wall in Pavillion's mission; removing it changes what the instance is
+- A short list of don'ts, with reasons: don't gate features behind contributions, don't email people who contributed once asking for more, don't hide the "no thanks" option, don't sell the contribution as anything other than what it is

--- a/docs/guides/instance-administrators/backups.md
+++ b/docs/guides/instance-administrators/backups.md
@@ -1,0 +1,18 @@
+---
+description: Back up a Pavillion instance — database, media, secrets, config — and test the restore before you need it.
+---
+
+# Backups
+
+> Status: placeholder. This guide will be written before launch.
+
+A backup you haven't tested isn't a backup. This is the most-skipped piece of admin work and the one that determines whether a server failure is an inconvenience or a community-rebuilding exercise.
+
+## Planned scope
+
+- What to back up, in order of importance: the PostgreSQL database (everything irreplaceable), the media volume or S3 bucket (event images and avatars), `.env` and `secrets/` (without these the restored database is encrypted noise), `config/local.yaml`, your reverse-proxy config
+- How to back up each piece: `pg_dump` for the database, volume snapshots or rsync for media, copying the secrets to a password manager
+- Where to store backups: not on the same disk as the instance, not in the same region if your provider is your only redundancy, encrypted at rest
+- How often: depends on the rate at which events get created. For most community instances, nightly database, weekly media. Higher-volume instances should think harder
+- The restore drill: stand up a fresh server, restore from backup, verify you can log in and see events. Do this *before* you need it. The first time you try to restore should not be the day after a disk failure
+- The "I lost the secrets but I have the database backup" recovery posture — what's recoverable, what isn't, and why your password manager matters

--- a/docs/guides/instance-administrators/being-a-good-admin.md
+++ b/docs/guides/instance-administrators/being-a-good-admin.md
@@ -1,0 +1,19 @@
+---
+description: Be the kind of Pavillion administrator that calendar owners want to host with — stewardship without paternalism, transparency without performance, longevity without burnout.
+---
+
+# Being a good admin
+
+> Status: placeholder. This guide will be written before launch.
+
+The closing guide in this section. Not a manifesto and not a list of platitudes — a short, concrete piece on the practices that make calendar owners want to stay on your instance and other admins want to federate with you. Each item anchored to a moment of decision, per the rest of the guides.
+
+## Planned scope
+
+- Answer mail. This is most of the job. The admin who responds to email within a day, even with "I'll get back to you," is the admin people trust
+- Be honest about outages, in writing. A two-sentence "the instance was down for 40 minutes this morning because of X" is worth more than silence and more than spin
+- Post-mortems when something breaks, even short ones. Public radio publishes its numbers; you publish what went wrong. Same principle
+- Don't surprise people with policy changes. Announce, give a window, then act. The thirty-day notice on a defederation is almost always cheaper than the trust cost of doing it the same day
+- The relationship with other admins is part of the job, not extra. The admins on the instances you federate with are colleagues, and the time you spend treating them that way pays back in the cases where you need their cooperation
+- Sustainability for the admin. Running a community instance can be a long-term thing or a short-term thing; both are fine, but the difference is whether you've planned the handoff. The admin who burns out without a successor leaves a vacancy that the community can't easily fill
+- The "I'm not sure I'm doing this right" question. The honest answer is that nobody starts out doing this right. The signal is whether you adjust when you find out you weren't

--- a/docs/guides/instance-administrators/code-of-conduct.md
+++ b/docs/guides/instance-administrators/code-of-conduct.md
@@ -1,0 +1,19 @@
+---
+description: Write a code of conduct for your Pavillion instance that's actually enforceable — distinguishing software rules from policy rules from culture.
+---
+
+# A code of conduct for your instance
+
+> Status: placeholder. This guide will be written before launch.
+
+Every Pavillion instance ends up needing some statement of what's allowed and what isn't. The mistake most first-time admins make is treating the code of conduct as a single document, when in practice there are three layers — what the software enforces, what your policy enforces, and what's just culture. The CoC is the middle layer. This guide is about writing one that pulls its weight.
+
+## Planned scope
+
+- The three layers, named: software (rate limits, reportable content, federation blocks), policy (your CoC — the things humans enforce by reading and acting), culture (the unwritten norms that take care of themselves when the first two are working)
+- What belongs in a policy CoC: behaviors that can be observed, reported, and acted on; consequences that the admin can actually impose; scope (this instance only? federated content shown here? off-platform behavior?)
+- What doesn't belong: aspirational statements that nobody can enforce, lists of slurs that age badly, vague clauses that turn every dispute into a re-litigation of the rules
+- Concrete clause examples — one that pulls its weight, one that doesn't, with the contrast doing the work
+- The relationship between your CoC and [federation policy](./federation-policy) — your CoC governs the calendars *on* your instance; defederation governs what *other* instances send you
+- Updating the CoC after an incident: when to amend, how to announce, what to backdate and what not to
+- The "we're a small instance, do we really need this" question — short answer, sketch the policy in private even if you don't publish it, you'll want it the first time something goes wrong

--- a/docs/guides/instance-administrators/communicating-with-calendar-owners.md
+++ b/docs/guides/instance-administrators/communicating-with-calendar-owners.md
@@ -1,0 +1,18 @@
+---
+description: Communicate with the calendar owners on your Pavillion instance — downtime, upgrades, policy changes, and the channels that exist for each.
+---
+
+# Communicating with your calendar owners
+
+> Status: placeholder. This guide will be written before launch.
+
+Calendar owners on your instance need to hear from you sometimes — the upgrade is happening Saturday morning, the federation policy is changing, the instance is moving to a new server. The mistake admins make is either communicating too little (people find out something changed because something broke) or communicating too much (announcements stop being read). This guide is about pitching it right.
+
+## Planned scope
+
+- The channels available to you: instance-wide email (transactional, not promotional), an admin announcement surface if your instance has one, a status page or system calendar, individual mail when the message is targeted
+- Which channel fits which message: downtime is email and a status post; policy change is email plus a longer-form public note; an upgrade that you expect to be invisible is an after-the-fact note in the changelog; a security rotation that logs everyone out warrants an advance email and a follow-up
+- Writing the announcement: lead with what changes for the reader, then the timing, then the why. The admin-jargon version ("we're rotating session secrets") becomes the user-readable version ("you'll be logged out tomorrow morning")
+- The tone calibration: warm, not corporate; honest, not hedged; specific, not "we're committed to communication"
+- The post-incident note: what happened, what you did, what you're changing, what you can't fix. Public-radio-style transparency builds the same kind of trust the funding model assumes
+- Rate-limiting yourself. An admin who emails the calendar owners once a quarter is read; one who emails monthly isn't

--- a/docs/guides/instance-administrators/configuration.md
+++ b/docs/guides/instance-administrators/configuration.md
@@ -1,0 +1,18 @@
+---
+description: Configure a Pavillion instance — config/local.yaml, environment variables, and the layered config priority that determines which setting actually takes effect.
+---
+
+# Configure your instance
+
+> Status: placeholder. This guide will be written before launch.
+
+Reference for everything you can tune. Pavillion uses layered configuration — defaults in the image, production overrides in the image, your `config/local.yaml` on a bind mount, and environment variables on top of all of it. This guide explains the layering and walks through the settings that actually matter.
+
+## Planned scope
+
+- The config priority chain: env vars > `config/local.yaml` > `config/production.yaml` > `config/default.yaml`, and what each layer is for
+- Which settings belong in `local.yaml` (instance-specific overrides — domain, email, branding) and which belong in `.env` (secrets and deploy-specific values)
+- Required settings vs. settings with sane defaults
+- The most consequential knobs, in prose: domain, email transport, media storage backend, federation toggles
+- A reference table of every environment variable at the bottom for fast lookup
+- The "I changed a setting and nothing happened" debugging path: restart the container, check the layer that actually won

--- a/docs/guides/instance-administrators/email.md
+++ b/docs/guides/instance-administrators/email.md
@@ -1,0 +1,23 @@
+---
+description: Configure transactional email for Pavillion — SMTP setup plus the deliverability work (SPF, DKIM, DMARC) that determines whether your password resets actually arrive.
+---
+
+# Email
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion sends email for password resets, editor invitations, calendar-owner notifications, and a handful of other low-volume transactional cases. SMTP setup is the easy half. Deliverability — whether the mail actually reaches inboxes — is the harder half, and the part most generic deployment docs skip.
+
+## Planned scope
+
+- SMTP configuration in `config/local.yaml`: host, port, secure flag, from address, credentials
+- Why a dedicated transactional sender (Postmark, Mailgun, SES, Resend) usually beats sending through a shared mailbox or your ISP
+- The deliverability checklist: SPF, DKIM, DMARC, and what each one actually does to your reputation
+- Testing your setup before anyone signs up — the password-reset round-trip, what the message looks like to a recipient, how to read a bounce
+- The "my users report password-reset email goes to spam" debugging path
+- Notes on rate limits and how Pavillion batches notification email
+
+::: tip <Lightbulb /> A note on the From address.
+:::
+
+The note above is a reminder for the writer: the From address has to match the domain whose DNS you control, not just any address you'd like to use. Detail goes in the body.

--- a/docs/guides/instance-administrators/federation-incidents.md
+++ b/docs/guides/instance-administrators/federation-incidents.md
@@ -1,0 +1,18 @@
+---
+description: Handle federation incidents — reports from off-instance about your content, reports from your users about off-instance content — without overreacting or under-reacting.
+---
+
+# Federation incidents
+
+> Status: placeholder. This guide will be written before launch.
+
+Sooner or later an admin from another instance will email you about a calendar on yours, or one of your calendar owners will report something on another instance. These are the moments when "running an instance" turns out to also be "doing diplomacy." This guide is about the order of operations.
+
+## Planned scope
+
+- The inbound case: another admin reports content hosted on your instance. What to ask them (specifics, links, what they've already done), what to evaluate (is this a CoC issue, a federation-policy issue, or a misunderstanding), what to do (talk to your calendar owner before acting, unless the situation requires otherwise)
+- The outbound case: one of your users reports content on another instance. What you can actually do (defederate, hide, encourage the calendar owner to unfollow), what you can't (force the other instance to act), how to communicate the limit to the reporter without sounding helpless
+- The order of operations for almost every case: investigate, talk to the calendar owner on your side, decide, act, document. Skipping the "talk to the calendar owner" step is the single most common admin mistake
+- When to defederate quickly without a full conversation: legal exposure, ongoing harassment, content that legally cannot be hosted. These are real and rare
+- Documenting the incident — not for performance, for your own memory. The third time the same instance comes up is the time you'll wish you had notes
+- The "I made a call and I'm not sure it was right" question. Adjusting in the open beats pretending you didn't change your mind

--- a/docs/guides/instance-administrators/federation-policy.md
+++ b/docs/guides/instance-administrators/federation-policy.md
@@ -1,0 +1,19 @@
+---
+description: Decide who your Pavillion instance federates with — allowlist, blocklist, and the harder question of what to do when another admin asks you to defederate from somewhere.
+---
+
+# Federation policy
+
+> Status: placeholder. This guide will be written before launch.
+
+The hardest social judgment in this section. Federation is by default open — your instance will accept activity from any other Pavillion or other ActivityPub event platform that asks. Most admins want some control over that. The shape of the control is a choice, and the consequences of getting it wrong cut both ways.
+
+## Planned scope
+
+- The two postures: blocklist (open-by-default, refuse specific instances by name) and allowlist (closed-by-default, accept only specific instances by name). Hybrid postures and when they make sense
+- When a blocklist is the right call: most community instances, most regional instances, anywhere "we federate with the network and handle bad actors by exception"
+- When an allowlist is the right call: org-internal instances that federate only with sister instances, high-risk or sensitive communities, instances that want a curated network experience
+- The mechanics: where the lists live, what blocking actually does (refuses inbound activities, doesn't send outbound, displays accordingly), how to add and remove entries
+- Inbound and outbound asymmetry — you can refuse to accept from somewhere and they can still receive from you, unless you also stop publishing federated copies of public events
+- The conversation that comes up sooner than you expect: another admin asks you to defederate from a third instance. How to handle it without becoming a clearinghouse. What to ask them, what counts as evidence, what isn't your job to evaluate
+- Documenting your policy publicly. A "who we federate with and why" page does more for trust than a long CoC does

--- a/docs/guides/instance-administrators/funding-plans-setup.md
+++ b/docs/guides/instance-administrators/funding-plans-setup.md
@@ -1,0 +1,19 @@
+---
+description: Set up Stripe so the calendar owners on your instance can offer community funding plans — keys, CSP, the difference between funding plans and subscriptions.
+---
+
+# Setting up funding plans
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion supports community funding plans — voluntary contributions from event-goers and community members to keep a calendar running, closer to public radio than to a software subscription. The plumbing for this is Stripe. As the instance administrator, you're the one who creates the Stripe account and gets the keys into config; the calendar owners are the ones who actually offer plans and talk to their communities about money.
+
+## Planned scope
+
+- Creating a Stripe account for your instance — you, the admin, are the merchant of record. This is not Stripe Connect; you don't onboard your calendar owners into Stripe individually
+- The keys you need: publishable key, secret key, webhook signing secret. Where each goes in config, how to rotate them ([secret rotation](./secret-rotation))
+- CSP changes for the Stripe embedded checkout iframe — what loads from where, what to allow
+- Webhook configuration on the Stripe side — the endpoint, the events to listen for, how to verify Pavillion is receiving them
+- Testing the funding flow before announcing it: Stripe's test mode, the test card numbers, what a successful contribution looks like in the database and in Stripe
+- The vocabulary boundary, explained once so the admin can explain it later: Pavillion calls these "funding plans" and never "subscriptions." That's because "subscription" already means something specific in ActivityPub (following an actor or calendar). The codebase, UI, and these guides keep the words separate
+- The "what about VAT, taxes, 1099s, donations vs. revenue" question — out of scope for this guide, but pointers to where to start

--- a/docs/guides/instance-administrators/how-federation-works-for-admins.md
+++ b/docs/guides/instance-administrators/how-federation-works-for-admins.md
@@ -1,0 +1,18 @@
+---
+description: Understand federation from the administrator's seat — what your instance is signing and sending, what it accepts, and the boundary between protocol and policy.
+---
+
+# How federation works, for admins
+
+> Status: placeholder. This guide will be written before launch.
+
+Calendar owners can use federation without thinking about how it works. Administrators can't. This guide is the admin-eye view: what your server is signing and sending, what it's accepting, where the protocol stops and your policy starts.
+
+## Planned scope
+
+- The mental model: your instance is an actor in a network of other actors, identified by domain. Domain is identity — you cannot change it without breaking every existing federation relationship
+- What the worker container actually does: signs outbound activities (Follow, Create, Update, Announce, Delete) with your instance's private key, delivers them to other instances' inboxes
+- What inbound looks like: other instances POST to your inbox endpoint with their signed activities; the app verifies signatures, applies them to the database
+- The pieces of federation behavior that are protocol (you can't change them) vs. the pieces that are your policy: who you accept activities from, what you do with them, when you reject
+- Public-key cryptography for actors, briefly. You don't need to be able to verify a signature by hand; you do need to know what happens if your instance's private key leaks
+- The line between [federation policy](./federation-policy) (whose activities you accept), [moderation boundaries](./moderation-boundaries) (what you do about local content), and [federation incidents](./federation-incidents) (what you do when something crosses instance lines)

--- a/docs/guides/instance-administrators/index.md
+++ b/docs/guides/instance-administrators/index.md
@@ -1,0 +1,39 @@
+---
+description: Guides for running a Pavillion server — installation, day-two operations, federation policy, instance moderation, and being the kind of admin people want to host with.
+---
+
+# For instance administrators
+
+This guide is for the people who run the server that other people put their calendars on — sysadmins at nonprofits and co-ops, technically inclined organizers running a neighborhood instance, IT staff at regional councils — anyone whose job it is to keep a Pavillion server up and to make the call about who gets a calendar on it.
+
+Your role has two halves:
+
+- **Operating the software** — installation, secrets, backups, upgrades; the infrastructure work that keeps the calendars on your instance reachable.
+- **Community Stewardship** — what your instance is *for*, who can host a calendar on it, how you decide which other instances to federate with, what to do when a calendar owner you host steps over a line.
+
+Two ways to read this section:
+
+- **Bringing up a new instance?** Start with the [Quickstart](./quickstart). It takes you from a clean server to running Pavillion instance with one admin account in about thirty minutes. Everything else is reference material to come back to.
+- **Already running one?** Browse the sidebar. Each guide answers a specific question — how to restore a backup, when to switch from local media storage to S3, what to do when another admin asks you to defederate. Read the one you need.
+
+## What's in this section
+
+**Get an instance running** — installation, configuration, reverse proxy, email, media storage. The technical baseline.
+
+**Shape your instance** — what your instance is for, who gets a calendar, what the rules are. The decisions that nobody else can make for you.
+
+**Operate your instance** — monitoring, backups, upgrades, secret rotation, troubleshooting. The day-two work.
+
+**Federate with the network** — how federation looks from the admin seat, testing it, deciding who to trust, handling incidents that cross instance boundaries.
+
+**Moderate at the instance level** — the boundary with calendar-owner moderation, removing a calendar, account-level operations.
+
+**Fund your instance** — Stripe setup for community funding, and the harder question of how to talk about money with the people who use what you run.
+
+**Relationship with your community** — communicating with your calendar owners, and the longer-term work of being someone people trust to host with.
+
+## What's not here
+
+- **Running a calendar on Pavillion.** That belongs to the [calendar-owner guides](/guides/calendar-owners/).
+- **Contributing to Pavillion itself.** That belongs to the developer guides.
+- **The ActivityPub protocol.** Referenced where you need it, not taught here. You don't need to read the spec to administer a federating server — but knowing what protocol your instance uses to talk to others helps when something goes wrong, and the guides will tell you where to look.

--- a/docs/guides/instance-administrators/installation.md
+++ b/docs/guides/instance-administrators/installation.md
@@ -1,0 +1,20 @@
+---
+description: Full first-deployment walkthrough for Pavillion — what each container does, what bin/deploy.sh actually generates, and what to verify before letting people sign up.
+---
+
+# Install a Pavillion instance
+
+> Status: placeholder. This guide will be written before launch.
+
+The detailed install — what the [Quickstart](./quickstart) glossed over. Covers the container topology so you know what's running and why, what `bin/deploy.sh` writes to disk on a fresh install, and the difference between install mode and upgrade mode.
+
+## Planned scope
+
+- Container topology: `pavillion-app` (the web server), `pavillion-worker` (background jobs and outbound federation), `pavillion-db` (PostgreSQL), `pavillion-autoheal` (restarts unhealthy containers), and optionally `pavillion-caddy` (standalone reverse proxy)
+- Why each container exists and what fails if it's not running
+- What `bin/deploy.sh` does in install mode: generates secrets, prompts for your domain, writes `.env` and `config/local.yaml`, pulls images, starts containers, polls `/health`
+- What to do when the script detects an existing `.env` (upgrade mode — see [upgrading](./upgrading))
+- Verifying the install: `docker compose ps`, the `/health` endpoint, the first admin login
+- Podman compatibility for sites that don't run Docker
+
+This guide assumes you've worked through the [Quickstart](./quickstart) at least once or are comfortable running Docker Compose in production.

--- a/docs/guides/instance-administrators/media-storage.md
+++ b/docs/guides/instance-administrators/media-storage.md
@@ -1,0 +1,18 @@
+---
+description: Choose between local filesystem and S3-compatible storage for Pavillion media uploads — and migrate from one to the other without losing anything.
+---
+
+# Media storage
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion stores uploaded media (event images, calendar avatars, banners) on a volume by default. That's fine for small instances. As your instance grows, or if you're running multiple app containers, S3-compatible object storage becomes the better fit. This guide names the choice and covers the migration path.
+
+## Planned scope
+
+- The default: a Docker volume mounted at `/app/storage/media`. What this means for backups, for restoring, for moving servers
+- When to switch to S3-compatible storage: more than one app container, media volume getting unwieldy in backups, you want a CDN in front, you don't want media tied to the server's disk
+- Supported providers: AWS S3, DigitalOcean Spaces, Backblaze B2, MinIO, anything that speaks the S3 API
+- The configuration: `S3_BUCKET`, `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_ENDPOINT` for non-AWS providers
+- Migrating an existing instance from local to S3 without losing media: the order of operations, the cutover, the "did anything fail to copy" verification step
+- The "do not delete the media volume the day you switch to S3" warning — keep it as a fallback until you've verified

--- a/docs/guides/instance-administrators/moderation-boundaries.md
+++ b/docs/guides/instance-administrators/moderation-boundaries.md
@@ -1,0 +1,18 @@
+---
+description: Understand the boundary between calendar-owner moderation and instance-administrator moderation — when to act, when to escalate, when to stay out.
+---
+
+# Moderation boundaries
+
+> Status: placeholder. This guide will be written before launch.
+
+Calendar owners moderate their own calendars — they handle visitor reports on their events, decide who their editors are, set the tone for what they publish. Instance admins handle things calendar owners can't: instance-wide issues, problems with a calendar owner themselves, escalations. The boundary matters, and reaching across it carelessly is one of the fastest ways to lose calendar owners' trust.
+
+## Planned scope
+
+- The default rule: calendar owners handle their own calendars. Admins don't reach in over an owner's head except in specific cases
+- The "specific cases" that justify admin reach-in: the calendar owner is unresponsive and the issue is time-sensitive, the calendar owner is themselves the problem, legal requirements (the rare-but-real category)
+- The escalation path the other direction: when a calendar owner asks for admin help. What you can do for them (suspend an external follower, defederate an instance, take action on a local user reporting their calendars maliciously), what you can't do for them (moderate their own events for them — that's the whole point of giving them a calendar)
+- The conversation that has to happen before action: even when you're going to override a calendar owner, talk to them first if you can. The five-minute conversation prevents the six-month resentment
+- The distinction between "the calendar is doing something I disagree with" and "the calendar is violating policy." The first is a conversation; the second is an action. Confusing them erodes the policy
+- Documenting admin moderation actions. Not for performance — for consistency. The fourth time you make a call, you'll want to know how you made the first three

--- a/docs/guides/instance-administrators/monitoring-and-logs.md
+++ b/docs/guides/instance-administrators/monitoring-and-logs.md
@@ -1,0 +1,18 @@
+---
+description: Monitor a Pavillion instance honestly — healthchecks, autoheal, container logs, and the gap where external alerting belongs but isn't built in.
+---
+
+# Monitoring and logs
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion ships with enough self-healing to recover from most short-lived problems on its own — Docker healthchecks plus the `autoheal` sidecar that restarts unhealthy containers. What it doesn't ship is alerting. If your app is down at 3am, nothing is going to wake you up unless you wire that part yourself. This guide is honest about both halves.
+
+## Planned scope
+
+- The healthcheck endpoints: `app` on `/health`, `worker` on its internal port, what each one actually verifies
+- How `autoheal` works, what containers it watches (the ones with `autoheal=true`), what it doesn't watch and why
+- Reading container logs: `docker compose logs -f app`, what to grep for, the patterns that indicate database trouble vs. federation trouble vs. email trouble
+- What Pavillion doesn't have: built-in alerting. Either you watch `docker compose ps` manually, or you point an external monitor at `/health`, or you accept that you'll find out when a user emails you
+- A short list of external monitoring options worth considering for community-scale instances (Uptime Kuma, Healthchecks.io, Better Stack) — short on opinions about which, longer on what to watch for
+- Log retention and rotation. The default is "until the disk fills up." That's almost never what you want

--- a/docs/guides/instance-administrators/quickstart.md
+++ b/docs/guides/instance-administrators/quickstart.md
@@ -1,0 +1,18 @@
+---
+description: Bring up a Pavillion instance from a clean Linux server to a federating server with one admin account in about thirty minutes.
+---
+
+# Quickstart
+
+> Status: placeholder. This guide will be written before launch.
+
+The on-ramp for a new admin. Starts with a clean Linux server and ends with a Pavillion instance that's reachable on its domain, has one working admin account, and has successfully federated with one known instance to prove the wiring works. About thirty minutes if your DNS is already in place.
+
+## Planned scope
+
+- Prerequisites stated honestly — a domain, DNS that resolves, a server with at least 1 GB of RAM, and either an existing reverse proxy or willingness to use the bundled Caddy
+- The `bin/deploy.sh` happy path: clone, run, answer the domain prompt, watch the health endpoint come up
+- Creating your first admin account
+- A one-event smoke test to confirm the site renders
+- Following a known federating instance to confirm outbound federation works
+- Where to go next: the [installation](./installation) guide for what `deploy.sh` actually did, [configuration](./configuration) for tuning, [email](./email) before anyone tries to sign up

--- a/docs/guides/instance-administrators/quickstart.md
+++ b/docs/guides/instance-administrators/quickstart.md
@@ -4,15 +4,123 @@ description: Bring up a Pavillion instance from a clean Linux server to a federa
 
 # Quickstart
 
-> Status: placeholder. This guide will be written before launch.
+This guide takes you from a clean Linux server to a Pavillion instance that's reachable on its domain, has one working admin account, and has successfully federated with one other Pavillion instance. It should take about thirty minutes if your DNS is already in place. There is a fully detailed [Installation](./installation) guide if you want to know the details of what is happening under the hood.
 
-The on-ramp for a new admin. Starts with a clean Linux server and ends with a Pavillion instance that's reachable on its domain, has one working admin account, and has successfully federated with one known instance to prove the wiring works. About thirty minutes if your DNS is already in place.
+## What you need before you start
 
-## Planned scope
+- **A domain you control.** A subdomain is fine — `events.example.org` works. The domain is your instance's identity on the federated network; once events have flown, you can't change it without breaking every existing federation relationship. Pick a domain you'll be comfortable with in five years.
+- **DNS that already resolves.** Point the domain's A or AAAA record at your server's public IP *before* you run the deploy. The script doesn't check, and federation handshakes won't work if other instances can't reach you at the name you claim.
+- **A Linux server with at least 1 GB of RAM.** If it's a freshly-imaged Debian or Ubuntu box, `bin/provision.sh` will install Docker, set up a deploy user, and harden SSH for you — see the [fresh server path](#fresh-server-use-the-provisioning-script) below. If you're putting Pavillion on a server you already run, you'll want Docker and Docker Compose installed and working (`docker compose version` should print a version). Podman with the compose plugin works too if your shop doesn't run Docker.
+- **A decision about TLS.** Either (a) you'll use the bundled standalone Caddy that ships with Pavillion's Compose file and let it get a Let's Encrypt cert automatically, or (b) you'll put your own http proxy (nginx, Caddy, etc) in front. The bundled option is simpler and right for a dedicated Pavillion server. Bring-your-own is right when your server hosts other apps and already has a proxy. The Quickstart assumes you'll used the bundled Caddy — if you're bringing your own, jump to [Reverse proxy and TLS](./reverse-proxy-and-tls) for the config snippets before continuing.
+- **Ports 80 and 443 open** on your server's firewall to the public internet. Caddy needs both — 80 for ACME HTTP-01 challenges, 443 for the actual traffic.
 
-- Prerequisites stated honestly — a domain, DNS that resolves, a server with at least 1 GB of RAM, and either an existing reverse proxy or willingness to use the bundled Caddy
-- The `bin/deploy.sh` happy path: clone, run, answer the domain prompt, watch the health endpoint come up
-- Creating your first admin account
-- A one-event smoke test to confirm the site renders
-- Following a known federating instance to confirm outbound federation works
-- Where to go next: the [installation](./installation) guide for what `deploy.sh` actually did, [configuration](./configuration) for tuning, [email](./email) before anyone tries to sign up
+::: tip <Lightbulb /> A note on DNS propagation.
+DNS changes can take minutes to propagate, sometimes longer. If you've *just* added the A record, the deploy might come up green while Caddy is still failing to get a cert behind the scenes. Wait for `dig +short events.example.org` to return your server's IP from the server itself *and* from somewhere off-network before running the deploy.
+:::
+
+## Run the deploy
+
+Two paths through this step, depending on what's on the server.
+
+### Fresh server: use the provisioning script
+
+If the server is a freshly-imaged Debian or Ubuntu box with nothing else on it, `bin/provision.sh` does the rest of the setup in one shot: creates a non-root deploy user, hardens SSH, configures the firewall (UFW, allowing only 22/80/443), installs Docker, clones the repo into `/opt/pavillion`, brings up the app, and enables the bundled standalone Caddy so your domain answers on 443 with a Let's Encrypt cert. Run it from your local machine — the provisioning script fetches itself onto the server via curl, so you don't need the Pavillion repo cloned locally first:
+
+```bash
+ssh -i ~/.ssh/YOUR_SSH_KEY root@YOUR_SERVER "curl -fsSL https://raw.githubusercontent.com/stephenhoward/pavillion/main/bin/provision.sh | bash -s -- --standalone --domain=yourdomain.example.org"
+```
+
+If you do already have the repo locally — you're upgrading another instance, or you've been hacking on Pavillion — you can pipe the local copy instead: `ssh root@your-server 'bash -s -- --standalone --domain=events.example.org' < bin/provision.sh`. Same result.
+
+The script needs your SSH public key already on the server's `root` account before you run it — `ssh-copy-id root@your-server` first if it isn't there. It refuses to continue otherwise, because the next thing it does is disable root SSH and password auth. From here on, you'll log into the server as `pavillion@your-server`, not `root`.
+
+When the script reports `Provisioning Complete`, the app containers are up, the standalone Caddy is fetching a TLS certificate, and `https://your-domain` should load within a few seconds. Drop `--standalone` if you'd rather put your own nginx, Caddy, or Traefik in front — without it the app listens on `127.0.0.1:3000` and waits for you to wire up your own proxy. See [Reverse proxy and TLS](./reverse-proxy-and-tls) for the bring-your-own snippets.
+
+Skip to [Create your first admin account](#create-your-first-admin-account) below once `https://your-domain` loads.
+
+### Existing server: clone and run the deploy script directly
+
+If the server already has its own deploy user, firewall, and Docker setup — or you don't want SSH hardening applied by the provisioning script — clone the repo and run `bin/deploy.sh` yourself:
+
+```bash
+git clone https://github.com/stephenhoward/pavillion.git
+cd pavillion
+COMPOSE_PROFILES=standalone bin/deploy.sh
+```
+
+The script detects this is a fresh install (no `.env` present), generates every secret it needs, and prompts for your domain:
+
+```
+Enter your domain name (e.g., events.example.org):
+```
+
+Type the domain you set DNS for and press Enter. The script writes `config/local.yaml` with that domain substituted in, pulls the container images, brings them up, and polls the `/health` endpoint until the app reports ready. About two to five minutes on a typical server, most of which is image pulls on the first run.
+
+When you see `[OK] Deploy complete.`, the app is up and the bundled Caddy is fetching a TLS certificate. Open `https://your-domain` in a browser. The first load may take a few seconds while Caddy finishes the ACME handshake.
+
+Drop the `COMPOSE_PROFILES=standalone` if you're putting your own proxy in front instead — see [Reverse proxy and TLS](./reverse-proxy-and-tls) for the config snippets.
+
+::: tip <Lightbulb /> A note on what gets written to disk.
+Either path writes the same files: a `.env` file (your secrets, mode 600), a `secrets/` directory (the same secrets as files, for containers that read them by path), a `.deploy-state` file (tracks which secrets have ever been provisioned, used by the upgrade path), and `config/local.yaml` (your instance-specific config). Back these up after the next step — see [Backups](./backups). Losing `.env` or `secrets/` means losing your federation identity.
+:::
+
+## Create your first admin account
+
+The first time a browser hits your instance, it gets redirected to `/setup`. This page only exists when the database has no admin accounts yet — once you create the first one, the route returns 404 forever.
+
+Pick an email address you actually read and a strong password. The setup page creates an account with admin role and signs you in. You land on the dashboard.
+
+::: tip <Lightbulb /> A note on the first email address.
+Use a mailbox you check daily. Password resets, account applications, and moderation and federation-incident notifications go there.
+:::
+
+## A one-event smoke test
+
+The one-event smoke test confirms the app is wired end-to-end — database writes, the public site renders, the URL handle resolves, images upload — before you invite anyone else in.
+
+From the dashboard:
+
+1. Create a calendar. Pick a short, durable handle — see [Customize your calendar's identity](/guides/calendar-owners/identity) for the longer version of why. A throwaway calendar named `test` is fine for the smoke test; you can delete it later.
+2. Publish one event. Any title, any future date. Save it.
+3. Open the calendar's public URL: `https://your-domain/view/<handle>`. Confirm the event renders, the page loads cleanly, and the link in the address bar is the `https://` version with a valid certificate.
+
+If the public page renders, the app, database, reverse proxy, and TLS are all working. If the page is blank, blocked, or the cert is invalid, stop here — fix the basics before going further. The [Troubleshooting](./troubleshooting) guide has the diagnostic loop.
+
+## Confirm federation works
+
+This is the part that's easy to silently get wrong. The app can come up green, the calendar can render, and federation can be completely broken because the app can't reach the network or your domain doesn't resolve from outside your network. So test it.
+
+The fastest test is to follow another live Pavillion instance and confirm at least one event arrives. You'll need the handle of a calendar on another instance to follow — ask in the community channels if you don't have one yet, or set up a second test instance and federate the two.
+
+From your dashboard, find the **Follow a calendar** field, type the handle (`somecalendar@their-instance.example`), and submit. Within a few seconds the follow should be accepted; within a few seconds more, any recent public events from that calendar should appear in your view of theirs.
+
+If nothing arrives within a minute or two, head to [Testing federation](./testing-federation). The most common causes are DNS that resolves locally but not externally, TLS that isn't trusted by the other instance, and clock skew breaking signature verification.
+
+## What's next
+
+You now have a working Pavillion instance with one admin account and confirmed federation. Before you open it up to other people:
+
+- **[Email](./email).** Configure SMTP before anyone signs up — password resets and invitations need a working transport. Without this, any user who forgets their password is locked out.
+- **[Backups](./backups).** Back up `.env`, `secrets/`, `config/local.yaml`, and the Postgres data volume. Losing the secrets means losing your federation identity — every other instance has cached your public key under that domain, and a new key on the same domain looks like an impostor.
+- **[What your instance is for](./what-your-instance-is-for) and [Who gets a calendar](./who-gets-a-calendar).** Before you invite the first calendar owner, decide what you're hosting and for whom. These are the questions nobody else can answer for you.
+- **[Federation policy](./federation-policy).** What you accept from the wider network, and what you don't.
+
+And to fill in what this guide glossed over:
+
+- **[Installation](./installation)** — what `bin/deploy.sh` actually did, container by container.
+- **[Configuration](./configuration)** — the settings worth tuning beyond the defaults.
+- **[Reverse proxy and TLS](./reverse-proxy-and-tls)** — the bring-your-own-proxy path, and what the bundled Caddy is doing on your behalf.
+
+## Things that trip people up
+
+**Re-running `bin/deploy.sh` on an existing install.** It detects an existing `.env` and switches to upgrade mode — it doesn't re-prompt for the domain and doesn't reset your data. That's by design. If you actually need to start over, delete `.env`, `secrets/`, `.deploy-state`, `config/local.yaml`, and the Postgres data volume, then re-run. There's no undo.
+
+**Running `bin/provision.sh` without an SSH key already on `root`.** The script checks `/root/.ssh/authorized_keys` and refuses to run if it's empty, because its next move is to disable password auth and root login — if you don't have a key on file, the script would lock you out the moment it finished. Run `ssh-copy-id root@your-server` from your local machine before piping the script over.
+
+**Dropping `--standalone` without setting up your own proxy.** Without the flag, `bin/provision.sh` leaves the app on the host's `127.0.0.1:3000` with no TLS terminator in front. The firewall opens 80 and 443 but nothing is listening on them, so `https://your-domain` will time out. If you meant to bring your own proxy, point it at `127.0.0.1:3000` next. If you didn't, re-run provisioning with `--standalone` — or, on the server, append `COMPOSE_PROFILES=standalone` to `/opt/pavillion/.env` and run `./bin/deploy.sh` again.
+
+**The domain you typed at the prompt is now baked in.** Federation identity is the domain — other instances cache your public key under it. Changing the domain after events have federated breaks every existing relationship. If you got the domain wrong on first install and *no events have federated yet*, the cleanest fix is the start-over path above. After federation has happened, you live with the domain you picked.
+
+**The bundled Caddy can't share ports with another proxy.** If your server already has nginx or another reverse proxy bound to 80 and 443, the standalone Caddy container will fail to start. Either stop the other proxy, or skip `COMPOSE_PROFILES=standalone` and follow [Reverse proxy and TLS](./reverse-proxy-and-tls) to put your existing proxy in front of Pavillion instead.
+
+**DNS resolves from inside your network but not from outside.** Split-horizon DNS, a hosts-file entry you forgot about, or a firewall that lets you reach the server from your office but blocks the public internet — any of these will make federation look broken in confusing ways. The other instance can't follow you back if it can't reach your domain. Test from somewhere off-network before assuming the wiring is right.

--- a/docs/guides/instance-administrators/removing-a-calendar.md
+++ b/docs/guides/instance-administrators/removing-a-calendar.md
@@ -1,0 +1,18 @@
+---
+description: Remove a calendar from your Pavillion instance — the procedure, what happens to federated copies, and how to communicate the decision.
+---
+
+# Removing a calendar
+
+> Status: placeholder. This guide will be written before launch.
+
+Removing a calendar is the heaviest admin action available. It ends a relationship between the instance and the owner, and it has consequences for everyone who was following that calendar from elsewhere. This guide is about doing it deliberately when it has to happen.
+
+## Planned scope
+
+- When to remove a calendar: the rare cases where it's appropriate, named explicitly (CoC violations after warning, legal compulsion, an owner who's left the community and asks you to remove it, an abandoned calendar the owner can't be reached about)
+- When *not* to remove a calendar: disagreement with what the owner publishes if it doesn't violate policy, dormancy that the owner could resume from, reports from off-instance that aren't policy violations on your end
+- The mechanical procedure: how to remove the calendar in the admin tools, what the operation actually does to the database, what gets federated as a result
+- What happens to federated copies: a Delete activity goes out to followers; well-behaved instances honor it; not all instances are well-behaved, so copies may persist on some
+- Communicating the decision: to the owner first (where possible), to the followers second (if appropriate), in writing where you can reference it
+- The "I removed a calendar and now I'm not sure" recovery posture. What's recoverable, what isn't

--- a/docs/guides/instance-administrators/reverse-proxy-and-tls.md
+++ b/docs/guides/instance-administrators/reverse-proxy-and-tls.md
@@ -1,0 +1,18 @@
+---
+description: Put a TLS-terminating reverse proxy in front of Pavillion — when to use the bundled standalone Caddy and when to bring your own nginx, Caddy, or Traefik.
+---
+
+# Reverse proxy and TLS
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion's app container listens on plain HTTP. Something else has to terminate TLS and pass traffic in. The two practical options are running your own reverse proxy (the usual choice if your server already hosts other things) or enabling the bundled standalone Caddy that ships with the Compose file. This guide names the choice and walks through both.
+
+## Planned scope
+
+- When standalone Caddy is the right pick: a dedicated server for Pavillion, you don't already run a proxy, you want automatic Let's Encrypt, you're willing to give Caddy ports 80 and 443
+- When bringing your own proxy is the right pick: you already run nginx/Caddy/Traefik, the server hosts other apps, you have a separate TLS strategy, the bundled Caddy can't co-exist with what's there
+- Example configs for nginx and Caddy (the WebSocket headers, the forwarded-proto, the X-Forwarded-For)
+- Enabling standalone mode: `COMPOSE_PROFILES=standalone`, the `DOMAIN` requirement, restricting the app port to localhost
+- The `caddy-extras.d/` extension point — what it's for, what's allowed inside a snippet, how to validate
+- The "don't `docker compose down -v` your Caddy data volume" warning, with the rate-limit consequence spelled out

--- a/docs/guides/instance-administrators/secret-rotation.md
+++ b/docs/guides/instance-administrators/secret-rotation.md
@@ -1,0 +1,18 @@
+---
+description: Rotate the secrets your Pavillion instance depends on — JWT, session, database password, SMTP, S3 — without locking your users out longer than necessary.
+---
+
+# Rotating secrets
+
+> Status: placeholder. This guide will be written before launch.
+
+You rotate secrets when you suspect they've leaked, when someone with access has left, when an audit asks, or on a calendar you've set for yourself. Pavillion's secrets aren't all equal — some rotations are invisible to users, some log everyone out, one of them locks you out of your own database if you do it wrong.
+
+## Planned scope
+
+- The secrets, in order of blast radius: `JWT_SECRET` (rotating logs everyone out), `SESSION_SECRET` (rotating invalidates sessions), `DB_PASSWORD` (rotating without coordination locks the app out of the database), `SMTP_PASSWORD` (rotating breaks outbound mail until updated), `S3_SECRET_KEY` (rotating breaks media uploads until updated), Stripe keys (rotating breaks the funding-plan checkout flow)
+- The rotation procedure, by secret: generate a new value, update the secret file or `.env`, restart the relevant containers, confirm
+- The "rotate the database password without losing access" procedure — change it in the database first, then in the secret, then restart. Order matters
+- When to rotate on a schedule and when scheduled rotation is security theater. Honest about both
+- Coordinated rotation when secrets are shared across systems (SMTP credentials in the SMTP provider's dashboard, S3 keys in the bucket policy)
+- The "I rotated something and now X is broken" recovery path

--- a/docs/guides/instance-administrators/testing-federation.md
+++ b/docs/guides/instance-administrators/testing-federation.md
@@ -1,0 +1,18 @@
+---
+description: Verify that your Pavillion instance can federate — the two-instance docker-compose setup, the smoke tests, and the diagnostic loop when something is silent.
+---
+
+# Testing federation
+
+> Status: placeholder. This guide will be written before launch.
+
+Federation is the part of the install that's easiest to get wrong without noticing — the app comes up green, the calendar renders, and nothing federates because the worker can't reach the network, or your TLS cert isn't trusted, or your domain doesn't resolve from outside your network. This guide is the diagnostic loop.
+
+## Planned scope
+
+- The two-instance docker-compose harness for testing federation locally — what it spins up, how to use it, what it does and doesn't catch
+- The smoke test on a new production instance: follow a known federating Pavillion, confirm the follow accept comes back, confirm at least one shared event arrives
+- The reverse smoke test: have a known instance follow you, confirm they receive a Follow accept, confirm they receive a Create when you publish
+- The diagnostic loop when federation looks silent: is the worker container running, are outbound activities being signed (worker logs), are they being POSTed (network), are they being received (the other side's logs if you can see them), are signatures verifying
+- Common failure modes: TLS cert not trusted by the other instance, clock skew breaking signature verification, the other instance has defederated yours, your domain resolves from inside your network but not from outside
+- The "I think I'm being blocked by a specific instance" diagnostic — usually true, sometimes a misconfiguration on your end

--- a/docs/guides/instance-administrators/troubleshooting.md
+++ b/docs/guides/instance-administrators/troubleshooting.md
@@ -1,0 +1,21 @@
+---
+description: Diagnose common Pavillion failures — container start failures, database connection errors, federation silence, email not sending — by symptom, with the underlying cause spelled out.
+---
+
+# Troubleshooting
+
+> Status: placeholder. This guide will be written before launch.
+
+A symptom-indexed troubleshooting guide. Each entry names the visible failure, the underlying cause, and the fix. The aim is to teach you to read the symptom — not to memorize incantations.
+
+## Planned scope
+
+- **Container won't start.** Common causes: secrets missing, database password not set, port collision, migrations failed mid-run. How to read `docker compose logs app` to tell which
+- **App container restarts in a loop.** Usually a startup probe failing or a runtime crash that autoheal is recovering from. Where to look in the logs to tell which
+- **"JWT_SECRET must be set in production" or similar.** The secrets pipeline didn't run, or a `_FILE` variable points somewhere the file doesn't exist
+- **Database connection failures.** Either the database container isn't healthy, the password is wrong, or the app started before the database was ready
+- **Migrations failed.** What to do when a migration is partway through. When to retry, when to restore from backup
+- **Email not sending.** SMTP credentials wrong, or right but blocked at the provider, or right but landing in spam (see [email](./email))
+- **Federation looks broken.** Outbound is the worker container's job; inbound depends on your domain being reachable and your TLS being valid. The diagnostic loop in [testing federation](./testing-federation)
+- **Health endpoint returns 500.** Read the app logs; the health check is usually telling you about a downstream dependency
+- **"Reset everything and start fresh"** — the nuclear option, what it deletes, when it's the right call

--- a/docs/guides/instance-administrators/upgrading.md
+++ b/docs/guides/instance-administrators/upgrading.md
@@ -1,0 +1,19 @@
+---
+description: Upgrade a Pavillion instance — release cadence, the changelog discipline, the upgrade ritual, and how to roll back when an upgrade goes wrong.
+---
+
+# Upgrading
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion releases regularly, with most releases being safe to pull and restart. The work of upgrading is mostly: read the changelog, take a backup, restart the containers, verify. This guide covers the ritual, the breaking-change handling, and the rollback path when something goes wrong.
+
+## Planned scope
+
+- The release model: image tags (`latest`, `main`, version pins), where the changelog lives, which release notes you actually have to read
+- Reading the changelog with an admin's eye: what counts as breaking (config schema, migration with no rollback, federation behavior change), what doesn't (UI, bug fixes, performance)
+- The upgrade ritual: take a backup *first* (see [backups](./backups)), pull the new image, run `bin/deploy.sh` in upgrade mode, watch the migration logs, verify with `/health`
+- Pinning the image tag for predictable production deploys vs. tracking `main` on staging
+- Rolling back: switch the image tag back, restart, restore the database from the pre-upgrade backup if migrations changed the schema. Why "just downgrade the container" rarely works if migrations ran
+- The "I upgraded and something broke" debugging path before you reach for rollback
+- Major-version upgrades when they happen — read the migration guide, take two backups, do it in staging first

--- a/docs/guides/instance-administrators/what-your-instance-is-for.md
+++ b/docs/guides/instance-administrators/what-your-instance-is-for.md
@@ -1,0 +1,23 @@
+---
+description: Decide what your Pavillion instance is for — a neighborhood, a region, a sector, an org — and what that decision implies about who you'll host and who you won't.
+---
+
+# What your instance is for
+
+> Status: placeholder. This guide will be written before launch.
+
+Pavillion instances aren't generic. The instance that serves one neighborhood is not the instance a regional arts council runs, and neither is the instance a national org runs for its chapters. Federation papers over a lot, but it doesn't paper over the fact that someone has to decide what your instance is — and that decision shapes everything from your signup policy to who other admins trust you with.
+
+## Planned scope
+
+- The shapes instances actually take in practice: geographic (a town, a metro, a region), sectoral (a music scene, faith communities, mutual-aid groups), organizational (one nonprofit's chapters), thematic (a single ongoing event series with satellite content)
+- Why "a Pavillion instance for everyone" isn't really a shape — it's a description of an unwritten policy you'll end up writing under pressure
+- How instance shape interacts with [who gets a calendar](./who-gets-a-calendar) and [federation policy](./federation-policy) — naming the shape up front makes the downstream calls easier
+- Naming and identity: your instance domain is what other admins will recognize you by; pick something that ages
+- Saying no when someone asks for a calendar that doesn't fit. How to do it without sounding officious
+- Changing the shape later. You can. It's less disruptive than you'd think, more disruptive than you'd hope
+
+::: tip <Lightbulb /> A note on the domain.
+:::
+
+The note above is a reminder for the writer: your instance domain is identity in federation. You can't change it without breaking every existing follow. Pick deliberately.

--- a/docs/guides/instance-administrators/who-gets-a-calendar.md
+++ b/docs/guides/instance-administrators/who-gets-a-calendar.md
@@ -1,0 +1,19 @@
+---
+description: Decide who can host a calendar on your Pavillion instance — open signup, invite-only, or admin-provisioned — and how to change your mind without breaking trust.
+---
+
+# Who gets a calendar
+
+> Status: placeholder. This guide will be written before launch.
+
+Three signup postures cover almost every Pavillion instance: open signup, invite-only, and admin-provisioned. They aren't ranked from worse to better — they trade off curation effort against abuse exposure against growth pace, and the right call depends on what your instance [is for](./what-your-instance-is-for).
+
+## Planned scope
+
+- **Open signup** — anyone with an email can apply for a calendar. Lowest friction, highest abuse exposure. Fits public-good instances with active admin attention
+- **Invite-only** — calendars come into existence by invitation from an existing owner or admin. Medium friction, much lower abuse exposure, slower growth. Fits most community-scale instances
+- **Admin-provisioned** — admins create every calendar. Highest friction, near-zero abuse exposure, deliberate growth. Fits org-internal and curated-aggregator instances
+- The configuration switch and what each posture looks like operationally
+- The application-review path when you run invite-only or open-with-review: what to read in an application, what's a yes, what's a soft no, what's a hard no
+- Switching postures later: from open to invite-only is graceful; the reverse takes some communication. The "we're tightening signup because" announcement is its own art
+- The "what about bad actors who already have a calendar" question — that's [moderation boundaries](./moderation-boundaries) and [removing a calendar](./removing-a-calendar) territory, not signup


### PR DESCRIPTION
## Motivation

The instance-administrators guide section was a set of stubs. Operators bringing up a new Pavillion instance need a single document that walks them from a clean Linux server to a federating instance with one admin account — the on-ramp that the rest of the admin guides can refer back to.

## Approach

Three commits on the branch:

1. **Scaffold the admin guides section** (`8423c4e`, pre-existing on the branch). Stub pages for each planned guide with a `> Status:` marker and a bulleted "Planned scope" so a reader can see what's coming.
2. **Add `--standalone` to `bin/provision.sh`** (`28285ad`). Lets the recommended fresh-server one-liner enable the bundled standalone Caddy in one shot. Two coordinated steps: prepend `COMPOSE_PROFILES=standalone` to the deploy.sh invocation so docker compose picks it up on the initial bring-up (necessary because `su -` strips most env vars), and persist `COMPOSE_PROFILES=standalone` to `.env` so subsequent `docker compose` calls see the profile too. The flag is opt-in; bring-your-own-proxy deployments are unaffected.
3. **Write the Quickstart guide** (`31fa11c`). Follows the documentation-playbook voice — concrete prerequisites (domain, DNS, server, TLS decision, ports), two deploy paths (fresh server via `bin/provision.sh`, existing server via `bin/deploy.sh`), first-admin-account creation via the `/setup` redirect, a one-event smoke test, a federation smoke test, what to do next before opening the instance up, and a "things that trip people up" section covering the genuinely non-obvious failures (domain baked in after deploy, dropping `--standalone` without a fallback proxy, clock skew breaking federation signatures, Caddy port conflicts, split-horizon DNS).

The fresh-server one-liner uses a remote curl so a new operator doesn't need the Pavillion repo cloned locally first.

## Validation

- `bash -n bin/provision.sh` — syntax valid.
- Verified the curl-pipe-bash pattern locally: `bash -s -- --standalone --domain=…` populates `$@` as expected, and `https://raw.githubusercontent.com/stephenhoward/pavillion/main/bin/provision.sh` returns 200.
- build-guardian: lint, unit (461 files / 7958 tests), integration (70 files / 610 tests), and build all PASS. E2E has 2 pre-existing failures (admin-moderation login timeout, import-sources missing federation TLS cert) that are unrelated to docs / bash changes on this branch — neither test exercises code paths touched here.
- Manual read-through of the rendered prose against `docs/guides/calendar-owners/identity.md` and `places.md` (the two most-developed exemplars) to calibrate voice and structure.