### PR TITLE
feat(client): add docs route map and help i18n keys

### DIFF
--- a/src/client/locales/en/system.json
+++ b/src/client/locales/en/system.json
@@ -35,6 +35,140 @@
     "copy": "Copy",
     "copied": "Copied"
   },
+  "help": {
+    "button_label": "Help with this page",
+    "panel_title": "Help with this page",
+    "panel_intro": "Guides on docs.pavillion.social related to what you're doing here.",
+    "open_in_docs": "Read on docs.pavillion.social",
+    "browse_all_calendar-owners": "Browse all calendar-owner guides",
+    "browse_all_instance-administrators": "Browse all administrator guides",
+    "guides": {
+      "quickstart": {
+        "label": "Quickstart",
+        "description": "Go from a fresh login to a published calendar with one event in about ten minutes."
+      },
+      "when_to_create": {
+        "label": "When to create a calendar",
+        "description": "Decide when to create a new calendar versus follow an existing one."
+      },
+      "public_url": {
+        "label": "Share your public URL",
+        "description": "Share your calendar's public URL and federation handle on the web or in a chat."
+      },
+      "embed": {
+        "label": "Embed your calendar",
+        "description": "Embed your calendar on your own website with a configurable widget."
+      },
+      "editors": {
+        "label": "Editors and access",
+        "description": "Invite editors, manage their access, and understand what they can and can't do."
+      },
+      "identity": {
+        "label": "Calendar identity",
+        "description": "Set your calendar's name, description, languages, URL handle, and default image."
+      },
+      "federation_etiquette": {
+        "label": "Federation etiquette",
+        "description": "Be a good neighbor across federated calendars — attribution, reposting, and when not to."
+      },
+      "recurring": {
+        "label": "Recurring events",
+        "description": "Set up an event that repeats weekly, monthly, or on a custom rule, with exceptions handled."
+      },
+      "categories": {
+        "label": "Categories",
+        "description": "Design a small, durable vocabulary that filters your page and matches across federated calendars."
+      },
+      "multilingual": {
+        "label": "Multilingual events",
+        "description": "Publish events in multiple languages and choose fallback behavior for visitors."
+      },
+      "cancel": {
+        "label": "Cancel an event",
+        "description": "Cancel an event the right way, and understand how it propagates to calendars reposting yours."
+      },
+      "series": {
+        "label": "Event series",
+        "description": "Group related events — like a concert season or lecture run — under one program name."
+      },
+      "places": {
+        "label": "Places",
+        "description": "Save event venues once and reuse them across many events."
+      },
+      "follow_repost": {
+        "label": "Follow and repost",
+        "description": "Follow other calendars, review their events in a private feed, and repost what fits."
+      },
+      "category_matching": {
+        "label": "Category matching",
+        "description": "Map categories from other calendars onto your own when reposting federated events."
+      },
+      "funding_owner": {
+        "label": "Community funding",
+        "description": "Enable a voluntary community funding plan — closer to public radio than a subscription."
+      },
+      "moderation_owner": {
+        "label": "Handle reports",
+        "description": "Review visitor reports on your calendar and take action, with admin escalation when needed."
+      },
+      "account": {
+        "label": "Your account",
+        "description": "Manage your password, email, and account-level settings that aren't tied to a calendar."
+      },
+      "admin_config": {
+        "label": "Configure your instance",
+        "description": "Configure your instance with local.yaml, environment variables, and the layered config priority."
+      },
+      "good_admin": {
+        "label": "Being a good admin",
+        "description": "Be the kind of admin calendar owners want to host with — stewardship without paternalism."
+      },
+      "admin_accounts": {
+        "label": "Account operations",
+        "description": "Suspend, reinstate, delete, and recover accounts on your instance."
+      },
+      "who_gets": {
+        "label": "Who gets a calendar",
+        "description": "Choose how new calendars are created — open signup, invite-only, or admin-provisioned."
+      },
+      "removing": {
+        "label": "Removing a calendar",
+        "description": "Remove a calendar from your instance, including how federated copies are affected."
+      },
+      "communicating": {
+        "label": "Talking to owners",
+        "description": "Reach calendar owners about downtime, upgrades, and policy changes."
+      },
+      "mod_boundaries": {
+        "label": "Moderation boundaries",
+        "description": "Know when to act, when to escalate, and when to stay out of owner-level moderation."
+      },
+      "coc": {
+        "label": "Code of conduct",
+        "description": "Write an enforceable code of conduct, separating software rules from policy and culture."
+      },
+      "fed_incidents": {
+        "label": "Federation incidents",
+        "description": "Handle reports from and about other instances without overreacting or under-reacting."
+      },
+      "how_fed_works": {
+        "label": "How federation works",
+        "description": "Understand what your instance signs, sends, and accepts — protocol versus policy."
+      },
+      "fed_policy": {
+        "label": "Federation policy",
+        "description": "Decide which instances to federate with, and how to handle defederation requests."
+      },
+      "funding_setup": {
+        "label": "Set up funding plans",
+        "description": "Set up Stripe so calendar owners on your instance can offer community funding plans."
+      },
+      "asking": {
+        "label": "Asking for money",
+        "description": "Ask the community that uses your instance for money — when, how often, and how transparent."
+      }
+    }
+  },
   "report": {
     "form_title": "Report Event",
     "close_dialog": "Close report dialog",

--- a/src/client/locales/es/system.json
+++ b/src/client/locales/es/system.json
@@ -35,6 +35,14 @@
     "copy": "Copiar",
     "copied": "Copiado"
   },
+  "help": {
+    "button_label": "Ayuda sobre esta página",
+    "panel_title": "Ayuda sobre esta página",
+    "panel_intro": "Guías en docs.pavillion.social relacionadas con lo que estás haciendo aquí.",
+    "open_in_docs": "Leer en docs.pavillion.social",
+    "browse_all_calendar-owners": "Ver todas las guías para propietarios de calendarios",
+    "browse_all_instance-administrators": "Ver todas las guías para administradores"
+  },
   "report": {
     "form_title": "Reportar Evento",
     "close_dialog": "Cerrar diálogo de reporte",

--- a/src/client/locales/fr/system.json
+++ b/src/client/locales/fr/system.json
@@ -35,6 +35,14 @@
     "copy": "Copier",
     "copied": "Copié"
   },
+  "help": {
+    "button_label": "Aide sur cette page",
+    "panel_title": "Aide sur cette page",
+    "panel_intro": "Guides sur docs.pavillion.social en lien avec ce que vous faites ici.",
+    "open_in_docs": "Lire sur docs.pavillion.social",
+    "browse_all_calendar-owners": "Parcourir tous les guides pour propriétaires de calendrier",
+    "browse_all_instance-administrators": "Parcourir tous les guides pour administrateurs"
+  },
   "report": {
     "form_title": "Signaler l'événement",
     "close_dialog": "Fermer la boîte de dialogue de signalement",

--- a/src/client/service/docs.ts
+++ b/src/client/service/docs.ts
@@ -1,0 +1,145 @@
+/**
+ * Public-docs surfacing: maps in-app routes to relevant guides on
+ * https://docs.pavillion.social and builds canonical URLs to them.
+ *
+ * The `key` field is an indirection into `system.help.guides.*` i18n keys
+ * rather than an inline label/description — this keeps user-visible strings
+ * in the locale files and lets one guide be referenced from multiple routes
+ * without duplicating its label.
+ */
+
+export const DOCS_BASE = 'https://docs.pavillion.social';
+
+export type Audience = 'calendar-owners' | 'instance-administrators';
+
+export type GuideRef = {
+  /** Slug relative to DOCS_BASE — no leading slash, no `.html` (docs site uses `cleanUrls`). */
+  slug: string;
+  /** Leaf key under `system:help.guides.*` providing `label` and `description`. */
+  key: string;
+};
+
+/** Builds a fully qualified URL on docs.pavillion.social for the given slug. */
+export function docsUrl(slug: string): string {
+  return `${DOCS_BASE}/${slug}`;
+}
+
+/** URL for the top-level audience landing page on the docs site. */
+export function browseAllUrl(audience: Audience): string {
+  return docsUrl(`guides/${audience}`);
+}
+
+/**
+ * Route name → ordered list of relevant guides (most relevant first).
+ * Keyed by Vue Router route name so the mapping survives URL refactors.
+ * Routes not listed here intentionally have no help affordance.
+ */
+export const ROUTE_GUIDES: Record<string, GuideRef[]> = {
+  // Calendar-owner surfaces
+  calendars: [
+    { slug: 'guides/calendar-owners/quickstart', key: 'quickstart' },
+    { slug: 'guides/calendar-owners/when-to-create-a-calendar', key: 'when_to_create' },
+  ],
+  calendar: [
+    { slug: 'guides/calendar-owners/public-url', key: 'public_url' },
+    { slug: 'guides/calendar-owners/embed', key: 'embed' },
+  ],
+  calendar_management: [
+    { slug: 'guides/calendar-owners/editors', key: 'editors' },
+    { slug: 'guides/calendar-owners/identity', key: 'identity' },
+    { slug: 'guides/calendar-owners/federation-etiquette', key: 'federation_etiquette' },
+  ],
+  event_new: [
+    { slug: 'guides/calendar-owners/recurring-events', key: 'recurring' },
+    { slug: 'guides/calendar-owners/categories', key: 'categories' },
+    { slug: 'guides/calendar-owners/multilingual', key: 'multilingual' },
+  ],
+  event_edit: [
+    { slug: 'guides/calendar-owners/cancel-event', key: 'cancel' },
+    { slug: 'guides/calendar-owners/series', key: 'series' },
+    { slug: 'guides/calendar-owners/recurring-events', key: 'recurring' },
+  ],
+  place_new: [
+    { slug: 'guides/calendar-owners/places', key: 'places' },
+  ],
+  place_edit: [
+    { slug: 'guides/calendar-owners/places', key: 'places' },
+  ],
+  feed: [
+    { slug: 'guides/calendar-owners/follow-and-repost', key: 'follow_repost' },
+  ],
+  calendar_category_mappings: [
+    { slug: 'guides/calendar-owners/category-matching', key: 'category_matching' },
+  ],
+  funding_plan: [
+    { slug: 'guides/calendar-owners/funding', key: 'funding_owner' },
+  ],
+  inbox: [
+    { slug: 'guides/calendar-owners/moderation', key: 'moderation_owner' },
+  ],
+  profile: [
+    { slug: 'guides/calendar-owners/account', key: 'account' },
+  ],
+
+  // Instance-administrator surfaces
+  admin_settings: [
+    { slug: 'guides/instance-administrators/configuration', key: 'admin_config' },
+    { slug: 'guides/instance-administrators/being-a-good-admin', key: 'good_admin' },
+  ],
+  accounts: [
+    { slug: 'guides/instance-administrators/accounts', key: 'admin_accounts' },
+    { slug: 'guides/instance-administrators/who-gets-a-calendar', key: 'who_gets' },
+  ],
+  admin_calendars: [
+    { slug: 'guides/instance-administrators/removing-a-calendar', key: 'removing' },
+    { slug: 'guides/instance-administrators/communicating-with-calendar-owners', key: 'communicating' },
+  ],
+  moderation: [
+    { slug: 'guides/instance-administrators/moderation-boundaries', key: 'mod_boundaries' },
+  ],
+  moderation_settings: [
+    { slug: 'guides/instance-administrators/code-of-conduct', key: 'coc' },
+  ],
+  blocked_instances: [
+    { slug: 'guides/instance-administrators/federation-incidents', key: 'fed_incidents' },
+  ],
+  federation: [
+    { slug: 'guides/instance-administrators/how-federation-works-for-admins', key: 'how_fed_works' },
+    { slug: 'guides/instance-administrators/federation-policy', key: 'fed_policy' },
+  ],
+  funding: [
+    { slug: 'guides/instance-administrators/funding-plans-setup', key: 'funding_setup' },
+    { slug: 'guides/instance-administrators/asking-your-community-for-money', key: 'asking' },
+  ],
+};
+
+/**
+ * Look up guides for a route by name. Returns an empty array for unknown
+ * routes (typed-string mismatches) or non-string route names (e.g., symbol
+ * route names from vue-router) so callers can safely render nothing.
+ */
+export function guidesForRoute(name: string | symbol | null | undefined): GuideRef[] {
+  return typeof name === 'string' ? (ROUTE_GUIDES[name] ?? []) : [];
+}
+
+/**
+ * Audience whose top-level landing page is most relevant for a route name.
+ * Admin routes map to `instance-administrators`; everything else (including
+ * unknown routes) maps to `calendar-owners`.
+ */
+export function audienceForRoute(name: string | symbol | null | undefined): Audience {
+  if (typeof name !== 'string') return 'calendar-owners';
+  return name in ADMIN_ROUTE_SET ? 'instance-administrators' : 'calendar-owners';
+}
+
+const ADMIN_ROUTE_SET: Record<string, true> = {
+  admin_settings: true,
+  accounts: true,
+  admin_calendars: true,
+  moderation: true,
+  moderation_report_detail: true,
+  moderation_settings: true,
+  blocked_instances: true,
+  federation: true,
+  funding: true,
+};

--- a/src/client/test/service/docs.test.ts
+++ b/src/client/test/service/docs.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DOCS_BASE,
+  docsUrl,
+  browseAllUrl,
+  guidesForRoute,
+  audienceForRoute,
+  ROUTE_GUIDES,
+} from '@/client/service/docs';
+import enSystem from '@/client/locales/en/system.json';
+
+const enGuides = (enSystem as { help: { guides: Record<string, { label: string; description: string }> } }).help.guides;
+
+describe('docsUrl', () => {
+  it('builds a URL on the public docs host with no extension', () => {
+    expect(docsUrl('guides/calendar-owners/quickstart'))
+      .toBe('https://docs.pavillion.social/guides/calendar-owners/quickstart');
+  });
+
+  it('uses the canonical docs base', () => {
+    expect(DOCS_BASE).toBe('https://docs.pavillion.social');
+  });
+
+  it('does not append .html (docs site uses cleanUrls)', () => {
+    expect(docsUrl('guides/calendar-owners/quickstart')).not.toMatch(/\.html$/);
+  });
+});
+
+describe('browseAllUrl', () => {
+  it('returns the calendar-owners landing page URL', () => {
+    expect(browseAllUrl('calendar-owners'))
+      .toBe('https://docs.pavillion.social/guides/calendar-owners');
+  });
+
+  it('returns the instance-administrators landing page URL', () => {
+    expect(browseAllUrl('instance-administrators'))
+      .toBe('https://docs.pavillion.social/guides/instance-administrators');
+  });
+});
+
+describe('guidesForRoute', () => {
+  it('returns the documented guides for a known calendar-owner route', () => {
+    const guides = guidesForRoute('calendars');
+    expect(guides.length).toBeGreaterThan(0);
+    expect(guides[0].slug).toBe('guides/calendar-owners/quickstart');
+    expect(guides[0].key).toBe('quickstart');
+  });
+
+  it('returns the documented guides for a known admin route', () => {
+    const guides = guidesForRoute('federation');
+    expect(guides.map(g => g.slug)).toContain(
+      'guides/instance-administrators/how-federation-works-for-admins',
+    );
+  });
+
+  it('returns an empty array for an unknown route name', () => {
+    expect(guidesForRoute('not_a_real_route')).toEqual([]);
+  });
+
+  it('returns an empty array for null', () => {
+    expect(guidesForRoute(null)).toEqual([]);
+  });
+
+  it('returns an empty array for undefined', () => {
+    expect(guidesForRoute(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array for a symbol route name', () => {
+    expect(guidesForRoute(Symbol('anon'))).toEqual([]);
+  });
+});
+
+describe('audienceForRoute', () => {
+  it('classifies known admin routes as instance-administrators', () => {
+    expect(audienceForRoute('federation')).toBe('instance-administrators');
+    expect(audienceForRoute('moderation')).toBe('instance-administrators');
+    expect(audienceForRoute('admin_settings')).toBe('instance-administrators');
+  });
+
+  it('classifies calendar-owner routes as calendar-owners', () => {
+    expect(audienceForRoute('calendars')).toBe('calendar-owners');
+    expect(audienceForRoute('event_edit')).toBe('calendar-owners');
+  });
+
+  it('defaults unknown or non-string inputs to calendar-owners', () => {
+    expect(audienceForRoute('not_a_real_route')).toBe('calendar-owners');
+    expect(audienceForRoute(undefined)).toBe('calendar-owners');
+    expect(audienceForRoute(Symbol('x') as never)).toBe('calendar-owners');
+  });
+});
+
+describe('ROUTE_GUIDES referential integrity', () => {
+  const referencedKeys = new Set(
+    Object.values(ROUTE_GUIDES).flatMap(guides => guides.map(g => g.key)),
+  );
+
+  it('every referenced guide key has a label and description in en/system.json', () => {
+    const missing: string[] = [];
+    for (const key of referencedKeys) {
+      const entry = enGuides[key];
+      if (!entry || typeof entry.label !== 'string' || typeof entry.description !== 'string') {
+        missing.push(key);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('every guide entry in en/system.json is referenced by at least one route', () => {
+    const orphaned = Object.keys(enGuides).filter(key => !referencedKeys.has(key));
+    expect(orphaned).toEqual([]);
+  });
+
+  it('every guide slug points under /guides/ on the docs site', () => {
+    const badSlugs: string[] = [];
+    for (const guides of Object.values(ROUTE_GUIDES)) {
+      for (const g of guides) {
+        if (!g.slug.startsWith('guides/calendar-owners/') && !g.slug.startsWith('guides/instance-administrators/')) {
+          badSlugs.push(g.slug);
+        }
+      }
+    }
+    expect(badSlugs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/client/service/docs.ts` — single source of truth mapping Vue Router route names to relevant guides on docs.pavillion.social (`ROUTE_GUIDES` table, `docsUrl()`, `browseAllUrl()`, `guidesForRoute()`, `audienceForRoute()`)
- Adds `system.help.*` i18n keys in en/es/fr with panel chrome translated and per-guide labels/descriptions in English only (docs site is English-only; es/fr fall back gracefully via i18next)
- Adds 17 tests including referential-integrity checks ensuring every `key` in the route map resolves to a label+description in the locale file, and vice versa

This is the data layer for surfacing contextual help links in the client app (PR 1 of 4 in the docs-surfacing series). The forthcoming `HelpButton` and `HelpPanel` components will consume these exports.

## Test plan

- [x] `npx vitest run src/client/test/service/docs.test.ts` — 17/17 pass
- [x] ESLint clean on new/changed `.ts` files
- [x] `tsc --noEmit` passes
- [x] All three locale JSON files parse without error
- [ ] Verify no regressions: `npm test` full suite

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAxXSWYntk6UCkBfpFV6f3)_