### PR TITLE
feat(client): add HelpButton and HelpPanel components

### DIFF
--- a/src/client/components/common/help-button.vue
+++ b/src/client/components/common/help-button.vue
@@ -1,0 +1,36 @@
+<template>
+  <button
+    v-if="guides.length > 0"
+    type="button"
+    class="btn btn--icon btn--ghost"
+    :aria-label="t('button_label')"
+    aria-haspopup="dialog"
+    @click="showPanel = true"
+  >
+    <CircleHelp :size="20" :stroke-width="1.5" aria-hidden="true" />
+  </button>
+
+  <HelpPanel
+    v-if="showPanel"
+    :guides="guides"
+    :audience="audience"
+    @close="showPanel = false"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useTranslation } from 'i18next-vue';
+import { CircleHelp } from 'lucide-vue-next';
+import HelpPanel from './help-panel.vue';
+import { guidesForRoute, audienceForRoute } from '@/client/service/docs';
+
+const { t } = useTranslation('system', { keyPrefix: 'help' });
+const route = useRoute();
+
+const guides = computed(() => guidesForRoute(route.name));
+const audience = computed(() => audienceForRoute(route.name));
+
+const showPanel = ref(false);
+</script>

--- a/src/client/components/common/help-panel.vue
+++ b/src/client/components/common/help-panel.vue
@@ -1,0 +1,135 @@
+<template>
+  <Sheet :title="t('panel_title')" @close="emit('close')">
+    <p class="help-panel__intro">{{ t('panel_intro') }}</p>
+
+    <ul class="help-panel__guides" role="list">
+      <li v-for="guide in props.guides" :key="guide.key" class="help-panel__guide">
+        <a
+          :href="docsUrl(guide.slug)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="help-panel__link"
+        >
+          <span class="help-panel__label">{{ t(`guides.${guide.key}.label`) }}</span>
+          <span class="help-panel__description">{{ t(`guides.${guide.key}.description`) }}</span>
+          <span class="help-panel__read-more">
+            {{ t('open_in_docs') }}
+            <ExternalLink :size="14" aria-hidden="true" />
+          </span>
+        </a>
+      </li>
+    </ul>
+
+    <footer class="help-panel__footer">
+      <a
+        :href="browseAllUrl(props.audience)"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="help-panel__browse-all"
+      >
+        {{ t(`browse_all_${props.audience}`) }}
+        <ExternalLink :size="14" aria-hidden="true" />
+      </a>
+    </footer>
+  </Sheet>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue';
+import { ExternalLink } from 'lucide-vue-next';
+import Sheet from '@/client/components/common/Sheet.vue';
+import { docsUrl, browseAllUrl } from '@/client/service/docs';
+import type { GuideRef, Audience } from '@/client/service/docs';
+
+const { t } = useTranslation('system', { keyPrefix: 'help' });
+
+const props = defineProps<{
+  guides: GuideRef[];
+  audience: Audience;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+}>();
+</script>
+
+<style scoped lang="scss">
+.help-panel__intro {
+  font-size: var(--pav-font-size-sm);
+  color: var(--pav-text-secondary);
+  margin: 0 0 var(--pav-space-4);
+}
+
+.help-panel__guides {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--pav-space-2);
+}
+
+.help-panel__link {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pav-space-1);
+  padding: var(--pav-space-3);
+  border-radius: var(--pav-border-radius-md);
+  text-decoration: none;
+  color: inherit;
+  transition: background-color 0.15s ease;
+
+  &:hover {
+    background-color: var(--pav-interactive-hover);
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+  }
+}
+
+.help-panel__label {
+  font-weight: var(--pav-font-weight-medium);
+  color: var(--pav-text-primary);
+}
+
+.help-panel__description {
+  font-size: var(--pav-font-size-sm);
+  color: var(--pav-text-secondary);
+  line-height: var(--pav-line-height-body);
+}
+
+.help-panel__read-more {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pav-space-1);
+  font-size: var(--pav-font-size-xs);
+  color: var(--pav-color-brand-primary);
+  margin-block-start: var(--pav-space-1);
+}
+
+.help-panel__footer {
+  margin-block-start: var(--pav-space-4);
+  padding-block-start: var(--pav-space-4);
+  border-block-start: var(--pav-border-width-1) solid var(--pav-border-primary);
+}
+
+.help-panel__browse-all {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pav-space-1);
+  font-size: var(--pav-font-size-sm);
+  color: var(--pav-color-brand-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+  }
+}
+</style>

--- a/src/client/components/logged_in/calendar-management/root.vue
+++ b/src/client/components/logged_in/calendar-management/root.vue
@@ -12,6 +12,7 @@ import ReportDetail from '@/client/components/moderation/report-detail.vue';
 import CalendarService from '../../../service/calendar';
 import Config from '@/client/service/config';
 import { CalendarInfo } from '@/common/model/calendar_info';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const route = useRoute();
 const calendarUrlName = Array.isArray(route.params.calendar)
@@ -129,7 +130,10 @@ const backToReports = () => {
               <span class="calendar-management-root__breadcrumb-separator">/</span>
               <span class="calendar-management-root__breadcrumb-item">{{ t('breadcrumb_settings') }}</span>
             </nav>
-            <h1 class="calendar-management-root__title">{{ t('page_title') }}</h1>
+            <div class="calendar-management-root__title-row">
+              <h1 class="calendar-management-root__title">{{ t('page_title') }}</h1>
+              <HelpButton />
+            </div>
           </div>
 
           <nav
@@ -361,6 +365,12 @@ const backToReports = () => {
   &__breadcrumb-separator {
     color: var(--pav-color-stone-400);
     flex-shrink: 0;
+  }
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
   &__title {

--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -7,6 +7,7 @@ import CalendarService from '@/client/service/calendar';
 import { CalendarInfo } from '@/common/model/calendar_info';
 import EmptyLayout from '@/client/components/common/empty_state.vue';
 import PillButton from '@/client/components/common/pill-button.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 import CreateCalendarForm from './CreateCalendarForm.vue';
 import CreateCalendarSheet from './CreateCalendarSheet.vue';
 
@@ -93,12 +94,15 @@ async function loadCalendars() {
               {{ t('calendar_count', { count: state.calendars.length }) }}
             </p>
           </div>
-          <PillButton
-            variant="primary"
-            @click="openCreateSheet"
-          >
-            {{ t('create_new_calendar_button') }}
-          </PillButton>
+          <div class="calendars-header__actions">
+            <HelpButton />
+            <PillButton
+              variant="primary"
+              @click="openCreateSheet"
+            >
+              {{ t('create_new_calendar_button') }}
+            </PillButton>
+          </div>
         </div>
         <ul class="calendar-cards" role="list">
           <li
@@ -187,6 +191,12 @@ async function loadCalendars() {
     font-size: var(--pav-font-size-body-small);
     color: var(--pav-color-text-secondary);
     margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--pav-space-2);
   }
 }
 

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -683,6 +683,7 @@ button {
       </button>
       <h1>{{ translatedPageTitle }}</h1>
       <div class="header-actions">
+        <HelpButton />
         <button
           type="button"
           class="btn-cancel"
@@ -1137,6 +1138,7 @@ import SeriesSelector from './series-selector.vue';
 import ModalLayout from '@/client/components/common/modal.vue';
 import PillButton from '@/client/components/common/pill-button.vue';
 import LanguageTabSelector from '@/client/components/common/language-tab-selector.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 import LocationDisplayCard from '@/client/components/common/location-display-card.vue';
 import LocationPickerModal from '@/client/components/common/location-picker-modal.vue';
 import CreateLocationForm from '@/client/components/common/create-location-form.vue';


### PR DESCRIPTION
## Summary

- Adds `help-button.vue` — a `CircleHelp` icon button that auto-detects the current route, calls `guidesForRoute()`, and renders nothing when no guides exist. Uses the existing `btn btn--icon btn--ghost` classes.
- Adds `help-panel.vue` — opens in the existing `Sheet` component (bottom-sheet on mobile, centered modal on desktop). Lists guide links with label, description, and "Read on docs.pavillion.social" external links. Footer links to the audience-appropriate landing page.
- Wires `<HelpButton />` into three high-traffic page headers as the initial rollout:
  - **Event editor** (`edit_event.vue`) — in the header actions alongside Cancel/Save
  - **Calendar management** (`calendar-management/root.vue`) — in the title row
  - **Calendars list** (`calendars.vue`) — in the header actions alongside "Create new calendar"

All external links use `target="_blank" rel="noopener noreferrer"` per DEC-004 privacy posture. No in-app Markdown rendering — docs site stays the single source of truth.

## Test plan

- [x] `npx vitest run src/client/test/service/docs.test.ts` — 17/17 pass (data layer from PR 1)
- [x] `npx vitest run src/client/test/edit_event.vue.test.ts` — 28/28 pass (no regression)
- [x] ESLint clean on all new/changed files
- [x] `npx vite build` succeeds (no compilation errors)
- [ ] Manual: log in, navigate to calendars list → ? icon visible, opens panel with Quickstart guide link
- [ ] Manual: open event editor → ? icon visible in header actions
- [ ] Manual: open calendar management → ? icon visible next to page title
- [ ] Manual: navigate to feed → no ? icon (no guides mapped yet — correct behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAxXSWYntk6UCkBfpFV6f3)_