### PR TITLE
feat(client): roll out HelpButton to remaining pages

### DIFF
--- a/src/client/components/account/funding-plan.vue
+++ b/src/client/components/account/funding-plan.vue
@@ -5,6 +5,7 @@ import { ref, computed, onMounted } from 'vue';
 import FundingService from '@/client/service/funding';
 import type { FundedCalendarInfo } from '@/client/service/funding';
 import { useCalendarStore } from '@/client/stores/calendarStore';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('funding');
 
@@ -153,7 +154,10 @@ onMounted(async () => {
   <section class="settings funding-plan-management" aria-labelledby="funding-plan-heading">
     <div class="settings-header">
       <router-link to="/profile" class="back-button">{{ t("back_to_settings") }}</router-link>
-      <h1 id="funding-plan-heading">{{ t("title") }}</h1>
+      <div class="settings-header__title-row">
+        <h1 id="funding-plan-heading">{{ t("title") }}</h1>
+        <HelpButton />
+      </div>
     </div>
 
     <div role="status" aria-live="polite">
@@ -281,6 +285,12 @@ onMounted(async () => {
     &:hover {
       text-decoration: underline;
     }
+  }
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
   h1 {

--- a/src/client/components/admin/accounts.vue
+++ b/src/client/components/admin/accounts.vue
@@ -10,6 +10,7 @@ import { useApplicationStore } from '@/client/stores/applicationStore';
 import { useInvitationStore } from '@/client/stores/invitationStore';
 import { DateTime } from 'luxon';
 import { useTabScroll } from '@/client/composables/useTabScroll';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'accounts',
@@ -97,6 +98,7 @@ const subTabs = computed(() => [
         <h1 id="accounts-heading">{{ t('page_title') }}</h1>
         <p class="page-subtitle">{{ t('page_subtitle') }}</p>
       </div>
+      <HelpButton />
       <button
         v-if="state.activeTab === 'invitations'"
         type="button"

--- a/src/client/components/admin/blocked-instances.vue
+++ b/src/client/components/admin/blocked-instances.vue
@@ -6,6 +6,7 @@ import { useModerationStore } from '@/client/stores/moderation-store';
 import LoadingMessage from '@/client/components/common/loading_message.vue';
 import Modal from '@/client/components/common/modal.vue';
 import type { BlockedInstance } from '@/common/model/blocked_instance';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'blocked_instances',
@@ -148,6 +149,7 @@ function formatDate(dateString: string): string {
         <h1>{{ t('title') }}</h1>
         <p class="page-subtitle">{{ t('subtitle') }}</p>
       </div>
+      <HelpButton />
     </div>
 
     <!-- Loading State -->

--- a/src/client/components/admin/calendars-dashboard.vue
+++ b/src/client/components/admin/calendars-dashboard.vue
@@ -7,6 +7,7 @@ import { DateTime } from 'luxon';
 import { useCalendarAdminStore } from '@/client/stores/calendarAdminStore';
 import type { AdminCalendarRow } from '@/client/service/admin-calendar';
 import LoadingMessage from '@/client/components/common/loading_message.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'calendars',
@@ -149,6 +150,7 @@ const hasActiveFilters = computed(() => {
         <h1>{{ t('page_title') }}</h1>
         <p class="page-subtitle">{{ t('page_subtitle') }}</p>
       </div>
+      <HelpButton />
     </div>
 
     <!-- Filters Section -->

--- a/src/client/components/admin/federation.vue
+++ b/src/client/components/admin/federation.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useTranslation } from 'i18next-vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'federation',
@@ -14,6 +15,7 @@ const { t } = useTranslation('admin', {
         <h1>{{ t("title") }}</h1>
         <p class="federation-subtitle">{{ t("subtitle") }}</p>
       </div>
+      <HelpButton />
     </div>
 
     <!-- Info Panel -->

--- a/src/client/components/admin/funding.vue
+++ b/src/client/components/admin/funding.vue
@@ -10,6 +10,7 @@ import ConfirmDisconnectModal from './confirm-disconnect-modal.vue';
 import AddProviderWizard from './add-provider-wizard.vue';
 import GrantForm from './grant-form.vue';
 import { ComplimentaryGrant } from '@/common/model/complimentary_grant';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'funding',
@@ -510,6 +511,7 @@ onMounted(async () => {
         <h1 id="funding-heading">{{ t("title") }}</h1>
         <p class="page-subtitle">{{ t("settings_section_title") }}</p>
       </div>
+      <HelpButton />
       <button
         v-if="activeSubTab === 'grants'"
         type="button"

--- a/src/client/components/admin/moderation-dashboard.vue
+++ b/src/client/components/admin/moderation-dashboard.vue
@@ -7,6 +7,7 @@ import { ReportStatus, ReportCategory, type EscalationType } from '@/common/mode
 import LoadingMessage from '@/client/components/common/loading_message.vue';
 import CreateReportModal from '@/client/components/admin/create-report.vue';
 import { DateTime } from 'luxon';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'moderation',
@@ -187,6 +188,7 @@ function goToSettings() {
         <h1>{{ t('title') }}</h1>
         <p class="page-subtitle">{{ t('subtitle') }}</p>
       </div>
+      <HelpButton />
       <div class="page-header-actions">
         <button type="button" class="action-button action-create" @click="openCreateModal">
           <svg width="16"

--- a/src/client/components/admin/moderation-settings.vue
+++ b/src/client/components/admin/moderation-settings.vue
@@ -3,6 +3,7 @@ import { onMounted, reactive } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import { useModerationStore } from '@/client/stores/moderation-store';
 import LoadingMessage from '@/client/components/common/loading_message.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('admin', {
   keyPrefix: 'moderation.settings',
@@ -135,6 +136,7 @@ async function saveSettings() {
         <h1>{{ t('title') }}</h1>
         <p class="page-subtitle">{{ t('subtitle') }}</p>
       </div>
+      <HelpButton />
     </div>
 
     <!-- Loading State -->

--- a/src/client/components/admin/settings.vue
+++ b/src/client/components/admin/settings.vue
@@ -8,6 +8,7 @@ import { DEFAULT_LANGUAGE_CODE } from '@/common/i18n/languages';
 import HousekeepingStatus from './housekeeping-status.vue';
 import LanguageSettings from './language-settings.vue';
 import LanguageTabSelector from '../common/language-tab-selector.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const site_config = inject('site_config');
 const { t } = useTranslation('admin', {
@@ -112,7 +113,10 @@ async function updateSettings() {
   <div class="settings-page">
     <!-- Page Header -->
     <div class="page-header">
-      <h1>{{ t("general_settings") }}</h1>
+      <div class="page-header__title-row">
+        <h1>{{ t("general_settings") }}</h1>
+        <HelpButton />
+      </div>
       <p class="page-subtitle">{{ t("settings_subtitle", "Monitor system health and configure instance settings") }}</p>
     </div>
 
@@ -282,6 +286,12 @@ async function updateSettings() {
   max-width: 800px;
 
   .page-header {
+    &__title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
     h1 {
       margin: 0 0 var(--pav-space-1) 0;
       font-size: var(--pav-font-size-2xl);

--- a/src/client/components/common/help-button.vue
+++ b/src/client/components/common/help-button.vue
@@ -29,8 +29,8 @@ import { guidesForRoute, audienceForRoute } from '@/client/service/docs';
 const { t } = useTranslation('system', { keyPrefix: 'help' });
 const route = useRoute();
 
-const guides = computed(() => guidesForRoute(route.name));
-const audience = computed(() => audienceForRoute(route.name));
+const guides = computed(() => guidesForRoute(route?.name));
+const audience = computed(() => audienceForRoute(route?.name));
 
 const showPanel = ref(false);
 </script>

--- a/src/client/components/logged_in/calendar/calendar.vue
+++ b/src/client/components/logged_in/calendar/calendar.vue
@@ -7,6 +7,7 @@ import CalendarService from '@/client/service/calendar';
 import EventService from '@/client/service/event';
 import { ExternalLink } from 'lucide-vue-next';
 import PillButton from '@/client/components/common/pill-button.vue';
+import HelpButton from '@/client/components/common/help-button.vue';
 import EventsTab from '@/client/components/logged_in/calendar-content/events-tab.vue';
 import CategoriesTab from '@/client/components/logged_in/calendar-content/categories.vue';
 import SeriesTab from '@/client/components/logged_in/calendar-content/series.vue';
@@ -191,6 +192,7 @@ const handleLoadEvents = async (filters) => {
               </a>
             </div>
             <div class="header-actions">
+              <HelpButton />
               <PillButton
                 variant="ghost"
                 @click="openCreateCalendarSheet"

--- a/src/client/components/logged_in/calendar/edit-place.vue
+++ b/src/client/components/logged_in/calendar/edit-place.vue
@@ -453,6 +453,7 @@ form {
       </button>
       <h1>{{ isEditMode ? t('editor_title_edit') : t('editor_title_new') }}</h1>
       <div class="header-actions">
+        <HelpButton />
         <button
           type="button"
           class="btn-cancel"
@@ -747,6 +748,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useTranslation } from 'i18next-vue';
 import i18next from 'i18next';
 import { ArrowLeft } from 'lucide-vue-next';
+import HelpButton from '@/client/components/common/help-button.vue';
 import LanguageTabSelector from '@/client/components/common/language-tab-selector.vue';
 import languagePicker from '@/client/components/common/language-picker.vue';
 import ConfirmDeleteDialog from '@/client/components/common/confirm-delete-dialog.vue';

--- a/src/client/components/logged_in/inbox.vue
+++ b/src/client/components/logged_in/inbox.vue
@@ -4,6 +4,7 @@ import { useTranslation } from 'i18next-vue';
 import EmptyLayout from '@/client/components/common/empty_state.vue';
 import { useNotificationStore } from '@/client/stores/notificationStore';
 import type { Notification } from '@/common/model/notification';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const { t } = useTranslation('inbox');
 const store = useNotificationStore();
@@ -75,9 +76,12 @@ onUnmounted(() => {
 
 <template>
   <div class="inbox-container">
-    <h1 class="inbox-heading">
-      {{ t('title') }}
-    </h1>
+    <div class="inbox-heading-row">
+      <h1 class="inbox-heading">
+        {{ t('title') }}
+      </h1>
+      <HelpButton />
+    </div>
 
     <ul
       v-if="notifications.length"
@@ -140,12 +144,19 @@ div.inbox-container {
   height: 100%;
   overflow-y: auto;
 
+  .inbox-heading-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--pav-space-6) var(--pav-space-4) var(--pav-space-4);
+  }
+
   h1.inbox-heading {
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--pav-color-stone-900);
     margin: 0;
-    padding: var(--pav-space-6) var(--pav-space-4) var(--pav-space-4);
+    padding: 0;
 
     @media (prefers-color-scheme: dark) {
       color: var(--pav-color-stone-100);

--- a/src/client/components/logged_in/settings/calendar-category-mappings.vue
+++ b/src/client/components/logged_in/settings/calendar-category-mappings.vue
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-vue-next';
 import CategoryMappingEditor from '@/client/components/logged_in/category-mapping-editor.vue';
 import { ADD_CATEGORY_VALUE } from '@/client/components/logged_in/category-mapping-constants';
 import FeedService, { type CategoryEntry, type CategoryMappingEntry } from '@/client/service/feed';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const props = defineProps<{
   calendarId: string;
@@ -105,7 +106,10 @@ async function save() {
     </button>
 
     <div class="page-header">
-      <h1>{{ t('page_title') }}</h1>
+      <div class="page-header__title-row">
+        <h1>{{ t('page_title') }}</h1>
+        <HelpButton />
+      </div>
       <p class="subtitle">{{ t('page_subtitle') }}</p>
     </div>
 
@@ -214,6 +218,12 @@ async function save() {
 
 .page-header {
   margin-bottom: var(--pav-space-6);
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
   h1 {
     font-size: 1.5rem;

--- a/src/client/components/logged_in/settings/root.vue
+++ b/src/client/components/logged_in/settings/root.vue
@@ -9,6 +9,7 @@ import FundingService from '@/client/service/funding';
 import AccountService from '@/client/service/account';
 import { AVAILABLE_LANGUAGES } from '@/common/i18n/languages';
 import { changeLanguage, applyAccountLanguage } from '@/client/service/locale';
+import HelpButton from '@/client/components/common/help-button.vue';
 
 const router = useRouter();
 const authn = inject('authn');
@@ -173,7 +174,10 @@ onMounted(async () => {
     <div class="settings-container">
       <!-- Page Header -->
       <div class="page-header">
-        <h1>{{ t("title") }}</h1>
+        <div class="page-header__title-row">
+          <h1>{{ t("title") }}</h1>
+          <HelpButton />
+        </div>
         <p class="subtitle">{{ t("subtitle", { defaultValue: "Manage your account preferences" }) }}</p>
       </div>
 
@@ -414,6 +418,12 @@ onMounted(async () => {
 
 .page-header {
   margin-bottom: var(--pav-space-8);
+
+  &__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
   h1 {
     font-size: 1.5rem;


### PR DESCRIPTION
## Summary

Rolls out `<HelpButton />` to all remaining pages that have an existing header area and a mapped guide set:

**Calendar-owner pages:**
- Single calendar view — in `.header-actions` alongside "New Calendar" and "Manage"
- Place editor — in `.header-actions` alongside Cancel/Save
- Category mappings — in `.page-header` title row
- Funding plan — in `.settings-header` title row
- Inbox — in new `.inbox-heading-row` wrapper
- Profile settings — in `.page-header` title row

**Admin pages (all 8):**
- Settings, Accounts, Calendars dashboard, Federation, Funding, Moderation dashboard, Moderation settings, Blocked instances — each placed after the `.page-header-text` div

Feed page is intentionally skipped (no header element to attach to — follow-up item).

## Test plan

- [x] ESLint clean on all 14 changed files
- [x] `npx vite build` succeeds
- [ ] Manual: each page shows `?` icon only when guides are mapped
- [ ] Manual: clicking `?` opens help panel with correct audience guides (calendar-owner vs administrator)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAxXSWYntk6UCkBfpFV6f3)_