### PR TITLE
feat(client): add guide prop to EmptyState for onboarding nudges

### DIFF
--- a/src/client/components/common/empty_state.vue
+++ b/src/client/components/common/empty_state.vue
@@ -6,21 +6,57 @@
     <h2 :id="titleId">{{ props.title }}</h2>
     <p v-if="props.description">{{ props.description }}</p>
     <slot/>
+    <a
+      v-if="guideUrl"
+      :href="guideUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="empty-state__guide-link"
+    >
+      {{ guideLabel }}
+      <ExternalLink :size="14" aria-hidden="true" />
+    </a>
   </section>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed } from 'vue';
+import { useTranslation } from 'i18next-vue';
+import { ExternalLink } from 'lucide-vue-next';
+import { docsUrl } from '@/client/service/docs';
+import type { GuideRef } from '@/client/service/docs';
 
-const props = defineProps({
-  title: String,
-  description: String,
-});
+const { t } = useTranslation('system', { keyPrefix: 'help' });
+
+const props = defineProps<{
+  title: string;
+  description?: string;
+  guide?: GuideRef;
+}>();
 
 const dialogId = Math.random().toString(36).substring(2, 11);
 const titleId = computed(() => `empty-title-${dialogId}`);
-
+const guideUrl = computed(() => props.guide ? docsUrl(props.guide.slug) : null);
+const guideLabel = computed(() => props.guide ? t(`guides.${props.guide.key}.label`) : '');
 </script>
 
 <style scoped lang="scss">
+.empty-state__guide-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pav-space-1);
+  margin-block-start: var(--pav-space-4);
+  font-size: var(--pav-font-size-sm);
+  color: var(--pav-color-brand-primary);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+  }
+}
 </style>

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -647,7 +647,8 @@ initializeFiltersFromURL();
     <!-- Empty State: No events at all -->
     <EmptyLayout v-else-if="!isLoading && !hasActiveFilters && (!calendarEvents || calendarEvents.length === 0)"
                  :title="t('noEvents')"
-                 :description="t('noEventsDescription')">
+                 :description="t('noEventsDescription')"
+                 :guide="{ slug: 'guides/calendar-owners/recurring-events', key: 'recurring' }">
       <PillButton variant="primary" @click="newEvent()">
         <Plus :size="20" :stroke-width="2" />
         {{ t('createEvent') }}

--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -162,7 +162,11 @@ async function loadCalendars() {
         </ul>
       </section>
     </nav>
-    <EmptyLayout v-else :title="t('create_first_calendar_header')">
+    <EmptyLayout
+      v-else
+      :title="t('create_first_calendar_header')"
+      :guide="{ slug: 'guides/calendar-owners/quickstart', key: 'quickstart' }"
+    >
       <CreateCalendarForm />
     </EmptyLayout>
 

--- a/src/client/components/logged_in/feed/events.vue
+++ b/src/client/components/logged_in/feed/events.vue
@@ -402,6 +402,7 @@ onUnmounted(() => {
     <EmptyLayout
       v-else
       :title="t('no_events')"
+      :guide="{ slug: 'guides/calendar-owners/follow-and-repost', key: 'follow_repost' }"
     >
       <button
         type="button"

--- a/src/client/components/logged_in/feed/follows.vue
+++ b/src/client/components/logged_in/feed/follows.vue
@@ -89,6 +89,7 @@ const handleFollowSuccess = async () => {
   <EmptyLayout
     v-else
     :title="t('no_follows')"
+    :guide="{ slug: 'guides/calendar-owners/follow-and-repost', key: 'follow_repost' }"
   >
     <button
       type="button"


### PR DESCRIPTION
## Summary

- Upgrades `EmptyState` component with an optional `guide` prop (accepts a `GuideRef`). When set, renders a "Read the [Guide Name] ↗" external link below the slot content. Existing call sites that omit the prop are unaffected.
- Wires guide links into four high-leverage onboarding empty states:
  - **Calendars list** (no calendars yet) → Quickstart guide
  - **Calendar events** (no events) → Recurring events guide
  - **Feed follows** (not following anyone) → Follow and repost guide
  - **Feed events** (no follows, no events) → Follow and repost guide

This is the final PR in the docs-surfacing series (PR 4 of 4).

## Test plan

- [x] `npm run test:unit` — 7970/7970 pass (all 462 test files)
- [x] `npx vite build` succeeds
- [ ] Manual: create a fresh account → calendars list shows "Quickstart" guide link
- [ ] Manual: navigate to an empty calendar → events empty state shows "Recurring events" guide link
- [ ] Manual: navigate to feed with no follows → both follows tab and events tab show "Follow and repost" guide link
- [ ] Manual: existing empty states without the `guide` prop render unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAxXSWYntk6UCkBfpFV6f3)_