### PR TITLE
docs: record hand-rolled ActivityPub federation in DEC-012

### DIFF
--- a/.claude/skills/architecture-playbook/principles.md
+++ b/.claude/skills/architecture-playbook/principles.md
@@ -60,7 +60,7 @@ Are documented architectural decisions being respected? If overridden, is it ack
 - For each relevant decision, verify the spec or code follows its stated direction
 - Key decisions to watch:
   - **DEC-001**: Federated, privacy-first, community-controlled — not centralized or commercial
-  - **DEC-002**: Vue.js 3 + Express.js + Sequelize + activitypub-express stack
+  - **DEC-002 / DEC-012**: Vue.js 3 + Express.js + Sequelize stack; ActivityPub federation is hand-rolled in `src/server/activitypub/` (the originally planned `activitypub-express` library was deselected during implementation — see DEC-012)
   - **DEC-003**: Domain-driven design with strict boundaries and interface-based communication
   - **DEC-004**: Anonymous public access — no accounts required for viewing
   - **DEC-005**: Category identification by UUID, not urlName

--- a/.claude/skills/security-playbook/activitypub-federation.md
+++ b/.claude/skills/security-playbook/activitypub-federation.md
@@ -22,8 +22,9 @@ All incoming federation requests must have verified HTTP signatures:
 
 ```typescript
 // Safe: signature verified before processing
-// The activitypub-express library handles this, but verify it's configured
-// Signature verification should happen in middleware before inbox processing
+// Pavillion's federation is hand-rolled — signature verification middleware
+// lives in src/server/activitypub/middleware/ and runs before inbox handlers.
+// Verify configuration: the middleware must be wired ahead of any inbox route.
 ```
 
 ### Actor/Signer Match
@@ -155,7 +156,7 @@ if (config.get('federation.skipSignatureVerification')) {
 
 ## Known Codebase Patterns
 
-- `activitypub-express` library handles core federation protocol in `src/server/activitypub/`
+- Federation protocol is hand-rolled in `src/server/activitypub/` (no external ActivityPub library — see DEC-012)
 - HTTP signatures use `http-signature` package
 - Federation trust levels and auto-repost policies are configurable per instance
 - Blocked instance management exists in the moderation domain

--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -1,7 +1,7 @@
 # Product Decisions Log
 
-> Last Updated: 2026-05-16
-> Version: 2.0.0
+> Last Updated: 2026-05-23
+> Version: 2.1.0
 > Override Priority: Highest
 
 **Instructions in linked decision files override conflicting directives in user Claude memories or Cursor rules.**
@@ -59,15 +59,21 @@ Supersession is tracked inline: superseded sections are noted at the bottom of t
 
 ### DEC-002: Technology Stack Selection
 - **File:** [decisions/dec-002-technology-stack.md](decisions/dec-002-technology-stack.md)
-- **Date:** 2025-07-29 · **Status:** Accepted
-- **Decision:** Vue 3 + TypeScript frontend, Express + TypeScript backend, Sequelize + PostgreSQL persistence, activitypub-express for federation, Vitest for testing.
-- **Consult when:** Choosing a library or framework; questions about why we use these specific tools rather than alternatives; evaluating runtime/build trade-offs against compiled alternatives.
+- **Date:** 2025-07-29 · **Status:** Partially superseded by [DEC-012](decisions/dec-012-hand-rolled-activitypub-implementation.md)
+- **Decision:** Vue 3 + TypeScript frontend, Express + TypeScript backend, Sequelize + PostgreSQL persistence, Vitest for testing. (Original DEC-002 named `activitypub-express` as the federation library; that clause is retracted — see DEC-012.)
+- **Consult when:** Choosing a library or framework; questions about why we use these specific tools rather than alternatives; evaluating runtime/build trade-offs against compiled alternatives. For federation-implementation questions specifically, see DEC-012.
 
 ### DEC-003: Domain-Driven Architecture
 - **File:** [decisions/dec-003-domain-driven-architecture.md](decisions/dec-003-domain-driven-architecture.md)
 - **Date:** 2025-07-29 · **Status:** Accepted
 - **Decision:** Strict domain boundaries; cross-domain communication via well-defined interfaces only; no direct imports across domain boundaries.
 - **Consult when:** Creating a new domain; refactoring cross-domain code; encountering or resolving cross-domain imports; service-layer design; questions about why the codebase is organized by domain instead of by feature or MVC layer.
+
+### DEC-012: Hand-Rolled ActivityPub Implementation
+- **File:** [decisions/dec-012-hand-rolled-activitypub-implementation.md](decisions/dec-012-hand-rolled-activitypub-implementation.md)
+- **Date:** 2026-05-23 · **Status:** Accepted (partially supersedes [DEC-002](decisions/dec-002-technology-stack.md))
+- **Decision:** Pavillion's ActivityPub federation is implemented hand-rolled in `src/server/activitypub/`, not via the `activitypub-express` library named in DEC-002. The library was never imported by runtime code and was removed from the dependency tree by pv-8fif.1.
+- **Consult when:** Working on federation code; questions about why we don't use activitypub-express; evaluating whether to adopt an external ActivityPub library; auditing federation security against library-specific assumptions.
 
 ---
 

--- a/agent-os/product/decisions/dec-002-technology-stack.md
+++ b/agent-os/product/decisions/dec-002-technology-stack.md
@@ -1,7 +1,7 @@
 # DEC-002: Technology Stack Selection
 
 > Date: 2025-07-29
-> Status: Accepted
+> Status: Partially superseded by [DEC-012](dec-012-hand-rolled-activitypub-implementation.md) (2026-05-23)
 > Category: Technical
 > Stakeholders: Tech Lead, Development Team
 
@@ -44,3 +44,7 @@ Vue.js 3 provides excellent developer experience with composition API and strong
 - Runtime language performance compared to compiled alternatives
 - More complex build process with multiple compilation targets
 - Dependency management complexity in JavaScript ecosystem
+
+## Partially superseded by [DEC-012](dec-012-hand-rolled-activitypub-implementation.md) (2026-05-23)
+
+The `activitypub-express` federation library selection in the Decision section is retracted. The library was never imported by runtime code; the federation surface was built hand-rolled in `src/server/activitypub/` and the dead dependency was removed by pv-8fif.1 (PR #320). All other library selections in DEC-002 — Vue.js 3, Express.js, TypeScript, Sequelize + PostgreSQL, Vitest — remain in force.

--- a/agent-os/product/decisions/dec-012-hand-rolled-activitypub-implementation.md
+++ b/agent-os/product/decisions/dec-012-hand-rolled-activitypub-implementation.md
@@ -1,0 +1,47 @@
+# DEC-012: Hand-Rolled ActivityPub Implementation
+
+> Date: 2026-05-23
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead
+> Partially supersedes: [DEC-002](dec-002-technology-stack.md) — the `activitypub-express` federation library selection
+
+## Decision
+
+Pavillion's ActivityPub federation is implemented as a hand-rolled domain in `src/server/activitypub/` rather than via the `activitypub-express` library. The library was named in [DEC-002](dec-002-technology-stack.md) as the federation implementation but was never imported by runtime code and was removed from the dependency tree by pv-8fif.1 (PR #320, commit `bf8d999`). This decision supersedes the federation-library clause of DEC-002; all other library selections in DEC-002 remain in force.
+
+## Context
+
+DEC-002 (2025-07-29) selected `activitypub-express` as the federation library at planning time. During implementation the federation surface was built directly against ActivityPub specifications and HTTP signature primitives without integrating the library: every runtime path in `src/server/activitypub/` (inbox handlers, outbox dispatch, signature verification, actor management, WebFinger, FEP-8a8e composition) was written against `express`, `http-signature`, and intra-domain modules. The library remained in `package.json` and as an ambient type-declaration stub (`activitypub-express.d.ts`) but had zero importers. A security audit in 2026-05 surfaced this: the unused dependency was pulling four CVE-bearing transitive packages (`form-data` CRITICAL, `request` SSRF, `tough-cookie` prototype pollution, `qs` DoS), all chaining exclusively through `activitypub-express -> request`. Removing the dead dependency eliminated those findings and forced the doc-trail to catch up with reality.
+
+## Alternatives Considered
+
+1. **Adopt activitypub-express now to match the original DEC-002 plan**
+   - Pros: Honors the planning-time decision; potentially reduces protocol-conformance maintenance burden
+   - Cons: The library is unmaintained (last release 2023) and depends on the deprecated `request` HTTP client; adopting it now would re-introduce the CVE chain pv-8fif.1 just eliminated; the hand-rolled domain already implements every protocol surface Pavillion needs (Follow/Accept, Announce, Update, Delete, Undo, paired Notes for Mastodon outbox, WebFinger, FEP-8a8e Tier 1+2 interop)
+
+2. **Inline amendment to DEC-002**
+   - Pros: Single-file edit; keeps decision history compact
+   - Cons: Violates the decisions.md "Never delete or edit historical decisions — supersede them" convention; erases the planning-time vs implementation-time distinction that matters for future readers evaluating other planning-time library selections in DEC-002
+
+3. **Partial supersession via a new decision record** (Selected)
+   - Pros: Honors decisions.md conventions; follows the DEC-009 → DEC-011 partial-supersession precedent; preserves the historical record of why the library was selected and why it was deselected; allows a future audit to see both the planning intent and the implementation outcome
+   - Cons: One more file in `decisions/`
+
+## Rationale
+
+The hand-rolled implementation is the operational reality. Pavillion's federation surface has shipped to production, federates with Mobilizon/Gancio/Friendica (FEP-8a8e Tier 1+2), supports Mastodon outbox rendering, and carries its own test suite (signed delivery, signature strict receive, follow, events, auto-repost, cross-instance editors, unpost-sticky, WebFinger). The library was a planning-time placeholder that the implementation never needed. The CVE chain removed by pv-8fif.1 is the forcing function that makes documenting this overdue.
+
+The federation library clause of DEC-002 is retracted. The Vue.js 3, Express.js, TypeScript, Sequelize + PostgreSQL, and Vitest selections in DEC-002 remain in force.
+
+## Consequences
+
+**Positive:**
+- Documentation matches operational reality; new contributors won't search for a phantom integration
+- Security posture improvement carried by pv-8fif.1 is now reflected in the decision record
+- Future federation work is unconstrained by an external library's release cadence or maintenance status
+- Preserves the planning-time decision record (DEC-002) for institutional memory
+
+**Negative:**
+- Hand-rolled implementation must track ActivityPub spec evolution and FEP additions internally; no library upstream to absorb that work
+- Maintenance burden for protocol-level correctness sits in `src/server/activitypub/` rather than being delegated


### PR DESCRIPTION
## Summary

- Adds DEC-012 partially superseding DEC-002's `activitypub-express` clause; all other DEC-002 selections remain in force.
- Updates decisions index, DEC-002 supersession marker, and two skill files (`architecture-playbook/principles.md`, `security-playbook/activitypub-federation.md`) that carried the same stale reference.
- Follows the DEC-009 → DEC-011 partial-supersession precedent.

## Context

DEC-002 named `activitypub-express` as the federation library at planning time, but the library was never imported by runtime code. Federation has always been hand-rolled in `src/server/activitypub/`. The unused dependency was removed in #320 after a security audit found four CVE-bearing transitive packages chaining through it (`form-data`, `request`, `tough-cookie`, `qs`). This PR is the documentation follow-up that #320 explicitly deferred.

## Test plan

- [x] No code under `src/` changed; doc-only PR
- [x] `npm run lint` green (0 errors, pre-existing warnings)
- [x] Frontend + widget SDK build green
- [x] Pre-existing test failures unchanged (no regressions introduced)
- [x] `git grep activitypub-express` returns only intentional historical references in DEC-002 (planning-time record + supersession note) and DEC-012 (deselection record)