### PR TITLE
docs: skip children prompt in /analyze-bead

### DIFF
--- a/.claude/commands/analyze-bead.md
+++ b/.claude/commands/analyze-bead.md
@@ -46,36 +46,8 @@ bd show <bead-id> --children
 
 ```
 IF bead has child beads:
-  COUNT the number of children
-  ASK user:
-    "This bead already has [count] child beads:
-
-    [list first 5 bead titles with IDs]
-
-    Would you like to:
-    1. **Enrich existing beads** - Add implementation context to existing beads (recommended)
-    2. **Delete and recreate** - Delete existing beads and create new decomposition
-    3. **Cancel** - Stop analysis
-
-    Choose option (1/2/3):"
-
-  WAIT for user response
-
-  IF user chooses 1 (Enrich):
-    SET analysis_mode = "hierarchy"
-    PROCEED to Phase 2 with existing beads
-
-  ELSE IF user chooses 2 (Delete and recreate):
-    ASK for confirmation:
-      "This will permanently delete [count] beads. Are you sure? (yes/no)"
-    IF confirmed:
-      DELETE all child beads: `bd delete <child-ids>`
-      SET analysis_mode = "needs_decomposition"
-      PROCEED to decomposition assessment below
-
-  ELSE IF user chooses 3 (Cancel):
-    STOP analysis
-    MESSAGE: "Analysis cancelled."
+  SET analysis_mode = "hierarchy"
+  PROCEED to Phase 2 with existing beads
 
 ELSE (no children):
   PROCEED to decomposition assessment below


### PR DESCRIPTION
## Motivation

When `/analyze-bead` runs on a bead that already has children, it prompts the user to choose between enriching the existing beads, deleting and recreating them, or cancelling. In practice the answer is always "enrich" — the prompt is friction without a meaningful choice.

## Approach

Removed the three-option prompt from Phase 1.5 in `.claude/commands/analyze-bead.md`. When a bead has children, the command now sets `analysis_mode = "hierarchy"` and proceeds straight to Phase 2. The decomposition-assessment branch for childless beads is unchanged.

## Validation

Documentation-only change. Reviewed the rendered command file to confirm the surrounding decision tree still reads correctly with the simplified branch.