### PR TITLE
feat(client): collapse calendar header buttons into actions menu

### DIFF
--- a/src/client/components/common/actions-menu-item.vue
+++ b/src/client/components/common/actions-menu-item.vue
@@ -1,0 +1,100 @@
+<template>
+  <li role="none" class="actions-menu-item">
+    <RouterLink
+      v-if="to"
+      :to="to"
+      role="menuitem"
+      class="actions-menu-item__action"
+      :aria-label="ariaLabel"
+      @click="handleActivate"
+    >
+      <component :is="icon"
+                 :size="16"
+                 :stroke-width="1.5"
+                 aria-hidden="true"
+                 class="actions-menu-item__icon" />
+      <span class="actions-menu-item__label"><slot /></span>
+    </RouterLink>
+
+    <button
+      v-else
+      type="button"
+      role="menuitem"
+      class="actions-menu-item__action"
+      :aria-label="ariaLabel"
+      @click="handleActivate"
+    >
+      <component :is="icon"
+                 :size="16"
+                 :stroke-width="1.5"
+                 aria-hidden="true"
+                 class="actions-menu-item__icon" />
+      <span class="actions-menu-item__label"><slot /></span>
+    </button>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { inject, type Component } from 'vue';
+import type { RouteLocationRaw } from 'vue-router';
+
+defineProps<{
+  icon: Component;
+  to?: RouteLocationRaw;
+  ariaLabel?: string;
+}>();
+
+const emit = defineEmits<{
+  click: [event: MouseEvent];
+}>();
+
+const closeMenu = inject<() => void>('actions-menu-close', () => {});
+
+function handleActivate(event: MouseEvent) {
+  emit('click', event);
+  closeMenu();
+}
+</script>
+
+<style scoped lang="scss">
+.actions-menu-item {
+  list-style: none;
+}
+
+.actions-menu-item__action {
+  display: flex;
+  align-items: center;
+  gap: var(--pav-space-2);
+  width: 100%;
+  padding: var(--pav-space-2) var(--pav-space-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--pav-border-radius-sm);
+  font: inherit;
+  color: var(--pav-text-primary, var(--pav-color-text-primary));
+  text-align: start;
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--pav-interactive-hover, var(--pav-color-surface-secondary));
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: -2px;
+  }
+}
+
+.actions-menu-item__icon {
+  flex-shrink: 0;
+  color: var(--pav-text-secondary, var(--pav-color-text-secondary));
+}
+
+.actions-menu-item__label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+}
+</style>

--- a/src/client/components/common/actions-menu.vue
+++ b/src/client/components/common/actions-menu.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="actions-menu" :class="`actions-menu--align-${align}`">
+    <button
+      ref="triggerEl"
+      type="button"
+      class="btn btn--icon btn--ghost actions-menu__trigger"
+      :aria-label="triggerLabel"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+      @click="toggle"
+      @keydown.down.prevent="openAndFocusFirst"
+      @keydown.up.prevent="openAndFocusLast"
+    >
+      <Menu :size="20" :stroke-width="1.5" aria-hidden="true" />
+    </button>
+
+    <ul
+      v-if="isOpen"
+      ref="panelEl"
+      role="menu"
+      class="actions-menu__panel"
+      @keydown.down.prevent="focusNext"
+      @keydown.up.prevent="focusPrev"
+      @keydown.home.prevent="focusFirst"
+      @keydown.end.prevent="focusLast"
+      @keydown.tab="close"
+    >
+      <slot />
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, provide, onBeforeUnmount } from 'vue';
+import { Menu } from 'lucide-vue-next';
+
+withDefaults(defineProps<{
+  triggerLabel: string;
+  align?: 'start' | 'end';
+}>(), {
+  align: 'end',
+});
+
+const isOpen = ref(false);
+const triggerEl = ref<HTMLButtonElement | null>(null);
+const panelEl = ref<HTMLUListElement | null>(null);
+
+function getItems(): HTMLElement[] {
+  if (!panelEl.value) return [];
+  return Array.from(panelEl.value.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+}
+
+function focusAt(index: number) {
+  const items = getItems();
+  if (items.length === 0) return;
+  const wrapped = (index + items.length) % items.length;
+  items[wrapped].focus();
+}
+
+function focusFirst() { focusAt(0); }
+function focusLast() { focusAt(-1); }
+
+function focusNext() {
+  const items = getItems();
+  const current = items.findIndex((el) => el === document.activeElement);
+  focusAt(current + 1);
+}
+
+function focusPrev() {
+  const items = getItems();
+  const current = items.findIndex((el) => el === document.activeElement);
+  focusAt(current - 1);
+}
+
+async function open() {
+  if (isOpen.value) return;
+  isOpen.value = true;
+  document.addEventListener('mousedown', handleOutsideMouseDown);
+  document.addEventListener('keydown', handleDocumentKeyDown);
+  await nextTick();
+}
+
+function close() {
+  if (!isOpen.value) return;
+  isOpen.value = false;
+  document.removeEventListener('mousedown', handleOutsideMouseDown);
+  document.removeEventListener('keydown', handleDocumentKeyDown);
+  triggerEl.value?.focus();
+}
+
+function toggle() {
+  if (isOpen.value) close();
+  else open();
+}
+
+async function openAndFocusFirst() {
+  await open();
+  focusFirst();
+}
+
+async function openAndFocusLast() {
+  await open();
+  focusLast();
+}
+
+function handleOutsideMouseDown(event: MouseEvent) {
+  const target = event.target as Node | null;
+  if (!target) return;
+  if (triggerEl.value?.contains(target)) return;
+  if (panelEl.value?.contains(target)) return;
+  close();
+}
+
+function handleDocumentKeyDown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    close();
+  }
+}
+
+provide('actions-menu-close', close);
+
+onBeforeUnmount(() => {
+  document.removeEventListener('mousedown', handleOutsideMouseDown);
+  document.removeEventListener('keydown', handleDocumentKeyDown);
+});
+</script>
+
+<style scoped lang="scss">
+.actions-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.actions-menu__panel {
+  position: absolute;
+  inset-block-start: calc(100% + var(--pav-space-1));
+  min-width: 12rem;
+  margin: 0;
+  padding: var(--pav-space-1);
+  list-style: none;
+  background: var(--pav-surface-primary, var(--pav-color-surface-primary));
+  border: var(--pav-border-width-1) solid var(--pav-border-primary, var(--pav-color-border-primary));
+  border-radius: var(--pav-border-radius-md);
+  box-shadow: var(--pav-shadow-modal, 0 8px 24px rgba(0, 0, 0, 0.12));
+  z-index: 20;
+}
+
+.actions-menu--align-end .actions-menu__panel {
+  inset-inline-end: 0;
+}
+
+.actions-menu--align-start .actions-menu__panel {
+  inset-inline-start: 0;
+}
+</style>

--- a/src/client/components/common/help-button.vue
+++ b/src/client/components/common/help-button.vue
@@ -7,7 +7,7 @@
     aria-haspopup="dialog"
     @click="showPanel = true"
   >
-    <CircleHelp :size="20" :stroke-width="1.5" aria-hidden="true" />
+    <BookOpenText :size="20" :stroke-width="1.5" aria-hidden="true" />
   </button>
 
   <HelpPanel
@@ -22,7 +22,7 @@
 import { ref, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useTranslation } from 'i18next-vue';
-import { CircleHelp } from 'lucide-vue-next';
+import { BookOpenText } from 'lucide-vue-next';
 import HelpPanel from './help-panel.vue';
 import { guidesForRoute, audienceForRoute } from '@/client/service/docs';
 

--- a/src/client/components/logged_in/calendar/calendar.vue
+++ b/src/client/components/logged_in/calendar/calendar.vue
@@ -5,9 +5,11 @@ import { useTranslation } from 'i18next-vue';
 import { useTabNavigation } from '@/client/composables/useTabNavigation';
 import CalendarService from '@/client/service/calendar';
 import EventService from '@/client/service/event';
-import { ExternalLink } from 'lucide-vue-next';
-import PillButton from '@/client/components/common/pill-button.vue';
-import HelpButton from '@/client/components/common/help-button.vue';
+import { ExternalLink, BookOpenText, CalendarPlus, Settings } from 'lucide-vue-next';
+import ActionsMenu from '@/client/components/common/actions-menu.vue';
+import ActionsMenuItem from '@/client/components/common/actions-menu-item.vue';
+import HelpPanel from '@/client/components/common/help-panel.vue';
+import { guidesForRoute, audienceForRoute } from '@/client/service/docs';
 import EventsTab from '@/client/components/logged_in/calendar-content/events-tab.vue';
 import CategoriesTab from '@/client/components/logged_in/calendar-content/categories.vue';
 import SeriesTab from '@/client/components/logged_in/calendar-content/series.vue';
@@ -93,6 +95,11 @@ async function closeCreateCalendarSheet() {
   await nextTick();
   createCalendarSheetTriggerEl.value?.focus();
 }
+
+// Help panel state — hosted directly on this page so the actions menu can open it
+const showHelpPanel = ref(false);
+const guides = computed(() => guidesForRoute(route?.name));
+const audience = computed(() => audienceForRoute(route?.name));
 
 onBeforeMount(async () => {
   await loadCalendarData();
@@ -192,27 +199,22 @@ const handleLoadEvents = async (filters) => {
               </a>
             </div>
             <div class="header-actions">
-              <HelpButton />
-              <PillButton
-                variant="ghost"
-                @click="openCreateCalendarSheet"
-              >
-                {{ tList('create_new_calendar_button') }}
-              </PillButton>
-              <RouterLink
-                v-if="state.calendar"
-                :to="{ name: 'calendar_management', params: { calendar: state.calendar.urlName } }"
-                custom
-                v-slot="{ navigate }"
-              >
-                <PillButton
-                  variant="ghost"
-                  @click="navigate"
+              <ActionsMenu :trigger-label="t('menu_label')">
+                <ActionsMenuItem :icon="BookOpenText" @click="showHelpPanel = true">
+                  {{ t('documentation') }}
+                </ActionsMenuItem>
+                <ActionsMenuItem :icon="CalendarPlus" @click="openCreateCalendarSheet">
+                  {{ tList('create_new_calendar_button') }}
+                </ActionsMenuItem>
+                <ActionsMenuItem
+                  v-if="state.calendar"
+                  :icon="Settings"
+                  :to="{ name: 'calendar_management', params: { calendar: state.calendar.urlName } }"
                   :aria-label="t('manage_calendar_label', { name: state.calendar.urlName })"
                 >
                   {{ t('manage_calendar') }}
-                </PillButton>
-              </RouterLink>
+                </ActionsMenuItem>
+              </ActionsMenu>
             </div>
           </div>
 
@@ -351,6 +353,14 @@ const handleLoadEvents = async (filters) => {
       v-if="showCreateCalendarSheet"
       @close="closeCreateCalendarSheet"
     />
+
+    <!-- Help Panel (triggered from the actions menu's Documentation item) -->
+    <HelpPanel
+      v-if="showHelpPanel"
+      :guides="guides"
+      :audience="audience"
+      @close="showHelpPanel = false"
+    />
   </div>
 </template>
 
@@ -447,19 +457,14 @@ const handleLoadEvents = async (filters) => {
 
   @media (max-width: 768px) {
     .header-title-section {
-      flex-direction: column;
-      align-items: stretch;
+      align-items: flex-start;
 
       h1 {
         font-size: 1.5rem;
       }
 
       .header-title-group {
-        width: 100%;
-      }
-
-      .header-actions {
-        width: 100%;
+        min-width: 0;
       }
     }
   }

--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { onBeforeMount, reactive, ref, nextTick } from 'vue';
+import { onBeforeMount, reactive, ref, nextTick, computed } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { useTranslation } from 'i18next-vue';
-import { Calendar, ChevronRight, Crown, ExternalLink } from 'lucide-vue-next';
+import { Calendar, ChevronRight, Crown, ExternalLink, BookOpenText, CalendarPlus } from 'lucide-vue-next';
 import CalendarService from '@/client/service/calendar';
 import { CalendarInfo } from '@/common/model/calendar_info';
 import EmptyLayout from '@/client/components/common/empty_state.vue';
-import PillButton from '@/client/components/common/pill-button.vue';
-import HelpButton from '@/client/components/common/help-button.vue';
+import ActionsMenu from '@/client/components/common/actions-menu.vue';
+import ActionsMenuItem from '@/client/components/common/actions-menu-item.vue';
+import HelpPanel from '@/client/components/common/help-panel.vue';
+import { guidesForRoute, audienceForRoute } from '@/client/service/docs';
 import CreateCalendarForm from './CreateCalendarForm.vue';
 import CreateCalendarSheet from './CreateCalendarSheet.vue';
 
@@ -39,6 +41,10 @@ async function closeCreateSheet() {
   await nextTick();
   createSheetTriggerEl.value?.focus();
 }
+
+const showHelpPanel = ref(false);
+const guides = computed(() => guidesForRoute(route?.name));
+const audience = computed(() => audienceForRoute(route?.name));
 
 /**
  * Returns the display description for a calendar card.
@@ -95,13 +101,14 @@ async function loadCalendars() {
             </p>
           </div>
           <div class="calendars-header__actions">
-            <HelpButton />
-            <PillButton
-              variant="primary"
-              @click="openCreateSheet"
-            >
-              {{ t('create_new_calendar_button') }}
-            </PillButton>
+            <ActionsMenu :trigger-label="t('menu_label')">
+              <ActionsMenuItem :icon="BookOpenText" @click="showHelpPanel = true">
+                {{ t('documentation') }}
+              </ActionsMenuItem>
+              <ActionsMenuItem :icon="CalendarPlus" @click="openCreateSheet">
+                {{ t('create_new_calendar_button') }}
+              </ActionsMenuItem>
+            </ActionsMenu>
           </div>
         </div>
         <ul class="calendar-cards" role="list">
@@ -173,6 +180,13 @@ async function loadCalendars() {
     <CreateCalendarSheet
       v-if="showCreateSheet"
       @close="closeCreateSheet"
+    />
+
+    <HelpPanel
+      v-if="showHelpPanel"
+      :guides="guides"
+      :audience="audience"
+      @close="showHelpPanel = false"
     />
   </main>
 </template>

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -27,7 +27,9 @@
         "role_editor": "Editor",
         "aria_navigate_calendar": "Navigate to calendar: {{calendarName}}, role: {{role}}",
         "aria_view_public_calendar": "View public calendar: {{name}} (opens in new tab)",
-        "error_loading_calendars": "Failed to load calendars"
+        "error_loading_calendars": "Failed to load calendars",
+        "menu_label": "Calendar list actions",
+        "documentation": "Documentation"
     },
     "selector": {
         "select_calendar_title": "Select Calendar",
@@ -51,6 +53,8 @@
         "view_public_calendar_label": "View public calendar: {{name}} (opens in new tab)",
         "manage_calendar": "Manage Calendar",
         "manage_calendar_label": "Manage calendar: {{name}}",
+        "menu_label": "Calendar actions",
+        "documentation": "Documentation",
         "events_section_label": "Calendar Events",
         "events_heading": "Calendar Events",
         "loading_events": "Loading events...",

--- a/src/client/test/components/common/actions-menu.test.ts
+++ b/src/client/test/components/common/actions-menu.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { createMemoryHistory, createRouter, Router, RouteRecordRaw } from 'vue-router';
+import { flushPromises } from '@vue/test-utils';
+import { CalendarPlus, Cog, BookOpenText } from 'lucide-vue-next';
+
+import ActionsMenu from '@/client/components/common/actions-menu.vue';
+import ActionsMenuItem from '@/client/components/common/actions-menu-item.vue';
+import { mountComponent } from '@/client/test/lib/vue';
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: {}, name: 'home' },
+  { path: '/destination', component: {}, name: 'destination' },
+];
+
+const Harness = defineComponent({
+  components: { ActionsMenu, ActionsMenuItem },
+  emits: ['doc', 'create'],
+  setup(_, { emit }) {
+    return () => h(ActionsMenu, { triggerLabel: 'Actions' }, () => [
+      h(
+        ActionsMenuItem,
+        { icon: BookOpenText, onClick: () => emit('doc') },
+        () => 'Documentation',
+      ),
+      h(
+        ActionsMenuItem,
+        { icon: CalendarPlus, onClick: () => emit('create') },
+        () => 'New Calendar',
+      ),
+      h(
+        ActionsMenuItem,
+        { icon: Cog, to: { name: 'destination' } },
+        () => 'Manage',
+      ),
+    ]);
+  },
+});
+
+const mountHarness = async () => {
+  const router: Router = createRouter({
+    history: createMemoryHistory(),
+    routes,
+  });
+
+  await router.push('/');
+  await router.isReady();
+
+  return mountComponent(Harness, router);
+};
+
+describe('ActionsMenu', () => {
+  let currentWrapper: any = null;
+
+  afterEach(() => {
+    if (currentWrapper) {
+      currentWrapper.unmount();
+      currentWrapper = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('renders the trigger with the provided aria-label and a closed panel', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    const trigger = wrapper.find('.actions-menu__trigger');
+    expect(trigger.exists()).toBe(true);
+    expect(trigger.attributes('aria-label')).toBe('Actions');
+    expect(trigger.attributes('aria-haspopup')).toBe('menu');
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('opens the panel on trigger click and closes it on the second click', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    const trigger = wrapper.find('.actions-menu__trigger');
+
+    await trigger.trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+    expect(trigger.attributes('aria-expanded')).toBe('true');
+
+    await trigger.trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('renders one menuitem per ActionsMenuItem child when open', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+
+    const items = wrapper.findAll('[role="menuitem"]');
+    expect(items).toHaveLength(3);
+    expect(items[0].text()).toContain('Documentation');
+    expect(items[1].text()).toContain('New Calendar');
+    expect(items[2].text()).toContain('Manage');
+  });
+
+  it('renders RouterLink items as anchor elements and button items as buttons', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+
+    const items = wrapper.findAll('[role="menuitem"]');
+    expect(items[0].element.tagName).toBe('BUTTON');
+    expect(items[1].element.tagName).toBe('BUTTON');
+    expect(items[2].element.tagName).toBe('A');
+  });
+
+  it('closes the menu and emits click when a button item is activated', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+
+    const docItem = wrapper.findAll('[role="menuitem"]')[0];
+    await docItem.trigger('click');
+
+    expect(wrapper.emitted('doc')).toBeTruthy();
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('closes the menu when a RouterLink item is activated', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+
+    const manageItem = wrapper.findAll('[role="menuitem"]')[2];
+    await manageItem.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('closes on Escape keydown', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await flushPromises();
+
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+  });
+
+  it('closes on mousedown outside the menu', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    document.body.appendChild(wrapper.element);
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await flushPromises();
+
+    expect(wrapper.find('[role="menu"]').exists()).toBe(false);
+    outside.remove();
+  });
+
+  it('does NOT close on mousedown inside the panel', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+
+    document.body.appendChild(wrapper.element);
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+
+    const panel = wrapper.find('[role="menu"]').element as HTMLElement;
+    panel.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    await flushPromises();
+
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+  });
+
+  it('ArrowDown on the trigger opens the menu and focuses the first item', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+    document.body.appendChild(wrapper.element);
+
+    const trigger = wrapper.find('.actions-menu__trigger');
+    await trigger.trigger('keydown', { key: 'ArrowDown' });
+    await flushPromises();
+
+    const items = wrapper.findAll('[role="menuitem"]');
+    expect(items.length).toBe(3);
+    expect(document.activeElement).toBe(items[0].element);
+  });
+
+  it('ArrowDown inside the panel moves focus to the next item; ArrowUp to the previous', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+    document.body.appendChild(wrapper.element);
+
+    await wrapper.find('.actions-menu__trigger').trigger('keydown', { key: 'ArrowDown' });
+    await flushPromises();
+
+    const items = wrapper.findAll('[role="menuitem"]');
+
+    await wrapper.find('[role="menu"]').trigger('keydown', { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items[1].element);
+
+    await wrapper.find('[role="menu"]').trigger('keydown', { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(items[0].element);
+  });
+
+  it('returns focus to the trigger when the menu closes', async () => {
+    const wrapper = await mountHarness();
+    currentWrapper = wrapper;
+    document.body.appendChild(wrapper.element);
+
+    const trigger = wrapper.find('.actions-menu__trigger').element as HTMLButtonElement;
+    await wrapper.find('.actions-menu__trigger').trigger('click');
+    expect(wrapper.find('[role="menu"]').exists()).toBe(true);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await flushPromises();
+
+    expect(document.activeElement).toBe(trigger);
+  });
+});


### PR DESCRIPTION
## Motivation

The calendar detail page header packed three controls — HelpButton, "Create New Calendar", "Manage Calendar" — into a flex row that crowded on desktop and stacked to full-width buttons on mobile. The calendar list page had a similar two-control row. Both surfaces benefit from collapsing those actions into a single overflow menu that scales cleanly across viewports.

Separately, the universal `HelpButton` icon (lucide `CircleHelp`, the `?` glyph) was reading as "I have a question" rather than "open the docs." Swapping to `BookOpenText` matches the intent better and aligns with the inline doc-link affordances PR #335 just introduced.

## Approach

Two new components under `src/client/components/common/`:

- **`actions-menu.vue`** — generic dropdown. Lucide `Menu` icon trigger, panel anchored beneath, opens on click or `ArrowDown`. Closes on Escape, outside-click, item activation, or Tab. Returns focus to the trigger on close. Arrow keys + Home/End navigate items. Right-aligns by default; `align="start"` flips it.
- **`actions-menu-item.vue`** — single row. Takes a lucide icon component and an optional `to` (for `RouterLink` form). Both forms render `role="menuitem"`. Activation emits `click` (button form) or navigates (link form) and then calls the parent-injected `closeMenu`.

Calendar detail page (`calendar/calendar.vue`) now hosts one `<ActionsMenu>` with three items: Documentation (`BookOpenText`), New Calendar (`CalendarPlus`), Manage Calendar (`Settings` — the gear icon used in the main nav). `HelpPanel` is mounted directly on this page rather than going through `HelpButton`, so the menu's Documentation item can flip a local `showHelpPanel` ref. `HelpButton` itself is untouched for every other consumer; the only change to it is the universal icon swap.

Calendar list page (`calendar/calendars.vue`) uses the same menu pattern with two items (Documentation + New Calendar). It interoperates cleanly with PR #335's inline guide on the empty state — the menu lives in the populated branch of the template, the guide link lives in the empty branch, so they never appear together.

Mobile breakpoint on the detail header now keeps the title and trigger on a single row. The trigger stays anchored top-right at every viewport width (verified at 320px, 390px, 768px, and desktop).

Two new English i18n keys for the menu trigger aria-label and the Documentation item; other locales fall back to English until separately translated.

## Validation

- `npx vitest run src/client/test/components/common/actions-menu.test.ts` — 12/12 pass (open/close, Escape, outside-click, arrow nav, Home/End, button-item emit, RouterLink-item navigation, focus return)
- `npm run test:unit` — 8178/8178 pass
- `npm run test:integration` — 651 pass / 5 pre-existing skips
- `npx vite build` — clean
- `npm run lint` on touched files — clean (one pre-existing trailing-spaces error in `src/server/moderation/events/types.ts` is unrelated)
- Browser (Playwright MCP): logged in, opened the menu on the calendar detail page, activated each item (HelpPanel opens, CreateCalendarSheet opens, navigates to `/calendar/:url/manage`). Verified Escape closes and returns focus. Resized to 320 / 390 / 1280 — trigger anchored top-right at every width, panel fits inside the viewport on mobile. Confirmed `BookOpenText` glyph on `HelpButton` at `/inbox` and other surfaces.