### PR TITLE
feat(client): standardize button system on design-system variants

### DIFF
--- a/.claude/skills/frontend-css/css.md
+++ b/.claude/skills/frontend-css/css.md
@@ -32,11 +32,22 @@ Check `src/client/assets/style/components/` first. Search for: buttons, modals, 
 
 | Need | Use | Never |
 |------|-----|-------|
-| Buttons | `.btn`, `.btn--primary`, `.btn--danger` | Custom button CSS |
+| Button group (hierarchy) | `.btn--primary` + `.btn--secondary`/`.btn--ghost` | Custom button CSS |
+| Single / call-to-action | `.btn--cta` | `.btn--primary` for a lone action |
+| Icon-only button | `.btn--icon` (elevated) / `.btn--icon.btn--subtle` (dense rows) | Custom icon-button CSS |
 | Modals/Dialogs | `<Modal>` / `<Sheet>` components | Custom overlays |
 | Spacing | `var(--pav-space-*)` tokens | Hardcoded px values |
 | Colors | `var(--pav-color-*)`, `var(--pav-surface-*)` | Hex values |
 | New patterns | Extract to `components/` if used 2+ times | One-off duplicates |
+
+## Button Hierarchy
+
+Pick the variant by **how many actions share the context**, not by how important the action feels:
+
+- **A group of actions** (modal footer, wizard step, toolbar with Cancel/Save, Back/Continue) → establish a hierarchy: one `.btn--primary` plus `.btn--secondary` or `.btn--ghost` peers.
+- **A single, standalone action** (empty-state CTA, a lone "Add"/"Follow" button with no peer action) → `.btn--cta`. It's a calm outlined pill at rest that commits to a solid brand fill on hover. Reach for it when `.btn--primary` is too loud at rest, `.btn--secondary` is semantically wrong, and `.btn--ghost` is too quiet.
+
+Do **not** use `.btn--primary` for a button that stands alone — that's what `.btn--cta` is for.
 
 ## Rule of Thumb
 

--- a/src/client/assets/style/components/_buttons.scss
+++ b/src/client/assets/style/components/_buttons.scss
@@ -7,8 +7,16 @@
  * - Context-specific overrides (e.g., `.welcome-card`) adjust shape/size only.
  */
 
-/* Base button reset — structural properties only, no color opinions */
-button:not([role="tab"]) {
+/* Base button reset — structural defaults only, no color opinions.
+   Deliberately wrapped in :where() so the whole reset sits at ZERO specificity.
+   The selector `button:not([role="tab"])` is (0,1,1) because of the `:not([attr])`,
+   which silently outranked every `.btn` variant (0,1,0) and forced the reset's
+   background/color/border AND its padding/font/border-radius onto them — so fills
+   were suppressed, borders never painted, size modifiers (--sm/--lg/--xl) were
+   no-ops, and radius modifiers (--icon/--cta/--pill) couldn't go fully round.
+   At zero specificity these values still apply to bare <button>s but any `.btn`
+   class wins cleanly. */
+:where(button:not([role="tab"])) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -229,15 +237,20 @@ button:not([role="tab"]) {
     }
   }
 
-  /* Ghost variant */
+  /* Ghost variant — the quietest button: no fill or border at rest, a subtle
+     neutral tint on hover (not a loud brand fill). */
   &--ghost {
     background-color: transparent;
     color: var(--pav-text-secondary);
     border-color: transparent;
 
     &:hover:not(:disabled) {
-      background-color: var(--pav-color-interactive-primary-hover);
-      color: var(--pav-text-inverse);
+      background-color: var(--pav-interactive-hover);
+      color: var(--pav-text-primary);
+    }
+
+    &:active:not(:disabled) {
+      background-color: var(--pav-interactive-active);
     }
   }
 
@@ -253,10 +266,76 @@ button:not([role="tab"]) {
     }
   }
 
-  /* Icon button variant */
+  /* Call-to-action variant — for a LONE, standalone button (not part of a
+     primary/secondary group). Calm outlined pill at rest that commits to a
+     solid brand fill on hover. Use primary/secondary/ghost for button GROUPS
+     where a hierarchy is needed; reach for --cta when a single action stands
+     on its own and primary is too loud, secondary is semantically wrong, and
+     ghost is too quiet. */
+  &--cta {
+    background-color: transparent;
+    color: var(--pav-text-primary);
+    border-color: var(--pav-border-primary);
+    border-radius: var(--pav-border-radius-full);
+
+    &:hover:not(:disabled) {
+      background-color: var(--pav-color-brand-primary);
+      color: var(--pav-text-inverse);
+      border-color: var(--pav-color-brand-primary);
+    }
+
+    &:active:not(:disabled) {
+      background-color: var(--pav-color-brand-primary-dark);
+      border-color: var(--pav-color-brand-primary-dark);
+      transform: translateY(1px);
+    }
+  }
+
+  /* Icon-only button variants — square hit area, the icon carries the color.
+     Two context-driven treatments:
+       .btn--icon             → standalone affordance: quiet at rest, lifts into a
+                                shadowed circle with a brand-colored icon on hover.
+       .btn--icon.btn--subtle → dense in-row actions: subtle gray fill, no elevation. */
   &--icon {
     padding: var(--pav-space-2);
     aspect-ratio: 1;
+    border-radius: var(--pav-border-radius-full);
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--pav-text-primary);
+
+    &:hover:not(:disabled) {
+      background-color: var(--pav-surface-card);
+      color: var(--pav-color-brand-primary);
+      box-shadow: var(--pav-shadow-md);
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(1px);
+    }
+
+    /* Selected / toggled / current — persistent brand-colored icon */
+    &[aria-pressed="true"],
+    &[aria-expanded="true"],
+    &[aria-current]:not([aria-current="false"]) {
+      color: var(--pav-color-brand-primary);
+    }
+
+    &:disabled {
+      color: var(--pav-text-muted);
+    }
+
+    /* Dense treatment — gray fill, rounded rect, no shadow (e.g. event row actions) */
+    &.btn--subtle {
+      border-radius: var(--pav-border-radius-md);
+      color: var(--pav-text-secondary);
+
+      &:hover:not(:disabled) {
+        background-color: var(--pav-interactive-hover);
+        color: var(--pav-color-brand-primary);
+        box-shadow: none;
+      }
+    }
 
     &.btn--xs { padding: var(--pav-space-1); }
     &.btn--sm { padding: var(--pav-space-1_5); }
@@ -310,22 +389,8 @@ button:not([role="tab"]) {
     }
   }
 
-  /* Ghost pill variant (transparent) */
-  &.btn--ghost {
-    background-color: transparent;
-    color: var(--pav-color-stone-700);
-    border-color: transparent;
-
-    &:hover:not(:disabled) {
-      background-color: var(--pav-color-stone-100);
-    }
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-200);
-
-      &:hover:not(:disabled) {
-        background-color: var(--pav-color-stone-800);
-      }
-    }
-  }
+  /* No ghost override here: `.btn--pill` contributes only the pill shape, and the
+     base `.btn--ghost` variant supplies the (semantic-token, theme-adaptive) color
+     + subtle hover. A hardcoded pill-ghost block used to live here and duplicated
+     that styling with raw stone values and a prefers-color-scheme block. */
 }

--- a/src/client/components/admin/accounts.vue
+++ b/src/client/components/admin/accounts.vue
@@ -210,7 +210,7 @@ const subTabs = computed(() => [
         </div>
       </div>
       <EmptyLayout v-else :title="t('noAccounts')" :description="t('noAccountsDescription')">
-        <button type="button" class="invite-button" @click="activateTab('invitations')">
+        <button type="button" class="btn btn--cta btn--lg" @click="activateTab('invitations')">
           {{ t('inviteNewAccount') }}
         </button>
       </EmptyLayout>

--- a/src/client/components/admin/accounts/invite_form.vue
+++ b/src/client/components/admin/accounts/invite_form.vue
@@ -19,7 +19,7 @@
       </div>
 
       <div class="form-actions">
-        <button type="button" class="btn-cancel" @click="$emit('close')">
+        <button type="button" class="btn btn--ghost btn--pill" @click="$emit('close')">
           {{ t('close_button') }}
         </button>
         <button
@@ -137,23 +137,6 @@ const sendInvitation = async () => {
     padding-top: var(--pav-space-4);
     border-top: 1px solid var(--pav-border-color-light);
 
-    .btn-cancel {
-      padding: var(--pav-space-2) var(--pav-space-5);
-      background: none;
-      border: 1px solid var(--pav-border-color-medium);
-      border-radius: var(--pav-border-radius-full);
-      color: var(--pav-color-text-secondary);
-      font-weight: var(--pav-font-weight-medium);
-      font-size: var(--pav-font-size-xs);
-      font-family: inherit;
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-
-      &:hover {
-        background: var(--pav-color-stone-50);
-      }
-    }
-
     .btn-submit {
       padding: var(--pav-space-2) var(--pav-space-6);
       background: var(--pav-color-brand-primary);
@@ -193,14 +176,6 @@ const sendInvitation = async () => {
         background: rgba(239, 68, 68, 0.1);
         border-color: rgba(239, 68, 68, 0.3);
         color: var(--pav-color-red-300);
-      }
-    }
-
-    .form-actions {
-      .btn-cancel {
-        &:hover {
-          background: var(--pav-color-stone-800);
-        }
       }
     }
   }

--- a/src/client/components/admin/grant-form.vue
+++ b/src/client/components/admin/grant-form.vue
@@ -183,7 +183,7 @@
       </div>
 
       <div class="form-actions">
-        <button type="button" class="btn-cancel" @click="$emit('close')">
+        <button type="button" class="btn btn--ghost btn--pill" @click="$emit('close')">
           {{ t('grants.form.cancel_button') }}
         </button>
         <button
@@ -646,23 +646,6 @@ async function submitCreateGrant() {
     gap: var(--pav-space-3);
     padding-top: var(--pav-space-4);
     border-top: 1px solid var(--pav-border-color-light);
-
-    .btn-cancel {
-      padding: var(--pav-space-2) var(--pav-space-5);
-      background: none;
-      border: 1px solid var(--pav-border-color-medium);
-      border-radius: var(--pav-border-radius-full);
-      color: var(--pav-color-text-secondary);
-      font-weight: var(--pav-font-weight-medium);
-      font-size: var(--pav-font-size-xs);
-      font-family: inherit;
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-
-      &:hover {
-        background: var(--pav-color-stone-50);
-      }
-    }
 
     .btn-submit {
       padding: var(--pav-space-2) var(--pav-space-6);

--- a/src/client/components/common/actions-menu.vue
+++ b/src/client/components/common/actions-menu.vue
@@ -3,7 +3,7 @@
     <button
       ref="triggerEl"
       type="button"
-      class="btn btn--icon btn--ghost actions-menu__trigger"
+      class="btn btn--icon actions-menu__trigger"
       :aria-label="triggerLabel"
       aria-haspopup="menu"
       :aria-expanded="isOpen"

--- a/src/client/components/common/help-button.vue
+++ b/src/client/components/common/help-button.vue
@@ -2,7 +2,7 @@
   <button
     v-if="guides.length > 0"
     type="button"
-    class="btn btn--icon btn--ghost"
+    class="btn btn--icon"
     :aria-label="t('button_label')"
     aria-haspopup="dialog"
     @click="showPanel = true"

--- a/src/client/components/logged_in/calendar-content/categories.vue
+++ b/src/client/components/logged_in/calendar-content/categories.vue
@@ -75,14 +75,15 @@
 
     <!-- Empty State -->
     <EmptyLayout v-else :title="t('no_categories')" :description="t('no_categories_description')">
-      <PillButton
-        variant="primary"
+      <button
+        type="button"
+        class="btn btn--cta btn--lg"
         @click="openCreateEditor"
         :disabled="state.isLoading"
       >
         <Plus :size="20" :stroke-width="2" />
         {{ t('add_category_button') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Category Editor Modal -->

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -599,7 +599,7 @@ initializeFiltersFromURL();
           <div class="event-actions">
             <button
               type="button"
-              class="edit-btn icon-btn"
+              class="edit-btn btn btn--icon btn--subtle"
               @click.stop="handleEditButtonClick(event, $event)"
               :aria-label="t('event.edit_label', { name: event.content('en').name })"
               :title="t('event.edit_title')"
@@ -608,7 +608,7 @@ initializeFiltersFromURL();
             </button>
             <button
               type="button"
-              class="duplicate-btn icon-btn"
+              class="duplicate-btn btn btn--icon btn--subtle"
               @click.stop="handleDuplicateEvent(event)"
               :aria-label="t('event.duplicate_label', { name: event.content('en').name })"
               :title="t('event.duplicate_label', { name: event.content('en').name })"
@@ -618,7 +618,7 @@ initializeFiltersFromURL();
             <button
               v-if="event.isRepost"
               type="button"
-              class="unpost-btn icon-btn"
+              class="unpost-btn btn btn--icon btn--subtle"
               @click.stop="handleUnpostButtonClick(event, $event)"
               :aria-label="t('event.unpost_aria_label', { name: event.content('en').name })"
               :title="t('event.unpost_button_label')"
@@ -627,7 +627,7 @@ initializeFiltersFromURL();
             </button>
             <button
               type="button"
-              class="report-btn icon-btn"
+              class="report-btn btn btn--icon btn--subtle"
               @click.stop="handleReportEvent(event)"
               :aria-label="tReport('report_event_label')"
               :title="tReport('report_button')"
@@ -649,10 +649,10 @@ initializeFiltersFromURL();
                  :title="t('noEvents')"
                  :description="t('noEventsDescription')"
                  :guide="{ slug: 'guides/calendar-owners/recurring-events', key: 'recurring' }">
-      <PillButton variant="primary" @click="newEvent()">
+      <button type="button" class="btn btn--cta btn--lg" @click="newEvent()">
         <Plus :size="20" :stroke-width="2" />
         {{ t('createEvent') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Bulk Operations Menu -->
@@ -886,29 +886,6 @@ initializeFiltersFromURL();
         gap: 0.5rem;
         opacity: 0;
         transition: opacity 0.2s ease;
-
-        .icon-btn {
-          background: transparent;
-          border: none;
-          border-radius: 0.5rem;
-          padding: 0.5rem;
-          cursor: pointer;
-          color: var(--pav-text-secondary);
-          transition: all 0.15s ease;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-
-          &:hover {
-            background: var(--pav-interactive-hover);
-            color: var(--pav-color-orange-500);
-          }
-
-          &:focus-visible {
-            outline: 2px solid var(--pav-color-focus-ring, var(--pav-color-orange-500));
-            outline-offset: 2px;
-          }
-        }
 
         @media (max-width: 768px) {
           opacity: 1;

--- a/src/client/components/logged_in/calendar-content/places-tab.vue
+++ b/src/client/components/logged_in/calendar-content/places-tab.vue
@@ -251,15 +251,16 @@ onMounted(async () => {
 
     <!-- Empty State -->
     <EmptyLayout v-else :title="t('no_places')" :description="t('no_places_description')">
-      <PillButton
+      <button
         ref="emptyAddPlaceButtonRef"
-        variant="primary"
+        type="button"
+        class="btn btn--cta btn--lg"
         @click="navigateToCreate"
         :disabled="state.isLoading"
       >
         <Plus :size="20" :stroke-width="2" />
         {{ t('add_place_button') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Delete Confirmation Modal -->

--- a/src/client/components/logged_in/calendar-content/series-editor.vue
+++ b/src/client/components/logged_in/calendar-content/series-editor.vue
@@ -210,7 +210,7 @@ onMounted(() => {
       <div class="header-actions">
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="$emit('close')"
           :disabled="state.isSaving"
         >
@@ -443,34 +443,6 @@ onMounted(() => {
 
     &:hover {
       background-color: var(--pav-color-stone-800);
-      color: var(--pav-color-stone-200);
-    }
-  }
-}
-
-.btn-cancel {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--pav-color-stone-600);
-  font-size: 0.9375rem;
-  font-weight: 400;
-  cursor: pointer;
-  transition: color 0.15s ease;
-
-  &:hover {
-    color: var(--pav-color-stone-900);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-
-    &:hover {
       color: var(--pav-color-stone-200);
     }
   }

--- a/src/client/components/logged_in/calendar-content/series.vue
+++ b/src/client/components/logged_in/calendar-content/series.vue
@@ -279,14 +279,15 @@ onMounted(async () => {
 
     <!-- Empty State -->
     <EmptyLayout v-else :title="t('no_series')" :description="t('no_series_description')">
-      <PillButton
-        variant="primary"
+      <button
+        type="button"
+        class="btn btn--cta btn--lg"
         @click="openCreateEditor"
         :disabled="state.isLoading"
       >
         <Plus :size="20" :stroke-width="2" />
         {{ t('add_series_button') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Series Editor Modal -->

--- a/src/client/components/logged_in/calendar-management/editors.vue
+++ b/src/client/components/logged_in/calendar-management/editors.vue
@@ -107,10 +107,15 @@
 
     <!-- Empty State — only shown when there is no error -->
     <EmptyLayout v-else-if="!state.error" :title="t('no_editors')" :description="t('no_editors_description')">
-      <PillButton v-if="props.isOwner" variant="primary" @click="openAddForm">
+      <button
+        v-if="props.isOwner"
+        type="button"
+        class="btn btn--cta btn--lg"
+        @click="openAddForm"
+      >
         <Plus :size="20" :stroke-width="2" />
         {{ t('add_editor_button') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Add Editor Form -->

--- a/src/client/components/logged_in/calendar-management/import-sources/ImportSourcesSection.vue
+++ b/src/client/components/logged_in/calendar-management/import-sources/ImportSourcesSection.vue
@@ -36,10 +36,10 @@
       :title="t('empty_title')"
       :description="t('empty_description')"
     >
-      <PillButton variant="primary" @click="openAddForm">
+      <button type="button" class="btn btn--cta btn--lg" @click="openAddForm">
         <Plus :size="20" :stroke-width="2" aria-hidden="true" />
         {{ t('add_button') }}
-      </PillButton>
+      </button>
     </EmptyLayout>
 
     <!-- Add import source modal -->

--- a/src/client/components/logged_in/calendar/CreateCalendarForm.vue
+++ b/src/client/components/logged_in/calendar/CreateCalendarForm.vue
@@ -196,7 +196,7 @@ async function createCalendar() {
       </div>
       <div v-if="!state.errorMessage" id="calendar-help" class="help-text">{{ t('calendar_name_help') }}</div>
       <button type="submit"
-              class="btn btn--primary"
+              class="btn btn--cta btn--lg"
               :disabled="state.isLoading"
               :aria-label="state.isLoading ? t('creating_calendar') : t('create_calendar_button')">
         {{ state.isLoading ? t('creating_calendar') : t('create_calendar_button') }}

--- a/src/client/components/logged_in/calendar/edit-place.vue
+++ b/src/client/components/logged_in/calendar/edit-place.vue
@@ -145,30 +145,6 @@ form {
   gap: 0;
 }
 
-.btn-cancel {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--pav-text-secondary);
-  font-size: var(--pav-font-size-sm);
-  cursor: pointer;
-  transition: color 0.15s ease;
-
-  &:hover:not(:disabled) {
-    color: var(--pav-text-primary);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--pav-color-interactive-active);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
 .btn-save {
   padding: var(--pav-space-sm) var(--pav-space-lg);
   border: none;
@@ -456,7 +432,7 @@ form {
         <HelpButton />
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="handleBack"
         >
           {{ t('cancel') }}

--- a/src/client/components/logged_in/calendar/edit-space.vue
+++ b/src/client/components/logged_in/calendar/edit-space.vue
@@ -263,7 +263,7 @@ onBeforeMount(() => {
       <footer class="space-editor-actions">
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="handleCancel"
         >
           {{ t('cancel') }}
@@ -363,30 +363,6 @@ onBeforeMount(() => {
   align-items: center;
   justify-content: flex-end;
   gap: var(--pav-space-md);
-}
-
-.btn-cancel {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--pav-text-secondary);
-  font-size: var(--pav-font-size-sm);
-  cursor: pointer;
-  transition: color 0.15s ease;
-
-  &:hover:not(:disabled) {
-    color: var(--pav-text-primary);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--pav-color-interactive-active);
-    outline-offset: 2px;
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
 }
 
 .remove-translation-link {

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -156,29 +156,6 @@ form {
   gap: 0;
 }
 
-.btn-cancel {
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--pav-color-stone-600);
-  font-size: 0.9375rem;
-  font-weight: 400;
-  cursor: pointer;
-  transition: color 0.15s ease;
-
-  &:hover {
-    color: var(--pav-color-stone-900);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-
-    &:hover {
-      color: var(--pav-color-stone-200);
-    }
-  }
-}
-
 .btn-save {
   padding: 0.625rem 1.5rem;
   border: none;
@@ -594,8 +571,14 @@ form {
   }
 }
 
-/* Button styling that follows semantic system */
-button {
+/* Local base for this component's bespoke buttons. Two guards work together:
+   - :where() keeps the rule at low specificity so the component's own
+     `.btn-save`/`.primary`/`.danger` classes still override it; and
+   - :not(.btn) excludes design-system buttons entirely, so the global `.btn`
+     system styles them (e.g. the ghost Cancel) instead of this legacy base.
+   Plain `button` here (0,1,1 once Vue adds [data-v]) used to outrank global
+   `.btn--ghost` (0,1,0); a bare :not(.btn) would instead out-specify `.btn-save`. */
+:where(button:not(.btn)) {
   font-size: 14px;
   border: 1px solid var(--pav-color-border-primary);
   border-radius: var(--pav-border-radius-sm);
@@ -686,7 +669,7 @@ button {
         <HelpButton />
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="handleBackClick"
         >
           Cancel

--- a/src/client/components/logged_in/feed/events.vue
+++ b/src/client/components/logged_in/feed/events.vue
@@ -406,7 +406,7 @@ onUnmounted(() => {
     >
       <button
         type="button"
-        class="btn btn--primary"
+        class="btn btn--cta btn--lg"
         @click="handleFollowCalendar($event)"
       >
         {{ t("follow_button") }}

--- a/src/client/components/logged_in/feed/follows.vue
+++ b/src/client/components/logged_in/feed/follows.vue
@@ -93,7 +93,7 @@ const handleFollowSuccess = async () => {
   >
     <button
       type="button"
-      class="btn btn--primary"
+      class="btn btn--cta btn--lg"
       @click="handleOpenAddModal"
     >
       {{ t('follow_button') }}

--- a/src/client/components/logged_in/settings/email_modal.vue
+++ b/src/client/components/logged_in/settings/email_modal.vue
@@ -95,7 +95,7 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
       <div class="modal-footer">
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="$emit('close', null)"
         >
           {{ t('close_button', { defaultValue: 'Cancel' }) }}
@@ -218,30 +218,10 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
   padding-top: var(--pav-space-2);
 }
 
-.btn-cancel {
+/* Both footer buttons stretch to split the row evenly. The Cancel button is now
+   the design-system .btn ghost pill; .btn-submit keeps its own flex below. */
+.modal-footer .btn {
   flex: 1;
-  padding: 0.75rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--pav-color-stone-700);
-  background: var(--pav-color-stone-100);
-  border: none;
-  border-radius: 9999px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-
-  &:hover {
-    background: var(--pav-color-stone-200);
-
-    @media (prefers-color-scheme: dark) {
-      background: var(--pav-color-stone-700);
-    }
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-    background: var(--pav-color-stone-800);
-  }
 }
 
 .btn-submit {

--- a/src/client/components/logged_in/settings/password_modal.vue
+++ b/src/client/components/logged_in/settings/password_modal.vue
@@ -83,7 +83,7 @@ const sendPasswordReset = async () => {
       <div class="modal-footer">
         <button
           type="button"
-          class="btn-cancel"
+          class="btn btn--ghost btn--pill"
           @click="$emit('close')"
         >
           {{ t('cancel_button', { defaultValue: 'Cancel' }) }}
@@ -197,30 +197,10 @@ const sendPasswordReset = async () => {
   gap: var(--pav-space-3);
 }
 
-.btn-cancel {
+/* Both footer buttons stretch to split the row evenly. The Cancel button is now
+   the design-system .btn ghost pill; .btn-submit keeps its own flex below. */
+.modal-footer .btn {
   flex: 1;
-  padding: 0.75rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--pav-color-stone-700);
-  background: var(--pav-color-stone-100);
-  border: none;
-  border-radius: 9999px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-
-  &:hover {
-    background: var(--pav-color-stone-200);
-
-    @media (prefers-color-scheme: dark) {
-      background: var(--pav-color-stone-700);
-    }
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-    background: var(--pav-color-stone-800);
-  }
 }
 
 .btn-submit {

--- a/src/client/test/components/calendar/edit-place.test.ts
+++ b/src/client/test/components/calendar/edit-place.test.ts
@@ -337,7 +337,7 @@ describe('EditPlaceView', () => {
     it('should navigate back on cancel click when not dirty', async () => {
       const wrapper = await createWrapper();
 
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
 
       expect(routerPushSpy).toHaveBeenCalledWith('/calendar/test-calendar?tab=places');
     });
@@ -976,7 +976,7 @@ describe('EditPlaceView', () => {
       window.confirm = confirmSpy;
       const wrapper = await createWrapper();
 
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
       await flushPromises();
 
       // Pristine state: no prompt; navigation proceeds.
@@ -990,7 +990,7 @@ describe('EditPlaceView', () => {
       const wrapper = await createWrapper();
 
       await wrapper.find('#place-name').setValue('Dirty');
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
       await flushPromises();
 
       expect(confirmSpy).toHaveBeenCalled();
@@ -1003,7 +1003,7 @@ describe('EditPlaceView', () => {
       const wrapper = await createWrapper();
 
       await wrapper.find('#place-name').setValue('Dirty');
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
       await flushPromises();
 
       expect(confirmSpy).toHaveBeenCalled();

--- a/src/client/test/components/calendar/edit-space.test.ts
+++ b/src/client/test/components/calendar/edit-space.test.ts
@@ -222,7 +222,7 @@ describe('EditSpaceView', () => {
     it('emits cancel when the cancel button is clicked', async () => {
       const wrapper = await createWrapper();
 
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
 
       expect(wrapper.emitted('cancel')).toBeTruthy();
       expect(wrapper.emitted('cancel')).toHaveLength(1);
@@ -231,7 +231,7 @@ describe('EditSpaceView', () => {
     it('does not emit save when cancelled without changes', async () => {
       const wrapper = await createWrapper();
 
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
       await flushPromises();
 
       expect(wrapper.emitted('save')).toBeFalsy();
@@ -241,7 +241,7 @@ describe('EditSpaceView', () => {
       const wrapper = await createWrapper();
 
       await wrapper.find('[id^="space-name-"]').setValue('Typed but cancelled');
-      await wrapper.find('.btn-cancel').trigger('click');
+      await wrapper.find('.btn--ghost').trigger('click');
       await flushPromises();
 
       expect(wrapper.emitted('save')).toBeFalsy();

--- a/src/client/test/components/calendar/editors.test.ts
+++ b/src/client/test/components/calendar/editors.test.ts
@@ -281,7 +281,7 @@ describe('Editors Component', () => {
       await flushPromises();
 
       // Empty state PillButton should be present for owners.
-      const pillButtons = wrapper.findAll('.pill-button--primary');
+      const pillButtons = wrapper.findAll('.btn--cta');
       expect(pillButtons.length).toBeGreaterThan(0);
     });
 
@@ -290,7 +290,7 @@ describe('Editors Component', () => {
       await flushPromises();
 
       // No primary pill button should appear for non-owners in empty state.
-      const pillButtons = wrapper.findAll('.pill-button--primary');
+      const pillButtons = wrapper.findAll('.btn--cta');
       expect(pillButtons.length).toBe(0);
     });
 
@@ -334,7 +334,7 @@ describe('Editors Component', () => {
 
       await flushPromises();
 
-      const pillButtons = wrapper.findAll('.pill-button--primary');
+      const pillButtons = wrapper.findAll('.btn--cta');
       expect(pillButtons.length).toBe(0);
     });
   });
@@ -352,7 +352,7 @@ describe('Editors Component', () => {
       await flushPromises();
       await nextTick();
 
-      const addButton = wrapper.find('.pill-button--primary');
+      const addButton = wrapper.find('.btn--cta');
       expect(addButton.exists()).toBe(true);
 
       await addButton.trigger('click');
@@ -381,7 +381,7 @@ describe('Editors Component', () => {
       await flushPromises();
       await nextTick();
 
-      await wrapper.find('.pill-button--primary').trigger('click');
+      await wrapper.find('.btn--cta').trigger('click');
       await nextTick();
 
       const input = wrapper.find('#email').element as HTMLInputElement;
@@ -419,7 +419,7 @@ describe('Editors Component', () => {
       await nextTick();
 
       // Open add form via the visible primary pill button.
-      await wrapper.find('.pill-button--primary').trigger('click');
+      await wrapper.find('.btn--cta').trigger('click');
       await nextTick();
 
       // Fill in the email field via real DOM interaction.
@@ -465,7 +465,7 @@ describe('Editors Component', () => {
       await nextTick();
 
       // Open add form via the visible primary pill button.
-      await wrapper.find('.pill-button--primary').trigger('click');
+      await wrapper.find('.btn--cta').trigger('click');
       await nextTick();
 
       await wrapper.find('#email').setValue('existing@example.com');
@@ -488,7 +488,7 @@ describe('Editors Component', () => {
       await flushPromises();
       await nextTick();
 
-      await wrapper.find('.pill-button--primary').trigger('click');
+      await wrapper.find('.btn--cta').trigger('click');
       await nextTick();
 
       await wrapper.find('#email').setValue('invited@example.com');

--- a/src/client/test/components/calendar/import-sources.test.ts
+++ b/src/client/test/components/calendar/import-sources.test.ts
@@ -116,7 +116,7 @@ describe('ImportSourcesSection', () => {
       await flushPromises();
 
       // Trigger empty-state add button
-      const addBtn = wrapper.find('.empty-state .pill-button--primary');
+      const addBtn = wrapper.find('.empty-state .btn--cta');
       expect(addBtn.exists()).toBe(true);
       await addBtn.trigger('click');
       await flushPromises();
@@ -144,7 +144,7 @@ describe('ImportSourcesSection', () => {
       const { wrapper } = mountSection();
       await flushPromises();
 
-      await wrapper.find('.empty-state .pill-button--primary').trigger('click');
+      await wrapper.find('.empty-state .btn--cta').trigger('click');
       await flushPromises();
 
       // Whitespace-only value — disabled submit button still won't fire, but
@@ -166,7 +166,7 @@ describe('ImportSourcesSection', () => {
       const { wrapper } = mountSection();
       await flushPromises();
 
-      await wrapper.find('.empty-state .pill-button--primary').trigger('click');
+      await wrapper.find('.empty-state .btn--cta').trigger('click');
       await flushPromises();
 
       const form = wrapper.find('form.add-import-source-form');
@@ -506,7 +506,7 @@ describe('ImportSourcesSection', () => {
       const { wrapper } = mountSection();
       await flushPromises();
 
-      await wrapper.find('.empty-state .pill-button--primary').trigger('click');
+      await wrapper.find('.empty-state .btn--cta').trigger('click');
       await flushPromises();
 
       const form = wrapper.find('form.add-import-source-form');

--- a/src/client/test/components/feed/events.test.ts
+++ b/src/client/test/components/feed/events.test.ts
@@ -109,7 +109,7 @@ describe('FollowedEventsView', () => {
     });
 
     expect(wrapper.text()).toContain('No events');
-    const button = wrapper.find('button.btn--primary');
+    const button = wrapper.find('button.btn--cta');
     expect(button.exists()).toBe(true);
     expect(button.text()).toContain('Follow a Calendar');
   });

--- a/tests/e2e/calendar-crud.spec.ts
+++ b/tests/e2e/calendar-crud.spec.ts
@@ -66,7 +66,7 @@ test.describe('Calendar CRUD Workflow', () => {
       expect(autoSlug).toBe('my-test-calendar');
 
       // Submit the form
-      const submitButton = page.locator('button[type="submit"].btn--primary');
+      const submitButton = page.locator('button[type="submit"].btn--cta');
       await submitButton.click();
 
       // Wait for navigation to the new calendar page
@@ -97,7 +97,7 @@ test.describe('Calendar CRUD Workflow', () => {
       await nameInput.fill('custom_name_cal');
 
       // Submit the form
-      const submitButton = page.locator('button[type="submit"].btn--primary');
+      const submitButton = page.locator('button[type="submit"].btn--cta');
       await submitButton.click();
 
       // Wait for navigation to the new calendar

--- a/tests/e2e/calendar-editors.spec.ts
+++ b/tests/e2e/calendar-editors.spec.ts
@@ -70,7 +70,7 @@ test.describe('Calendar Editor Collaboration', () => {
       await page.waitForTimeout(1000);
 
       // Click the Add Editor button
-      const addEditorButton = page.locator('button.pill-button--primary').filter({ hasText: /Add Editor/i });
+      const addEditorButton = page.locator('button.btn--cta').filter({ hasText: /Add Editor/i });
       await expect(addEditorButton).toBeVisible({ timeout: 5000 });
       await addEditorButton.click();
 

--- a/tests/e2e/calendar-validation.spec.ts
+++ b/tests/e2e/calendar-validation.spec.ts
@@ -61,7 +61,7 @@ test.describe('Calendar Name Validation UX', () => {
     await calendarInput.fill('ab');
     await calendarInput.blur();
 
-    const submitButton = page.locator('button[type="submit"].btn--primary');
+    const submitButton = page.locator('button[type="submit"].btn--cta');
     await submitButton.click();
     await page.waitForTimeout(1000);
 


### PR DESCRIPTION
## Motivation

The client button styles had drifted: standalone calls-to-action, icon buttons, and "Cancel" buttons were each styled in bespoke, per-component CSS rather than through the shared `.btn` design system. This produced visual inconsistency (loud orange icon-hover fills, mismatched roundness, dark-gray hover bleed on cancels) and duplicated patterns. While reworking it, a long-standing specificity bug surfaced: the bare-button reset outranked the `.btn` variants, so raw `.btn--primary`/`.btn--danger` buttons rendered transparent instead of filled, variant borders never painted, and the size/radius modifiers were silently inert.

## Approach

- **New `.btn--cta` variant** — a calm outlined pill that commits to a solid brand fill on hover, for lone call-to-action buttons (empty-state CTAs across the app). Documented the group-vs-single convention in the `frontend-css` skill.
- **Reworked `.btn--icon`** into two treatments: an elevated shadowed circle for standalone affordances (help, actions menu) and a subtle gray-fill variant (`.btn--subtle`) for dense in-row actions (event row edit/duplicate/report).
- **Fixed the reset specificity bug** by moving the bare-button reset to zero specificity via `:where()`, so the `.btn` variants win. This restores primary/danger fills, variant borders, and the `--sm`/`--lg`/`--xl`/`--pill` modifiers app-wide. The same pattern fixed a component-local bare-`button` rule in the event editor.
- **Softened `.btn--ghost` hover** from a brand fill to a subtle neutral tint, and **migrated every bespoke "Cancel" button** to `.btn--ghost .btn--pill` so they match their pill siblings and drop the native-appearance hover bleed.
- **Consolidated** the redundant pill-ghost styling and migrated `PillButton`-based and custom-class empty-state buttons onto the `.btn` system.
- Updated affected component tests to select the migrated buttons by their new design-system classes (behavioral assertions unchanged).

## Validation

- `npm run build` passes.
- `npm run test:unit` (full unit + integration suite): 8178 tests across 471 files all pass, including the 5 component test files whose selectors were updated.
- `npm run lint`: clean on all changed files. (One pre-existing, unrelated lint error remains in `src/server/moderation/events/types.ts`, untouched by this branch.)
- Each change was verified in a real browser via Playwright across light states: icon buttons (elevated circle vs. subtle rect, fully round), `.btn--cta` rest/hover/sizing, primary/secondary/ghost/danger fills and contrast, and every migrated Cancel button rendering as a ghost pill matching its Save/Submit sibling with a subtle gray hover.
- E2E (`npm run test:e2e`) was not run locally; these are styling/markup changes with no logic paths, and e2e selectors are role/text/test-id based.