### PR TITLE
feat(client): open empty-state documentation links in the help modal

### DIFF
--- a/src/client/components/common/Sheet.vue
+++ b/src/client/components/common/Sheet.vue
@@ -93,6 +93,11 @@ defineExpose({ open, close });
     border: var(--pav-border-width-1) solid var(--pav-border-primary);
     box-shadow: var(--pav-shadow-modal);
 
+    /* Reset alignment so the modal is context-independent: the native
+       <dialog> renders inline in the DOM, so a triggering ancestor like
+       .empty-state (text-align: center) would otherwise leak into it. */
+    text-align: start;
+
     /* Mobile: rounded top corners */
     border-radius: var(--pav-border-radius-modal) var(--pav-border-radius-modal) 0 0;
   }

--- a/src/client/components/common/doc-link.vue
+++ b/src/client/components/common/doc-link.vue
@@ -1,0 +1,71 @@
+<template>
+  <button
+    type="button"
+    class="doc-link"
+    aria-haspopup="dialog"
+    @click="show = true"
+  >
+    <BookOpenText :size="14" :stroke-width="1.5" aria-hidden="true" />
+    <!-- Slot text is the button's accessible name; callers must provide it. -->
+    <slot />
+  </button>
+
+  <HelpPanel
+    v-if="show"
+    :guides="[props.guide]"
+    :audience="resolvedAudience"
+    @close="show = false"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, useSlots } from 'vue';
+import { useRoute } from 'vue-router';
+import { BookOpenText } from 'lucide-vue-next';
+import HelpPanel from '@/client/components/common/help-panel.vue';
+import { audienceForRoute } from '@/client/service/docs';
+import type { GuideRef, Audience } from '@/client/service/docs';
+
+const props = defineProps<{
+  guide: GuideRef;
+  audience?: Audience;
+}>();
+
+const route = useRoute();
+const show = ref(false);
+const resolvedAudience = computed<Audience>(
+  () => props.audience ?? audienceForRoute(route?.name),
+);
+
+const slots = useSlots();
+onMounted(() => {
+  if (import.meta.env.DEV && !slots.default) {
+    console.warn('[DocLink] No slot content provided; the trigger button will have no accessible name.');
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.doc-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pav-space-1);
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--pav-font-size-sm);
+  color: var(--pav-color-brand-primary);
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+  }
+}
+</style>

--- a/src/client/components/common/empty_state.vue
+++ b/src/client/components/common/empty_state.vue
@@ -6,24 +6,18 @@
     <h2 :id="titleId">{{ props.title }}</h2>
     <p v-if="props.description">{{ props.description }}</p>
     <slot/>
-    <a
-      v-if="guideUrl"
-      :href="guideUrl"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="empty-state__guide-link"
-    >
-      {{ guideLabel }}
-      <ExternalLink :size="14" aria-hidden="true" />
-    </a>
+    <div v-if="props.guide" class="empty-state__doc-link">
+      <DocLink :guide="props.guide">
+        {{ props.guideLabel ?? t(`guides.${props.guide.key}.label`) }}
+      </DocLink>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useTranslation } from 'i18next-vue';
-import { ExternalLink } from 'lucide-vue-next';
-import { docsUrl } from '@/client/service/docs';
+import DocLink from '@/client/components/common/doc-link.vue';
 import type { GuideRef } from '@/client/service/docs';
 
 const { t } = useTranslation('system', { keyPrefix: 'help' });
@@ -32,31 +26,15 @@ const props = defineProps<{
   title: string;
   description?: string;
   guide?: GuideRef;
+  guideLabel?: string;
 }>();
 
 const dialogId = Math.random().toString(36).substring(2, 11);
 const titleId = computed(() => `empty-title-${dialogId}`);
-const guideUrl = computed(() => props.guide ? docsUrl(props.guide.slug) : null);
-const guideLabel = computed(() => props.guide ? t(`guides.${props.guide.key}.label`) : '');
 </script>
 
 <style scoped lang="scss">
-.empty-state__guide-link {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--pav-space-1);
+.empty-state__doc-link {
   margin-block-start: var(--pav-space-4);
-  font-size: var(--pav-font-size-sm);
-  color: var(--pav-color-brand-primary);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:focus-visible {
-    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
-    outline-offset: var(--pav-space-0_5);
-  }
 }
 </style>

--- a/src/client/components/logged_in/calendar-content/categories.vue
+++ b/src/client/components/logged_in/calendar-content/categories.vue
@@ -74,7 +74,11 @@
     </div>
 
     <!-- Empty State -->
-    <EmptyLayout v-else :title="t('no_categories')" :description="t('no_categories_description')">
+    <EmptyLayout v-else
+                 :title="t('no_categories')"
+                 :description="t('no_categories_description')"
+                 :guide="{ slug: 'guides/calendar-owners/categories', key: 'categories' }"
+                 :guide-label="t('guide_link')">
       <button
         type="button"
         class="btn btn--cta btn--lg"

--- a/src/client/components/logged_in/calendar-content/events-tab.vue
+++ b/src/client/components/logged_in/calendar-content/events-tab.vue
@@ -648,7 +648,8 @@ initializeFiltersFromURL();
     <EmptyLayout v-else-if="!isLoading && !hasActiveFilters && (!calendarEvents || calendarEvents.length === 0)"
                  :title="t('noEvents')"
                  :description="t('noEventsDescription')"
-                 :guide="{ slug: 'guides/calendar-owners/recurring-events', key: 'recurring' }">
+                 :guide="{ slug: 'guides/calendar-owners/quickstart', key: 'quickstart' }"
+                 :guide-label="t('guide_link')">
       <button type="button" class="btn btn--cta btn--lg" @click="newEvent()">
         <Plus :size="20" :stroke-width="2" />
         {{ t('createEvent') }}

--- a/src/client/components/logged_in/calendar-content/places-tab.vue
+++ b/src/client/components/logged_in/calendar-content/places-tab.vue
@@ -250,7 +250,11 @@ onMounted(async () => {
     </div>
 
     <!-- Empty State -->
-    <EmptyLayout v-else :title="t('no_places')" :description="t('no_places_description')">
+    <EmptyLayout v-else
+                 :title="t('no_places')"
+                 :description="t('no_places_description')"
+                 :guide="{ slug: 'guides/calendar-owners/places', key: 'places' }"
+                 :guide-label="t('guide_link')">
       <button
         ref="emptyAddPlaceButtonRef"
         type="button"

--- a/src/client/components/logged_in/calendar-content/series.vue
+++ b/src/client/components/logged_in/calendar-content/series.vue
@@ -278,7 +278,11 @@ onMounted(async () => {
     </div>
 
     <!-- Empty State -->
-    <EmptyLayout v-else :title="t('no_series')" :description="t('no_series_description')">
+    <EmptyLayout v-else
+                 :title="t('no_series')"
+                 :description="t('no_series_description')"
+                 :guide="{ slug: 'guides/calendar-owners/series', key: 'series' }"
+                 :guide-label="t('guide_link')">
       <button
         type="button"
         class="btn btn--cta btn--lg"

--- a/src/client/components/logged_in/calendar-management/editors.vue
+++ b/src/client/components/logged_in/calendar-management/editors.vue
@@ -106,7 +106,11 @@
     </div>
 
     <!-- Empty State — only shown when there is no error -->
-    <EmptyLayout v-else-if="!state.error" :title="t('no_editors')" :description="t('no_editors_description')">
+    <EmptyLayout v-else-if="!state.error"
+                 :title="t('no_editors')"
+                 :description="t('no_editors_description')"
+                 :guide="{ slug: 'guides/calendar-owners/editors', key: 'editors' }"
+                 :guide-label="t('guide_link')">
       <button
         v-if="props.isOwner"
         type="button"

--- a/src/client/components/logged_in/calendar-management/import-sources/ImportSourcesSection.vue
+++ b/src/client/components/logged_in/calendar-management/import-sources/ImportSourcesSection.vue
@@ -35,6 +35,8 @@
       v-else
       :title="t('empty_title')"
       :description="t('empty_description')"
+      :guide="{ slug: 'guides/calendar-owners/ics-import', key: 'ics_import' }"
+      :guide-label="t('guide_link')"
     >
       <button type="button" class="btn btn--cta btn--lg" @click="openAddForm">
         <Plus :size="20" :stroke-width="2" aria-hidden="true" />

--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -173,6 +173,7 @@ async function loadCalendars() {
       v-else
       :title="t('create_first_calendar_header')"
       :guide="{ slug: 'guides/calendar-owners/quickstart', key: 'quickstart' }"
+      :guide-label="t('guide_link')"
     >
       <CreateCalendarForm />
     </EmptyLayout>

--- a/src/client/components/logged_in/feed/events.vue
+++ b/src/client/components/logged_in/feed/events.vue
@@ -403,6 +403,7 @@ onUnmounted(() => {
       v-else
       :title="t('no_events')"
       :guide="{ slug: 'guides/calendar-owners/follow-and-repost', key: 'follow_repost' }"
+      :guide-label="t('guide_link')"
     >
       <button
         type="button"

--- a/src/client/components/logged_in/feed/follows.vue
+++ b/src/client/components/logged_in/feed/follows.vue
@@ -90,6 +90,7 @@ const handleFollowSuccess = async () => {
     v-else
     :title="t('no_follows')"
     :guide="{ slug: 'guides/calendar-owners/follow-and-repost', key: 'follow_repost' }"
+    :guide-label="t('guide_link')"
   >
     <button
       type="button"

--- a/src/client/components/moderation/reports-dashboard.vue
+++ b/src/client/components/moderation/reports-dashboard.vue
@@ -207,6 +207,8 @@ onMounted(async () => {
       v-else-if="!store.hasReports"
       :title="t('dashboard.empty')"
       :description="t('dashboard.empty_description')"
+      :guide="{ slug: 'guides/calendar-owners/moderation', key: 'moderation_owner' }"
+      :guide-label="t('dashboard.guide_link')"
     />
 
     <!-- Reports Table -->

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -29,7 +29,8 @@
         "aria_view_public_calendar": "View public calendar: {{name}} (opens in new tab)",
         "error_loading_calendars": "Failed to load calendars",
         "menu_label": "Calendar list actions",
-        "documentation": "Documentation"
+        "documentation": "Documentation",
+        "guide_link": "How to create a calendar"
     },
     "selector": {
         "select_calendar_title": "Select Calendar",
@@ -85,7 +86,8 @@
         "recurrence_monthly": "Repeats monthly",
         "recurrence_yearly": "Repeats yearly",
         "recurrence_generic": "Recurring event",
-        "language_count": "{{count}} languages"
+        "language_count": "{{count}} languages",
+        "guide_link": "Create your first event"
     },
     "editors": {
         "title": "Calendar Editors",
@@ -93,6 +95,7 @@
         "loading": "Loading editors...",
         "no_editors": "No editors have been granted access to this calendar.",
         "no_editors_description": "Add editors to allow others to manage this calendar with you.",
+        "guide_link": "Invite editors and manage access",
         "remove_button": "Remove",
         "removing": "Removing...",
         "add_editor_title": "Add Editor",
@@ -147,6 +150,7 @@
         "add_category_button": "Add Category",
         "no_categories": "No categories",
         "no_categories_description": "You haven't created any event categories yet.",
+        "guide_link": "Organize events with categories",
         "loading": "Loading categories...",
         "add_category_title": "Add New Category",
         "edit_category_title": "Edit Category",
@@ -263,6 +267,7 @@
         "loading": "Loading import sources...",
         "empty_title": "No import sources",
         "empty_description": "Add an import source to mirror events from an external calendar (ICS) feed.",
+        "guide_link": "Import events from another calendar",
         "error_loading": "Failed to load import sources.",
         "error_creating": "Failed to add import source.",
         "error_removing": "Failed to remove import source.",
@@ -354,6 +359,7 @@
         "add_place_button": "Add Place",
         "no_places": "No places",
         "no_places_description": "You haven't added any places yet. Create places to reuse locations across events.",
+        "guide_link": "Manage event locations",
         "loading": "Loading places...",
         "unnamed_place": "Unnamed Place",
         "edit_button": "Edit",

--- a/src/client/locales/en/feed.json
+++ b/src/client/locales/en/feed.json
@@ -27,7 +27,8 @@
         "auto_repost_reposts": "Also auto-repost shared events",
         "auto_repost_reposts_help": "Also share events this calendar has reposted from others",
         "unfollow_button": "Unfollow",
-        "local_calendar_label": "Posting to: {{name}}"
+        "local_calendar_label": "Posting to: {{name}}",
+        "guide_link": "How following and reposting work"
     },
     "events": {
         "title": "Events",
@@ -51,7 +52,8 @@
         "report_aria_label": "Report event: {{eventTitle}}",
         "details_button": "Details",
         "details_aria_label": "View details for: {{eventTitle}}",
-        "close_aria_label": "Close details"
+        "close_aria_label": "Close details",
+        "guide_link": "How following and reposting work"
     },
     "categoryMapping": {
         "repostDialogTitle": "Repost with categories",

--- a/src/client/locales/en/series.json
+++ b/src/client/locales/en/series.json
@@ -5,6 +5,7 @@
     "loading": "Loading series...",
     "no_series": "No series found",
     "no_series_description": "Create series to group related events.",
+    "guide_link": "Group related events into a series",
     "error_loading": "Error loading series",
     "create_button": "Create Series",
     "cancel_button": "Cancel",

--- a/src/client/locales/en/system.json
+++ b/src/client/locales/en/system.json
@@ -166,6 +166,10 @@
       "asking": {
         "label": "Asking for money",
         "description": "Ask the community that uses your instance for money — when, how often, and how transparent."
+      },
+      "ics_import": {
+        "label": "Import events via ICS",
+        "description": "Migrate events from another calendar into this one with a one-time ICS file import."
       }
     }
   },
@@ -204,6 +208,7 @@
       "pagination_label": "Reports pagination",
       "empty": "No reports found",
       "empty_description": "There are no reports for events in this calendar.",
+      "guide_link": "Review and handle reports",
       "filter_status": "Filter by status",
       "filter_category": "Filter by category",
       "all_statuses": "All statuses",

--- a/src/client/locales/es/calendars.json
+++ b/src/client/locales/es/calendars.json
@@ -27,7 +27,8 @@
         "role_editor": "Editor",
         "aria_navigate_calendar": "Ir al calendario: {{calendarName}}, rol: {{role}}",
         "aria_view_public_calendar": "Ver calendario público: {{name}} (se abre en una pestaña nueva)",
-        "error_loading_calendars": "Error al cargar los calendarios"
+        "error_loading_calendars": "Error al cargar los calendarios",
+        "guide_link": "Cómo crear un calendario"
     },
     "selector": {
         "select_calendar_title": "Seleccionar calendario",
@@ -81,7 +82,8 @@
         "recurrence_monthly": "Se repite cada mes",
         "recurrence_yearly": "Se repite cada año",
         "recurrence_generic": "Evento recurrente",
-        "language_count": "{{count}} idiomas"
+        "language_count": "{{count}} idiomas",
+        "guide_link": "Crea tu primer evento"
     },
     "editors": {
         "title": "Editores del calendario",
@@ -89,6 +91,7 @@
         "loading": "Cargando editores...",
         "no_editors": "No se ha concedido acceso a ningún editor en este calendario.",
         "no_editors_description": "Añade editores para permitir que otros gestionen este calendario contigo.",
+        "guide_link": "Invita a editores y gestiona el acceso",
         "remove_button": "Eliminar",
         "removing": "Eliminando...",
         "add_editor_title": "Añadir editor",
@@ -143,6 +146,7 @@
         "add_category_button": "Añadir categoría",
         "no_categories": "Sin categorías",
         "no_categories_description": "Aún no has creado ninguna categoría de evento.",
+        "guide_link": "Organiza los eventos con categorías",
         "loading": "Cargando categorías...",
         "add_category_title": "Añadir nueva categoría",
         "edit_category_title": "Editar categoría",
@@ -259,6 +263,7 @@
         "loading": "Cargando fuentes de importación...",
         "empty_title": "Sin fuentes de importación",
         "empty_description": "Añade una fuente de importación para reflejar eventos desde un feed de calendario externo (ICS).",
+        "guide_link": "Importa eventos desde otro calendario",
         "error_loading": "Error al cargar las fuentes de importación.",
         "error_creating": "Error al añadir la fuente de importación.",
         "error_removing": "Error al eliminar la fuente de importación.",
@@ -350,6 +355,7 @@
         "add_place_button": "Añadir lugar",
         "no_places": "Sin lugares",
         "no_places_description": "Aún no has añadido ningún lugar. Crea lugares para reutilizar ubicaciones en distintos eventos.",
+        "guide_link": "Gestiona los lugares de eventos",
         "loading": "Cargando lugares...",
         "unnamed_place": "Lugar sin nombre",
         "edit_button": "Editar",

--- a/src/client/locales/es/feed.json
+++ b/src/client/locales/es/feed.json
@@ -27,7 +27,8 @@
         "auto_repost_reposts": "Reenviar también eventos compartidos",
         "auto_repost_reposts_help": "Comparte también los eventos que este calendario ha reenviado de otros",
         "unfollow_button": "Dejar de seguir",
-        "local_calendar_label": "Publicando en: {{name}}"
+        "local_calendar_label": "Publicando en: {{name}}",
+        "guide_link": "Cómo funcionan seguir y reenviar"
     },
     "events": {
         "title": "Eventos",
@@ -51,7 +52,8 @@
         "report_aria_label": "Reportar evento: {{eventTitle}}",
         "details_button": "Detalles",
         "details_aria_label": "Ver detalles de: {{eventTitle}}",
-        "close_aria_label": "Cerrar detalles"
+        "close_aria_label": "Cerrar detalles",
+        "guide_link": "Cómo funcionan seguir y reenviar"
     },
     "categoryMapping": {
         "repostDialogTitle": "Reenviar con categorías",

--- a/src/client/locales/es/series.json
+++ b/src/client/locales/es/series.json
@@ -5,6 +5,7 @@
     "loading": "Cargando series...",
     "no_series": "No se encontraron series",
     "no_series_description": "Crea series para agrupar eventos relacionados.",
+    "guide_link": "Agrupa eventos relacionados en una serie",
     "error_loading": "Error al cargar las series",
     "create_button": "Crear Serie",
     "cancel_button": "Cancelar",

--- a/src/client/locales/es/system.json
+++ b/src/client/locales/es/system.json
@@ -78,6 +78,7 @@
       "pagination_label": "Paginación de reportes",
       "empty": "No se encontraron reportes",
       "empty_description": "No hay reportes para los eventos de este calendario.",
+      "guide_link": "Revisa y gestiona los reportes",
       "filter_status": "Filtrar por estado",
       "filter_category": "Filtrar por categoría",
       "all_statuses": "Todos los estados",

--- a/src/client/locales/fr/calendars.json
+++ b/src/client/locales/fr/calendars.json
@@ -27,7 +27,8 @@
         "role_editor": "Éditeur",
         "aria_navigate_calendar": "Aller au calendrier : {{calendarName}}, rôle : {{role}}",
         "aria_view_public_calendar": "Voir le calendrier public : {{name}} (s'ouvre dans un nouvel onglet)",
-        "error_loading_calendars": "Échec du chargement des calendriers"
+        "error_loading_calendars": "Échec du chargement des calendriers",
+        "guide_link": "Comment créer un calendrier"
     },
     "selector": {
         "select_calendar_title": "Sélectionner un calendrier",
@@ -81,7 +82,8 @@
         "recurrence_monthly": "Se répète chaque mois",
         "recurrence_yearly": "Se répète chaque année",
         "recurrence_generic": "Événement récurrent",
-        "language_count": "{{count}} langues"
+        "language_count": "{{count}} langues",
+        "guide_link": "Créez votre premier événement"
     },
     "editors": {
         "title": "Éditeurs du calendrier",
@@ -89,6 +91,7 @@
         "loading": "Chargement des éditeurs...",
         "no_editors": "Aucun éditeur n'a reçu d'accès à ce calendrier.",
         "no_editors_description": "Ajoutez des éditeurs pour permettre à d'autres personnes de gérer ce calendrier avec vous.",
+        "guide_link": "Invitez des éditeurs et gérez les accès",
         "remove_button": "Supprimer",
         "removing": "Suppression...",
         "add_editor_title": "Ajouter un éditeur",
@@ -143,6 +146,7 @@
         "add_category_button": "Ajouter une catégorie",
         "no_categories": "Aucune catégorie",
         "no_categories_description": "Vous n'avez pas encore créé de catégorie d'événement.",
+        "guide_link": "Organisez les événements avec des catégories",
         "loading": "Chargement des catégories...",
         "add_category_title": "Ajouter une nouvelle catégorie",
         "edit_category_title": "Modifier la catégorie",
@@ -259,6 +263,7 @@
         "loading": "Chargement des sources d'importation...",
         "empty_title": "Aucune source d'importation",
         "empty_description": "Ajoutez une source d'importation pour refléter les événements d'un flux de calendrier externe (ICS).",
+        "guide_link": "Importez des événements depuis un autre calendrier",
         "error_loading": "Échec du chargement des sources d'importation.",
         "error_creating": "Échec de l'ajout de la source d'importation.",
         "error_removing": "Échec de la suppression de la source d'importation.",
@@ -350,6 +355,7 @@
         "add_place_button": "Ajouter un lieu",
         "no_places": "Aucun lieu",
         "no_places_description": "Vous n'avez pas encore ajouté de lieu. Créez des lieux pour réutiliser des emplacements dans plusieurs événements.",
+        "guide_link": "Gérez les lieux des événements",
         "loading": "Chargement des lieux...",
         "unnamed_place": "Lieu sans nom",
         "edit_button": "Modifier",

--- a/src/client/locales/fr/feed.json
+++ b/src/client/locales/fr/feed.json
@@ -27,7 +27,8 @@
         "auto_repost_reposts": "Repartager aussi les événements partagés",
         "auto_repost_reposts_help": "Partager aussi les événements que ce calendrier a repartagés depuis d'autres",
         "unfollow_button": "Ne plus suivre",
-        "local_calendar_label": "Publication sur : {{name}}"
+        "local_calendar_label": "Publication sur : {{name}}",
+        "guide_link": "Comment fonctionnent le suivi et le repartage"
     },
     "events": {
         "title": "Événements",
@@ -51,7 +52,8 @@
         "report_aria_label": "Signaler l'événement : {{eventTitle}}",
         "details_button": "Détails",
         "details_aria_label": "Voir les détails de : {{eventTitle}}",
-        "close_aria_label": "Fermer les détails"
+        "close_aria_label": "Fermer les détails",
+        "guide_link": "Comment fonctionnent le suivi et le repartage"
     },
     "categoryMapping": {
         "repostDialogTitle": "Repartager avec des catégories",

--- a/src/client/locales/fr/series.json
+++ b/src/client/locales/fr/series.json
@@ -5,6 +5,7 @@
     "loading": "Chargement des séries...",
     "no_series": "Aucune série trouvée",
     "no_series_description": "Créez des séries pour regrouper des événements liés.",
+    "guide_link": "Regroupez des événements liés en une série",
     "error_loading": "Erreur lors du chargement des séries",
     "create_button": "Créer la série",
     "cancel_button": "Annuler",

--- a/src/client/locales/fr/system.json
+++ b/src/client/locales/fr/system.json
@@ -78,6 +78,7 @@
       "pagination_label": "Pagination des signalements",
       "empty": "Aucun signalement trouvé",
       "empty_description": "Il n'y a aucun signalement pour les événements de ce calendrier.",
+      "guide_link": "Examinez et traitez les signalements",
       "filter_status": "Filtrer par statut",
       "filter_category": "Filtrer par catégorie",
       "all_statuses": "Tous les statuts",

--- a/src/client/service/docs.ts
+++ b/src/client/service/docs.ts
@@ -48,6 +48,7 @@ export const ROUTE_GUIDES: Record<string, GuideRef[]> = {
     { slug: 'guides/calendar-owners/editors', key: 'editors' },
     { slug: 'guides/calendar-owners/identity', key: 'identity' },
     { slug: 'guides/calendar-owners/federation-etiquette', key: 'federation_etiquette' },
+    { slug: 'guides/calendar-owners/ics-import', key: 'ics_import' },
   ],
   event_new: [
     { slug: 'guides/calendar-owners/recurring-events', key: 'recurring' },

--- a/src/client/test/components/common/doc-link.test.ts
+++ b/src/client/test/components/common/doc-link.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { createMemoryHistory, createRouter, Router, RouteRecordRaw } from 'vue-router';
+import { flushPromises } from '@vue/test-utils';
+import { BookOpenText } from 'lucide-vue-next';
+
+import DocLink from '@/client/components/common/doc-link.vue';
+import HelpPanel from '@/client/components/common/help-panel.vue';
+import { mountComponent } from '@/client/test/lib/vue';
+import type { GuideRef, Audience } from '@/client/service/docs';
+
+const GUIDE: GuideRef = { slug: 'guides/calendar-owners/quickstart', key: 'quickstart' };
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: {}, name: 'calendars' },
+  { path: '/federation', component: {}, name: 'federation' },
+];
+
+// Stub Sheet so happy-dom does not need HTMLDialogElement.showModal().
+// HelpPanel still mounts, so its props remain assertable.
+const sheetStub = {
+  Sheet: {
+    template: '<div role="dialog"><slot /></div>',
+    props: ['title'],
+    emits: ['close'],
+  },
+};
+
+const Harness = defineComponent({
+  props: {
+    guide: { type: Object, required: true },
+    audience: { type: String, default: undefined },
+  },
+  setup(props) {
+    return () => h(DocLink, { guide: props.guide, audience: props.audience }, () => 'Read the guide');
+  },
+});
+
+const mountDocLink = async (
+  props: { guide: GuideRef; audience?: Audience } = { guide: GUIDE },
+  routeName = 'calendars',
+) => {
+  const router: Router = createRouter({ history: createMemoryHistory(), routes });
+  await router.push({ name: routeName });
+  await router.isReady();
+  return mountComponent(Harness, router, { props, stubs: sheetStub });
+};
+
+describe('DocLink', () => {
+  let currentWrapper: any = null;
+
+  afterEach(() => {
+    if (currentWrapper) {
+      currentWrapper.unmount();
+      currentWrapper = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('renders an inline button (not an anchor) with the slot text, book icon, and dialog semantics', async () => {
+    const wrapper = await mountDocLink();
+    currentWrapper = wrapper;
+
+    const trigger = wrapper.find('button.doc-link');
+    expect(trigger.exists()).toBe(true);
+    expect(trigger.attributes('type')).toBe('button');
+    expect(trigger.attributes('aria-haspopup')).toBe('dialog');
+    expect(trigger.text()).toContain('Read the guide');
+    expect(wrapper.findComponent(BookOpenText).exists()).toBe(true);
+    expect(trigger.element.tagName).toBe('BUTTON');
+  });
+
+  it('does not mount HelpPanel until the trigger is clicked', async () => {
+    const wrapper = await mountDocLink();
+    currentWrapper = wrapper;
+
+    expect(wrapper.findComponent(HelpPanel).exists()).toBe(false);
+  });
+
+  it('opens HelpPanel scoped to the single guide on click', async () => {
+    const wrapper = await mountDocLink();
+    currentWrapper = wrapper;
+
+    await wrapper.find('button.doc-link').trigger('click');
+    await flushPromises();
+
+    const panel = wrapper.findComponent(HelpPanel);
+    expect(panel.exists()).toBe(true);
+    expect(panel.props('guides')).toEqual([GUIDE]);
+    expect(panel.props('audience')).toBe('calendar-owners');
+  });
+
+  it('defaults audience from the current route', async () => {
+    const wrapper = await mountDocLink({ guide: GUIDE }, 'federation');
+    currentWrapper = wrapper;
+
+    await wrapper.find('button.doc-link').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.findComponent(HelpPanel).props('audience')).toBe('instance-administrators');
+  });
+
+  it('uses an explicit audience prop over the route default', async () => {
+    const wrapper = await mountDocLink({ guide: GUIDE, audience: 'instance-administrators' }, 'calendars');
+    currentWrapper = wrapper;
+
+    await wrapper.find('button.doc-link').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.findComponent(HelpPanel).props('audience')).toBe('instance-administrators');
+  });
+
+  it('closes HelpPanel on its close event', async () => {
+    const wrapper = await mountDocLink();
+    currentWrapper = wrapper;
+
+    await wrapper.find('button.doc-link').trigger('click');
+    await flushPromises();
+    expect(wrapper.findComponent(HelpPanel).exists()).toBe(true);
+
+    wrapper.findComponent(HelpPanel).vm.$emit('close');
+    await flushPromises();
+    expect(wrapper.findComponent(HelpPanel).exists()).toBe(false);
+  });
+});

--- a/src/client/test/components/common/empty-state.test.ts
+++ b/src/client/test/components/common/empty-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createMemoryHistory, createRouter, Router, RouteRecordRaw } from 'vue-router';
+
+import EmptyState from '@/client/components/common/empty_state.vue';
+import DocLink from '@/client/components/common/doc-link.vue';
+import { mountComponent } from '@/client/test/lib/vue';
+import type { GuideRef } from '@/client/service/docs';
+
+const GUIDE: GuideRef = { slug: 'guides/calendar-owners/quickstart', key: 'quickstart' };
+
+const routes: RouteRecordRaw[] = [{ path: '/', component: {}, name: 'calendars' }];
+
+const sheetStub = {
+  Sheet: {
+    template: '<div role="dialog"><slot /></div>',
+    props: ['title'],
+    emits: ['close'],
+  },
+};
+
+const mountEmpty = async (props: Record<string, unknown>) => {
+  const router: Router = createRouter({ history: createMemoryHistory(), routes });
+  await router.push('/');
+  await router.isReady();
+  return mountComponent(EmptyState, router, { props, stubs: sheetStub });
+};
+
+describe('EmptyState', () => {
+  let currentWrapper: any = null;
+
+  afterEach(() => {
+    if (currentWrapper) {
+      currentWrapper.unmount();
+      currentWrapper = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('renders the title and no DocLink when no guide is provided', async () => {
+    const wrapper = await mountEmpty({ title: 'Nothing here' });
+    currentWrapper = wrapper;
+
+    expect(wrapper.find('h2').text()).toBe('Nothing here');
+    expect(wrapper.findComponent(DocLink).exists()).toBe(false);
+  });
+
+  it('renders a DocLink for the guide and never an external doc anchor', async () => {
+    const wrapper = await mountEmpty({ title: 'Empty', guide: GUIDE });
+    currentWrapper = wrapper;
+
+    const docLink = wrapper.findComponent(DocLink);
+    expect(docLink.exists()).toBe(true);
+    expect(docLink.props('guide')).toEqual(GUIDE);
+    expect(wrapper.find('a[target="_blank"]').exists()).toBe(false);
+  });
+
+  it('uses the guide i18n label as DocLink text when no guideLabel is given', async () => {
+    const wrapper = await mountEmpty({ title: 'Empty', guide: GUIDE });
+    currentWrapper = wrapper;
+
+    expect(wrapper.findComponent(DocLink).text()).toContain('Quickstart');
+  });
+
+  it('uses the custom guideLabel as DocLink text when provided', async () => {
+    const wrapper = await mountEmpty({ title: 'Empty', guide: GUIDE, guideLabel: 'How to create a calendar' });
+    currentWrapper = wrapper;
+
+    expect(wrapper.findComponent(DocLink).text()).toContain('How to create a calendar');
+  });
+});


### PR DESCRIPTION
## Motivation

Empty-state pages linked to documentation with a plain external anchor that jumped to docs.pavillion.social in a new tab — diverging from the in-app pattern used by the ActionsMenu help affordance (a book-icon trigger that opens the HelpPanel modal). This unifies the two and lets each empty state show custom, context-specific link text instead of a generic guide label.

## Approach

- New reusable `DocLink` component (`src/client/components/common/doc-link.vue`): an inline link-styled `<button aria-haspopup="dialog">` with a book icon and slot text that opens the existing `HelpPanel` modal scoped to a single guide. Audience defaults from the current route with an optional override. Mirrors the existing `help-button.vue` mechanism rather than reimplementing it.
- `empty_state.vue` keeps its `guide` prop, gains an optional `guideLabel`, and delegates the link to `DocLink` (wrapped in a margin div, since `DocLink` has a fragment root and can't inherit a class). The old external anchor and its styles are removed; the i18n guide-label fallback preserves existing behavior for call sites that pass only `:guide`.
- Four empty-state call sites (calendars, events tab, feed events, follows) pass custom trigger text from new `guide_link` keys added to their own locale namespaces in en/es/fr.
- A dev-only guard warns if `DocLink` is rendered without slot text (its accessible name).

## Validation

- TDD throughout: new unit tests for `doc-link.vue` (6) and `empty_state.vue` (4), all passing.
- Full suite: unit (8189) and integration (651) pass; production build passes. The single lint error and the e2e failures are pre-existing and unrelated to this client-only change (a server-side trailing-space lint error; e2e login-timeout and port-binding infrastructure failures).
- Post-code review across accessibility, stylesheet, i18n, consistency, testing, and complexity — all pass. Act-now findings were fixed (dev-mode accessibility slot guard, margin-bleed reset, test tightening). A systemic dark-mode link-color token migration was deferred to a separate follow-up.