### PR TITLE
chore: use dot separator in branch naming convention

### DIFF
--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -870,7 +870,7 @@ const BRANCH_PREFIX_MAP: Record<string, string> = {
 /**
  * Derive a branch name from bead metadata. Pure function.
  *
- * Format: <prefix>/<kebab-title>
+ * Format: <prefix>.<kebab-title>
  * Max length: 60 chars total.
  *
  * Bead IDs do not appear in branch names — see git-workflow skill's
@@ -891,7 +891,7 @@ export function branchName(
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 
-  // Reserve space: prefix + "/"
+  // Reserve space: prefix + "."
   const reserved = prefix.length + 1;
   const budget = Math.max(8, MAX_LEN - reserved);
 
@@ -899,7 +899,7 @@ export function branchName(
     ? kebabFull.slice(0, budget).replace(/-+$/, '')
     : kebabFull;
 
-  return `${prefix}/${kebab}`;
+  return `${prefix}.${kebab}`;
 }
 
 // =============================================================================

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -59,8 +59,8 @@ function enrichedBeadText(): string {
 // ---------------------------------------------------------------------------
 // branchName('Implement widget feature', 'task')
 // → prefix='chore', kebab='implement-widget-feature'
-// → 'chore/implement-widget-feature'
-const EXPECTED_BRANCH = 'chore/implement-widget-feature';
+// → 'chore.implement-widget-feature'
+const EXPECTED_BRANCH = 'chore.implement-widget-feature';
 
 describe('Integration: leaf happy path', () => {
   let scripts: ScriptRouter;

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -548,22 +548,22 @@ describe('bdEnrichmentCheck', () => {
 describe('branchName', () => {
   it('derives chore prefix for task type', () => {
     const result = branchName('Fix the broken widget', 'task');
-    expect(result).toBe('chore/fix-the-broken-widget');
+    expect(result).toBe('chore.fix-the-broken-widget');
   });
 
   it('uses feat prefix for feature type', () => {
     const result = branchName('Add calendar discovery', 'feature');
-    expect(result).toMatch(/^feat\//);
+    expect(result).toMatch(/^feat\./);
   });
 
   it('uses feat prefix for epic type', () => {
     const result = branchName('Build search', 'epic');
-    expect(result).toMatch(/^feat\//);
+    expect(result).toMatch(/^feat\./);
   });
 
   it('uses fix prefix for bug type', () => {
     const result = branchName('Fix broken links', 'bug');
-    expect(result).toMatch(/^fix\//);
+    expect(result).toMatch(/^fix\./);
   });
 
   it('does not embed bead IDs in output', () => {
@@ -576,18 +576,18 @@ describe('branchName', () => {
     const longTitle = 'This is a very long title that would exceed the maximum length limit easily and should be truncated cleanly';
     const result = branchName(longTitle, 'task');
     expect(result.length).toBeLessThanOrEqual(60);
-    expect(result).toMatch(/^chore\//);
+    expect(result).toMatch(/^chore\./);
     expect(result.endsWith('-')).toBe(false);
   });
 
   it('defaults to chore for unknown issue type', () => {
     const result = branchName('Some work', 'unknown');
-    expect(result).toMatch(/^chore\//);
+    expect(result).toMatch(/^chore\./);
   });
 
   it('strips leading and trailing non-alphanumerics from the title', () => {
     const result = branchName('  --Add Search-- ', 'feature');
-    expect(result).toBe('feat/add-search');
+    expect(result).toBe('feat.add-search');
   });
 });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -1123,8 +1123,8 @@ describe('branch', () => {
 
   it('should skip checkout if already on target branch', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
-    // branchName('A Task', 'task') = 'chore/a-task'
-    const expectedBranch = 'chore/a-task';
+    // branchName('A Task', 'task') = 'chore.a-task'
+    const expectedBranch = 'chore.a-task';
     const spawn = seqSpawn(
       // gitSafeToStart:
       fakeSpawn('true', '', 0),

--- a/.claude/skills/bead-branch-and-pr/SKILL.md
+++ b/.claude/skills/bead-branch-and-pr/SKILL.md
@@ -25,15 +25,15 @@ The functions live in `.claude/orchestrators/lib/helpers.ts` and are pure (no I/
 
 ### `branchName(title, issueType)`
 
-Returns `<type>/<kebab-title>`, capped at 60 characters total. The type prefix maps from the bead's `issue_type`:
+Returns `<type>.<kebab-title>`, capped at 60 characters total. The type prefix maps from the bead's `issue_type`:
 
 | `issue_type` | Branch prefix |
 |--------------|---------------|
-| `bug`        | `fix/`        |
-| `feature`    | `feat/`       |
-| `epic`       | `feat/`       |
-| `task`       | `chore/`      |
-| (anything else) | `chore/`   |
+| `bug`        | `fix.`        |
+| `feature`    | `feat.`       |
+| `epic`       | `feat.`       |
+| `task`       | `chore.`      |
+| (anything else) | `chore.`   |
 
 Bead IDs are not embedded in the output. The orchestrator's bookkeeping of which bead a branch belongs to is tracked in its run-context, not in the branch name.
 

--- a/.claude/skills/git-workflow/branches.md
+++ b/.claude/skills/git-workflow/branches.md
@@ -3,14 +3,14 @@
 ## Pattern
 
 ```
-<type>/<kebab-title>
+<type>.<kebab-title>
 ```
 
 Examples:
 
-- `feat/widget-powered-by-footer`
-- `fix/widget-config-accent-light-mode`
-- `refactor/client-shadow-focus-brand`
+- `feat.widget-powered-by-footer`
+- `fix.widget-config-accent-light-mode`
+- `refactor.client-shadow-focus-brand`
 
 ## Allowed types
 
@@ -30,8 +30,8 @@ The full conventional-commit set:
 ## Casing and characters
 
 - Lowercase only.
-- Alphanumerics and hyphens. The only slash is the one separating the type prefix from the title.
-- Words separated by single hyphens. No underscores or dots.
+- Alphanumerics, hyphens, and a single dot. The only dot is the one separating the type prefix from the title. No slashes anywhere.
+- Words within the title separated by single hyphens. No underscores.
 
 ## Length
 
@@ -48,12 +48,12 @@ The convention above applies to the **remote (`origin`) branch name** — the na
 Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone — but when pushing, push to a properly-named remote ref:
 
 ```bash
-git push -u origin HEAD:feat/widget-powered-by-footer
+git push -u origin HEAD:feat.widget-powered-by-footer
 ```
 
-This sets the upstream so subsequent `git push` calls go to the same remote name. Verify with `git branch -vv` after the first push: the local branch should show `[origin/feat/widget-powered-by-footer]` as its upstream.
+This sets the upstream so subsequent `git push` calls go to the same remote name. Verify with `git branch -vv` after the first push: the local branch should show `[origin/feat.widget-powered-by-footer]` as its upstream.
 
-If the local branch name already conforms (e.g. you created it manually with `git checkout -b feat/...`), `git push -u origin HEAD` is fine — no rename needed.
+If the local branch name already conforms (e.g. you created it manually with `git checkout -b feat.<title>`), `git push -u origin HEAD` is fine — no rename needed.
 
 ## Disallowed
 
@@ -61,4 +61,5 @@ If the local branch name already conforms (e.g. you created it manually with `gi
 - Suffix-style ID encoding (no `<title>-<id>`, no trailing identifiers).
 - Mixed case in the remote name.
 - Underscores in the remote name.
+- Slashes anywhere in the remote name. The type and title are joined with a single dot, not a slash.
 - Pushing a nonsense auto-generated branch name (from `superset.sh` or similar) straight to `origin` without renaming on push.

--- a/.claude/skills/git-workflow/pull-requests.md
+++ b/.claude/skills/git-workflow/pull-requests.md
@@ -51,7 +51,7 @@ In the PR body, place the reference wherever it reads naturally — top of Motiv
 Before the first push, verify the local branch name conforms to [branches.md](branches.md). If it does **not** (for example, an auto-generated name from `superset.sh` like `apple-father` or `abrupt-grapple`), push with an explicit remote ref so the GitHub branch follows the convention:
 
 ```bash
-git push -u origin HEAD:<type>/<kebab-title>
+git push -u origin HEAD:<type>.<kebab-title>
 ```
 
 The `-u` flag wires the local branch's upstream to the renamed remote, so future pushes (`git push`) go to the same ref without re-specifying it.


### PR DESCRIPTION
## Motivation

The branch-naming convention joined the type prefix and kebab title with a slash (`feat/widget-foo`). Slashes create hierarchical git refs and trip up some worktree/tooling setups. This switches the separator to a dot (`feat.widget-foo`) and disallows slashes anywhere in the remote branch name.

## Approach

Propagated the `/` → `.` change through every governing reference so the documented convention and the tooling that implements it stay in sync:

- **git-workflow skill** — `branches.md` (pattern, examples, casing/characters rule, push/upstream examples, new Disallowed entry for slashes) and `pull-requests.md` (push example).
- **bead-branch-and-pr skill** — return-format line and the `fix.`/`feat.`/`chore.` prefix table.
- **orchestrator code** — `branchName()` now returns `${prefix}.${kebab}`; comments updated.
- **orchestrator tests** — the `branchName` unit assertions and the two `branchName()`-derived expected-branch constants in `phases.test.ts` and `leaf-happy-path.test.ts`.

Local branch names remain convention-exempt (per `branches.md`), so `git branch --show-current` fixtures in `execute.test.ts`/`verification-gate.test.ts` and the local-branch parsing example in `complexity-auditor.md` were deliberately left unchanged.

## Validation

- Orchestrator suite: 183/183 tests pass (`helpers`, `phases`, `execute`, `leaf-happy-path`), confirming the unchanged local-branch fixtures are decoupled from the separator.
- ESLint on the changed `.ts` files: 0 errors (only pre-existing unused-var warnings).
- Changes are confined to `.claude/` dev tooling and skill docs; product `src/` is untouched, so the product build and e2e paths are unaffected.