### PR TITLE
fix(activitypub): return 404 not 500 for missing event

### DIFF
--- a/src/server/activitypub/api/v1/server.ts
+++ b/src/server/activitypub/api/v1/server.ts
@@ -169,7 +169,17 @@ export default class ActivityPubServerRoutes {
       }
 
       // Get the event by ID
-      const event = await this.calendarService.getEventById(eventid);
+      let event;
+      try {
+        event = await this.calendarService.getEventById(eventid);
+      }
+      catch (error) {
+        if (error instanceof EventNotFoundError) {
+          res.status(404).send('Event not found');
+          return;
+        }
+        throw error;
+      }
       if (!event) {
         res.status(404).send('Event not found');
         return;

--- a/src/server/activitypub/test/api/get-endpoints.test.ts
+++ b/src/server/activitypub/test/api/get-endpoints.test.ts
@@ -43,7 +43,8 @@ describe('GET /calendars/:urlname/events/:eventid', () => {
 
   it('should return 404 when event not found', async () => {
     sandbox.stub(calendarAPI, 'getCalendarByName').resolves(new Calendar('cal-id', 'mycal'));
-    sandbox.stub(calendarAPI, 'getEventById').resolves(null as any);
+    // Regression: getEventById throws EventNotFoundError, not null — stub must reject (pv-ttak)
+    sandbox.stub(calendarAPI, 'getEventById').rejects(new EventNotFoundError('nonexistent'));
 
     const req = { params: { urlname: 'mycal', eventid: 'nonexistent' } };
     const res = { status: sinon.stub(), send: sinon.stub(), setHeader: sinon.stub(), json: sinon.stub() };


### PR DESCRIPTION
## Motivation

The ActivityPub `GET /calendars/:urlname/events/:eventid` handler returned a 500 Internal Server Error when the requested event did not exist, instead of a 404. `getEventById` throws `EventNotFoundError` on a miss (its return type is `Promise<CalendarEvent>`, never null), so the thrown error fell through to the handler's catch-all and surfaced as a 500. The existing `if (!event)` null guard never ran because the service never returns null. A unit test stubbed `getEventById` with `.resolves(null)`, which masked the broken path and let the bug ship.

## Approach

Wrapped the `getEventById` call in `getEvent` in a narrower try/catch that maps `EventNotFoundError` to `res.status(404).send('Event not found')` and rethrows any other error to the outer catch-all. This mirrors the already-shipped `getNote` handler in the same file verbatim. The pre-existing `if (!event)` guard is kept for structural parity with `getNote`. Corrected the masking unit-test stub from `.resolves(null as any)` to `.rejects(new EventNotFoundError(...))` so it exercises the real throw path, with a regression comment.

Out of scope: `getEvent` still lacks the UUID-format param guard that `getNote` performs — left for a separate follow-up.

## Validation

- `npm run lint`: 0 errors (no new warnings).
- Unit tests: full suite green (8189 passed), including the 24 tests in `get-endpoints.test.ts`; the corrected stub now genuinely asserts the `EventNotFoundError` → 404 mapping.
- Integration tests: green (651 passed).
- Build: green.
- E2E: the 3 failures observed are pre-existing infrastructure issues (docker TLS cert, connection-refused, moderation timeout) in domains unrelated to this change.