### PR TITLE
refactor(client): migrate report-event dialog to shared Modal

### DIFF
--- a/src/client/components/report-event.vue
+++ b/src/client/components/report-event.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { ref, reactive, computed, inject, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { ref, reactive, computed, inject } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import ReportService from '@/client/service/report';
 import { DuplicateReportError, ReportValidationError } from '@/common/exceptions/report';
 import { EventNotFoundError } from '@/common/exceptions/calendar';
 import { ReportCategory } from '@/common/model/report';
+import Modal from '@/client/components/common/modal.vue';
 
 const { t } = useTranslation('system', {
   keyPrefix: 'report',
@@ -22,17 +23,17 @@ const emit = defineEmits<{
 /** Maximum allowed length for report description text. */
 const MAX_DESCRIPTION_LENGTH = 2000;
 
-/** Unique ID for accessible label association. */
-const dialogId = Math.random().toString(36).substring(2, 11);
-const titleId = `report-dialog-title-${dialogId}`;
-
-const dialogRef = ref<HTMLDialogElement | null>(null);
-const categoryRef = ref<HTMLSelectElement | null>(null);
-
-/** Reference to the element that triggered the modal, for focus restoration. */
-let triggerElement: HTMLElement | null = null;
+/** Unique ID for accessible label association of form fields. */
+const fieldId = Math.random().toString(36).substring(2, 11);
 
 const reportService = new ReportService();
+
+/**
+ * Ref to the Modal instance. In-slot close paths (Cancel, success dismiss)
+ * route through the Modal's exposed close() so useDialog restores focus to the
+ * triggering element before the @close handler runs.
+ */
+const modalRef = ref<InstanceType<typeof Modal> | null>(null);
 
 /** Authentication service injected from the client app. */
 const authn = inject<{ userEmail: () => string | null }>('authn');
@@ -66,45 +67,6 @@ const descriptionCharsRemaining = computed(() => {
 });
 
 /**
- * Opens the modal dialog and focuses the first field.
- */
-function open() {
-  triggerElement = document.activeElement as HTMLElement;
-  if (dialogRef.value && !dialogRef.value.open) {
-    dialogRef.value.showModal();
-    document.body.classList.add('modal-open');
-    nextTick(() => {
-      categoryRef.value?.focus();
-    });
-  }
-}
-
-/**
- * Closes the modal dialog and restores focus to the trigger.
- */
-function close() {
-  if (dialogRef.value && dialogRef.value.open) {
-    dialogRef.value.close();
-  }
-  document.body.classList.remove('modal-open');
-  resetForm();
-  emit('close');
-  // Restore focus to the element that opened the modal
-  nextTick(() => {
-    triggerElement?.focus();
-  });
-}
-
-/**
- * Handles backdrop clicks to close the modal.
- */
-function handleBackdropClick(event: MouseEvent) {
-  if (event.target === dialogRef.value) {
-    close();
-  }
-}
-
-/**
  * Resets form fields and state to initial values.
  */
 function resetForm() {
@@ -113,6 +75,17 @@ function resetForm() {
   state.isSubmitting = false;
   state.isSuccess = false;
   state.error = '';
+}
+
+/**
+ * Fires once for every close path (header X, Escape, backdrop, Cancel, and the
+ * success dismiss button) via the Modal's @close event. By this point
+ * useDialog.close() has already restored focus to the triggering element.
+ * Resets the form, then re-emits close so the parent can unmount the component.
+ */
+function handleClose() {
+  resetForm();
+  emit('close');
 }
 
 /**
@@ -176,227 +149,144 @@ async function handleSubmit() {
   }
 }
 
-onMounted(() => {
-  open();
-});
-
-onBeforeUnmount(() => {
-  document.body.classList.remove('modal-open');
-});
-
-defineExpose({ open, close, state });
+defineExpose({ state });
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
-    class="report-dialog"
-    :aria-labelledby="titleId"
-    :aria-modal="true"
-    @keydown.esc="close"
-    @click="handleBackdropClick"
+  <Modal
+    ref="modalRef"
+    :title="t('form_title')"
+    size="lg"
+    @close="handleClose"
   >
-    <div class="report-dialog__content">
-      <header class="report-dialog__header">
-        <div class="report-dialog__title-block">
-          <h2 :id="titleId">{{ t('form_title') }}</h2>
-          <p
-            v-if="props.eventTitle"
-            class="report-dialog__event-subtitle"
-          >{{ t('event_subtitle', { title: props.eventTitle }) }}</p>
-        </div>
-        <button
-          type="button"
-          class="btn btn--ghost report-dialog__close"
-          :aria-label="t('close_dialog')"
-          @click="close"
-        >&times;</button>
-      </header>
+    <p
+      v-if="props.eventTitle"
+      class="report-dialog__event-subtitle"
+    >{{ t('event_subtitle', { title: props.eventTitle }) }}</p>
 
-      <!-- Success State -->
+    <!-- Success State -->
+    <div
+      v-if="state.isSuccess"
+      class="report-dialog__success"
+      role="status"
+    >
+      <p>{{ t('success_message') }}</p>
+      <button
+        type="button"
+        class="btn btn--secondary"
+        @click="modalRef?.close()"
+      >{{ t('cancel_button') }}</button>
+    </div>
+
+    <!-- Form State -->
+    <form
+      v-else
+      @submit.prevent="handleSubmit"
+      novalidate
+    >
       <div
-        v-if="state.isSuccess"
-        class="report-dialog__success"
-        role="status"
+        v-if="state.error"
+        class="alert alert--error alert--sm"
+        role="alert"
+        aria-live="polite"
       >
-        <p>{{ t('success_message') }}</p>
+        {{ state.error }}
+      </div>
+
+      <div class="form__group">
+        <label
+          class="form__label"
+          :for="`report-category-${fieldId}`"
+        >
+          {{ t('category_label') }} <span aria-hidden="true">*</span>
+        </label>
+        <select
+          :id="`report-category-${fieldId}`"
+          v-model="form.category"
+          class="select"
+          required
+          :disabled="state.isSubmitting"
+        >
+          <option
+            value=""
+            disabled
+          >{{ t('category_label') }}</option>
+          <option
+            v-for="option in categoryOptions"
+            :key="option.value"
+            :value="option.value"
+          >{{ t(option.labelKey) }}</option>
+        </select>
+      </div>
+
+      <div class="form__group">
+        <label
+          class="form__label"
+          :for="`report-description-${fieldId}`"
+        >
+          {{ t('description_label') }} <span aria-hidden="true">*</span>
+        </label>
+        <textarea
+          :id="`report-description-${fieldId}`"
+          v-model="form.description"
+          class="textarea"
+          :placeholder="t('description_placeholder')"
+          :maxlength="MAX_DESCRIPTION_LENGTH"
+          rows="4"
+          required
+          :disabled="state.isSubmitting"
+          :aria-describedby="`report-description-counter-${fieldId}`"
+        />
+        <p
+          :id="`report-description-counter-${fieldId}`"
+          class="form__help report-dialog__char-counter"
+          :class="{ 'report-dialog__char-counter--warning': descriptionCharsRemaining <= 100 }"
+          aria-live="polite"
+        >{{ t('description_char_count', { remaining: descriptionCharsRemaining, max: MAX_DESCRIPTION_LENGTH }) }}</p>
+      </div>
+
+      <!-- Email display (read-only for authenticated users) -->
+      <div class="form__group">
+        <label
+          class="form__label"
+          :for="`report-email-${fieldId}`"
+        >
+          {{ t('email_label') }}
+        </label>
+        <div
+          :id="`report-email-${fieldId}`"
+          class="input report-dialog__email-display"
+        >{{ userEmail }}</div>
+      </div>
+
+      <footer class="report-dialog__actions">
         <button
           type="button"
           class="btn btn--secondary"
-          @click="close"
+          :disabled="state.isSubmitting"
+          @click="modalRef?.close()"
         >{{ t('cancel_button') }}</button>
-      </div>
-
-      <!-- Form State -->
-      <form
-        v-else
-        @submit.prevent="handleSubmit"
-        novalidate
-      >
-        <div
-          v-if="state.error"
-          class="alert alert--error alert--sm"
-          role="alert"
-          aria-live="polite"
-        >
-          {{ state.error }}
-        </div>
-
-        <div class="form__group">
-          <label
-            class="form__label"
-            :for="`report-category-${dialogId}`"
-          >
-            {{ t('category_label') }} <span aria-hidden="true">*</span>
-          </label>
-          <select
-            :id="`report-category-${dialogId}`"
-            ref="categoryRef"
-            v-model="form.category"
-            class="select"
-            required
-            :disabled="state.isSubmitting"
-          >
-            <option
-              value=""
-              disabled
-            >{{ t('category_label') }}</option>
-            <option
-              v-for="option in categoryOptions"
-              :key="option.value"
-              :value="option.value"
-            >{{ t(option.labelKey) }}</option>
-          </select>
-        </div>
-
-        <div class="form__group">
-          <label
-            class="form__label"
-            :for="`report-description-${dialogId}`"
-          >
-            {{ t('description_label') }} <span aria-hidden="true">*</span>
-          </label>
-          <textarea
-            :id="`report-description-${dialogId}`"
-            v-model="form.description"
-            class="textarea"
-            :placeholder="t('description_placeholder')"
-            :maxlength="MAX_DESCRIPTION_LENGTH"
-            rows="4"
-            required
-            :disabled="state.isSubmitting"
-            :aria-describedby="`report-description-counter-${dialogId}`"
-          />
-          <p
-            :id="`report-description-counter-${dialogId}`"
-            class="form__help report-dialog__char-counter"
-            :class="{ 'report-dialog__char-counter--warning': descriptionCharsRemaining <= 100 }"
-            aria-live="polite"
-          >{{ t('description_char_count', { remaining: descriptionCharsRemaining, max: MAX_DESCRIPTION_LENGTH }) }}</p>
-        </div>
-
-        <!-- Email display (read-only for authenticated users) -->
-        <div class="form__group">
-          <label
-            class="form__label"
-            :for="`report-email-${dialogId}`"
-          >
-            {{ t('email_label') }}
-          </label>
-          <div
-            :id="`report-email-${dialogId}`"
-            class="input report-dialog__email-display"
-          >{{ userEmail }}</div>
-        </div>
-
-        <footer class="report-dialog__actions">
-          <button
-            type="button"
-            class="btn btn--secondary"
-            :disabled="state.isSubmitting"
-            @click="close"
-          >{{ t('cancel_button') }}</button>
-          <button
-            type="submit"
-            class="btn btn--primary"
-            :disabled="state.isSubmitting"
-          >{{ state.isSubmitting ? t('submitting_button') : t('submit_button') }}</button>
-        </footer>
-      </form>
-    </div>
-  </dialog>
+        <button
+          type="submit"
+          class="btn btn--primary"
+          :disabled="state.isSubmitting"
+        >{{ state.isSubmitting ? t('submitting_button') : t('submit_button') }}</button>
+      </footer>
+    </form>
+  </Modal>
 </template>
 
 <style scoped lang="scss">
 // ================================================================
 // REPORT EVENT DIALOG (Client / Authenticated)
 // ================================================================
-// A modal dialog for authenticated users to report an event.
-// Uses the native <dialog> element for built-in accessibility.
-// Leverages the design system tokens for theming (auto dark mode).
-// Only component-specific layout styles remain here.
+// Content styles for the report-event form. The modal shell (backdrop,
+// header, close button, scroll lock) is owned by the shared <Modal>
+// component; only component-specific layout styles remain here.
 // ================================================================
 
-.report-dialog {
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  max-height: 100%;
-  padding: 0;
-  margin: 0;
-  border: none;
-  background: transparent;
-  overflow: auto;
-  z-index: var(--pav-z-index-modal);
-
-  &::backdrop {
-    background-color: rgb(0 0 0 / 50%);
-    backdrop-filter: blur(4px);
-  }
-}
-
-.report-dialog__content {
-  margin-block-start: 10vh;
-  margin-inline: auto;
-  padding: var(--pav-space-xl);
-  width: 100%;
-  max-width: 480px;
-  background-color: var(--pav-surface-primary);
-  border-radius: var(--pav-border-radius-modal);
-  border: var(--pav-border-width-1) solid var(--pav-border-primary);
-  box-shadow: var(--pav-shadow-modal);
-
-  @media (max-width: 768px) {
-    margin: var(--pav-space-md);
-    max-width: calc(100% - var(--pav-space-xl));
-  }
-}
-
-.report-dialog__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-block-end: var(--pav-space-xl);
-  padding-block-end: var(--pav-space-md);
-  border-block-end: var(--pav-border-width-1) solid var(--pav-border-subtle);
-
-  h2 {
-    margin: 0;
-    font-size: var(--pav-font-size-h6);
-    font-weight: var(--pav-font-weight-semibold);
-    color: var(--pav-text-primary);
-  }
-}
-
-.report-dialog__title-block {
-  display: flex;
-  flex-direction: column;
-  gap: var(--pav-space-xs);
-}
-
 .report-dialog__event-subtitle {
-  margin: 0;
+  margin: 0 0 var(--pav-space-lg) 0;
   font-size: var(--pav-font-size-sm);
   color: var(--pav-text-muted);
   font-style: italic;
@@ -404,14 +294,6 @@ defineExpose({ open, close, state });
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 320px;
-}
-
-.report-dialog__close {
-  font-size: var(--pav-font-size-xl);
-  line-height: 1;
-  min-width: 44px;
-  min-height: 44px;
-  flex-shrink: 0;
 }
 
 .report-dialog__success {
@@ -442,7 +324,7 @@ defineExpose({ open, close, state });
 
 .report-dialog__actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: end;
   gap: var(--pav-space-md);
   margin-block-start: var(--pav-space-xl);
   padding-block-start: var(--pav-space-lg);
@@ -452,10 +334,5 @@ defineExpose({ open, close, state });
 // Required asterisk color
 .form__label span {
   color: var(--pav-color-error);
-}
-
-// Prevent background scroll when modal is open
-:global(body.modal-open) {
-  overflow: hidden;
 }
 </style>

--- a/src/client/test/components/feed/events.test.ts
+++ b/src/client/test/components/feed/events.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { ref } from 'vue';
 import sinon from 'sinon';
@@ -60,9 +60,17 @@ describe('FollowedEventsView', () => {
     mockUnrepostEvent.mockReset();
     mockConfirmRepost.mockReset();
 
-    // Mock native dialog methods not implemented in happy-dom
-    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => {});
-    vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(() => {});
+    // Mock native dialog methods not implemented in happy-dom. The shared
+    // <Modal> component (via useDialog) guards close() on dialog.open, so the
+    // mocks must toggle the `open` property to keep that lifecycle faithful —
+    // a pure no-op would leave open=false and make close() a no-op, breaking
+    // the close-cascade assertion.
+    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(function (this: HTMLDialogElement) {
+      this.open = true;
+    });
+    vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(function (this: HTMLDialogElement) {
+      this.open = false;
+    });
 
     // Setup calendar store with a test calendar
     const calendarStore = useCalendarStore();
@@ -280,14 +288,15 @@ describe('FollowedEventsView', () => {
       },
     });
 
-    // Modal is not rendered initially
-    expect(wrapper.find('.report-dialog').exists()).toBe(false);
+    // Modal is not rendered initially (report-event modal is v-if-gated and
+    // renders its <dialog> via the shared <Modal> component)
+    expect(wrapper.find('dialog').exists()).toBe(false);
 
     // Install local spy before triggering so we can assert on this specific call
     const showModalSpy = vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => {});
     await wrapper.find('button[data-testid="report-button"]').trigger('click');
 
-    expect(wrapper.find('.report-dialog').exists()).toBe(true);
+    expect(wrapper.find('dialog').exists()).toBe(true);
     expect(showModalSpy).toHaveBeenCalled();
   });
 
@@ -317,12 +326,16 @@ describe('FollowedEventsView', () => {
 
     // Open the modal
     await wrapper.find('button[data-testid="report-button"]').trigger('click');
-    expect(wrapper.find('.report-dialog').exists()).toBe(true);
+    expect(wrapper.find('dialog').exists()).toBe(true);
 
-    // Close via the modal's close button
-    await wrapper.find('.report-dialog__close').trigger('click');
+    // Close via the Modal's close button (labelled with the 'modal.close' key).
+    // The close cascade runs through useDialog.close() -> Modal @close ->
+    // report-event handleClose -> emit('close') -> parent clears reportingEventId,
+    // so flush the reactive queue before asserting the v-if removed the dialog.
+    await wrapper.find('button[aria-label="modal.close"]').trigger('click');
+    await flushPromises();
 
-    expect(wrapper.find('.report-dialog').exists()).toBe(false);
+    expect(wrapper.find('dialog').exists()).toBe(false);
   });
 
   it('loads more events on scroll when intersection observer triggers', async () => {

--- a/src/client/test/components/report-event.test.ts
+++ b/src/client/test/components/report-event.test.ts
@@ -31,7 +31,6 @@ const TEST_EVENT_TITLE = 'Summer Festival';
  */
 const reportTranslations: Record<string, string> = {
   'report.form_title': 'report.form_title',
-  'report.close_dialog': 'report.close_dialog',
   'report.category_label': 'report.category_label',
   'report.category_spam': 'report.category_spam',
   'report.category_inappropriate': 'report.category_inappropriate',
@@ -51,6 +50,9 @@ const reportTranslations: Record<string, string> = {
   'report.error_generic': 'report.error_generic',
   'report.error_validation': 'report.error_validation',
   'report.event_subtitle': 'Reporting: {{title}}',
+  // Modal renders its close button with useTranslation('system') (no keyPrefix),
+  // so the aria-label key is 'modal.close'.
+  'modal.close': 'modal.close',
 };
 
 /** Helper to get the mocked submitReport from the most recent ReportService instance. */
@@ -253,7 +255,8 @@ describe('ReportEvent Component (Client)', () => {
       const wrapper = mountReportEvent();
       await flushPromises();
 
-      const closeButton = wrapper.find('.report-dialog__close');
+      // The Modal renders its own close button labelled with the 'modal.close' key.
+      const closeButton = wrapper.find('button[aria-label="modal.close"]');
       expect(closeButton.exists()).toBe(true);
       wrapper.unmount();
     });
@@ -570,7 +573,7 @@ describe('ReportEvent Component (Client)', () => {
       const wrapper = mountReportEvent();
       await flushPromises();
 
-      await wrapper.find('.report-dialog__close').trigger('click');
+      await wrapper.find('button[aria-label="modal.close"]').trigger('click');
       await flushPromises();
 
       expect(wrapper.emitted('close')).toBeTruthy();
@@ -604,7 +607,7 @@ describe('ReportEvent Component (Client)', () => {
       wrapper.unmount();
     });
 
-    it('should reset form fields after closing and reopening', async () => {
+    it('should reset form fields when the modal is closed', async () => {
       const wrapper = mountReportEvent();
       await flushPromises();
 
@@ -612,16 +615,15 @@ describe('ReportEvent Component (Client)', () => {
       await wrapper.find('select').setValue(ReportCategory.SPAM);
       await wrapper.find('textarea').setValue('Some description');
 
-      // Close the modal
-      await wrapper.find('.report-dialog__close').trigger('click');
+      // Close the modal via the Modal close button. handleClose() resets the
+      // form before emitting close (the production pattern unmounts on close,
+      // but the reset must still run on every close path).
+      await wrapper.find('button[aria-label="modal.close"]').trigger('click');
       await flushPromises();
 
-      // Re-open by calling exposed open method
-      const vm = wrapper.vm as any;
-      vm.open();
-      await flushPromises();
+      expect(wrapper.emitted('close')).toBeTruthy();
 
-      // Fields should be reset
+      // Fields are reset back to their initial empty values.
       expect((wrapper.find('select').element as HTMLSelectElement).value).toBe('');
       expect((wrapper.find('textarea').element as HTMLTextAreaElement).value).toBe('');
       wrapper.unmount();
@@ -631,7 +633,9 @@ describe('ReportEvent Component (Client)', () => {
       const wrapper = mountReportEvent();
       await flushPromises();
 
-      await wrapper.find('.report-dialog__close').trigger('click');
+      expect(document.body.classList.contains('modal-open')).toBe(true);
+
+      await wrapper.find('button[aria-label="modal.close"]').trigger('click');
       await flushPromises();
 
       expect(document.body.classList.contains('modal-open')).toBe(false);


### PR DESCRIPTION
## Motivation

`report-event.vue` was a hand-rolled `<dialog>`: it built its own focus management, header/close button, backdrop click handler, and scroll lock instead of consuming the canonical `<Modal>` component. Because of this it never inherited improvements to the shared `useDialog` composable — notably the heading-focus-on-open behavior — and it duplicated backdrop/header/close SCSS that had drifted from the shared component. The `frontend-modals` standard explicitly calls this out: "Do not hand-roll modal overlays."

## Approach

Replace the hand-rolled `<dialog>` with `<Modal :title="t('form_title')" size="lg">`, moving the form into the default slot and relocating the event subtitle into the slot body (Modal's `:title` is a plain string). Delete the local `dialogRef`/`titleId`/`open()`/`handleBackdropClick()`/lifecycle plumbing and the duplicated `.report-dialog*` SCSS — all now owned by `<Modal>` and `useDialog`.

The key correctness point: every close path (Escape, header close button, Cancel, success-dismiss) routes through Modal's exposed `close()`, which restores focus to the triggering element before emitting `close`. An earlier iteration had the in-slot Cancel/dismiss buttons bypass this and drop focus to `document.body` — a WCAG 2.4.3 (Level A) regression — which was caught in review and fixed.

Tests were updated to assert against the Modal-mediated DOM (`button[aria-label="modal.close"]`, the rendered `<dialog>`) instead of the removed `.report-dialog` classes. The consumer test `feed/events.test.ts` was also updated, and its `HTMLDialogElement` mocks corrected to toggle `open` so `useDialog.close()`'s guard executes.

No parent-component changes were needed: both consumers already render the component behind `v-if` and listen for `@close`.

## Validation

- `npm run lint`: 0 errors.
- Unit + integration suites green via build-guardian (8,189 unit / 651 integration passing); `report-event.test.ts` (34) and `feed/events.test.ts` (7) pass. Pre-existing e2e failures (admin-accounts, admin-moderation, import-sources SSL cert, widget-config-roundtrip) are unrelated to this change.
- Manual browser validation (Playwright): dialog opens with focus on the heading; focus restores to the trigger button on all three close paths (Escape, header ×, Cancel); `body.modal-open` scroll lock sets and clears correctly; no console errors attributable to the dialog.