### PR TITLE
feat(ap-inbox): cascade Note Update/Delete for re-shared remote events

### DIFF
--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -1541,6 +1541,43 @@ class ProcessInboxService {
     // and the AP handler (skip re-broadcast to federation) that this originated remotely.
     if (updatedEvent) {
       this.eventBus.emit('eventUpdated', { calendar: null, event: updatedEvent });
+
+      // Paired Update(Note) cascade for inbox-originated updates of a remote
+      // event THIS calendar has re-shared. The `eventUpdated { calendar: null }`
+      // emission above is the remote loop guard — the outbox handler early-returns
+      // on the null calendar, so it emits no Note. We mirror the Create(Note)
+      // cascade in checkAndPerformAutoRepost here so Mastodon-class followers of
+      // a reposting calendar see edits replace the post.
+      //
+      // Gate on CURRENT sharing state — does this calendar have a
+      // SharedEventEntity row for this event? — NOT on RepostDismissalEntity
+      // (DEC-008): the dismissal record governs the separate re-share-creation
+      // path; an unposted calendar already has its SharedEventEntity row
+      // destroyed (members.ts unshareEvent), so it is naturally skipped here.
+      //
+      // A locally-owned event is excluded here by the SharedEventEntity lookup
+      // returning null: a calendar never re-shares its own event (the loop guard
+      // in checkAndPerformAutoRepost), so no share row exists for it. `apObject`
+      // is non-null on every path that reaches this point — the eventParams
+      // build above already dereferences `apObject.event_id` — so the lookup
+      // below is safe.
+      const share = await SharedEventEntity.findOne({
+        where: { event_id: apObject.event_id, calendar_id: calendar.id },
+      });
+      if (share) {
+        const actorUrl = ActivityPubActor.actorUrl(calendar);
+        // Reconstruct the Note identically to the Create(Note) cascade so the
+        // Update(Note) IRI byte-matches the original — a mismatch makes
+        // Mastodon silently no-op the edit.
+        await addToOutbox(
+          this.eventBus,
+          calendar,
+          new UpdateActivity(
+            actorUrl,
+            new NoteObject(calendar, updatedEvent, { urlOverride: apObjectId }),
+          ).addressPublic(`${actorUrl}/followers`),
+        );
+      }
     }
 
     // Update source_series on the AP object record (strict allowlist validation)
@@ -1697,11 +1734,44 @@ class ProcessInboxService {
       }
     }
 
+    // Capture the SharedEventEntity row BEFORE the delete so we know whether
+    // this calendar had re-shared the event (existingEvent is guaranteed
+    // non-null by the `if (!existingEvent || !eventIdToDelete) return` guard
+    // above). Gate on current sharing state, NOT RepostDismissalEntity — see
+    // the rationale in processUpdateEvent. A source-initiated delete is not an
+    // owner unpost, so no RepostDismissalEntity is written.
+    const share = await SharedEventEntity.findOne({
+      where: { event_id: eventIdToDelete, calendar_id: calendar.id },
+    });
+
     await this.calendarInterface.deleteRemoteEvent(eventIdToDelete);
 
     // Also delete the EventObjectEntity record if it exists
     if (apObject) {
       await apObject.destroy();
+    }
+
+    // Paired Delete(Note) cascade for inbox-originated deletes of a remote
+    // event THIS calendar has re-shared. Mirrors handleEventDeleted's Note IRI
+    // string form so the Delete(Note) IRI byte-matches the Create(Note) the
+    // cascade originally minted — a mismatch makes Mastodon silently no-op.
+    if (share) {
+      const actorUrl = ActivityPubActor.actorUrl(calendar);
+      try {
+        await addToOutbox(
+          this.eventBus,
+          calendar,
+          new DeleteActivity(
+            actorUrl,
+            NoteObject.noteUrl(calendar, existingEvent),
+          ).addressPublic(`${actorUrl}/followers`),
+        );
+      }
+      finally {
+        // Clean up the now-orphaned SharedEventEntity row even if addToOutbox
+        // throws — the event no longer exists, so the share row must not linger.
+        await share.destroy();
+      }
     }
 
     logger.info(`Deleted event ${eventIdToDelete} from ${isPersonActor ? 'Person' : 'Calendar'} actor ${actorUri}`);

--- a/src/server/activitypub/test/inbox-source-series.test.ts
+++ b/src/server/activitypub/test/inbox-source-series.test.ts
@@ -21,6 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ProcessInboxService from '@/server/activitypub/service/inbox';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
+import { SharedEventEntity } from '@/server/activitypub/entity/activitypub';
 import CreateActivity from '@/server/activitypub/model/action/create';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
@@ -61,6 +62,12 @@ describe('ProcessInboxService - source_series parsing', () => {
 
     // Stub checkAndPerformAutoRepost to avoid follow-up processing
     sandbox.stub(inboxService as any, 'checkAndPerformAutoRepost').resolves();
+
+    // These tests exercise source_series parsing, not re-shared events, so the
+    // lifecycle Note cascade must not fire. Stub the SharedEventEntity lookup to
+    // return null (no share row) — this file stubs entities rather than syncing
+    // a real schema, so without this the new findOne would hit a missing table.
+    sandbox.stub(SharedEventEntity, 'findOne').resolves(null);
 
   });
 

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -12,6 +12,7 @@ import AnnounceActivity from '@/server/activitypub/model/action/announce';
 import CreateActivity from '@/server/activitypub/model/action/create';
 import UpdateActivity from '@/server/activitypub/model/action/update';
 import DeleteActivity from '@/server/activitypub/model/action/delete';
+import { NoteObject } from '@/server/activitypub/model/object/note';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
 import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { CalendarEntity } from '@/server/calendar/entity/calendar';
@@ -1196,14 +1197,375 @@ describe('ProcessInboxService - checkAndPerformAutoRepost paired Note emission',
     expect(apForm.url).toBeUndefined();
   });
 
-  // GAP DOCUMENTATION: Update(Event) and Delete(Event) cascades for
-  // SharedEventEntity-bound events do not exist as distinct inbox emission
-  // sites. `processUpdateEvent` emits `eventUpdated` with calendar: null
-  // (which the outbox handler returns from early — loop prevention) and
-  // `processDeleteEvent` makes no bus emission at all. Paired Note Update /
-  // Delete propagation for locally-owned events lives in the outbox event
-  // handlers (handleEventUpdated / handleEventDeleted) and is covered by
-  // sibling pv-l35p.2.
+});
+
+describe('ProcessInboxService - inbox-originated lifecycle Note cascade (pv-taf2)', () => {
+  let sandbox: sinon.SinonSandbox;
+  let inboxService: ProcessInboxService;
+  let eventBus: EventEmitter;
+  let testCalendar: Calendar;
+  let calendarInterface: CalendarInterface;
+
+  const sourceActorUri = 'https://remote.instance/calendars/source-calendar';
+
+  beforeEach(async () => {
+    await setupActivityPubSchema();
+    sandbox = sinon.createSandbox();
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    inboxService = new ProcessInboxService(eventBus, calendarInterface);
+
+    testCalendar = new Calendar('test-calendar-id', 'test-calendar');
+    testCalendar.addContent('en', new CalendarContent('en'));
+    testCalendar.content('en').title = 'Test Calendar';
+
+    await CalendarEntity.create({
+      id: testCalendar.id,
+      url_name: testCalendar.urlName,
+      account_id: uuidv4(),
+      languages: 'en',
+    });
+
+    // Other test files may leave `PRAGMA foreign_keys = ON` on the shared
+    // SQLite connection; share/dismissal rows reference EventEntity, which
+    // setupActivityPubSchema() does not sync.
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = OFF');
+
+    sandbox.stub(console, 'log');
+    sandbox.stub(console, 'warn');
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await teardownActivityPubSchema();
+    const db = (await import('@/server/common/entity/db')).default;
+    await db.query('PRAGMA foreign_keys = ON');
+  });
+
+  function buildReconstitutedEvent(eventId: string): CalendarEvent {
+    const event = new CalendarEvent(eventId, null);
+    event.addContent(new CalendarEventContent('en', 'Reposted Event', ''));
+    return event;
+  }
+
+  async function seedEventObject(eventId: string, eventApId: string) {
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: sourceActorUri,
+    });
+  }
+
+  async function seedShare(eventId: string) {
+    await SharedEventEntity.create({
+      id: uuidv4(),
+      event_id: eventId,
+      calendar_id: testCalendar.id,
+      auto_posted: true,
+    });
+  }
+
+  // AC1: re-shared event Update → paired Update(Note) to the reposting calendar.
+  it('emits a paired Update(Note) when an Update(Event) lands on a re-shared event', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    await seedShare(eventId);
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'updateRemoteEvent').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const updateMessage = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: sourceActorUri,
+      object: { id: eventApId, type: 'Event', name: 'Updated Event' },
+    });
+
+    await inboxService.processUpdateEvent(testCalendar, updateMessage!);
+
+    const updates = enqueued.filter(a => a.type === 'Update');
+    expect(updates.length).toBe(1);
+    const noteUpdate = updates[0];
+    expect(noteUpdate.object.type).toBe('Note');
+    expect(noteUpdate.object.attributedTo).toContain('/calendars/test-calendar');
+    expect(noteUpdate.to).toContain('https://www.w3.org/ns/activitystreams#Public');
+    expect(noteUpdate.cc[0]).toContain('/calendars/test-calendar/followers');
+    // Serialized Note `url` equals the remote canonical IRI (urlOverride).
+    expect(noteUpdate.object.toActivityPubObject().url).toBe(eventApId);
+  });
+
+  // AC2: no share row → no Update(Note); failed update → no Update(Note).
+  it('emits no Update(Note) when the event is not re-shared', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    // No SharedEventEntity row.
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'updateRemoteEvent').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const updateMessage = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: sourceActorUri,
+      object: { id: eventApId, type: 'Event', name: 'Updated Event' },
+    });
+
+    await inboxService.processUpdateEvent(testCalendar, updateMessage!);
+
+    expect(enqueued.filter(a => a.type === 'Update').length).toBe(0);
+  });
+
+  it('emits no Update(Note) when updateRemoteEvent returns null even with a share row', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    await seedShare(eventId);
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'updateRemoteEvent').resolves(null);
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const updateMessage = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: sourceActorUri,
+      object: { id: eventApId, type: 'Event', name: 'Updated Event' },
+    });
+
+    await inboxService.processUpdateEvent(testCalendar, updateMessage!);
+
+    expect(enqueued.filter(a => a.type === 'Update').length).toBe(0);
+  });
+
+  // AC3: re-shared event Delete → paired Delete(Note), IRI string === noteUrl.
+  it('emits a paired Delete(Note) when a Delete(Event) lands on a re-shared event', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    await seedShare(eventId);
+
+    const existingEvent = buildReconstitutedEvent(eventId);
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(existingEvent);
+    sandbox.stub(calendarInterface, 'deleteRemoteEvent').resolves();
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const deleteMessage = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: sourceActorUri,
+      object: eventApId,
+    });
+
+    await inboxService.processDeleteEvent(testCalendar, deleteMessage!);
+
+    const deletes = enqueued.filter(a => a.type === 'Delete');
+    expect(deletes.length).toBe(1);
+    const noteDelete = deletes[0];
+    // object is the Note IRI string, equal to noteUrl(calendar, event).
+    expect(noteDelete.object).toBe(NoteObject.noteUrl(testCalendar, existingEvent));
+    expect(noteDelete.to).toContain('https://www.w3.org/ns/activitystreams#Public');
+    expect(noteDelete.cc[0]).toContain('/calendars/test-calendar/followers');
+  });
+
+  // AC4: Delete(Note) IRI equals the IRI the Create(Note) cascade minted for the
+  // same (calendar, event) pair — executable cross-path parity (not a tautology).
+  it('Delete(Note) IRI byte-matches the Create(Note) cascade IRI for the same (calendar, event)', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+
+    // Seed full auto-repost prerequisites so the real Create(Note) cascade runs.
+    const remoteCalendarActorId = uuidv4();
+    await CalendarActorEntity.create({
+      id: remoteCalendarActorId,
+      actor_type: 'remote',
+      actor_uri: sourceActorUri,
+      remote_display_name: null,
+      remote_domain: 'remote.instance',
+      calendar_id: null,
+      private_key: null,
+    });
+    await FollowingCalendarEntity.create({
+      id: uuidv4(),
+      calendar_actor_id: remoteCalendarActorId,
+      calendar_id: testCalendar.id,
+      auto_repost_originals: true,
+      auto_repost_reposts: false,
+    });
+    await seedEventObject(eventId, eventApId);
+
+    const event = buildReconstitutedEvent(eventId);
+    sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
+    sandbox.stub(calendarInterface, 'getEventById').resolves(event);
+
+    const cascadeEnqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => cascadeEnqueued.push(activity));
+
+    // Run the real Create(Note) cascade.
+    await (inboxService as any).checkAndPerformAutoRepost(
+      testCalendar, sourceActorUri, eventApId, true,
+    );
+    const createNote = cascadeEnqueued.find(a => a.type === 'Create' && a.object?.type === 'Note');
+    expect(createNote).toBeDefined();
+    const createNoteIri = createNote.object.toActivityPubObject().id;
+
+    // Now run the Delete(Event) for the same (calendar, event). The cascade
+    // already created the SharedEventEntity row, so this is a true re-shared
+    // event delete.
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'deleteRemoteEvent').resolves();
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const deleteEnqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => deleteEnqueued.push(activity));
+
+    const deleteMessage = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: sourceActorUri,
+      object: eventApId,
+    });
+    await inboxService.processDeleteEvent(testCalendar, deleteMessage!);
+
+    const deleteNote = deleteEnqueued.find(a => a.type === 'Delete');
+    expect(deleteNote).toBeDefined();
+    expect(deleteNote.object).toBe(createNoteIri);
+  });
+
+  // AC5: non-reshared event Delete → no Delete(Note).
+  it('emits no Delete(Note) when the deleted event is not re-shared', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    // No SharedEventEntity row.
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'deleteRemoteEvent').resolves();
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const deleteMessage = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: sourceActorUri,
+      object: eventApId,
+    });
+
+    await inboxService.processDeleteEvent(testCalendar, deleteMessage!);
+
+    expect(enqueued.filter(a => a.type === 'Delete').length).toBe(0);
+  });
+
+  // AC6: orphaned SharedEventEntity row removed on delete; no RepostDismissalEntity written.
+  it('removes the orphaned SharedEventEntity row and writes no RepostDismissalEntity on delete', async () => {
+    const eventId = uuidv4();
+    const eventApId = `https://remote.instance/events/${eventId}`;
+    await seedEventObject(eventId, eventApId);
+    await seedShare(eventId);
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(false);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'deleteRemoteEvent').resolves();
+    sandbox.stub(inboxService as any, 'actorOwnsObject').resolves(true);
+
+    const deleteMessage = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: sourceActorUri,
+      object: eventApId,
+    });
+
+    await inboxService.processDeleteEvent(testCalendar, deleteMessage!);
+
+    const remainingShares = await SharedEventEntity.count({
+      where: { event_id: eventId, calendar_id: testCalendar.id },
+    });
+    expect(remainingShares).toBe(0);
+
+    const dismissals = await RepostDismissalEntity.count({
+      where: { event_id: eventId, calendar_id: testCalendar.id },
+    });
+    expect(dismissals).toBe(0);
+  });
+
+  // AC7: Person-actor update/delete of a locally-owned (non-reshared) event emits no Note.
+  it('emits no Note on a Person-actor update of a locally-owned event with no share row', async () => {
+    const personActorUri = 'https://user.instance/users/editor';
+    const eventApId = 'https://remote.instance/events/owned-event';
+    const eventId = uuidv4();
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: 'https://remote.instance/calendars/source',
+    });
+    // No SharedEventEntity row — locally-owned events are never re-shared.
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(true);
+    sandbox.stub(inboxService as any, 'isAuthorizedRemoteEditor').resolves(true);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'updateRemoteEvent').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const updateMessage = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: personActorUri,
+      object: {
+        id: eventApId,
+        type: 'Event',
+        name: 'Editor Updated Event',
+        eventParams: { id: eventId, name: 'Editor Updated Event' },
+      },
+    });
+
+    await inboxService.processUpdateEvent(testCalendar, updateMessage!);
+
+    expect(enqueued.filter(a => a.type === 'Update').length).toBe(0);
+  });
+
+  it('emits no Note on a Person-actor delete of a locally-owned event with no share row', async () => {
+    const personActorUri = 'https://user.instance/users/editor';
+    const eventApId = 'https://remote.instance/events/owned-event-2';
+    const eventId = uuidv4();
+    await EventObjectEntity.create({
+      event_id: eventId,
+      ap_id: eventApId,
+      attributed_to: 'https://remote.instance/calendars/source',
+    });
+    // No SharedEventEntity row.
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(true);
+    sandbox.stub(inboxService as any, 'isAuthorizedRemoteEditor').resolves(true);
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    sandbox.stub(calendarInterface, 'deleteRemoteEvent').resolves();
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+
+    const deleteMessage = DeleteActivity.fromObject({
+      type: 'Delete',
+      actor: personActorUri,
+      object: { id: eventApId, type: 'Tombstone', eventId },
+    });
+
+    await inboxService.processDeleteEvent(testCalendar, deleteMessage!);
+
+    expect(enqueued.filter(a => a.type === 'Delete').length).toBe(0);
+  });
 });
 
 describe('ProcessInboxService - processUpdateEvent', () => {


### PR DESCRIPTION
## Motivation

Pavillion already emits a paired `Create(Note)` when a calendar auto-reposts a remote event, so Mastodon-class followers (which ignore `type: Event` activities) render the post. The lifecycle follow-through was never built: when the source instance later edited or deleted the event, no `Update(Note)` or `Delete(Note)` reached the reposting calendar's followers. Those followers saw the post appear, never saw edits, and kept seeing a stale post after the source deleted the event — contradicting the rendering model's promise that edits replace and deletions remove.

The self-owned-event path (`events/index.ts` outbox handlers) already emits the full Create/Update/Delete Note triad. This change closes the equivalent gap on the inbox-originated re-shared path.

## Approach

Two emissions added in `src/server/activitypub/service/inbox.ts`, mirroring the existing `Create(Note)` cascade structurally:

- **`processUpdateEvent`** emits a paired `Update(Note)` to the receiving calendar's followers when that calendar currently re-shares the event.
- **`processDeleteEvent`** emits a paired `Delete(Note)` (string IRI form, mirroring the self-owned `handleEventDeleted`), then removes the now-orphaned `SharedEventEntity` row in a `finally` so cleanup runs even if the outbox enqueue throws.

Design notes:

- **Per-receiving-calendar emission**, not iterate-all-shares: each inbox message is scoped to one calendar, and the source delivers separately to each follower's inbox, so iterating all shares would produce O(N²) emissions and cross-calendar outbox-ownership confusion.
- **Gated on current sharing state** (`SharedEventEntity` presence), not on the dismissal record — these govern distinct operations; an unposted calendar already has its share row destroyed and is naturally skipped. The source-initiated delete writes no dismissal (it is not an owner unpost).
- **Note IRIs reconstructed identically** to the original `Create(Note)`. A mismatch makes peers silently no-op the edit/delete, so the IRI parity is load-bearing.

Out of scope (documented, pre-existing federation limitations): transitive reposts, and unpost not withdrawing the Note.

## Validation

- New lock-in tests in `inbox.test.ts` replace the prior gap-documentation block: update/delete emission, negative paths (no share row; failed update), an executable cross-path IRI-parity assertion (real `Create(Note)` vs `Delete(Note)` for the same calendar/event), orphan-row cleanup with no dismissal written, and Person-actor no-emission.
- `inbox.test.ts` (52) and `inbox-source-series.test.ts` (13) pass; the latter gained a `SharedEventEntity.findOne` stub since it stubs entities rather than syncing a schema.
- `npm run lint`: 0 errors. Full unit suite green for the ActivityPub surface; build, integration, and e2e pass. (One notifications test file flakes under full-suite ordering but passes in isolation — a pre-existing test-isolation issue in an unrelated domain.)