### PR TITLE
fix(calendar): require auth on location GET endpoints

### DIFF
--- a/src/server/calendar/api/v1/location.ts
+++ b/src/server/calendar/api/v1/location.ts
@@ -57,9 +57,9 @@ export default class LocationRoutes {
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
 
-    router.get('/calendars/:calendarId/locations', this.listLocations.bind(this));
+    router.get('/calendars/:calendarId/locations', ExpressHelper.loggedInOnly, this.listLocations.bind(this));
     router.post('/calendars/:calendarId/locations', ExpressHelper.loggedInOnly, this.createLocation.bind(this));
-    router.get('/calendars/:calendarId/locations/:locationId', this.getLocation.bind(this));
+    router.get('/calendars/:calendarId/locations/:locationId', ExpressHelper.loggedInOnly, this.getLocation.bind(this));
     router.put('/calendars/:calendarId/locations/:locationId', ExpressHelper.loggedInOnly, this.updateLocation.bind(this));
     router.delete('/calendars/:calendarId/locations/:locationId', ExpressHelper.loggedInOnly, this.deleteLocation.bind(this));
     router.post(

--- a/src/server/calendar/test/api/location.test.ts
+++ b/src/server/calendar/test/api/location.test.ts
@@ -252,6 +252,9 @@ describe('Location API Tests', () => {
         'OR',
         '97221',
       );
+      // Federated Place — originUri is a server-internal AP-origin hint.
+      // Authenticated callers receive the unchanged full shape (pv-if96).
+      location.originUri = 'https://remote.example/locations/abc';
 
       (calendarInterface.getCalendar as sinon.SinonStub).resolves(testCalendar);
       (calendarInterface.getLocationById as sinon.SinonStub).resolves(location);
@@ -262,6 +265,9 @@ describe('Location API Tests', () => {
 
       expect(response.body.name).toBe('Washington Park');
       expect(response.body.address).toBe('4033 SW Canyon Rd');
+      // Positive-contract guard: authenticated GET still includes originUri
+      // for federated Places (gating, not stripping — pv-if96).
+      expect(response.body.originUri).toBe('https://remote.example/locations/abc');
     });
 
     it('should return location with content', async () => {
@@ -777,6 +783,67 @@ describe('Location API Tests', () => {
       expect(response.body.errorName).toBe('InsufficientCalendarPermissionsError');
       // Auth check fails before the service call
       expect((calendarInterface.reassignEvents as sinon.SinonStub).called).toBe(false);
+    });
+  });
+
+  // Anonymous-rejection contract (pv-if96): both GET endpoints are gated by
+  // ExpressHelper.loggedInOnly, so anonymous callers are rejected (403) before
+  // any location data — including the server-internal originUri AP-origin hint
+  // — is serialized. Uses its own sandbox/app because the shared sandbox
+  // already stubs loggedInOnly to inject a user; re-stubbing the same property
+  // throws.
+  describe('GET endpoints reject anonymous requests', () => {
+    let anonSandbox: sinon.SinonSandbox;
+    let anonApp: Application;
+    let anonInterface: CalendarInterface;
+
+    beforeEach(() => {
+      anonSandbox = sinon.createSandbox();
+      anonApp = express();
+      anonApp.use(express.json());
+
+      // Stub loggedInOnly to a reject middleware standing in for the real
+      // passport-jwt 403 on a missing/invalid token.
+      anonSandbox.stub(ExpressHelper, 'loggedInOnly').value([
+        (req: Request, res: Response) => {
+          res.status(403).json({ message: 'forbidden' });
+        },
+      ]);
+
+      anonInterface = {
+        getCalendar: anonSandbox.stub(),
+        getLocationsForCalendar: anonSandbox.stub(),
+        getLocationById: anonSandbox.stub(),
+      } as unknown as CalendarInterface;
+
+      const anonRoutes = new LocationRoutes(anonInterface);
+      anonRoutes.installHandlers(anonApp, '/api/v1');
+    });
+
+    afterEach(() => {
+      anonSandbox.restore();
+    });
+
+    it('listLocations returns 403 and never invokes the location service', async () => {
+      await request(anonApp)
+        .get('/api/v1/calendars/cal-123/locations')
+        .expect(403);
+
+      // 403 alone proves the handler did not run; the service-not-called
+      // assertion documents that no location data was serialized.
+      expect((anonInterface.getCalendar as sinon.SinonStub).called).toBe(false);
+      expect((anonInterface.getLocationsForCalendar as sinon.SinonStub).called).toBe(false);
+    });
+
+    it('getLocation returns 403 and never invokes the location service', async () => {
+      const locationId = 'c3d4e5f6-0001-4000-8000-000000000001';
+
+      await request(anonApp)
+        .get(`/api/v1/calendars/cal-123/locations/${encodeURIComponent(locationId)}`)
+        .expect(403);
+
+      expect((anonInterface.getCalendar as sinon.SinonStub).called).toBe(false);
+      expect((anonInterface.getLocationById as sinon.SinonStub).called).toBe(false);
     });
   });
 });

--- a/src/server/calendar/test/integration/place_atomic_save.test.ts
+++ b/src/server/calendar/test/integration/place_atomic_save.test.ts
@@ -196,6 +196,7 @@ describe('Place + Spaces atomic-save - Integration', () => {
 
       const verify = await request(env.app)
         .get(`/api/v1/calendars/${testCalendar.id}/locations/${encodeURIComponent(placeId)}`)
+        .set('Authorization', 'Bearer ' + ownerAuthKey)
         .expect(200);
       expect(verify.body.spaces).toHaveLength(2);
       expect(verify.body.spaces.map((s: any) => s.id).sort()).toEqual(
@@ -235,6 +236,7 @@ describe('Place + Spaces atomic-save - Integration', () => {
       // before any diff write runs). Verify by re-reading.
       const verify = await request(env.app)
         .get(`/api/v1/calendars/${testCalendar.id}/locations/${encodeURIComponent(placeA.body.id)}`)
+        .set('Authorization', 'Bearer ' + ownerAuthKey)
         .expect(200);
       expect(verify.body.spaces).toHaveLength(placeASpaces.length);
       // Place B's Space row also still exists.


### PR DESCRIPTION
## Motivation

The two GET handlers on the authenticated calendar location API — `GET /api/v1/calendars/:calendarId/locations` (list) and `GET /api/v1/calendars/:calendarId/locations/:locationId` (single) — lacked an authentication guard. Both serialize `originUri`, a server-internal ActivityPub-origin identity hint for federated Places (and per-space `originUri`). Anonymous visitors could therefore observe which AP instance a Place federated from — an internal implementation detail with no public use case, and a data-minimization gap. The POST/PUT/DELETE/reassign routes on the same router were already gated; only the two GETs leaked.

## Approach

Add `ExpressHelper.loggedInOnly` to both GET route registrations in `installHandlers`, mirroring the mutating routes on the same router. Anonymous requests now receive 403 before any location data is serialized.

Gating was chosen over stripping `originUri` from the serializer. The authenticated client round-trips fetched locations through `EventLocation.fromObject()` on save; `fromObject` leaves `originUri` null when absent, so stripping it from the GET would null out `originUri` on federated Places when the client saves an edit — silent data loss. Gating preserves the authenticated wire shape; anonymous location display continues to flow through the separate public API (`/api/public/v1/`), which already strips internal fields.

This closes the anonymous (Tier-1) exposure. Residual cross-account read scope — any authenticated user can read any calendar's locations because these GETs carry no per-calendar authorization — is intentionally out of scope here and tracked as a separate follow-up.

## Validation

- New API tests assert anonymous rejection (403) on both GET endpoints, using a separate sandbox/app with `loggedInOnly` stubbed to a reject middleware, and verify the location service is never invoked (proving the guard fires before serialization).
- Added a positive-contract assertion that an authenticated GET still includes a non-null `originUri` — a regression guard locking in gating-not-stripping.
- Updated the place atomic-save integration test to authenticate its verification reads (they previously relied on the GET being ungated).
- `npm run lint`: 0 errors. Full integration suite: 651 passed, 0 failed. Unit suite and production build green. The two e2e failures observed locally are pre-existing environment issues (no dev server on :3100; missing federation SSL fixture) unrelated to this change.