### PR TITLE
fix: connect autoheal to socket-proxy over a unix socket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,10 +179,21 @@ services:
       - ./docker/socket-proxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
       # Read-only mount: the HAProxy ruleset enforces the API allowlist.
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    # No host port published — reachable only on the internal compose network.
+      # HAProxy publishes the locked-down API as a unix socket here; autoheal
+      # mounts the same volume to reach it. No TCP port is exposed.
+      - autoheal-proxy-sock:/run/proxy
+    # No host port published — reachable only via the shared socket volume.
     security_opt:
       - no-new-privileges:true
     restart: unless-stopped
+    # autoheal's entrypoint checks `[ -e "$DOCKER_SOCK" ]` at startup, so it must
+    # not start until HAProxy has created the proxied socket. Gate it on this.
+    healthcheck:
+      test: ["CMD-SHELL", "test -S /run/proxy/docker.sock"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
     logging:
       driver: "json-file"
       options:
@@ -190,22 +201,30 @@ services:
         max-file: "5"
 
   # Autoheal monitors container health and restarts unhealthy containers.
-  # It reaches the Docker API through socket-proxy over the internal network
-  # rather than mounting /var/run/docker.sock directly. Pinned by digest; this
-  # is the 1.2.0 image already running in production (the amd64 variant is
-  # healthy — note the arm64 variant of this tag has a broken entrypoint).
+  # It reaches the Docker API through socket-proxy via a shared unix socket
+  # rather than mounting /var/run/docker.sock directly. The socket path is a
+  # real file, which satisfies autoheal's `[ -e "$DOCKER_SOCK" ]` startup guard
+  # and selects its plain-HTTP unix-socket mode (its tcp:// mode would demand
+  # client TLS certs the proxy does not serve). Pinned by digest so a tag
+  # re-push of the third-party image cannot silently change the binary.
   autoheal:
     image: willfarrell/autoheal:1.2.0@sha256:31f580ef0279eaced5b38d631b08c474d70d8403c1c2fdd6ddcf2e879d5f3f7c
     container_name: pavillion-autoheal
     depends_on:
-      - socket-proxy
+      # Wait for HAProxy to create the proxied socket before starting, or the
+      # `[ -e "$DOCKER_SOCK" ]` guard fails and autoheal exits 127.
+      socket-proxy:
+        condition: service_healthy
     environment:
       - AUTOHEAL_CONTAINER_LABEL=autoheal
       - AUTOHEAL_INTERVAL=30
       - AUTOHEAL_START_PERIOD=120
-      # Talk to the locked-down proxy instead of the raw socket. autoheal
-      # converts a tcp:// DOCKER_SOCK into an HTTP endpoint internally.
-      - DOCKER_SOCK=tcp://socket-proxy:2375
+      # Plain-HTTP unix socket served by the locked-down proxy.
+      - DOCKER_SOCK=/run/proxy/docker.sock
+    volumes:
+      # Shared with socket-proxy; carries only the proxied API socket, never the
+      # raw /var/run/docker.sock.
+      - autoheal-proxy-sock:/run/proxy
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -275,6 +294,11 @@ volumes:
     name: pavillion-caddy-data
   caddy-config:
     name: pavillion-caddy-config
+  # Carries only the proxied Docker API socket that HAProxy publishes for
+  # autoheal. The raw /var/run/docker.sock is never placed here.
+  autoheal-proxy-sock:
+    name: pavillion-autoheal-proxy-sock
+
   pavillion-backups:
     name: pavillion-backups
     # Operators can configure this volume to use different backing storage:

--- a/docker/socket-proxy.cfg
+++ b/docker/socket-proxy.cfg
@@ -37,7 +37,18 @@ backend dockerbackend
     server dockersocket /var/run/docker.sock
 
 frontend dockerfrontend
-    bind *:2375
+    # autoheal connects over a unix socket shared through a Docker volume rather
+    # than a TCP port. willfarrell/autoheal 1.2.0 only speaks two dialects: a
+    # filesystem socket path (plain HTTP over --unix-socket) or a tcp:// URL that
+    # it rewrites to https:// and expects to be guarded by client TLS certs. It
+    # has no plain-HTTP-over-TCP mode, and its entrypoint additionally guards the
+    # monitor loop with `[ -e "$DOCKER_SOCK" ]`, which is false for a tcp:// URL —
+    # so a tcp:// endpoint makes it exit 127 in a crash loop. Exposing a unix
+    # socket sidesteps both problems and is strictly more locked down: only the
+    # container that mounts the shared socket volume (autoheal) can reach the
+    # proxy, not every container on the compose network. HAProxy runs as root and
+    # autoheal connects as root, so mode 660 suffices.
+    bind unix@/run/proxy/docker.sock mode 660
 
     # Reads (GET) and the restart action (POST) only. DELETE/PUT/etc. are denied.
     http-request deny unless METH_GET || METH_POST

--- a/src/server/housekeeping/test/docker-config.test.ts
+++ b/src/server/housekeeping/test/docker-config.test.ts
@@ -124,13 +124,34 @@ describe('Docker Configuration', () => {
       expect(hasDockerSocket).toBe(false);
     });
 
-    it('should reach the Docker API through the socket-proxy', () => {
+    it('should reach the Docker API through the socket-proxy unix socket', () => {
       const composeContent = readFileSync('docker-compose.yml', 'utf-8');
       const config = parseYaml(composeContent);
 
+      // autoheal 1.2.0 has no plain-HTTP-over-TCP mode and guards its monitor
+      // loop with `[ -e "$DOCKER_SOCK" ]`, so it must be pointed at a real
+      // socket file, not a tcp:// URL. It reaches the proxied API over a unix
+      // socket shared with socket-proxy via the autoheal-proxy-sock volume.
       const env = config.services.autoheal.environment;
-      expect(env).toContain('DOCKER_SOCK=tcp://socket-proxy:2375');
-      expect(config.services.autoheal.depends_on).toContain('socket-proxy');
+      expect(env).toContain('DOCKER_SOCK=/run/proxy/docker.sock');
+      expect(env).not.toContain('DOCKER_SOCK=tcp://socket-proxy:2375');
+
+      const volumes = config.services.autoheal.volumes ?? [];
+      expect(volumes).toContain('autoheal-proxy-sock:/run/proxy');
+      expect(config.volumes['autoheal-proxy-sock']).toBeDefined();
+    });
+
+    it('should wait for socket-proxy to be healthy before starting', () => {
+      const composeContent = readFileSync('docker-compose.yml', 'utf-8');
+      const config = parseYaml(composeContent);
+
+      // The proxied socket must exist before autoheal's `[ -e "$DOCKER_SOCK" ]`
+      // guard runs, otherwise it exits 127 in a crash loop. Gate on the proxy's
+      // healthcheck rather than plain ordering.
+      expect(config.services.autoheal.depends_on['socket-proxy'].condition).toBe(
+        'service_healthy',
+      );
+      expect(config.services['socket-proxy'].healthcheck).toBeDefined();
     });
 
     it('should set autoheal restart policy', () => {


### PR DESCRIPTION
## Motivation

`pavillion-autoheal` was crash-looping on staging (`Restarting (127)`) after #352. The hardening in #352 wired autoheal to the new socket-proxy with `DOCKER_SOCK=tcp://socket-proxy:2375`, but `willfarrell/autoheal:1.2.0` cannot use a plain-HTTP TCP endpoint:

- Its entrypoint guards the monitor loop with `[ -e "$DOCKER_SOCK" ]`. A `tcp://` URL is not a file, so the guard is false, the script skips the loop and falls through to `exec "$@"` — which tries to exec a non-existent `autoheal` binary and exits 127. Hence the crash loop.
- Even past that guard, autoheal's `tcp://` branch rewrites the endpoint to `https://` and requires client TLS certs at `/certs/*.pem`. The proxy serves plain HTTP with no certs. autoheal 1.2.0 has no plain-HTTP-over-TCP mode.

Net effect: autoheal has been non-functional since #352 deployed, not merely crash-looping.

## Approach

Keep the socket-proxy security model (#352) but reach it the way autoheal 1.2.0 actually supports — a unix socket:

- HAProxy now binds `unix@/run/proxy/docker.sock` instead of TCP `*:2375`, published on a shared `autoheal-proxy-sock` volume.
- autoheal mounts that volume and uses `DOCKER_SOCK=/run/proxy/docker.sock`. A real socket file satisfies the `[ -e ]` guard and selects autoheal's plain-HTTP unix-socket mode.
- autoheal now `depends_on` the proxy with `condition: service_healthy`, gated by a new socket-proxy healthcheck (`test -S /run/proxy/docker.sock`), so it never starts before the socket exists.

The HAProxy allowlist (GET `/containers`, POST `/containers/{id}/restart`; everything else denied) is unchanged. The boundary is in fact tighter than the TCP version: the proxy is reachable only by the container that mounts the shared volume (autoheal), not by every container on the compose network.

## Validation

- `docker-config.test.ts` updated to the unix-socket contract; full file passes (24 tests), lint clean.
- Verified end-to-end on the staging host with isolated throwaway containers (the live stack was not modified) using the exact pinned images and the new cfg:
  - socket-proxy starts and creates the unix socket on the shared volume.
  - autoheal runs with `exitcode=0 restarts=0` (no crash loop; reproduced the old `tcp://` config exiting 127 for contrast).
  - Through the proxy socket: `GET /containers/json` → **200** (autoheal's real query path), `GET /images/json` → **403**, `POST /containers/create` → **403** — allowlist intact.
- The live crash-looping container was stopped on staging; this PR is the durable fix to deploy.