### PR TITLE
fix(calendar): scope replaceEventCategories destroy to acting calendar

### DIFF
--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -2024,11 +2024,35 @@ class EventService {
         }
       }
 
-      // 5. Destroy all existing assignments for this event
-      await EventCategoryAssignmentEntity.destroy({
-        where: { event_id: eventId },
+      // 5. Destroy this event's assignments owned by the acting calendar only.
+      //
+      // A reposted event is shared across multiple calendars, each of which may
+      // have attached its own categories. Destroying every assignment for the
+      // event (the prior behavior) silently wiped other sharing calendars' rows.
+      // EventCategoryAssignmentEntity carries no calendar_id and deliberately has
+      // no association to join through (see event_category_assignment.ts), so we
+      // scope the destroy through category ownership: each EventCategoryEntity is
+      // owned by exactly one calendar (calendar_id, never reparented), so the set
+      // of categories owned by effectiveCalendarId fully determines which
+      // assignments belong to the acting calendar.
+      const ownedCategories = await EventCategoryEntity.findAll({
+        where: { calendar_id: effectiveCalendarId },
+        attributes: ['id'],
         transaction,
       });
+      const ownedCategoryIds = ownedCategories.map(c => c.id);
+
+      // Explicit empty-set guard. Do NOT rely on IN([]) no-op behavior: its
+      // codegen diverges by driver (PostgreSQL -> WHERE 1=0; SQLite has
+      // historically dropped the clause entirely, yielding an UNSCOPED destroy
+      // that reintroduces the cross-calendar wipe). When the acting calendar
+      // owns no categories there is nothing of its own to remove.
+      if (ownedCategoryIds.length > 0) {
+        await EventCategoryAssignmentEntity.destroy({
+          where: { event_id: eventId, category_id: { [Op.in]: ownedCategoryIds } },
+          transaction,
+        });
+      }
 
       // 6. Bulk create new assignments (skip if empty)
       if (uniqueCategoryIds.length > 0) {

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -63,6 +63,7 @@ describe('EventService.replaceEventCategories', () => {
   function stubCommonDependencies(options: {
     eventEntity?: any;
     categories?: any[];
+    ownedCategories?: any[];
     userCalendars?: Calendar[];
     calendar?: Calendar | null;
     repostEntity?: any[];
@@ -85,9 +86,34 @@ describe('EventService.replaceEventCategories', () => {
         .resolves(options.calendar);
     }
 
-    if (options.categories) {
-      sandbox.stub(EventCategoryEntity, 'findAll').resolves(options.categories);
-    }
+    // EventCategoryEntity.findAll is consulted in two places in
+    // replaceEventCategories: step 4 (validate incoming categories belong to
+    // the effective calendar — keys on `id` + `calendar_id`, skipped when
+    // categoryIds is empty) and step 5 (the owned-category lookup that scopes
+    // the destroy, pv-bv78 — keys on `calendar_id` only, with attributes:['id']).
+    // We dispatch on the where-clause shape so the owned lookup resolves
+    // `ownedCategories` regardless of call order (the validation call may be
+    // skipped). Defaults: validation -> `categories`; owned -> `ownedCategories`
+    // ?? `categories` ?? [] (empty = acting calendar owns no categories).
+    //
+    // FRAGILE: this dispatch keys on the owned lookup having `calendar_id` and
+    // NO `id` in its where-clause. If step 5's query in replaceEventCategories
+    // changes shape — e.g. it gains an `id` constraint, adds another filter
+    // field, or switches `calendar_id` to an `Op.ne`/`literal()` form — the
+    // `isOwnedLookup` guard below silently misroutes both calls to the default
+    // branch, returning `categories` instead of `ownedCategories`. The
+    // zero-owned and scoping smoke checks would then pass against wrong stub
+    // data without surfacing the regression. Update this guard if that query
+    // shape changes. (Behavioral proof lives in the real-DB integration test.)
+    const findAllStub = sandbox.stub(EventCategoryEntity, 'findAll');
+    findAllStub.callsFake(async (opts: any) => {
+      const where = opts?.where ?? {};
+      const isOwnedLookup = where.id === undefined && where.calendar_id !== undefined;
+      if (isOwnedLookup) {
+        return options.ownedCategories ?? options.categories ?? [];
+      }
+      return options.categories ?? [];
+    });
 
     if (options.repostEntity) {
       sandbox.stub(EventRepostEntity, 'findAll').resolves(options.repostEntity);
@@ -145,6 +171,74 @@ describe('EventService.replaceEventCategories', () => {
     expect((mockTransaction.commit as sinon.SinonStub).calledOnce).toBe(true);
   });
 
+  it('should look up the acting calendar owned categories before destroying (pv-bv78)', async () => {
+    // Smoke check that the scoping lookup runs: the owned-category findAll is
+    // queried and the destroy + bulkCreate fire. Cross-calendar row survival is
+    // proven by the real-DB integration test, not here — this asserts only that
+    // the lookup is wired in, NOT the internal shape of the destroy where-clause.
+    const mockEvent = EventEntity.build({
+      id: validEventId,
+      calendar_id: calendarId,
+      account_id: 'test-account-id',
+    });
+
+    const mockCategories = [validCategoryId1].map(id =>
+      EventCategoryEntity.build({ id, calendar_id: calendarId }),
+    );
+
+    stubCommonDependencies({
+      eventEntity: mockEvent,
+      categories: mockCategories,
+      ownedCategories: [EventCategoryEntity.build({ id: validCategoryId1, calendar_id: calendarId })],
+      userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      repostEntity: [],
+    });
+
+    const destroyStub = sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
+    const bulkCreateStub = sandbox.stub(EventCategoryAssignmentEntity, 'bulkCreate').resolves([]);
+
+    const returnedEvent = new CalendarEvent(validEventId, calendarId);
+    sandbox.stub(service, 'getEventById').resolves(returnedEvent);
+
+    await service.replaceEventCategories(mockAccount, validEventId, [validCategoryId1]);
+
+    // The owned-category lookup runs (step 4 validation + step 5 owned lookup).
+    expect((EventCategoryEntity.findAll as sinon.SinonStub).callCount).toBeGreaterThanOrEqual(2);
+    expect(destroyStub.calledOnce).toBe(true);
+    expect(bulkCreateStub.calledOnce).toBe(true);
+  });
+
+  it('should skip the destroy when the acting calendar owns zero categories (pv-bv78)', async () => {
+    // When the owned-category lookup returns empty, the length guard skips the
+    // destroy entirely (no reliance on driver-specific IN([]) behavior). Distinct
+    // from the caller passing an empty categoryIds array — here categoryIds is
+    // empty AND the calendar owns nothing.
+    const mockEvent = EventEntity.build({
+      id: validEventId,
+      calendar_id: calendarId,
+      account_id: 'test-account-id',
+    });
+
+    stubCommonDependencies({
+      eventEntity: mockEvent,
+      userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Acting calendar owns no categories.
+      ownedCategories: [],
+      repostEntity: [],
+    });
+
+    const destroyStub = sandbox.stub(EventCategoryAssignmentEntity, 'destroy').resolves(0);
+
+    const returnedEvent = new CalendarEvent(validEventId, calendarId);
+    returnedEvent.categories = [];
+    sandbox.stub(service, 'getEventById').resolves(returnedEvent);
+
+    await service.replaceEventCategories(mockAccount, validEventId, []);
+
+    // Length guard short-circuits — destroy must not run.
+    expect(destroyStub.called).toBe(false);
+  });
+
   it('should clear all categories when categoryIds is empty', async () => {
     const mockEvent = EventEntity.build({
       id: validEventId,
@@ -155,6 +249,9 @@ describe('EventService.replaceEventCategories', () => {
     const mockTransaction = stubCommonDependencies({
       eventEntity: mockEvent,
       userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Acting calendar owns one category, so the scoped destroy runs even
+      // though the caller passed an empty categoryIds array (pv-bv78).
+      ownedCategories: [EventCategoryEntity.build({ id: validCategoryId1, calendar_id: calendarId })],
       // Owned event: no repost rows for the post-commit lookup.
       repostEntity: [],
     });
@@ -349,6 +446,9 @@ describe('EventService.replaceEventCategories', () => {
     const mockTransaction = stubCommonDependencies({
       eventEntity: mockEvent,
       userCalendars: [new Calendar(calendarId, 'test-calendar')],
+      // Acting calendar owns a category so the scoped destroy actually runs
+      // (and throws) even with an empty categoryIds array (pv-bv78).
+      ownedCategories: [EventCategoryEntity.build({ id: validCategoryId1, calendar_id: calendarId })],
     });
 
     // Destroy throws an error

--- a/src/server/calendar/test/integration/replace_event_categories.test.ts
+++ b/src/server/calendar/test/integration/replace_event_categories.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Integration regression for pv-bv78: replaceEventCategories must scope its
+ * destroy to the acting calendar's assignments only.
+ *
+ * Category assignments link an event to a category, and each category is owned
+ * by exactly one calendar (event_category.calendar_id, never reparented). A
+ * reposted event is shared across multiple calendars, each of which may have
+ * attached its own categories. The pre-fix code destroyed EVERY assignment for
+ * the event before recreating the acting calendar's set, silently wiping the
+ * source calendar's (and every other sharing calendar's) assignments.
+ *
+ * These tests run against a real DB (TestEnvironment) so row survival is
+ * proven by direct DB queries — sinon unit stubs cannot prove that other
+ * calendars' rows survive. Fixture conventions mirror
+ * integration/listing_with_reposts.test.ts (EventRepostEntity for the repost
+ * link) and integration/bulk_category_assignment.test.ts (two accounts /
+ * calendars with their own categories).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent } from '@/common/model/events';
+import { EventCategory } from '@/common/model/event_category';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
+import { EventCategoryAssignmentEntity } from '@/server/calendar/entity/event_category_assignment';
+
+describe('replaceEventCategories calendar-scoped destroy (pv-bv78)', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let eventBus: EventEmitter;
+
+  let accountA: Account;
+  let accountB: Account;
+  let calendarA: Calendar;
+  let calendarB: Calendar;
+  let categoryA: EventCategory;
+  let categoryB1: EventCategory;
+  let categoryB2: EventCategory;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    // Minimal AP interface stub. resolveEffectiveCalendarId consults
+    // getCalendarIdsForSharedEvent; the post-commit repostStatus lookup uses
+    // getSharedEventIds / getSharedEventStatusMap. The repost link under test
+    // is an EventRepostEntity row (legacy table), so all AP stubs return empty.
+    calendarInterface.setActivityPubInterface({
+      getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
+      getCalendarIdsForSharedEvent: async () => [],
+      getEventSourceActorUris: async () => new Map<string, string>(),
+      findCalendarActorByCalendarId: async () => null,
+    } as never);
+
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const infoA = await accountService._setupAccount('replace-cat-a@pavillion.dev', 'testpassword');
+    accountA = infoA.account;
+    calendarA = await calendarInterface.createCalendar(accountA, 'replacecata');
+
+    const infoB = await accountService._setupAccount('replace-cat-b@pavillion.dev', 'testpassword');
+    accountB = infoB.account;
+    calendarB = await calendarInterface.createCalendar(accountB, 'replacecatb');
+
+    // Calendar A owns one category; Calendar B owns two.
+    categoryA = await calendarInterface.createCategory(accountA, calendarA.id, {
+      name: 'Source Category',
+      language: 'en',
+    });
+    categoryB1 = await calendarInterface.createCategory(accountB, calendarB.id, {
+      name: 'Reposter Category One',
+      language: 'en',
+    });
+    categoryB2 = await calendarInterface.createCategory(accountB, calendarB.id, {
+      name: 'Reposter Category Two',
+      language: 'en',
+    });
+  });
+
+  afterAll(async () => {
+    if (eventBus) {
+      eventBus.removeAllListeners();
+    }
+    if (env) {
+      await env.cleanup();
+    }
+  });
+
+  /**
+   * Build a fresh shared event: created on calendar A (with A's category
+   * assigned), reposted to calendar B via an EventRepostEntity row, with one of
+   * B's categories assigned. Returns the event id. Each test creates its own
+   * event so prior replaces don't leak across cases.
+   */
+  async function createSharedEventWithBothAssignments(name: string): Promise<string> {
+    const event: CalendarEvent = await calendarInterface.createEvent(accountA, {
+      calendarId: calendarA.id,
+      content: { en: { name, description: name } },
+      start_date: '2026-09-01',
+      start_time: '10:00',
+      end_date: '2026-09-01',
+      end_time: '11:00',
+    });
+
+    // Calendar A attaches its own category (as the source/owning calendar).
+    await calendarInterface.replaceEventCategories(accountA, event.id, [categoryA.id]);
+
+    // Calendar B reposts the event.
+    await EventRepostEntity.create({
+      id: uuidv4(),
+      event_id: event.id,
+      calendar_id: calendarB.id,
+    });
+
+    // Calendar B attaches one of its own categories to its view of the event.
+    await calendarInterface.replaceEventCategories(accountB, event.id, [categoryB1.id]);
+
+    return event.id;
+  }
+
+  async function assignmentCategoryIds(eventId: string): Promise<string[]> {
+    const rows = await EventCategoryAssignmentEntity.findAll({
+      where: { event_id: eventId },
+      attributes: ['category_id'],
+    });
+    return rows.map(r => r.category_id);
+  }
+
+  it('leaves the source calendar A assignment intact when calendar B replaces its categories', async () => {
+    const eventId = await createSharedEventWithBothAssignments('Shared Event - survival');
+
+    // Sanity: both calendars' assignments exist before the replace.
+    const before = await assignmentCategoryIds(eventId);
+    expect(before).toEqual(expect.arrayContaining([categoryA.id, categoryB1.id]));
+
+    // Calendar B replaces its categories (B1 -> B2). This must NOT touch A's row.
+    await calendarInterface.replaceEventCategories(accountB, eventId, [categoryB2.id]);
+
+    const after = await assignmentCategoryIds(eventId);
+    // Calendar A's assignment survives.
+    expect(after).toContain(categoryA.id);
+    // Calendar B's own prior assignment (B1) is fully replaced by B2.
+    expect(after).toContain(categoryB2.id);
+    expect(after).not.toContain(categoryB1.id);
+    // Exactly two assignments remain: A's category + B's new category.
+    expect(after).toHaveLength(2);
+  });
+
+  it('clearing categories from calendar B removes only B assignments, not A', async () => {
+    const eventId = await createSharedEventWithBothAssignments('Shared Event - clear');
+
+    // Calendar B clears its categories (empty array).
+    await calendarInterface.replaceEventCategories(accountB, eventId, []);
+
+    const after = await assignmentCategoryIds(eventId);
+    // A's assignment survives; B's is gone.
+    expect(after).toEqual([categoryA.id]);
+  });
+
+  it('fully replaces the acting calendar A own prior assignments', async () => {
+    // Calendar A (owning calendar) sets, then replaces, its own categories on a
+    // non-reposted event. Proves the acting calendar's own set is still fully
+    // replaced (no stale rows) after the scoping fix.
+    const event = await calendarInterface.createEvent(accountA, {
+      calendarId: calendarA.id,
+      content: { en: { name: 'A own replace', description: 'A own replace' } },
+      start_date: '2026-09-02',
+      start_time: '10:00',
+      end_date: '2026-09-02',
+      end_time: '11:00',
+    });
+
+    const extraCategoryA = await calendarInterface.createCategory(accountA, calendarA.id, {
+      name: 'Source Category Extra',
+      language: 'en',
+    });
+
+    await calendarInterface.replaceEventCategories(accountA, event.id, [categoryA.id]);
+    expect(await assignmentCategoryIds(event.id)).toEqual([categoryA.id]);
+
+    await calendarInterface.replaceEventCategories(accountA, event.id, [extraCategoryA.id]);
+    const after = await assignmentCategoryIds(event.id);
+    expect(after).toEqual([extraCategoryA.id]);
+  });
+
+  it('does not delete other calendars assignments when the acting calendar owns zero categories', async () => {
+    // Distinct from the caller passing an empty categoryIds array: here calendar
+    // B owns NO categories at all, so the owned-id lookup returns empty and the
+    // length guard skips the destroy entirely. A's assignment must survive, and
+    // nothing must throw.
+    const infoC = await (new AccountService(
+      eventBus, new ConfigurationInterface(), new SetupInterface(),
+    ))._setupAccount('replace-cat-c@pavillion.dev', 'testpassword');
+    const accountC = infoC.account;
+    const calendarC = await calendarInterface.createCalendar(accountC, 'replacecatc');
+
+    const event = await calendarInterface.createEvent(accountA, {
+      calendarId: calendarA.id,
+      content: { en: { name: 'Zero-owned-categories', description: 'Zero-owned-categories' } },
+      start_date: '2026-09-03',
+      start_time: '10:00',
+      end_date: '2026-09-03',
+      end_time: '11:00',
+    });
+    await calendarInterface.replaceEventCategories(accountA, event.id, [categoryA.id]);
+
+    // Calendar C reposts; C owns zero categories.
+    await EventRepostEntity.create({
+      id: uuidv4(),
+      event_id: event.id,
+      calendar_id: calendarC.id,
+    });
+
+    // Calendar C replaces with empty set. Owned-id lookup is empty -> destroy
+    // skipped. A thrown error fails the test naturally; the row-survival
+    // assertion below carries the meaningful check.
+    await calendarInterface.replaceEventCategories(accountC, event.id, []);
+
+    const after = await assignmentCategoryIds(event.id);
+    expect(after).toEqual([categoryA.id]);
+  });
+});


### PR DESCRIPTION
## Motivation

`EventService.replaceEventCategories` destroyed **every** category assignment for an event before recreating the acting calendar's set, via an unscoped `EventCategoryAssignmentEntity.destroy({ where: { event_id } })`.

Category assignments link an event to a category, and each category is owned by exactly one calendar. A reposted event is shared across multiple calendars, each of which may attach its own categories. The unscoped destroy deleted every sharing calendar's assignments, then recreated assignments only for the acting calendar. A curator hitting `PUT /api/v1/events/:id/categories` on a reposted event silently wiped the source calendar's (and every other sharing calendar's) category assignments — cross-calendar data loss the user never intended. This is an IDOR-class data-integrity defect: one calendar mutates another's data.

## Approach

Scope the destroy through category ownership. `EventCategoryAssignmentEntity` carries no `calendar_id` (and deliberately no association to join through, to keep the import graph acyclic), so the acting calendar's owned category ids are resolved first (`EventCategoryEntity.findAll` by `calendar_id`, `attributes: ['id']`), then the destroy is scoped with a category-scoped `IN` clause.

An explicit `ownedCategoryIds.length > 0` guard skips the destroy when the acting calendar owns no categories, deliberately avoiding driver-specific empty-`IN` codegen (SQLite has historically dropped the clause, which would reintroduce the unscoped destroy). This matches the existing select-ids-then-destroy precedent in `purgeOldRuns` and the length-guard form already used elsewhere in the same service. The change stays entirely within the Calendar domain; the globally-shared `EventEntity` and federation sync are intentionally untouched, upholding the per-calendar-policy vs globally-shared-fact split.

## Validation

- New real-DB integration test (`test/integration/replace_event_categories.test.ts`): two calendars each with their own categories and assignments on one shared/reposted event; replacing as calendar B leaves calendar A's rows intact while fully replacing B's. Covers cross-calendar survival, clear-only-own, full self-replace, and the zero-owned-categories guard path. Confirmed to fail before the fix (reproducing the wipe) and pass after.
- Extended unit smoke tests (`test/EventService/replace_event_categories.test.ts`): assert the owned-category lookup runs and the length guard skips the destroy when zero categories are owned, without asserting on the internal destroy where-clause shape.
- Full suite green via build-guardian: lint (0 errors), 8263 unit tests, 669 integration tests, build all pass. (The only e2e failures observed were pre-existing environmental issues — port contention and a missing TLS fixture — unrelated to this change.)