### PR TITLE
feat(federation): resolve WebFinger probes by actor URL form

### DIFF
--- a/src/server/activitypub/service/server.ts
+++ b/src/server/activitypub/service/server.ts
@@ -69,19 +69,55 @@ export default class ActivityPubService {
   /**
    * Parse WebFinger resource format into type, name, and domain
    *
-   * Supports two formats:
+   * Supports three formats:
    * - @user@domain - Person actor (user)
    * - calendar@domain - Group actor (calendar)
+   * - https://{our-domain}/users/{name} or /calendars/{name} - the actor's own
+   *   URL form (RFC 7033 §4.5), the inverse of the hrefs WebFingerLink emits.
    *
-   * @param resource - WebFinger resource string (e.g., "acct:@alice@example.com" or "community@example.com")
+   * @param resource - WebFinger resource string (e.g., "acct:@alice@example.com", "community@example.com", or "https://events.example/users/alice")
    * @returns { type: 'user' | 'calendar' | 'unknown', name: string, domain: string }
    */
   parseWebFingerResource(resource: string): { type: 'user' | 'calendar' | 'unknown', name: string, domain: string } {
-    // Remove acct: prefix if present
+    // Remove acct: prefix if present (no-op on an https:// URL)
     resource = resource.replace('acct:', '');
 
     // Check if empty
     if (!resource || resource.length === 0) {
+      return { type: 'unknown', name: '', domain: '' };
+    }
+
+    // URL form (RFC 7033 §4.5): the actor's own self-link URL, the inverse of
+    // the href WebFingerLink emits (model/webfinger.ts). A peer that read our
+    // WebFinger response and re-probes by actor URL gets a resolvable answer.
+    if (resource.startsWith('https://')) {
+      let url: URL;
+      try {
+        url = new URL(resource);
+      }
+      catch {
+        return { type: 'unknown', name: '', domain: '' };
+      }
+
+      // Only resolve actors on our own domain — no cross-host resolution, no
+      // outbound fetch. Compare url.host (not url.hostname) so the port in
+      // config.get('domain') (e.g. 'localhost:3000') matches. This enforces the
+      // same locality rule lookupWebFinger applies to the extracted domain,
+      // here applied to the raw URL as defense in depth.
+      if (url.host !== config.get('domain')) {
+        return { type: 'unknown', name: '', domain: '' };
+      }
+
+      const userMatch = url.pathname.match(/^\/users\/([^/]+)$/);
+      if (userMatch) {
+        return { type: 'user', name: userMatch[1], domain: url.host };
+      }
+
+      const calendarMatch = url.pathname.match(/^\/calendars\/([^/]+)$/);
+      if (calendarMatch) {
+        return { type: 'calendar', name: calendarMatch[1], domain: url.host };
+      }
+
       return { type: 'unknown', name: '', domain: '' };
     }
 

--- a/src/server/activitypub/test/service/webfinger.test.ts
+++ b/src/server/activitypub/test/service/webfinger.test.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { EventEmitter } from 'events';
 
 import ActivityPubService from '@/server/activitypub/service/server';
+import { WebFingerResponse } from '@/server/activitypub/model/webfinger';
 import CalendarInterface from '@/server/calendar/interface';
 import AccountsInterface from '@/server/accounts/interface';
 import config from 'config';
@@ -79,6 +80,86 @@ describe('ActivityPubService.parseWebFingerResource', () => {
       type: 'calendar',
       name: 'community',
       domain: 'example.com',
+    });
+  });
+
+  describe('URL-form resource (RFC 7033 §4.5)', () => {
+    beforeEach(() => {
+      sandbox.stub(config, 'get').withArgs('domain').returns('events.example');
+    });
+
+    it('should resolve a calendar actor URL on our domain', () => {
+      const result = service.parseWebFingerResource('https://events.example/calendars/community');
+
+      expect(result).toEqual({
+        type: 'calendar',
+        name: 'community',
+        domain: 'events.example',
+      });
+    });
+
+    it('should resolve a user actor URL on our domain', () => {
+      const result = service.parseWebFingerResource('https://events.example/users/alice');
+
+      expect(result).toEqual({
+        type: 'user',
+        name: 'alice',
+        domain: 'events.example',
+      });
+    });
+
+    it('should not resolve a URL on a different host', () => {
+      const result = service.parseWebFingerResource('https://evil.example/calendars/community');
+
+      expect(result).toEqual({
+        type: 'unknown',
+        name: '',
+        domain: '',
+      });
+    });
+
+    it('should not resolve a URL on our host with an unrecognized path', () => {
+      const result = service.parseWebFingerResource('https://events.example/o/foo');
+
+      expect(result).toEqual({
+        type: 'unknown',
+        name: '',
+        domain: '',
+      });
+    });
+
+    it('should not throw on a malformed URL', () => {
+      const result = service.parseWebFingerResource('https://');
+
+      expect(result).toEqual({
+        type: 'unknown',
+        name: '',
+        domain: '',
+      });
+    });
+
+    it('should parse a user actor href emitted by WebFingerLink back to its actor', () => {
+      const href = new WebFingerResponse('alice', config.get('domain') as string, 'user').links[0].href;
+
+      const result = service.parseWebFingerResource(href);
+
+      expect(result).toEqual({
+        type: 'user',
+        name: 'alice',
+        domain: 'events.example',
+      });
+    });
+
+    it('should parse a calendar actor href emitted by WebFingerLink back to its actor', () => {
+      const href = new WebFingerResponse('community', config.get('domain') as string, 'calendar').links[0].href;
+
+      const result = service.parseWebFingerResource(href);
+
+      expect(result).toEqual({
+        type: 'calendar',
+        name: 'community',
+        domain: 'events.example',
+      });
     });
   });
 });


### PR DESCRIPTION
## Motivation

`parseWebFingerResource` accepted only the `acct:` handle forms (`@user@host`, `calendar@host`). RFC 7033 §4.5 permits an arbitrary URI as the WebFinger resource. When a peer probed us with the actor's own URL form — `https://{our-domain}/users/{username}` or `https://{our-domain}/calendars/{urlName}` — we fell through to the calendar-handle branch, failed the `split('@')` check, and returned `unknown`, which the API surfaced as a 400. The actor exists; we refused to resolve it by its own URL.

This is a federation interop gap: peers legitimately re-probe by actor URL (the href forms our own WebFinger responses emit), and rejecting them silently drops otherwise-valid lookups. Friendica fixed the inverse defect on their side in PR #15758.

## Approach

Added a third recognized form to `parseWebFingerResource`, placed after the empty-resource guard and before the `@`-handle handling: detect an `https://` URL, parse it with the `URL` constructor inside a try/catch (malformed → `unknown`), then resolve `/users/{name}` → user and `/calendars/{name}` → calendar.

Host validation is the security-relevant decision. Any URL whose host is not our configured domain resolves to `unknown` with no outbound fetch — this is the inbound WebFinger responder, which is only authoritative for actors we host; cross-host resolution stays on the outbound discovery paths where it belongs. The check compares `url.host` (not `url.hostname`) so a port-bearing `config.get('domain')` (e.g. `localhost:3000`) still matches, and the returned `domain` is `url.host` so it round-trips the hrefs `WebFingerLink` emits. The anchored `([^/]+)` path regexes are not ReDoS-susceptible and reject multi-segment/encoded traversal; the userinfo-in-URL trick (`https://evil@our-domain/...`) parses to our host and resolves only our own actors, harmless.

## Validation

Eight new unit tests in `webfinger.test.ts` cover user/calendar URL resolution, cross-host rejection, unrecognized-path, malformed-URL (no throw), and two round-trip cases pinning the parser as the inverse of the `WebFingerLink` emitter; existing handle-parse tests are unchanged. lint (0 errors), the full unit suite (8268), the integration suite (665), and the build all pass. A security review confirmed the host check fails closed on host-spoof attempts, introduces no SSRF, and that downstream account/calendar queries remain Sequelize-parameterized.