### PR TITLE
fix: scope JSON body parsers so raw-body webhook routes work

### DIFF
--- a/src/server/accounts/api/v1.ts
+++ b/src/server/accounts/api/v1.ts
@@ -8,7 +8,11 @@ import AccountsInterface from '@/server/accounts/interface';
 export default class AccountApiV1 {
 
   static install(app: Application, internalAPI: AccountsInterface) {
-    app.use(express.json());
+    // Scope JSON parsing to this domain's routes. A global app.use(express.json())
+    // is a cross-cutting side effect that also consumes the body of raw-body routes
+    // (e.g. the Stripe webhook at /api/funding/webhooks), breaking signature
+    // verification (pv-ufag). Keep parsers scoped to the prefixes they serve.
+    app.use('/api/v1', express.json());
 
     const accountRouteHandlers = new AccountRoutes(internalAPI);
     accountRouteHandlers.installHandlers(app, '/api/v1');

--- a/src/server/activitypub/api/v1.ts
+++ b/src/server/activitypub/api/v1.ts
@@ -9,7 +9,11 @@ import UserActorService from '@/server/activitypub/service/user_actor';
 export default class ActivityPubAPI {
 
   static install(app: Application, internalAPI: ActivityPubInterface, calendarAPI: CalendarInterface): void {
-    app.use(express.json());
+    // Scoped to the member API only. The federation routers mounted at '/' below
+    // register their own router-level express.json (with activity+json types), and
+    // a bare global app.use(express.json()) here would consume raw-body routes like
+    // the Stripe webhook (/api/funding/webhooks) and break signatures (pv-ufag).
+    app.use('/api/v1', express.json());
 
     const activityPubRoutes = new ActivityPubServerRoutes(internalAPI,calendarAPI);
     activityPubRoutes.installHandlers(app, '/');

--- a/src/server/authentication/api/v1.ts
+++ b/src/server/authentication/api/v1.ts
@@ -46,7 +46,10 @@ export default class AuthenticationAPI {
       return done(null, account);
     }));
 
-    app.use(express.json());
+    // Scoped, not global: a bare app.use(express.json()) would also consume
+    // raw-body routes like the Stripe webhook (/api/funding/webhooks) and break
+    // signature verification (pv-ufag).
+    app.use('/api/auth/v1', express.json());
 
     const authenticationRoutes = new AuthenticationRoutes(internalAPI, accountAPI);
     authenticationRoutes.installHandlers(app, '/api/auth/v1');

--- a/src/server/calendar/api/v1.ts
+++ b/src/server/calendar/api/v1.ts
@@ -16,7 +16,10 @@ import CalendarInterface from '../interface';
 export default class CalendarAPI {
 
   static install(app: Application, internalAPI: CalendarInterface): void {
-    app.use(express.json());
+    // Scoped to this domain's prefixes (not a global parser): a bare
+    // app.use(express.json()) would consume raw-body routes like the Stripe
+    // webhook (/api/funding/webhooks) and break signature verification (pv-ufag).
+    app.use(['/api/v1', '/api/widget/v1'], express.json());
 
     let eventsRoutes = new EventRoutes(internalAPI);
     eventsRoutes.installHandlers(app, '/api/v1');

--- a/src/server/funding/api/v1.ts
+++ b/src/server/funding/api/v1.ts
@@ -14,7 +14,12 @@ import FundingInterface from '@/server/funding/interface';
  */
 export default class FundingApiV1 {
   static install(app: Application, internalAPI: FundingInterface): void {
-    app.use(express.json());
+    // Scope JSON body parsing to the /v1 API only. The Stripe webhook route
+    // (mounted below at /api/funding/webhooks) needs the raw request body for
+    // signature verification — a global app.use(express.json()) would consume
+    // and parse the body first, leaving the webhook handler with "[object
+    // Object]" and breaking every signature check (pv-ufag).
+    app.use('/api/funding/v1', express.json());
 
     // Install admin routes
     const adminRoutes = new AdminRoutes(internalAPI, internalAPI.providerConnectionService);

--- a/src/server/funding/test/webhooks.test.ts
+++ b/src/server/funding/test/webhooks.test.ts
@@ -7,6 +7,8 @@ import { v4 as uuidv4 } from 'uuid';
 import db from '@/server/common/entity/db';
 import FundingService from '@/server/funding/service/funding';
 import WebhookRoutes from '@/server/funding/api/v1/webhooks';
+import FundingApiV1 from '@/server/funding/api/v1';
+import AccountApiV1 from '@/server/accounts/api/v1';
 import { FundingPlanEntity } from '@/server/funding/entity/funding_plan';
 import { FundingEventEntity } from '@/server/funding/entity/funding_event';
 import { CalendarFundingPlanEntity } from '@/server/funding/entity/calendar_funding_plan';
@@ -154,6 +156,84 @@ describe('Webhook Handling', () => {
         expect(response.status).toBe(500);
         expect(response.body.error).toBe('Internal server error');
       });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full-wiring tests — mounts through FundingApiV1.install, exactly as the
+  // running app does. Regression guard for pv-ufag: a global express.json()
+  // registered before the raw webhook route consumes the body, so the handler
+  // receives the parsed object ("[object Object]") instead of the raw bytes
+  // Stripe signed — making signature verification fail for every real event.
+  // -------------------------------------------------------------------------
+  describe('Full FundingApiV1 wiring (raw body preservation)', () => {
+    let app: Application;
+    let sandbox: sinon.SinonSandbox;
+    let handleStripeWebhook: sinon.SinonStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      handleStripeWebhook = sandbox.stub().resolves();
+      const mockInterface = {
+        handleStripeWebhook,
+        providerConnectionService: {},
+      };
+
+      app = express();
+      FundingApiV1.install(app, mockInterface as any);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      vi.clearAllMocks();
+    });
+
+    it('delivers the exact raw JSON body to the service for signature verification', async () => {
+      const webhookPayload = JSON.stringify({ id: 'evt_raw_body', type: 'invoice.paid' });
+
+      const response = await request(app)
+        .post('/api/funding/webhooks/stripe')
+        .set('stripe-signature', 'valid_signature')
+        .set('Content-Type', 'application/json')
+        .send(webhookPayload);
+
+      expect(response.status).toBe(200);
+      expect(handleStripeWebhook.calledOnce).toBe(true);
+
+      // The raw body must reach the service byte-for-byte. If a global json
+      // parser ran first, this would be "[object Object]" and Stripe signature
+      // verification would fail.
+      const [rawBody, signature] = handleStripeWebhook.firstCall.args;
+      expect(rawBody).toBe(webhookPayload);
+      expect(signature).toBe('valid_signature');
+    });
+
+    it('preserves the raw body when an earlier domain has already registered a parser (boot-order regression)', async () => {
+      // The production bug was cross-domain: accounts (and authentication)
+      // initialize before funding in server.ts and used to register a GLOBAL
+      // express.json() that consumed the webhook body before funding's raw route
+      // ran. A funding-only test cannot catch that — this composes the real
+      // accounts installer first, exactly as the app boots. Every domain parser
+      // must be scoped so /api/funding/webhooks stays raw (pv-ufag).
+      const bootApp = express();
+      AccountApiV1.install(bootApp, {} as any);
+      FundingApiV1.install(bootApp, {
+        handleStripeWebhook,
+        providerConnectionService: {},
+      } as any);
+
+      const webhookPayload = JSON.stringify({ id: 'evt_boot_order', type: 'invoice.paid' });
+
+      const response = await request(bootApp)
+        .post('/api/funding/webhooks/stripe')
+        .set('stripe-signature', 'valid_signature')
+        .set('Content-Type', 'application/json')
+        .send(webhookPayload);
+
+      expect(response.status).toBe(200);
+      expect(handleStripeWebhook.calledOnce).toBe(true);
+      const [rawBody] = handleStripeWebhook.firstCall.args;
+      expect(rawBody).toBe(webhookPayload);
     });
   });
 

--- a/src/server/media/api/v1.ts
+++ b/src/server/media/api/v1.ts
@@ -5,7 +5,9 @@ import MediaRoutes from './v1/media';
 export default class MediaAPI {
 
   static install(app: Application, internalAPI: MediaInterface): void {
-    app.use(express.json());
+    // Scoped, not global: a bare app.use(express.json()) would also consume
+    // raw-body routes like the Stripe webhook (/api/funding/webhooks) (pv-ufag).
+    app.use('/api/v1/media', express.json());
 
     let mediaRoutes = new MediaRoutes(internalAPI);
     mediaRoutes.installHandlers(app, '/api/v1/media');

--- a/src/server/moderation/index.ts
+++ b/src/server/moderation/index.ts
@@ -75,7 +75,10 @@ export default class ModerationDomain {
   }
 
   public installAPI(app: Application): void {
-    app.use(express.json());
+    // Scoped to this domain's prefixes (not a global parser): a bare
+    // app.use(express.json()) would consume raw-body routes like the Stripe
+    // webhook (/api/funding/webhooks) and break signature verification (pv-ufag).
+    app.use(['/api/public/v1', '/api/v1'], express.json());
 
     const publicReportRoutes = new PublicReportRoutes(this.interface);
     publicReportRoutes.installHandlers(app, '/api/public/v1');

--- a/src/server/notifications/api/v1.ts
+++ b/src/server/notifications/api/v1.ts
@@ -6,7 +6,9 @@ import NotificationsInterface from '@/server/notifications/interface';
 export default class NotificationAPI {
 
   static install(app: Application, internalAPI: NotificationsInterface): void {
-    app.use(express.json());
+    // Scoped, not global: a bare app.use(express.json()) would also consume
+    // raw-body routes like the Stripe webhook (/api/funding/webhooks) (pv-ufag).
+    app.use('/api/v1', express.json());
 
     const notificationRoutes = new NotificationRoutes(internalAPI);
     notificationRoutes.installHandlers(app, '/api/v1');

--- a/src/server/public/api/v1.ts
+++ b/src/server/public/api/v1.ts
@@ -4,7 +4,9 @@ import PublicCalendarInterface from '../interface';
 
 export default class PublicCalendarAPI {
   static install(app: Application, internalAPI: PublicCalendarInterface): void {
-    app.use(express.json());
+    // Scoped, not global: a bare app.use(express.json()) would also consume
+    // raw-body routes like the Stripe webhook (/api/funding/webhooks) (pv-ufag).
+    app.use('/api/public/v1', express.json());
 
     let eventsRoutes = new CalendarRoutes(internalAPI);
     eventsRoutes.installHandlers(app, '/api/public/v1');

--- a/src/server/setup/api/v1.ts
+++ b/src/server/setup/api/v1.ts
@@ -7,7 +7,9 @@ import SetupInterface from '@/server/setup/interface';
  */
 export default class SetupApiV1 {
   static install(app: Application, setupInterface: SetupInterface): void {
-    app.use(express.json());
+    // Scoped, not global: a bare app.use(express.json()) would also consume
+    // raw-body routes like the Stripe webhook (/api/funding/webhooks) (pv-ufag).
+    app.use('/api/v1', express.json());
 
     const setupRouteHandlers = new SetupRouteHandlers(setupInterface);
     setupRouteHandlers.installHandlers(app, '/api/v1');


### PR DESCRIPTION
## Motivation

Stripe reported repeated webhook delivery failures to the staging endpoint `https://staging.pavillion.dev/api/funding/webhooks/stripe`. Investigation of the live app logs showed every genuine Stripe event failing with `WebhookSignatureError` and returning HTTP 400 — the events were being dropped, so funding fulfillment via webhooks did not work at all.

Root cause: nine backend domains registered an **unscoped, global** `app.use(express.json())` as a side effect of installing their API routes. Because `accounts` and `authentication` initialize before `funding` in `server.ts`, their global parsers consumed the webhook request body before funding's `express.raw` route ran. The handler then stringified the already-parsed object to `"[object Object]"` and handed that to `stripe.webhooks.constructEvent`, which can never match the signature. The funding webhook route's own route-level `express.raw` was correct but powerless — a body parser earlier in the global middleware chain had already read the stream.

## Approach

Scope every JSON parser to the prefix(es) its domain actually mounts, so none is a prefix of `/api/funding/webhooks/stripe`:

- `accounts`, `setup`, `notifications` → `/api/v1`
- `authentication` → `/api/auth/v1`
- `calendar` → `['/api/v1', '/api/widget/v1']`
- `moderation` → `['/api/public/v1', '/api/v1']`
- `public` → `/api/public/v1`
- `media` → `/api/v1/media`
- `activitypub` → `/api/v1` (its federation routers mounted at `/` already self-parse at the router level with `application/activity+json` types)
- `funding` → `/api/funding/v1`, with the webhook left on `express.raw`

`configuration` was already correctly scoped; `housekeeping` has no body-reading routes. Verified that no domain relied on another domain's leaked global parser — every body-reading domain registers its own parser covering all the prefixes it mounts. Each scoped registration carries a short comment so the global form is not reintroduced.

## Validation

- TDD: added a raw-body-integrity test through the real `FundingApiV1.install` wiring (failed with `"[object Object]"` before the fix, passes after), plus a boot-order regression that mounts the real `accounts` installer before `funding` exactly as `server.ts` does. The boot-order test was confirmed to fail when `accounts` uses a global parser and pass when scoped — so it has teeth against the actual cross-domain bug.
- Full unit + integration suite green: 475 files / 8263 unit tests, 80 files / 665 integration tests. Lint clean. Production build passes.
- E2E (single-instance): 141 passed. Two failures are pre-existing and unrelated to this change — `import-sources` fails in its own setup with `ENOENT` on a missing federation SSL cert fixture, and `admin-accounts` flaked on a render timeout under full-suite load (the full `admin-accounts.spec.ts` passes 5/5 when run in isolation against this branch).
- Post-merge: after deploy, replay a failed event from the Stripe dashboard against staging and confirm a 200 plus a new `funding_events` row.