### PR TITLE
fix(caddy): strip client X-Forwarded-* so trust-proxy: 1 holds

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,24 @@
 {$DOMAIN} {
 	encode gzip zstd
 
+	# Strip any client-supplied forwarding headers before Caddy appends its
+	# own. Express runs with `trust proxy: 1`, so it trusts exactly one hop's
+	# X-Forwarded-For — that hop must be Caddy, never the client. Header
+	# matching is case-insensitive (Caddy normalises on ingest). Caddy executes
+	# `request_header` (an alias of `header`) before `reverse_proxy` in its
+	# canonical directive order, so these strips apply to every request — and to
+	# every imported snippet's proxying — regardless of textual position. They
+	# are placed at the top of the block for readability. The operator invariant:
+	# a snippet must not re-add a client-supplied forwarding value (e.g. via
+	# `request_header +` or `header_up` sourced from a client header).
+	request_header -X-Forwarded-For
+	request_header -X-Forwarded-Proto
+	request_header -X-Forwarded-Host
+	request_header -X-Real-IP
+	request_header -Forwarded
+	request_header -CF-Connecting-IP
+	request_header -True-Client-IP
+
 	# Operator extension point. Drop *.caddyfile snippets into ./caddy-extras.d/
 	# to add per-instance handlers (e.g., a webhook listener on a staging
 	# server). The directory is gitignored, so production deploys ship with no

--- a/caddy-extras.d/README.md
+++ b/caddy-extras.d/README.md
@@ -57,3 +57,37 @@ will receive forwarded `/hooks/*` requests.
   ```bash
   docker compose --profile standalone exec caddy caddy validate --config /etc/caddy/Caddyfile
   ```
+
+## Trust-proxy constraint
+
+The tracked `Caddyfile` strips all client-supplied forwarding headers
+(`X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Real-IP`,
+`Forwarded`, `CF-Connecting-IP`, `True-Client-IP`) at the top of the site
+block. Caddy executes `request_header` before `reverse_proxy` in its canonical
+directive order, so the strips apply to every request — and to any proxying an
+imported snippet performs — regardless of where the directives sit in the file.
+Express runs with `trust proxy: 1` — it trusts exactly one upstream hop's
+`X-Forwarded-For`, and that hop must be Caddy. This is what makes `req.ip` (used
+for rate limiting and moderation IP records) trustworthy. Two cases are easy to
+confuse:
+
+- **A snippet that proxies to its own backend — NOT a concern.** A snippet that
+  `reverse_proxy`s to its own upstream (e.g. the `/hooks/*` example above)
+  receives headers Caddy has already sanitised and regenerated. There is
+  nothing to do; this is safe by default. Snippets must not re-add a
+  client-supplied forwarding header (e.g. via `request_header +` or `header_up`
+  sourced from a client header) — that would undo the site-level strip.
+
+- **A proxy or CDN placed *upstream* of Caddy — the real footgun.** Caddy must
+  remain the **outermost trusted hop**. If you front this stack with a CDN or
+  load balancer (Cloudflare, an external LB, etc.), the trust boundary moves
+  one hop out and the header-strip protection no longer covers it. To keep
+  `req.ip` trustworthy you must BOTH:
+  1. Bump Express `trust proxy` (in `src/server/server.ts`) to match the new
+     total hop count, AND
+  2. Ensure the new outermost hop strips client-supplied forwarding headers
+     before forwarding inward.
+
+  Doing only one re-opens the spoofing hole one hop up. Changing the hop count
+  is an operator decision, not a default — the shipped single-Caddy topology
+  uses `1`.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -177,6 +177,20 @@ function setupHealthCheck(app: express.Application): void {
 }
 
 /**
+ * Configure Express reverse-proxy trust and log the hop count at boot so a
+ * topology/config mismatch is visible. The fronting proxy (Caddy) must strip
+ * client-supplied X-Forwarded-* headers; adding hops requires bumping this
+ * value (see caddy-extras.d/README.md). Logs only the configured integer — no
+ * headers, no request, no IP.
+ *
+ * @param app - Express application instance
+ */
+function configureProxy(app: express.Application): void {
+  app.set('trust proxy', 1);
+  logger.info(`Express trust proxy hops configured: ${app.get('trust proxy')}`);
+}
+
+/**
  * Initializes the Pavillion server with express application configuration.
  * Sets up view templates, internationalization, API routes and starts the server listener.
  *
@@ -189,9 +203,7 @@ const initPavillionServer = async (app: express.Application, port: number): Prom
   // Validate production environment configuration before starting
   validateProductionEnvironment();
 
-  // Configure Express to trust proxy headers for accurate client IP detection
-  // This is essential for rate limiting behind reverse proxies like nginx
-  app.set('trust proxy', 1);
+  configureProxy(app);
 
   // Set up health check endpoint first (before other routes and middleware)
   setupHealthCheck(app);
@@ -428,4 +440,4 @@ const initPavillionServer = async (app: express.Application, port: number): Prom
 };
 
 export default initPavillionServer;
-export { checkDatabaseHealth, setupHealthCheck, validateProductionEnvironment };
+export { checkDatabaseHealth, setupHealthCheck, validateProductionEnvironment, configureProxy };

--- a/src/server/test/configure-proxy.test.ts
+++ b/src/server/test/configure-proxy.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Application } from 'express';
+
+// Mock the logger so we can assert the boot-time log line without producing
+// real output. vi.hoisted keeps the mock reference valid despite hoisting.
+const { infoMock } = vi.hoisted(() => ({ infoMock: vi.fn() }));
+vi.mock('@/server/common/helper/logger', () => ({
+  default: { info: infoMock, error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  createLogger: () => ({ info: infoMock, error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}));
+
+import { configureProxy } from '@/server/server';
+
+// Minimal Express-app stand-in that actually stores settings, so set/get
+// round-trip like the real app. We avoid importing `express` directly here:
+// pulling it into the test's own import graph trips a transform error in an
+// unrelated transitive CJS dependency (isomorphic-dompurify). `app.get('trust
+// proxy')` on the real Express returns the raw set value (1), so this fake
+// behaves identically for the helper's purposes.
+function makeApp(): Application {
+  const settings: Record<string, unknown> = {};
+  return {
+    set: (key: string, value: unknown) => { settings[key] = value; },
+    get: (key: string) => settings[key],
+  } as unknown as Application;
+}
+
+describe('configureProxy', () => {
+  beforeEach(() => {
+    infoMock.mockClear();
+  });
+
+  it('sets the trust proxy hop count to 1', () => {
+    // Assert the resulting state (req.ip's trust boundary), not merely that
+    // app.set was called — the stored value is what actually governs req.ip.
+    const app = makeApp();
+
+    configureProxy(app);
+
+    expect(app.get('trust proxy')).toBe(1);
+  });
+
+  it('logs only the configured integer hop count at info level', () => {
+    // The logged value round-trips through the same set/get the helper uses,
+    // so a hardcoded message string would not survive this assertion.
+    const app = makeApp();
+
+    configureProxy(app);
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    const message = infoMock.mock.calls[0][0];
+    // Single string argument (no object payload, no headers, no IP) per DEC-004.
+    expect(typeof message).toBe('string');
+    expect(message).toBe('Express trust proxy hops configured: 1');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,9 @@ export default defineConfig({
             ...sharedExclude,
             'src/common/test/utils/render-markdown.test.ts',
             'src/server/configuration/test/service_settings.test.ts',
+            // Imports the full @/server/server entry module, whose graph reaches
+            // renderPolicyMarkdown → isomorphic-dompurify.
+            'src/server/test/configure-proxy.test.ts',
             // Tests that transitively import ServiceSettings (which depends on renderPolicyMarkdown)
             'src/server/accounts/test/account_service.test.ts',
             'src/server/accounts/test/admin_pagination.test.ts',
@@ -91,6 +94,9 @@ export default defineConfig({
           include: [
             'src/common/test/utils/render-markdown.test.ts',
             'src/server/configuration/test/service_settings.test.ts',
+            // Imports the full @/server/server entry module, whose graph reaches
+            // renderPolicyMarkdown → isomorphic-dompurify.
+            'src/server/test/configure-proxy.test.ts',
             // Tests that transitively import ServiceSettings (which depends on renderPolicyMarkdown)
             'src/server/accounts/test/account_service.test.ts',
             'src/server/accounts/test/admin_pagination.test.ts',


### PR DESCRIPTION
## Motivation

Production fronts Express with Caddy, and `src/server/server.ts` sets `app.set('trust proxy', 1)` — Express trusts exactly one upstream hop's `X-Forwarded-For`. But Caddy's `reverse_proxy` *appends* the client IP to `X-Forwarded-For` without stripping a client-supplied value first. A request arriving with a forged `X-Forwarded-For: 1.2.3.4` therefore produced `req.ip === 1.2.3.4` (attacker-chosen).

Every `req.ip`-keyed surface was spoofable as a result: per-IP rate-limit buckets (rotate the forged header to bypass limits) and moderation IP audit records (poison them with arbitrary values).

## Approach

Three coordinated changes:

1. **`Caddyfile`** — strip all client-supplied forwarding headers (`X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Real-IP`, `Forwarded`, `CF-Connecting-IP`, `True-Client-IP`) at the top of the `{$DOMAIN}` site block. Caddy regenerates the trusted `X-Forwarded-*` values itself, so legitimate forwarding is unaffected. Caddy executes `request_header` before `reverse_proxy` in its canonical directive order, so the strip applies to every request — and to any proxying an imported snippet performs — regardless of textual position.
2. **`caddy-extras.d/README.md`** — a "Trust-proxy constraint" section distinguishing the safe case (a snippet proxying to its own backend receives sanitised headers) from the real footgun (a CDN/LB placed *upstream* of Caddy moves the trust boundary, requiring both a higher `trust proxy` hop count and header stripping at the new outermost hop).
3. **`src/server/server.ts`** — extract a `configureProxy(app)` helper that sets the hop count and logs only the configured integer at boot, surfacing a topology/config mismatch without leaking any request data (DEC-004-clean).

The hop count stays at `1` — correct for the shipped single-Caddy topology; multi-hop is an operator concern, documented rather than coded.

## Validation

- New unit test `src/server/test/configure-proxy.test.ts` asserts `trust proxy` resolves to `1` and that the boot log emits a single string with no object payload (no headers/IP). Registered in the `dompurify-isolated` vitest project, since importing the server entry module transitively pulls in `isomorphic-dompurify`.
- Full suite via build-guardian: lint (0 errors), 8263 unit tests pass, integration pass, build pass. Pre-existing e2e connection-refused failures are environmental and touch none of the changed files.
- `caddy validate` and the live forged-`X-Forwarded-For` curl check require a running standalone-profile stack and are documented as operator verification steps.