### PR TITLE
fix(ap-inbox): tag local-dispatched inbox rows with local_dispatch

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -1,6 +1,6 @@
 # Product Decisions Log
 
-> Last Updated: 2026-05-23
+> Last Updated: 2026-06-10
 > Version: 2.1.0
 > Override Priority: Highest
 
@@ -79,7 +79,7 @@ Supersession is tracked inline: superseded sections are noted at the bottom of t
 - **File:** [decisions/dec-013-inbox-authenticated-activity-log.md](decisions/dec-013-inbox-authenticated-activity-log.md)
 - **Date:** 2026-05-16 · **Status:** Accepted
 - **Decision:** Every `ap_inbox` row is authenticated by a recorded mechanism, captured in `auth_source` (open string enum: `'http_signature'`, `'outbox_pull'`, ...) with an audit-only `auth_origin`. Authentication runs at the ingest boundary; the table's invariant is "authenticated by *some* recorded mechanism," not "arrived via signed POST." `auth_source` is diagnostic — never a policy surface. Backfill and live ingest share one storage model and one chronological dispatch pipeline.
-- **Consult when:** Adding a new ingest path (ICS pull, hosted-provider OAuth, Facebook import); reading from or writing to `ap_inbox`; designing or modifying the inbox dispatch pipeline; deciding how to gate trust on inbound activities; questions about why `auth_source` is not consulted by handlers, or why backfill writes real rows instead of dispatching synthetically.
+- **Consult when:** Adding a new ingest path (ICS pull, hosted-provider OAuth, Facebook import); local in-process outbox→inbox dispatch to same-instance recipients (`auth_source='local_dispatch'`); reading from or writing to `ap_inbox`; designing or modifying the inbox dispatch pipeline; deciding how to gate trust on inbound activities; questions about why `auth_source` is not consulted by handlers, or why backfill writes real rows instead of dispatching synthetically.
 
 ---
 

--- a/agent-os/product/decisions/dec-013-inbox-authenticated-activity-log.md
+++ b/agent-os/product/decisions/dec-013-inbox-authenticated-activity-log.md
@@ -64,3 +64,11 @@ The choice to make `auth_source` diagnostic rather than access-controlling is de
 - User-perceptible feed latency for follow-backfill is pagination time plus a single end-of-pagination drain, not per-page dispatch. At the 60 req/min per-host rate limit, a 50-page outbox takes ~50 seconds minimum before the user sees any backfilled history. Per-page drain is not an option — it would dispatch Undos before their target Announces on reverse-chronological outboxes, breaking the strict cross-check.
 - Schema migration adds two columns to `ap_inbox`. PostgreSQL ≥11 makes `ADD COLUMN ... DEFAULT` a metadata-only operation; older versions backfill synchronously. Production version must be verified before deploying.
 - `auth_source` is an open string enum, not a closed union. Application-layer code must treat unknown values as opaque diagnostic data rather than branching on them.
+
+## Amendment 2026-06-10: `'local_dispatch'` provenance value
+
+A third known `auth_source` value is added: `'local_dispatch'`. It tags `ap_inbox` rows produced by the in-process outbox→inbox dispatch path (`ProcessInboxService.handleLocalActivityDispatch`) for same-instance recipients — the case where a local calendar's outbox activity is delivered to another local calendar's inbox without ever leaving the process.
+
+This is a **provenance** value recording structural trust, not remote authentication. Trust for these rows is structural: the activity never left the process, so there is no signed HTTP POST and no remote party to verify it against. `'local_dispatch'` must not be read to imply that any remote server was authenticated. Accordingly, `auth_origin` is `null` for these rows — there is no remote authenticating party to record.
+
+This amendment is additive and consistent with the original decision: the column was always an open string enum, and adding a value requires no schema or migration change (the `NOT NULL DEFAULT 'http_signature'` default is unchanged). `auth_source` remains diagnostic-only; no handler branches on `'local_dispatch'`. `Status: Accepted` is unchanged — this clarifies an ingest path the original decision already anticipated ("future ingest paths add new values without schema changes"), it does not supersede anything.

--- a/src/server/activitypub/entity/activitypub.ts
+++ b/src/server/activitypub/entity/activitypub.ts
@@ -93,8 +93,10 @@ class ActivityPubInboxMessageEntity extends ActivityPubMessageEntity {
   /**
    * Authentication mechanism that admitted this row to the inbox (DEC-013).
    * Open string enum; known values: `'http_signature'` (live inbox POST
-   * verified by HTTP Signatures) and `'outbox_pull'` (follow-backfill
-   * signed-GET outbox crawl). NOT NULL with a `'http_signature'` default
+   * verified by HTTP Signatures), `'outbox_pull'` (follow-backfill
+   * signed-GET outbox crawl), and `'local_dispatch'` (in-process
+   * outbox→inbox dispatch to same-instance recipients; structural trust,
+   * `auth_origin` null). NOT NULL with a `'http_signature'` default
    * so pre-DEC-013 rows backfill on migration.
    *
    * Internal field. NOT serialized via `toModel()` and MUST NOT appear in

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -2141,6 +2141,12 @@ class ProcessInboxService {
           type: activity.type,
           message_time: publishedDate,
           message: messagePayload,
+          // Provenance for in-process outbox→inbox dispatch to a same-instance
+          // recipient. These rows are NOT produced by a signed HTTP POST, so
+          // they must not inherit the column default 'http_signature' (DEC-013).
+          // auth_origin is null because there is no remote authenticating party.
+          auth_source: 'local_dispatch',
+          auth_origin: null,
         });
       }
       catch (createError: any) {

--- a/src/server/activitypub/test/integration/handle-local-activity-dispatch.integration.test.ts
+++ b/src/server/activitypub/test/integration/handle-local-activity-dispatch.integration.test.ts
@@ -339,6 +339,11 @@ describe('ProcessInboxService.handleLocalActivityDispatch (integration)', () => 
     expect(inboxRow, 'local dispatch must write an inbox row for the Create').not.toBeNull();
     expect(inboxRow!.type).toBe('Create');
     expect(inboxRow!.processed_status).toBe('ok');
+    // Provenance (DEC-013): in-process dispatch rows must record
+    // 'local_dispatch', not inherit the column default 'http_signature'.
+    // auth_origin is null because there is no remote authenticating party.
+    expect(inboxRow!.auth_source).toBe('local_dispatch');
+    expect(inboxRow!.auth_origin).toBeNull();
 
     const apObject = await EventObjectEntity.findOne({ where: { ap_id: apEventId } });
     expect(apObject, 'processCreateEvent must create an EventObjectEntity mapping').not.toBeNull();


### PR DESCRIPTION
## Motivation

`ProcessInboxService.handleLocalActivityDispatch` created `ap_inbox` rows without setting `auth_source`, so each in-process row inherited the column default `auth_source='http_signature'`. That label is semantically false: these rows are produced by the same-instance outbox→inbox dispatch path, never by a signed HTTP POST. The mislabeling corrupted the one signal federation/audit tooling uses to distinguish in-process traffic from inbound signed traffic.

Per DEC-013, `auth_source` is a diagnostic/audit-only field that must record the actual mechanism that produced the row; no handler branches on it. This is an audit-correctness fix, not a security or trust-gate change.

## Approach

- `handleLocalActivityDispatch` now passes `auth_source: 'local_dispatch'` and `auth_origin: null` to `ActivityPubInboxMessageEntity.create`. `auth_origin` is null because there is no remote authenticating party for an in-process row — trust on this path is structural (the activity never left the process), established via the existing `trustLocalOrigin` flag, not derived from the provenance label.
- No schema/migration change: `auth_source` is an open string enum, so a new value needs no DDL and the `DEFAULT 'http_signature'` stays. No trust-gate logic changed — `auth_source` remains non-policy.
- DEC-013's known-values prose gains an additive, dated amendment framing `'local_dispatch'` as structural-trust provenance (explicitly not remote authentication); `decisions.md` index `Last Updated` bumped and DEC-013's "Consult when" entry updated. The entity JSDoc enumeration was extended to list the new value.

## Validation

- New integration assertions in `handle-local-activity-dispatch.integration.test.ts`: a locally-dispatched row persists with `auth_source === 'local_dispatch'` and `auth_origin === null`, mirroring the existing `http_signature` and `outbox_pull` ingest-path tests.
- Full suite via build-guardian: lint 0 errors, unit (8274) pass, integration (669, incl. the new assertions) pass, frontend build clean. Two pre-existing e2e failures (admin-moderation flake, ICS-import missing cert) are environmental and unrelated to this change.
- Post-code audits (architecture, consistency, testing, security) all PASS; confirmed no handler consults `auth_source` and the signed-POST authentication path is untouched.