### PR TITLE
test: add XSS regression corpus across sanitization callsites

### DIFF
--- a/src/common/test/utils/render-markdown.test.ts
+++ b/src/common/test/utils/render-markdown.test.ts
@@ -49,6 +49,76 @@ const xssVectors: Array<{ name: string; input: string }> = [
     name: 'raw <style> block',
     input: '<style>body{background:url(javascript:alert(1))}</style>',
   },
+  // --- pv-dzy3 corpus expansion: bypass classes the original 9 vectors miss ---
+  {
+    // MathML mutation-XSS: <math>/<mglyph> are absent from ALLOWED_TAGS. In
+    // foreign-content parsing contexts mglyph can be a mutation gadget; this
+    // fixture locks the closed allowlist so math/mglyph can never re-enter it.
+    name: 'MathML mglyph mXSS wrapper',
+    input: '<math><mglyph><img src=x onerror=alert(1)></mglyph></math>',
+  },
+  {
+    // SVG <animate> driving an href to a javascript: value — the URI is in a
+    // values= attribute, not directly in href=, so URI-scheme allowlisting on
+    // href alone would miss it. svg/animate are forbidden tags; the whole
+    // subtree must drop.
+    name: 'SVG animate xlink:href values=javascript:',
+    input: '<svg><a><animate xlink:href="#x" attributeName="href" values="javascript:alert(1)"/></a></svg>',
+  },
+  {
+    // formaction on a button overrides the form action with a javascript: URI.
+    // form is a forbidden tag and formaction is not in ALLOWED_ATTR.
+    name: 'form button formaction=javascript:',
+    input: '<form><button formaction="javascript:alert(1)">click</button></form>',
+  },
+  {
+    // noscript mutation XSS: the title attribute closes </noscript> early in
+    // parsers that switch tokenizer state on noscript, re-materializing the
+    // <img onerror> as live markup. noscript is not in ALLOWED_TAGS.
+    name: 'noscript mutation XSS via title',
+    input: '<noscript><p title="</noscript><img src=x onerror=alert(1)>"></p>',
+  },
+  {
+    // Raw <a href="javascript:..."> reaching DOMPurify directly — the
+    // raw-HTML form, distinct from the marked-minted markdown-link form at
+    // index 2. Exercises ALLOWED_URI_REGEXP on a literal anchor token.
+    name: 'raw anchor javascript: scheme',
+    input: '<a href="javascript:alert(1)">click</a>',
+  },
+  {
+    // data:text/html in markdown-link form — a navigable HTML document URI.
+    name: 'markdown link data:text/html',
+    input: '[click](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)',
+  },
+  {
+    // data:text/html in raw-anchor form — the same scheme reaching DOMPurify
+    // through a literal <a href> rather than through marked.
+    name: 'raw anchor data:text/html href',
+    input: '<a href="data:text/html,&lt;script&gt;alert(1)&lt;/script&gt;">click</a>',
+  },
+  // --- cure53-derived allowlist-bypass vectors (tag/attribute smuggling) ---
+  {
+    // <template> holds inert DOM that some sanitizers fail to traverse;
+    // template is not in ALLOWED_TAGS and must be stripped with its contents.
+    name: 'cure53 template content smuggling',
+    input: '<template><img src=x onerror=alert(1)></template>',
+  },
+  {
+    // CSS @import pulling a javascript: stylesheet — style is a forbidden tag.
+    name: 'cure53 style @import javascript:',
+    input: '<style>@import "javascript:alert(1)";</style>',
+  },
+  {
+    // <details ontoggle> — event handler on a non-allowlisted interactive tag.
+    name: 'cure53 details ontoggle handler',
+    input: '<details open ontoggle=alert(1)>x</details>',
+  },
+  {
+    // <marquee onstart> — legacy element with an event handler; marquee is not
+    // in ALLOWED_TAGS.
+    name: 'cure53 marquee onstart handler',
+    input: '<marquee onstart=alert(1)>x</marquee>',
+  },
 ];
 
 /**
@@ -56,12 +126,20 @@ const xssVectors: Array<{ name: string; input: string }> = [
  * matches a `<tag` token boundary so that allowed content (e.g. an
  * inline `<a>` link) is never mistaken for a forbidden tag.
  */
-const FORBIDDEN_TAGS = ['script', 'iframe', 'object', 'base', 'style', 'svg', 'animate', 'embed', 'form'];
+const FORBIDDEN_TAGS = [
+  'script', 'iframe', 'object', 'base', 'style', 'svg', 'animate', 'embed', 'form',
+  // pv-dzy3 additions — closed-allowlist drift guards
+  'math', 'mglyph', 'template', 'noscript', 'marquee', 'details', 'button',
+];
 
 /**
  * Forbidden attributes — inline event handlers and identity/styling vectors.
  */
-const FORBIDDEN_ATTRS = ['onerror', 'onload', 'onbegin', 'onclick', 'onmouseover', 'onfocus'];
+const FORBIDDEN_ATTRS = [
+  'onerror', 'onload', 'onbegin', 'onclick', 'onmouseover', 'onfocus',
+  // pv-dzy3 additions — formaction (action-override) and ontoggle/onstart handlers
+  'formaction', 'ontoggle', 'onstart', 'xlink:href',
+];
 
 /**
  * Forbidden URI schemes that must never appear in attribute-position
@@ -86,7 +164,15 @@ describe('renderPolicyMarkdown', () => {
           expect(output.toLowerCase()).not.toMatch(new RegExp(`<${tag}\\b`, 'i'));
         }
 
-        // No inline event-handler attributes.
+        // No LIVE inline event-handler attribute. Anchored to a live tag run
+        // (`<...on*=`) the way the AP expectInert helper does, so a payload that
+        // renders as escaped, inert TEXT (e.g. a code-fenced `&lt;img onerror=`)
+        // does not false-fail merely because the substring survives as content.
+        expect(output).not.toMatch(/<[^>]*\son\w+\s*=/i);
+
+        // Belt-and-suspenders substring check for the specific handler/attribute
+        // tokens. Safe for current fixtures (none render the token as inert
+        // text); kept alongside the live-tag-run regex above for defense in depth.
         for (const attr of FORBIDDEN_ATTRS) {
           expect(output.toLowerCase()).not.toContain(attr);
         }
@@ -210,28 +296,46 @@ describe('isPolicySourceSafe', () => {
   });
 
   describe('returns false for XSS vectors', () => {
-    it('rejects raw <script> tags', () => {
-      expect(isPolicySourceSafe('<script>alert(1)</script>')).toBe(false);
-    });
-
-    it('rejects <iframe> tags', () => {
-      expect(isPolicySourceSafe('<iframe src="https://evil.example"></iframe>')).toBe(false);
-    });
-
-    it('rejects <img> with onerror handler', () => {
-      expect(isPolicySourceSafe('<img onerror=alert(1) src=x>')).toBe(false);
-    });
-
-    it('rejects markdown link with javascript: scheme', () => {
-      expect(isPolicySourceSafe('[click](javascript:alert(1))')).toBe(false);
-    });
-
     it('rejects raw <a> with javascript: href', () => {
       expect(isPolicySourceSafe('<a href="javascript:alert(1)">click</a>')).toBe(false);
     });
 
-    it('rejects markdown image with data: URI', () => {
-      expect(isPolicySourceSafe('![img](data:image/svg+xml,<svg onload=alert(1)>)')).toBe(false);
+    // Note: the individual data:-URI and other per-vector cases are covered by
+    // the for-loop below, which asserts isPolicySourceSafe(input) === false for
+    // every entry in the shared xssVectors corpus (including the data:image/svg
+    // markdown-image vector at index 3). No standalone duplicates needed.
+
+    // Every vector in the shared corpus must also be REJECTED by the save-time
+    // predicate, not merely stripped at render time. isPolicySourceSafe is a
+    // plain boolean (string-equality on the normalized parsed-vs-purified
+    // output, render-markdown.ts:155-159) — it never throws, so each dangerous
+    // vector asserts `toBe(false)`. This locks the save-time refusal contract
+    // alongside the render-time strip contract above.
+    for (const { name, input } of xssVectors) {
+      it(`rejects: ${name}`, () => {
+        expect(isPolicySourceSafe(input)).toBe(false);
+      });
+    }
+  });
+
+  describe('normalization-boundary safe content (numeric/named entities)', () => {
+    // normalizeEntitiesForComparison (render-markdown.ts:118-126) decodes only
+    // the apostrophe/quote entity family on BOTH sides of the equality check,
+    // because marked emits &#39;/&quot; for ASCII ' and " while DOMPurify
+    // normalizes them back to literal characters. These fixtures assert the
+    // boundary holds: content carrying those numeric entities is accepted
+    // (no false-positive strip). &#x3C; (a literal '<') is intentionally NOT
+    // in this set — it decodes to a structural char and is correctly rejected.
+    it('accepts &#39; numeric apostrophe entity', () => {
+      expect(isPolicySourceSafe('it&#39;s here')).toBe(true);
+    });
+
+    it('accepts &#x27; hex apostrophe entity', () => {
+      expect(isPolicySourceSafe('don&#x27;t stop')).toBe(true);
+    });
+
+    it('accepts &#34; numeric double-quote entity', () => {
+      expect(isPolicySourceSafe('a &#34;quoted&#34; phrase')).toBe(true);
     });
   });
 

--- a/src/server/activitypub/test/model/object/event.xss.test.ts
+++ b/src/server/activitypub/test/model/object/event.xss.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest';
+
+import { EventObject } from '@/server/activitypub/model/object/event';
+
+/**
+ * XSS regression suite for the FEDERATED-CONTENT strip path (pv-dzy3).
+ *
+ * Config under test: the module-private `stripHtmlTags` in
+ * `src/server/activitypub/model/object/event.ts` —
+ *   `striptags(he.decode(html)).trim()`
+ * This is the ONLY sanitizer on inbound federated text fields. It is NOT
+ * DOMPurify: there is no allowlist and no DOM parse. striptags is a
+ * state-machine stripper that removes everything between `<` and `>`; he.decode
+ * runs first so HTML entity references re-materialize into live tag tokens that
+ * striptags then removes.
+ *
+ * Audit notes anchored here (full audit on the bead):
+ *   - he.decode runs ONLY on text fields routed through stripHtmlTags. URL
+ *     fields (attachment href, pavillion id) bypass decode entirely and go raw
+ *     to sanitizeExternalUrlHref / _validatePavillionId — out of scope here.
+ *   - Double-encoded entities are EXPECTED to survive as inert entity text
+ *     (one he.decode pass un-nests one level), never as live markup. See the
+ *     double-encode block below for the asserted direction.
+ *
+ * stripHtmlTags is module-private by design (event.test.ts drives it through
+ * public entry points rather than exporting it); these tests follow the same
+ * convention via `EventObject.fromActivityPubObject`. The assertions confirm
+ * every text-field ingestion branch yields plain text: no `<tag` token, no
+ * `on*=` handler, no `javascript:`/`data:` attribute scheme.
+ *
+ * SECURITY BOUNDARY these "inert" assertions rely on:
+ *   Federated event text fields are stored as PLAIN TEXT and are NEVER bound
+ *   via `v-html`. The only `v-html` sink in the app is admin-authored policy
+ *   markdown in instance-policy.vue (guarded by the DOMPurify pipeline tested
+ *   in render-markdown.test.ts). Because federated text reaches the DOM only
+ *   through text interpolation, token-absence (no `<tag`, no `on*=`, no live
+ *   scheme) is a sufficient inertness check here.
+ *   IF a future feature ever binds a federated event field to `v-html`, this
+ *   boundary collapses: these token-absence assertions would NO LONGER be
+ *   sufficient, and that field would need a DOMPurify-grade allowlist sanitizer
+ *   instead of the striptags strip path.
+ */
+
+/** A parsed field is inert when it carries no tag token, handler, or live scheme. */
+function expectInert(value: unknown): void {
+  expect(typeof value).toBe('string');
+  const s = value as string;
+  // No opening tag token survives (striptags removes < … >).
+  expect(s).not.toMatch(/<[a-z!/]/i);
+  // No inline event-handler attribute survives.
+  expect(s).not.toMatch(/\son\w+\s*=/i);
+  // No dangerous URI scheme wired into an attribute survives.
+  expect(s).not.toMatch(/=\s*["']?\s*(?:javascript|data|vbscript):/i);
+}
+
+describe('EventObject.fromActivityPubObject — federated XSS strip path', () => {
+
+  // ---------------------------------------------------------------------------
+  // Positive controls: one per ingestion branch. Benign HTML must strip to the
+  // expected NON-EMPTY plain text. These run first so the negative assertions
+  // below are trustworthy — they prove the harness actually reaches each branch
+  // and that stripping happens (rather than the field being dropped/empty).
+  // ---------------------------------------------------------------------------
+  describe('positive controls (harness wiring per ingestion branch)', () => {
+    it('bare name/summary strips benign HTML to plain text', () => {
+      const r = EventObject.fromActivityPubObject({
+        name: '<p>Hello <strong>world</strong></p>',
+        summary: '<em>Friendly</em> description',
+      });
+      expect(r.content.en.name).toBe('Hello world');
+      expect(r.content.en.description).toBe('Friendly description');
+    });
+
+    it('bare content string fallback strips benign HTML to plain text', () => {
+      const r = EventObject.fromActivityPubObject({
+        name: 'Title',
+        content: '<p>Body <b>text</b></p>',
+      });
+      expect(r.content.en.description).toBe('Body text');
+    });
+
+    it('nameMap/summaryMap strip benign HTML per language', () => {
+      const r = EventObject.fromActivityPubObject({
+        nameMap: { en: '<b>Bold</b> Title', es: '<i>Evento</i>' },
+        summaryMap: { en: '<u>Desc</u>', es: 'Normal' },
+      });
+      expect(r.content.en.name).toBe('Bold Title');
+      expect(r.content.es.name).toBe('Evento');
+      expect(r.content.en.description).toBe('Desc');
+    });
+
+    it('contentMap fallback (no summaryMap) strips benign HTML to plain text', () => {
+      const r = EventObject.fromActivityPubObject({
+        nameMap: { en: 'Title' },
+        contentMap: { en: '<p>Html <strong>Body</strong></p>' },
+      });
+      expect(r.content.en.description).toBe('Html Body');
+    });
+
+    it('pavillion:content strips benign HTML in name, description, accessibilityInfo', () => {
+      const r = EventObject.fromActivityPubObject({
+        'pavillion:content': {
+          en: {
+            name: '<b>Festival</b>',
+            description: '<p>A <em>fun</em> time</p>',
+            accessibilityInfo: '<i>Ramp access</i>',
+          },
+        },
+      });
+      expect(r.content.en.name).toBe('Festival');
+      expect(r.content.en.description).toBe('A fun time');
+      expect(r.content.en.accessibilityInfo).toBe('Ramp access');
+    });
+
+    it('pavillion:place strips benign HTML in name, address, accessibilityInfo', () => {
+      const r = EventObject.fromActivityPubObject({
+        'pavillion:place': {
+          id: 'https://peer.example/p/1',
+          address: '<b>123</b> Main St',
+          content: { en: { name: '<i>City Park</i>', accessibilityInfo: '<u>Step-free</u>' } },
+        },
+      });
+      expect(r.location.name).toBe('City Park');
+      expect(r.location.address).toBe('123 Main St');
+      expect(r.location.content.en.accessibilityInfo).toBe('Step-free');
+    });
+
+    it('pavillion:space (parent-path matched) strips benign HTML in content', () => {
+      const r = EventObject.fromActivityPubObject({
+        'pavillion:place': {
+          id: 'https://peer.example/p/1',
+          content: { en: { name: 'Parent Place' } },
+        },
+        'pavillion:space': {
+          id: 'https://peer.example/p/1/spaces/9',
+          content: { en: { name: '<b>Main Hall</b>', accessibilityInfo: '<i>Wide doors</i>' } },
+        },
+      });
+      expect(r.space.content.en.name).toBe('Main Hall');
+      expect(r.space.content.en.accessibilityInfo).toBe('Wide doors');
+    });
+
+    it('flat as:location string strips benign HTML to plain text', () => {
+      const r = EventObject.fromActivityPubObject({ location: '<b>Downtown</b> Plaza' });
+      expect(r.location.name).toBe('Downtown Plaza');
+    });
+
+    it('flat as:Place object strips benign HTML in name and address fields', () => {
+      const r = EventObject.fromActivityPubObject({
+        location: {
+          type: 'Place',
+          name: '<b>Hall</b>',
+          address: {
+            type: 'PostalAddress',
+            streetAddress: '<i>5</i> Ave',
+            addressLocality: '<em>Springfield</em>',
+          },
+        },
+      });
+      expect(r.location.name).toBe('Hall');
+      expect(r.location.address).toBe('5 Ave');
+      expect(r.location.city).toBe('Springfield');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Raw-markup vectors: literal tags reaching the strip path. striptags removes
+  // the tag tokens; only inert text content may remain.
+  // ---------------------------------------------------------------------------
+  describe('raw-markup vectors strip to inert text', () => {
+    const rawVectors: Array<{ name: string; input: string }> = [
+      { name: 'raw <script>', input: '<script>alert(1)</script>Title' },
+      { name: '<img> onerror handler', input: '<img src=x onerror=alert(1)>Title' },
+      { name: '<svg><script>', input: '<svg><script>alert(1)</script></svg>Title' },
+      { name: '<a> javascript: href', input: '<a href="javascript:alert(1)">Title</a>' },
+      { name: '<iframe> srcdoc', input: '<iframe srcdoc="<script>alert(1)</script>">Title</iframe>' },
+    ];
+    for (const { name, input } of rawVectors) {
+      it(`bare name: ${name}`, () => {
+        const r = EventObject.fromActivityPubObject({ name: input });
+        expectInert(r.content.en.name);
+        expect(r.content.en.name).not.toContain('script>');
+      });
+    }
+
+    it('pavillion:content name + description strip raw markup inertly', () => {
+      const r = EventObject.fromActivityPubObject({
+        'pavillion:content': {
+          en: {
+            name: '<script>alert("xss")</script>Event',
+            description: '<img src=x onerror=alert(1)>Desc',
+          },
+        },
+      });
+      expectInert(r.content.en.name);
+      expectInert(r.content.en.description);
+    });
+
+    it('flat as:Place name strips raw markup inertly', () => {
+      const r = EventObject.fromActivityPubObject({
+        location: { type: 'Place', name: '<script>alert(1)</script>Park' },
+      });
+      expectInert(r.location.name);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Single-encoded entities: the REAL decode-then-strip probe. he.decode turns
+  // &lt;script&gt; back into a live <script> token BEFORE striptags runs, so a
+  // sanitizer that stripped first and decoded second would leak markup. This
+  // confirms ordering: decode → strip → inert.
+  // ---------------------------------------------------------------------------
+  describe('single-encoded entity vectors (decode-then-strip)', () => {
+    const encVectors: Array<{ name: string; input: string }> = [
+      { name: '&lt;script&gt; entity', input: '&lt;script&gt;alert(1)&lt;/script&gt;Title' },
+      { name: '&lt;img onerror&gt; entity', input: '&lt;img src=x onerror=alert(1)&gt;Title' },
+    ];
+    for (const { name, input } of encVectors) {
+      it(`bare name: ${name}`, () => {
+        const r = EventObject.fromActivityPubObject({ name: input });
+        expectInert(r.content.en.name);
+      });
+    }
+
+    it('summary field decodes-then-strips single-encoded markup', () => {
+      const r = EventObject.fromActivityPubObject({
+        summary: '&lt;script&gt;steal(cookies)&lt;/script&gt;Safe description',
+      });
+      expectInert(r.content.en.description);
+    });
+
+    it('nameMap value decodes-then-strips single-encoded markup', () => {
+      const r = EventObject.fromActivityPubObject({
+        nameMap: { en: '&lt;img src=x onerror=alert(1)&gt;Evento' },
+        summaryMap: { en: 'Desc' },
+      });
+      expectInert(r.content.en.name);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Double-encoded entities: CONTRACT test. he.decode runs exactly once, so
+  // `&amp;lt;script&amp;gt;` un-nests one level to the inert TEXT `<script>`
+  // (entity-decoded but NOT re-parsed as markup). The assertion direction:
+  // the result is plain text containing the literal characters `<script>`, and
+  // it is inert — there is no live tag token because striptags sees a `<`
+  // followed by text, not a parser-recognized element with attributes, and the
+  // value is never re-decoded. This documents that a single decode pass cannot
+  // be chained by an attacker into live markup.
+  // ---------------------------------------------------------------------------
+  describe('double-encoded entity vectors (contract: inert text, not markup)', () => {
+    it('double-encoded script un-nests one level to inert entity text', () => {
+      const r = EventObject.fromActivityPubObject({ name: '&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;' });
+      // One he.decode pass: &amp; -> & leaves the literal text "<script>…".
+      // striptags then removes the angle-bracketed run, leaving inert text.
+      // The field is plain text with no live handler/scheme and is never
+      // decoded a second time, so no execution context exists.
+      expectInert(r.content.en.name);
+      // Positive direction: the (now inert) decoded content is present as text,
+      // confirming we tested the real un-nest behavior rather than a drop.
+      expect(r.content.en.name).toContain('alert(1)');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // striptags parser-edge cases: striptags is a state machine, not a DOM
+  // parser. These probe its tokenizer boundaries — no-whitespace attribute
+  // separators, null bytes in tag position, and unterminated/broken close
+  // sequences. Each must still yield inert output.
+  // ---------------------------------------------------------------------------
+  describe('striptags parser-edge vectors', () => {
+    it('no-whitespace attribute separator (<img/onerror=...>)', () => {
+      const r = EventObject.fromActivityPubObject({ name: '<img/onerror=alert(1)>Title' });
+      expectInert(r.content.en.name);
+    });
+
+    it('null byte inside a tag-name run', () => {
+      // A NUL embedded in the opening tag-name. striptags treats `<`…`>` as a
+      // tag regardless of interior bytes, so the whole run is removed.
+      const input = 'pre <scr' + String.fromCharCode(0) + 'ipt>alert(1)</script> post';
+      const r = EventObject.fromActivityPubObject({ name: input });
+      expectInert(r.content.en.name);
+      expect(r.content.en.name).not.toContain('script');
+    });
+
+    it('unterminated/broken close-tag sequence', () => {
+      const r = EventObject.fromActivityPubObject({ name: '<img src=x onerror=alert(1)//Trailing' });
+      expectInert(r.content.en.name);
+    });
+
+    it('mixed live + entity-encoded markup in one field', () => {
+      const r = EventObject.fromActivityPubObject({ name: 'Hi <b>there</b> &lt;script&gt;x&lt;/script&gt;' });
+      expectInert(r.content.en.name);
+    });
+  });
+});

--- a/src/server/activitypub/test/model/object/note.xss.test.ts
+++ b/src/server/activitypub/test/model/object/note.xss.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import config from 'config';
+import { DateTime } from 'luxon';
+
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent, CalendarEventContent, CalendarEventSchedule } from '@/common/model/events';
+import { EventLocation } from '@/common/model/location';
+import { NoteObject } from '@/server/activitypub/model/object/note';
+
+const startDt = DateTime.fromISO('2026-06-15T18:30:00.000Z');
+
+const domain = config.get<string>('domain');
+
+/**
+ * XSS regression suite for the OUTBOUND Note rendering path (pv-dzy3).
+ *
+ * Config under test: `NoteObject.toActivityPubObject` in
+ * `src/server/activitypub/model/object/note.ts`. The Note is the ONE place in
+ * AP serialization where Pavillion EMITS HTML (a `<p><a href>…</a></p>`
+ * paragraph) for Mastodon-class consumers that render Note content verbatim.
+ *
+ * NoteObject has NO `fromActivityPubObject` — Pavillion never ingests remote
+ * Notes (note.ts:45-47). So unlike the EventObject strip path, the threat here
+ * is not inbound markup smuggling; it is OUTBOUND template injection. If a
+ * locally-stored event title or location name contained HTML/quote characters
+ * and were interpolated raw into the content string, a malicious value could
+ * break out of the anchor and inject markup into a downstream renderer.
+ *
+ * The defense is `he.encode` applied to title, href, and location before
+ * interpolation (note.ts:144-151,159). These fixtures lock that contract: a
+ * title/location/override-URL carrying `<`, `"`, or `>` must appear ONLY in
+ * encoded form, never as a live tag, attribute break-out, or quote break-out.
+ *
+ * The anchor href is additionally constrained by `sanitizeExternalUrlHref` on
+ * the urlOverride path (rejects non-http(s) schemes); that scheme validator is
+ * tested in note.test.ts. Here we cover the he.encode escaping layer.
+ */
+
+/**
+ * A Note content string is safe when injected payload chars appear only in
+ * he.encode'd form — i.e. no RAW angle bracket introduces a tag beyond
+ * Pavillion's own wrapper. Once every `<`/`>`/`"` from user content is encoded
+ * to `&#x3C;`/`&#x3E;`/`&#x22;`, a residual literal `onerror=alert(1)` is inert
+ * text, not a live attribute, because there is no live element to host it. So
+ * the load-bearing assertion is the absence of an unexpected raw tag token; the
+ * handler check is anchored to live `<…>` runs only, not to bare text.
+ */
+function expectNoLiveBreakout(html: string): void {
+  // Strip Pavillion's known-good wrapper tags, then assert no other RAW tag
+  // token remains. he.encode'd payload (&#x3C;img…) is text, not a tag, so it
+  // is correctly not matched here.
+  const withoutWrapper = html
+    .replace(/<p>/g, '')
+    .replace(/<\/p>/g, '')
+    .replace(/<a href="[^"]*">/g, '')
+    .replace(/<\/a>/g, '');
+  expect(withoutWrapper).not.toMatch(/<[a-z!/]/i);
+  // No event handler hosted inside a residual live tag run. Anchored to a
+  // raw `<…on*=` sequence so encoded payload text (which can legitimately
+  // contain the literal `onerror=`) does not false-positive.
+  expect(withoutWrapper).not.toMatch(/<[^>]*\son\w+\s*=/i);
+}
+
+function buildEvent(title: string, opts: { locationName?: string } = {}): { calendar: Calendar; event: CalendarEvent } {
+  const calendar = new Calendar('cal-uuid', 'mycal');
+  const event = new CalendarEvent('event-uuid', 'cal-uuid');
+  event.addContent(new CalendarEventContent('en', title, ''));
+  event.schedules = [new CalendarEventSchedule('s1', startDt)];
+  event.date = '2026-06-15';
+  if (opts.locationName !== undefined) {
+    event.location = new EventLocation('loc-uuid', opts.locationName);
+  }
+  return { calendar, event };
+}
+
+describe('NoteObject.toActivityPubObject — outbound template-injection escaping', () => {
+
+  // ---------------------------------------------------------------------------
+  // Positive control: benign content renders the expected wrapper + readable
+  // text so the negative assertions below are trustworthy.
+  // ---------------------------------------------------------------------------
+  it('positive control: benign title and location render readable, wrapped content', () => {
+    const { calendar, event } = buildEvent('Coffee Meetup', { locationName: 'Riverside Park' });
+    const result = new NoteObject(calendar, event).toActivityPubObject();
+
+    expect(result.content).toContain('<a href=');
+    expect(result.content).toContain('Coffee Meetup');
+    expect(result.content).toContain('Riverside Park');
+    expect(result.name).toBe('Coffee Meetup');
+    expectNoLiveBreakout(result.content);
+  });
+
+  describe('title escaping (name and content fields)', () => {
+    const titleVectors: Array<{ name: string; title: string }> = [
+      { name: 'script tag in title', title: '<script>alert(1)</script>Party' },
+      { name: 'img onerror in title', title: '<img src=x onerror=alert(1)>Gala' },
+      { name: 'attribute break-out via quote', title: 'Show"><img src=x onerror=alert(1)>' },
+      { name: 'angle brackets only', title: 'A < B > C' },
+    ];
+    for (const { name, title } of titleVectors) {
+      it(`encodes title: ${name}`, () => {
+        const { calendar, event } = buildEvent(title);
+        const result = new NoteObject(calendar, event).toActivityPubObject();
+
+        // name field is he.encode'd directly.
+        expect(result.name).not.toMatch(/<[a-z!/]/i);
+        // content paragraph carries no live break-out beyond the wrapper.
+        expectNoLiveBreakout(result.content);
+        // The dangerous '<' is present only in encoded form within content —
+        // a raw '<script' / '<img' tag token never appears. (A residual
+        // literal 'onerror=' inside encoded text is inert: its host tag's
+        // angle brackets are encoded, so there is no live attribute.)
+        expect(result.content).not.toContain('<script');
+        expect(result.content).not.toContain('<img');
+      });
+    }
+  });
+
+  describe('location escaping (content field)', () => {
+    it('encodes a malicious location name in the content segment', () => {
+      const { calendar, event } = buildEvent('Benign Title', {
+        locationName: '<img src=x onerror=alert(1)>Hall',
+      });
+      const result = new NoteObject(calendar, event).toActivityPubObject();
+
+      expectNoLiveBreakout(result.content);
+      // Raw tag token never appears; the payload is encoded to inert text.
+      expect(result.content).not.toContain('<img');
+    });
+
+    it('encodes a quote-breakout location name', () => {
+      const { calendar, event } = buildEvent('Benign Title', {
+        locationName: 'Room"><script>alert(1)</script>',
+      });
+      const result = new NoteObject(calendar, event).toActivityPubObject();
+
+      expectNoLiveBreakout(result.content);
+      expect(result.content).not.toContain('<script');
+    });
+  });
+
+  describe('multi-language contentMap escaping', () => {
+    it('encodes malicious titles in every contentMap/nameMap language entry', () => {
+      const calendar = new Calendar('cal-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'cal-uuid');
+      event.addContent(new CalendarEventContent('en', '<script>en</script>English', ''));
+      event.addContent(new CalendarEventContent('es', 'Show"><img src=x onerror=alert(1)>', ''));
+      event.schedules = [new CalendarEventSchedule('s1', startDt)];
+      event.date = '2026-06-15';
+
+      const result = new NoteObject(calendar, event).toActivityPubObject();
+
+      expect(result.nameMap.en).not.toMatch(/<[a-z!/]/i);
+      expect(result.nameMap.es).not.toMatch(/<[a-z!/]/i);
+      expectNoLiveBreakout(result.contentMap.en);
+      expectNoLiveBreakout(result.contentMap.es);
+      // Raw tag tokens never appear in either language's content.
+      expect(result.contentMap.en).not.toContain('<script');
+      expect(result.contentMap.es).not.toContain('<img');
+    });
+  });
+
+  describe('anchor href escaping (urlOverride path)', () => {
+    it('rejects a non-http(s) override scheme, falling back to the local href', () => {
+      const { calendar, event } = buildEvent('Title');
+      // sanitizeExternalUrlHref rejects javascript: — url is omitted and the
+      // anchor href falls back to the local event page (no scheme break-out).
+      const result = new NoteObject(calendar, event, {
+        urlOverride: 'javascript:alert(1)',
+      }).toActivityPubObject();
+
+      expect(result).not.toHaveProperty('url');
+      expect(result.content).not.toContain('javascript:');
+      expect(result.content).toContain(`href="https://${domain}/calendars/mycal/events/event-uuid"`);
+      expectNoLiveBreakout(result.content);
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

Pavillion renders user- and federation-sourced HTML on pages served to anonymous visitors, so every HTML-sanitization callsite must reliably neutralize injected markup. The codebase had uneven regression coverage: the admin policy-markdown path had a 9-vector suite that missed several modern allowlist-bypass classes, and the federated ActivityPub strip/encode paths had **no** XSS fixtures at all. This adds a bypass-fixture corpus that locks the inertness contract for each callsite at PR time, supporting safe anonymous public rendering.

Test-only — no production code changes.

## Approach

A planning investigation mapped the three distinct sanitization callsites, each with a different mechanism, and a corpus was written per callsite:

- **`render-markdown.test.ts`** (admin policy markdown, `marked` → DOMPurify closed allowlist): extended the table-driven corpus with allowlist-bypass classes the prior vectors missed — MathML `mglyph` mXSS, SVG `animate` `values=javascript:`, `formaction`, `noscript` mutation XSS, `data:`/`javascript:` URIs (markdown and raw-anchor forms), and cure53-derived vectors. Each is asserted against both `renderPolicyMarkdown` (inert output) and `isPolicySourceSafe` (rejected), plus normalization-boundary true-cases.
- **`event.xss.test.ts`** (new, federated inbound `striptags(he.decode(...))`): drives the module-private strip path through every public ActivityPub text-field ingestion branch (bare/map fields, `pavillion:content`, place/space, flat location), with a positive control per branch, single/double-encoded entity vectors, and striptags parser-edge cases (no-whitespace attribute, NUL byte, broken close tags).
- **`note.xss.test.ts`** (new, outbound Note emission via `he.encode`): covers attribute/quote breakout and `javascript:` scheme rejection.

The two ActivityPub suites are split into co-located `*.xss.test.ts` files rather than extended into the already-1000+-line `event.test.ts`. A per-callsite config audit (he.decode text-field-only scope, double-encode assertion direction, RETURN_DOM absence, marked html-passthrough, no post-sanitize concatenation) is recorded alongside the tests.

Every fixture produces inert output on every callsite — zero surviving bypasses, so no follow-up hardening was required.

## Validation

- Targeted run of the three files: **97 passed**.
- Full suite via build-guardian: lint **0 errors**, unit **8337/8337**, integration **669/669**, build **PASS**. The only e2e failures are two pre-existing environmental issues (auth-login navigation with no dev server; ICS import requiring Docker federation SSL certs), unrelated to these test-only changes.
- Reviewed by testing and security auditors. Security auditor independently reproduced the sanitizer behavior and probed for missed bypass classes (mXSS reparse, DOMPurify v3.11 vectors, SVG/MathML namespace confusion, decode-then-strip double-pass) — confirmed the zero-surviving-bypass claim. Two low-severity assertion-strength findings were applied before merge.