### PR TITLE
feat: add rate-limit coverage to unprotected high-risk routes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,22 @@
+# Global server options. Request timeouts mitigate slowloris-class DoS
+# against public read endpoints: a client that opens a connection and then
+# dribbles headers/body slower than these limits has its connection closed
+# rather than holding a server slot open indefinitely.
+#   read_header — max time to receive the full request header (5s)
+#   read_body   — max time to receive the full request body (10s)
+#   idle        — max time a keep-alive connection may sit idle (2m)
+# This is timeout-based mitigation only; per-IP rate limiting and
+# connection-count caps are explicitly out of scope here.
+{
+	servers {
+		timeouts {
+			read_body 10s
+			read_header 5s
+			idle 2m
+		}
+	}
+}
+
 {$DOMAIN} {
 	encode gzip zstd
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -86,6 +86,16 @@ rateLimit:
     byEmail:
       windowMs: 3600000  # 1 hour in milliseconds
       max: 3  # 3 requests per email per hour
+    confirm:
+      byIp:
+        windowMs: 900000  # 15 minutes in milliseconds
+        # Token brute-force defense for POST /api/auth/v1/reset-password/:code.
+        # Threshold matches application.confirm.byIp (20/15m): the audit
+        # (pv-qqno.1, OQ3 verdict) found reset codes are randomBytes(16) =
+        # 128-bit CSPRNG (account.ts:528) with 1-hour expiry, exceeding UUIDv4
+        # entropy. The keyspace is far too large to brute-force, so this is an
+        # abuse cap rather than a guessing wall and does not need a tighter limit.
+        max: 20  # 20 confirmation attempts per IP per 15 minutes
   login:
     byIp:
       windowMs: 900000  # 15 minutes in milliseconds
@@ -100,6 +110,9 @@ rateLimit:
     calendar:
       windowMs: 60000  # 1 minute in milliseconds
       max: 120  # 120 requests per calendar per minute
+    user:
+      windowMs: 60000  # 1 minute in milliseconds
+      max: 120  # 120 requests per user inbox per minute
   moderation:
     reportByIp:
       windowMs: 900000  # 15 minutes in milliseconds
@@ -133,6 +146,16 @@ rateLimit:
     byAccount:
       windowMs: 900000  # 15 minutes in milliseconds
       max: 10  # 10 requests per account per 15 minutes
+  fundingWebhook:
+    byIp:
+      windowMs: 60000  # 1 minute in milliseconds
+      # Deliberately generous. Stripe signature verification (DEC-007) is the
+      # primary defense for POST /api/funding/webhooks/stripe; this limiter is
+      # belt-and-braces only and must never gate legitimate Stripe delivery,
+      # which can burst many events per minute and aggressively retries failed
+      # (non-2xx) deliveries for up to 72 hours. 300/min sits well above any
+      # realistic legitimate burst from a single Stripe source IP.
+      max: 300  # 300 requests per IP per minute
   importSource:
     verifyBySource:
       windowMs: 3600000  # 1 hour in milliseconds
@@ -159,6 +182,30 @@ rateLimit:
       byIp:
         windowMs: 900000  # 15 minutes in milliseconds
         max: 20  # 20 confirmation attempts per IP per 15 minutes
+  register:
+    byIp:
+      windowMs: 900000  # 15 minutes in milliseconds
+      max: 5  # 5 registration submissions per IP per 15 minutes
+    byEmail:
+      windowMs: 3600000  # 1 hour in milliseconds
+      max: 3  # 3 registration submissions per email per hour
+  invitation:
+    accept:
+      byIp:
+        windowMs: 900000  # 15 minutes in milliseconds
+        max: 20  # 20 invitation acceptance attempts per IP per 15 minutes
+  emailChange:
+    byAccount:
+      windowMs: 3600000  # 1 hour in milliseconds
+      # Probe/enumeration defense-in-depth for POST /api/auth/v1/email. The
+      # audit (pv-qqno.1, OQ2 verdict) found that changeEmail verifies the
+      # password then writes the new email directly to the DB: there is NO
+      # outbound email and NO confirm route, so the original outbound-email
+      # amplifier rationale does not apply. The residual risk is password-oracle
+      # probing (InvalidPasswordError) and email-existence enumeration
+      # (EmailAlreadyExistsError). This account-keyed cap bounds that probe rate;
+      # it does not close the differential-response enumeration oracle itself.
+      max: 10  # 10 email-change attempts per account per hour
 
 # Housekeeping configuration for automated server maintenance
 housekeeping:

--- a/src/server/accounts/api/v1/accounts.ts
+++ b/src/server/accounts/api/v1/accounts.ts
@@ -6,6 +6,7 @@ import { Account } from '@/common/model/account';
 import { logError } from '@/server/common/helper/error-logger';
 import { ValidationError } from '@/common/exceptions/base';
 import { createLogger } from '@/server/common/helper/logger';
+import { registerByIp, registerByEmail } from '@/server/common/middleware/rate-limiters';
 
 const logger = createLogger('accounts');
 
@@ -18,7 +19,13 @@ export default class AccountRouteHandlers {
 
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
-    router.post('/register', ...ExpressHelper.noUserOnly, this.registerHandler.bind(this));
+    // Rate limit POST /register by IP (anti-spam) and by email (anti-
+    // enumeration probing). Both limiters are pre-configured singletons in
+    // rate-limiters.ts; they fall back to no-op middleware when rate limiting
+    // is disabled in config. The email limiter increments uniformly on every
+    // attempt regardless of account existence, so it cannot leak which emails
+    // are registered (DEC-004).
+    router.post('/register', registerByIp, registerByEmail, ...ExpressHelper.noUserOnly, this.registerHandler.bind(this));
     router.get('/accounts/me', ...ExpressHelper.loggedInOnly, this.getCurrentUser.bind(this));
     router.patch('/accounts/me/profile', ...ExpressHelper.loggedInOnly, this.updateProfile.bind(this));
     app.use(routePrefix, router);

--- a/src/server/accounts/api/v1/invitations.ts
+++ b/src/server/accounts/api/v1/invitations.ts
@@ -5,6 +5,7 @@ import { ValidationError } from '@/common/exceptions/base';
 import AccountsInterface from '@/server/accounts/interface';
 import ExpressHelper from '@/server/common/helper/express';
 import { logError } from '@/server/common/helper/error-logger';
+import { acceptInvitationByIp } from '@/server/common/middleware/rate-limiters';
 
 export default class AccountInvitationRouteHandlers {
   private service: AccountsInterface;
@@ -18,7 +19,7 @@ export default class AccountInvitationRouteHandlers {
     router.get('/invitations', ExpressHelper.loggedInOnly, this.listInvitations.bind(this));
     router.post('/invitations', ExpressHelper.loggedInOnly, this.inviteToRegister.bind(this));
     router.get('/invitations/:code', ...ExpressHelper.noUserOnly, this.checkInviteCode.bind(this));
-    router.post('/invitations/:code', ...ExpressHelper.noUserOnly, this.acceptInvite.bind(this));
+    router.post('/invitations/:code', acceptInvitationByIp, ...ExpressHelper.noUserOnly, this.acceptInvite.bind(this));
     router.delete('/invitations/:id', ExpressHelper.adminOnly, this.cancelInvite.bind(this));
     router.post('/invitations/:id/resend', ExpressHelper.adminOnly, this.resendInvite.bind(this));
     app.use(routePrefix, router);

--- a/src/server/accounts/test/integration/rate_limiting.test.ts
+++ b/src/server/accounts/test/integration/rate_limiting.test.ts
@@ -7,6 +7,9 @@ import {
   applicationByIp,
   applicationByEmail,
   confirmApplicationByIp,
+  registerByIp,
+  registerByEmail,
+  acceptInvitationByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 /**
@@ -55,6 +58,15 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     });
     app.post('/confirm-ip-only', confirmApplicationByIp, (req, res) => {
       res.json({ route: 'confirm' });
+    });
+    app.post('/register-ip-only', registerByIp, (req, res) => {
+      res.json({ route: 'register-ip' });
+    });
+    app.post('/register-email-only', registerByEmail, (req, res) => {
+      res.json({ route: 'register-email' });
+    });
+    app.post('/accept-invitation-ip-only', acceptInvitationByIp, (req, res) => {
+      res.json({ route: 'accept-invitation-ip' });
     });
   });
 
@@ -251,6 +263,200 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
       );
       expect(realPost.status).toBe(429);
       expect(realPost.body.errorName).toBe('RateLimitError');
+
+      await realEnv.cleanup();
+    });
+  });
+
+  describe('registerByEmail', () => {
+    it('should return 429 once the per-email limit is exhausted, incrementing uniformly regardless of account existence', async () => {
+      const maxRequests = config.get<number>('rateLimit.register.byEmail.max');
+
+      // Unique email so this test owns its own credential bucket. This email
+      // maps to no account, yet it still exhausts the limiter — and the
+      // key-isolation test below uses an equally non-existent email — proving
+      // the limiter increments uniformly and cannot be used to enumerate which
+      // emails are registered (DEC-004).
+      const sameEmail = `register-email-${Date.now()}@example.com`;
+      const responses = [];
+      for (let i = 0; i < maxRequests + 1; i++) {
+        responses.push(
+          await request(app)
+            .post('/register-email-only')
+            .send({ email: sameEmail }),
+        );
+      }
+
+      for (let i = 0; i < maxRequests; i++) {
+        expect(responses[i].status).toBe(200);
+      }
+
+      const blocked = responses[maxRequests];
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.errorName).toBe('RateLimitError');
+      expect(blocked.body.error).toBe(
+        'Too many register requests for this email, please try again later.',
+      );
+      // Generic 429 body never echoes the email or IP that was throttled.
+      expect(JSON.stringify(blocked.body)).not.toContain(sameEmail);
+
+      expect(blocked.headers['ratelimit-limit']).toBe(String(maxRequests));
+      expect(blocked.headers['ratelimit-remaining']).toBe('0');
+      expect(blocked.headers['retry-after']).toBeDefined();
+    });
+
+    it('should isolate buckets per email: exhausting email A leaves email B unthrottled', async () => {
+      const maxRequests = config.get<number>('rateLimit.register.byEmail.max');
+
+      const emailA = `register-isolation-a-${Date.now()}@example.com`;
+      const emailB = `register-isolation-b-${Date.now()}@example.com`;
+
+      // Exhaust email A to 429.
+      let lastA;
+      for (let i = 0; i < maxRequests + 1; i++) {
+        lastA = await request(app)
+          .post('/register-email-only')
+          .send({ email: emailA });
+      }
+      expect(lastA!.status).toBe(429);
+
+      // Email B has its own bucket and must still be accepted.
+      const responseB = await request(app)
+        .post('/register-email-only')
+        .send({ email: emailB });
+      expect(responseB.status).toBe(200);
+    });
+  });
+
+  describe('registerByIp', () => {
+    it('should return 429 once the per-IP limit is exhausted, and the same singleton limiter is wired on POST /api/v1/register', async () => {
+      const ipMax = config.get<number>('rateLimit.register.byIp.max');
+
+      // Vary the email so the email-keyed limiter (mounted on a separate route
+      // in this file) cannot be the cause of any blocking here.
+      const responses = [];
+      for (let i = 0; i < ipMax + 1; i++) {
+        responses.push(
+          await request(app)
+            .post('/register-ip-only')
+            .send({ email: `register-ip-${i}@example.com` }),
+        );
+      }
+
+      for (let i = 0; i < ipMax; i++) {
+        expect(responses[i].status).toBe(200);
+      }
+
+      const blocked = responses[ipMax];
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.errorName).toBe('RateLimitError');
+      expect(blocked.body.error).toBe(
+        'Too many register requests from this IP, please try again later.',
+      );
+      expect(blocked.headers['ratelimit-limit']).toBe(String(ipMax));
+      expect(blocked.headers['ratelimit-remaining']).toBe('0');
+      expect(blocked.headers['retry-after']).toBeDefined();
+
+      // Phase 2: prove the same `registerByIp` singleton is wired onto the
+      // real POST /api/v1/register route. The IP limiter store is module-global
+      // and already exhausted above, so a fresh request to the real route
+      // (still on localhost) must short-circuit at 429 before the handler runs.
+      // Imports are deferred so full-server init cost is only paid when this
+      // test actually runs.
+      const { TestEnvironment } = await import('@/server/common/test/lib/test_environment');
+      const { EventEmitter } = await import('events');
+      const { default: AccountService } = await import('@/server/accounts/service/account');
+      const { default: ConfigurationInterface } = await import('@/server/configuration/interface');
+      const { default: SetupInterface } = await import('@/server/setup/interface');
+
+      const realEnv = new TestEnvironment();
+      await realEnv.init();
+
+      // Setup-mode middleware returns 503 for unauthenticated API calls until
+      // an admin exists; provision one so the rate limiter is what blocks.
+      const accountService = new AccountService(
+        new EventEmitter(),
+        new ConfigurationInterface(),
+        new SetupInterface(),
+      );
+      await accountService._setupAccount('rate-limit-register-admin@pavillion.dev', 'testpassword!1');
+
+      const realPost = await request(realEnv.app)
+        .post('/api/v1/register')
+        .send({ email: `real-route-register-${Date.now()}@example.com` });
+      expect(realPost.status).toBe(429);
+      expect(realPost.body.errorName).toBe('RateLimitError');
+      expect(realPost.body.error).toBe(
+        'Too many register requests from this IP, please try again later.',
+      );
+
+      await realEnv.cleanup();
+    });
+  });
+
+  describe('acceptInvitationByIp', () => {
+    it('should return 429 once the per-IP limit is exhausted, and the same singleton limiter is wired on POST /api/v1/invitations/:code', async () => {
+      const ipMax = config.get<number>('rateLimit.invitation.accept.byIp.max');
+
+      // Vary the path code so nothing else can be the cause of any blocking;
+      // this limiter is IP-keyed and shares localhost across the suite.
+      const responses = [];
+      for (let i = 0; i < ipMax + 1; i++) {
+        responses.push(
+          await request(app)
+            .post('/accept-invitation-ip-only')
+            .send({ password: `testpassword!1-${i}` }),
+        );
+      }
+
+      for (let i = 0; i < ipMax; i++) {
+        expect(responses[i].status).toBe(200);
+      }
+
+      const blocked = responses[ipMax];
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.errorName).toBe('RateLimitError');
+      expect(blocked.body.error).toBe(
+        'Too many invitation-accept requests from this IP, please try again later.',
+      );
+      // Generic 429 body never echoes the throttled key.
+      expect(JSON.stringify(blocked.body)).not.toContain('127.0.0.1');
+      expect(blocked.headers['ratelimit-limit']).toBe(String(ipMax));
+      expect(blocked.headers['ratelimit-remaining']).toBe('0');
+      expect(blocked.headers['retry-after']).toBeDefined();
+
+      // Phase 2: prove the same `acceptInvitationByIp` singleton is wired onto
+      // the real POST /api/v1/invitations/:code route. The IP limiter store is
+      // module-global and already exhausted above, so a fresh request to the
+      // real route (still on localhost) must short-circuit at 429 before the
+      // handler runs. Imports are deferred so full-server init cost is only
+      // paid when this test actually runs.
+      const { TestEnvironment } = await import('@/server/common/test/lib/test_environment');
+      const { EventEmitter } = await import('events');
+      const { default: AccountService } = await import('@/server/accounts/service/account');
+      const { default: ConfigurationInterface } = await import('@/server/configuration/interface');
+      const { default: SetupInterface } = await import('@/server/setup/interface');
+
+      const realEnv = new TestEnvironment();
+      await realEnv.init();
+
+      // Setup-mode middleware returns 503 for unauthenticated API calls until
+      // an admin exists; provision one so the rate limiter is what blocks.
+      const accountService = new AccountService(
+        new EventEmitter(),
+        new ConfigurationInterface(),
+        new SetupInterface(),
+      );
+      await accountService._setupAccount('rate-limit-invitation-admin@pavillion.dev', 'testpassword!1');
+
+      const realPost = await request(realEnv.app)
+        .post('/api/v1/invitations/any-code-here')
+        .send({ password: 'testpassword!1' });
+      expect(realPost.status).toBe(429);
+      expect(realPost.body.errorName).toBe('RateLimitError');
+      expect(realPost.body.error).toBe(
+        'Too many invitation-accept requests from this IP, please try again later.',
+      );
 
       await realEnv.cleanup();
     });

--- a/src/server/activitypub/api/v1/user-actor.ts
+++ b/src/server/activitypub/api/v1/user-actor.ts
@@ -2,6 +2,10 @@ import express, { Request, Response, Application, RequestHandler } from 'express
 
 import UserActorService from '@/server/activitypub/service/user_actor';
 import { verifyHttpSignature } from '@/server/activitypub/helper/http_signature';
+import {
+  createActorRateLimiter,
+  createUserRateLimiter,
+} from '@/server/activitypub/middleware/rate-limit';
 import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('activitypub');
@@ -34,8 +38,15 @@ export default class UserActorRoutes {
     // Public endpoint - Person actor discovery
     router.get('/users/:username', this.getUserActor.bind(this));
 
-    // Secure endpoint - User inbox requires HTTP signature
-    router.post('/users/:username/inbox', verifyHttpSignature as RequestHandler, this.postToInbox.bind(this));
+    // Secure endpoint - User inbox requires HTTP signature.
+    // Rate limiters run BEFORE signature verification, mirroring the calendar
+    // inbox chain (activitypub/api/v1/server.ts), so abusive senders are shed
+    // at the ingest boundary before any signature work (DEC-013).
+    router.post('/users/:username/inbox',
+      createActorRateLimiter(),
+      createUserRateLimiter(),
+      verifyHttpSignature as RequestHandler,
+      this.postToInbox.bind(this));
 
     // Outbox endpoint - basic implementation (no auth for now, as it returns empty collection)
     router.get('/users/:username/outbox', this.getUserOutbox.bind(this));

--- a/src/server/activitypub/middleware/rate-limit.ts
+++ b/src/server/activitypub/middleware/rate-limit.ts
@@ -156,6 +156,11 @@ type ActorRateLimitStore = RateLimitStore<string>;
 type CalendarRateLimitStore = RateLimitStore<string>;
 
 /**
+ * Type alias for user-based rate limiting
+ */
+type UserRateLimitStore = RateLimitStore<string>;
+
+/**
  * Get ActivityPub actor rate limit configuration
  */
 function getActorRateLimitConfig() {
@@ -175,9 +180,20 @@ function getCalendarRateLimitConfig() {
   };
 }
 
+/**
+ * Get ActivityPub user rate limit configuration
+ */
+function getUserRateLimitConfig() {
+  return {
+    max: config.get<number>('rateLimit.activitypub.user.max'),
+    windowMs: config.get<number>('rateLimit.activitypub.user.windowMs'),
+  };
+}
+
 // Shared store instances
 let sharedActorStore: ActorRateLimitStore | null = null;
 let sharedCalendarStore: CalendarRateLimitStore | null = null;
+let sharedUserStore: UserRateLimitStore | null = null;
 
 /**
  * Gets or creates the shared actor rate limit store
@@ -203,6 +219,19 @@ function getCalendarStore(windowMs: number): CalendarRateLimitStore {
     sharedCalendarStore = new RateLimitStore<string>(windowMs);
   }
   return sharedCalendarStore;
+}
+
+/**
+ * Gets or creates the shared user rate limit store
+ *
+ * @param windowMs - Time window in milliseconds
+ * @returns The shared store instance
+ */
+function getUserStore(windowMs: number): UserRateLimitStore {
+  if (!sharedUserStore) {
+    sharedUserStore = new RateLimitStore<string>(windowMs);
+  }
+  return sharedUserStore;
 }
 
 /**
@@ -249,6 +278,49 @@ function extractCalendarFromRequest(req: Request): string | null {
 }
 
 /**
+ * Extracts the username from the request parameters.
+ *
+ * @param req - Express request object
+ * @returns The username or null if not found
+ */
+function extractUserFromRequest(req: Request): string | null {
+  // Route parameter is :username in user-actor.ts
+  const username = req.params?.username;
+
+  if (typeof username === 'string' && username.length > 0) {
+    return username;
+  }
+
+  return null;
+}
+
+/**
+ * Marker property attached to every ActivityPub rate-limit middleware returned by the
+ * factories below. The common express-rate-limit limiters are self-identifying (they
+ * expose `getKey`/`resetKey` methods), but these AP limiters are plain closures over an
+ * in-memory LRU store and carry no such signature. The rate-limit coverage guard test
+ * (`src/server/common/test/rate-limit-coverage.test.ts`) walks the real router stack and
+ * uses this marker to recognize AP inbox limiters by presence rather than by fragile
+ * function-name matching. The property is non-enumerable so it never leaks into
+ * serialization or middleware introspection elsewhere.
+ */
+export const AP_RATE_LIMITER_MARKER = '__pavillionApRateLimiter';
+
+/**
+ * Tags a middleware closure as an ActivityPub rate limiter so the coverage guard test can
+ * detect it by presence. Returns the same function for fluent use in the factories.
+ */
+function markAsApRateLimiter(handler: RequestHandler): RequestHandler {
+  Object.defineProperty(handler, AP_RATE_LIMITER_MARKER, {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return handler;
+}
+
+/**
  * Creates an Express middleware for per-actor rate limiting on ActivityPub inbox endpoints.
  *
  * This middleware limits the number of requests from each unique actor (identified by
@@ -278,7 +350,7 @@ export function createActorRateLimiter(
   const finalWindowMs = windowMs ?? actorConfig.windowMs;
   const store = getActorStore(finalWindowMs);
 
-  return (req: Request, res: Response, next: NextFunction) => {
+  return markAsApRateLimiter((req: Request, res: Response, next: NextFunction) => {
     const actorId = extractActorFromRequest(req);
 
     // If no actor can be identified, allow the request but log a warning
@@ -305,7 +377,7 @@ export function createActorRateLimiter(
     }
 
     next();
-  };
+  });
 }
 
 /**
@@ -338,7 +410,7 @@ export function createCalendarRateLimiter(
   const finalWindowMs = windowMs ?? calendarConfig.windowMs;
   const store = getCalendarStore(finalWindowMs);
 
-  return (req: Request, res: Response, next: NextFunction) => {
+  return markAsApRateLimiter((req: Request, res: Response, next: NextFunction) => {
     const calendarUrlName = extractCalendarFromRequest(req);
 
     // If no calendar can be identified, allow the request but log a warning
@@ -365,7 +437,71 @@ export function createCalendarRateLimiter(
     }
 
     next();
-  };
+  });
+}
+
+/**
+ * Creates an Express middleware for per-user rate limiting on the user (Person)
+ * ActivityPub inbox endpoint.
+ *
+ * This middleware limits the total number of requests to each user's inbox endpoint
+ * within a sliding time window, keyed on the username path parameter, regardless of
+ * which actor is making the request.
+ *
+ * Default values are loaded from config (rateLimit.activitypub.user.*). The global
+ * rateLimit.enabled flag should be checked before installing this middleware on routes.
+ *
+ * @param maxRequests - Maximum number of requests allowed per user in the time window (default from config)
+ * @param windowMs - Time window in milliseconds (default from config)
+ * @returns Express middleware function that enforces rate limiting
+ *
+ * @example
+ * // Use defaults from config
+ * router.post('/users/:username/inbox', createUserRateLimiter(), inboxHandler);
+ *
+ * @example
+ * // Custom limits: 60 requests per 30 seconds
+ * router.post('/users/:username/inbox', createUserRateLimiter(60, 30000), inboxHandler);
+ */
+export function createUserRateLimiter(
+  maxRequests?: number,
+  windowMs?: number,
+): RequestHandler {
+  const userConfig = getUserRateLimitConfig();
+  const finalMaxRequests = maxRequests ?? userConfig.max;
+  const finalWindowMs = windowMs ?? userConfig.windowMs;
+  const store = getUserStore(finalWindowMs);
+
+  return markAsApRateLimiter((req: Request, res: Response, next: NextFunction) => {
+    const username = extractUserFromRequest(req);
+
+    // If no user can be identified, allow the request but log a warning
+    // The downstream handler should validate the request anyway
+    if (!username) {
+      logger.warn('Could not extract user from request, allowing request');
+      return next();
+    }
+
+    const result = store.check(username, finalMaxRequests);
+
+    if (!result.allowed) {
+      const retryAfterMs = store.getRetryAfter(username);
+      const retryAfterSeconds = Math.ceil(retryAfterMs / 1000);
+
+      // DEC-004: do not log the local-account username (it is account-identifying PII).
+      // count/max are sufficient for ops diagnostics without tying the event to a named account.
+      logger.warn({ count: result.count, max: finalMaxRequests }, 'Rate limit exceeded for user inbox');
+
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({
+        error: 'Too many requests to this user, please try again later.',
+        retryAfter: retryAfterSeconds,
+      });
+      return;
+    }
+
+    next();
+  });
 }
 
 /**
@@ -412,4 +548,27 @@ export function getCalendarRateLimitStore(windowMs?: number): CalendarRateLimitS
   const calendarConfig = getCalendarRateLimitConfig();
   const finalWindowMs = windowMs ?? calendarConfig.windowMs;
   return getCalendarStore(finalWindowMs);
+}
+
+/**
+ * Resets the user rate limit store. Useful for testing.
+ */
+export function resetUserRateLimitStore(): void {
+  if (sharedUserStore) {
+    sharedUserStore.destroy();
+    sharedUserStore = null;
+  }
+}
+
+/**
+ * Gets the current user store for testing purposes.
+ * Creates a new store if one doesn't exist.
+ *
+ * @param windowMs - Time window in milliseconds (default from config)
+ * @returns The store instance
+ */
+export function getUserRateLimitStore(windowMs?: number): UserRateLimitStore {
+  const userConfig = getUserRateLimitConfig();
+  const finalWindowMs = windowMs ?? userConfig.windowMs;
+  return getUserStore(finalWindowMs);
 }

--- a/src/server/activitypub/test/integration/rate_limiting.test.ts
+++ b/src/server/activitypub/test/integration/rate_limiting.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import express, { Application } from 'express';
+import request from 'supertest';
+import config from 'config';
+
+import UserActorRoutes from '@/server/activitypub/api/v1/user-actor';
+import {
+  resetActorRateLimitStore,
+  resetUserRateLimitStore,
+} from '@/server/activitypub/middleware/rate-limit';
+
+/**
+ * Integration tests for ActivityPub user-inbox rate limiting.
+ *
+ * These tests exercise the REAL route-level middleware chain installed by
+ * UserActorRoutes.installHandlers on POST /users/:username/inbox:
+ *
+ *   createActorRateLimiter() -> createUserRateLimiter() -> verifyHttpSignature -> handler
+ *
+ * The limiters run BEFORE HTTP signature verification, mirroring the calendar
+ * inbox chain (activitypub/api/v1/server.ts) and the DEC-013 ingest-boundary
+ * posture. Signature verification is bypassed here (SKIP_SIGNATURES) so requests
+ * reach the limiters and the terminal handler without managing certificates;
+ * this isolates limiter behavior while still proving the wiring and ordering.
+ *
+ * The federation-identity limiters use the AP-domain in-memory LRU store
+ * (rateLimit.activitypub.{actor,user}) and assert on 429 status, not on the
+ * express-rate-limit ratelimit-* headers used by the common HTTP-client limiters.
+ *
+ * NOTE: These tests require rate limiting to be enabled in the test environment.
+ * Run with: npm run test:ratelimiting
+ */
+
+const rateLimitEnabled = config.get<boolean>('rateLimit.enabled');
+const describeOrSkip = rateLimitEnabled ? describe : describe.skip;
+
+/**
+ * Minimal stub of UserActorService. The user-inbox limiters precede the handler,
+ * so the handler only needs to resolve a user and return 200 for under-limit
+ * requests. processAdd/Remove are never reached for the default activity type.
+ */
+function createStubUserActorService(): any {
+  return {
+    getActorByUsername: async (username: string) => ({
+      actorUri: `https://local.example/users/${username}`,
+      publicKey: 'stub-public-key',
+    }),
+    processAddActivity: async () => undefined,
+    processRemoveActivity: async () => undefined,
+  };
+}
+
+function buildApp(): Application {
+  const app = express();
+  const routes = new UserActorRoutes(createStubUserActorService());
+  routes.installHandlers(app, '/');
+  return app;
+}
+
+describeOrSkip('ActivityPub User Inbox Rate Limiting Integration Tests', () => {
+  let app: Application;
+
+  beforeAll(() => {
+    // Bypass HTTP signature verification so requests reach the limiters and the
+    // terminal handler. The limiters run before verifyHttpSignature, so this
+    // lets us assert end-to-end limiter behavior without valid signatures.
+    process.env.SKIP_SIGNATURES = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.SKIP_SIGNATURES;
+  });
+
+  beforeEach(() => {
+    resetActorRateLimitStore();
+    resetUserRateLimitStore();
+    app = buildApp();
+  });
+
+  afterEach(() => {
+    resetActorRateLimitStore();
+    resetUserRateLimitStore();
+  });
+
+  describe('per-user limiter', () => {
+    it('returns 429 once the per-user threshold is exceeded', async () => {
+      // Config default: rateLimit.activitypub.user.max = 120 per minute.
+      const max = config.get<number>('rateLimit.activitypub.user.max');
+
+      // Vary the actor each request so the actor limiter (max 60) does not fire
+      // first; this isolates the per-user limiter as the cause of the 429.
+      for (let i = 0; i < max; i++) {
+        const response = await request(app)
+          .post('/users/alice/inbox')
+          .send({ type: 'Follow', actor: `https://remote.example/users/sender${i}` });
+
+        expect(response.status).toBe(200);
+      }
+
+      const blocked = await request(app)
+        .post('/users/alice/inbox')
+        .send({ type: 'Follow', actor: 'https://remote.example/users/senderN' });
+
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers['retry-after']).toBeDefined();
+    });
+
+    it('keeps per-user limits isolated: exhausting user A does not affect user B', async () => {
+      const max = config.get<number>('rateLimit.activitypub.user.max');
+
+      // Exhaust user A's per-user budget, varying actors to avoid the actor cap.
+      for (let i = 0; i < max; i++) {
+        const response = await request(app)
+          .post('/users/alice/inbox')
+          .send({ type: 'Follow', actor: `https://remote.example/users/sender${i}` });
+
+        expect(response.status).toBe(200);
+      }
+
+      const aBlocked = await request(app)
+        .post('/users/alice/inbox')
+        .send({ type: 'Follow', actor: 'https://remote.example/users/senderN' });
+
+      expect(aBlocked.status).toBe(429);
+
+      // User B is unaffected by user A's exhaustion.
+      const bAllowed = await request(app)
+        .post('/users/bob/inbox')
+        .send({ type: 'Follow', actor: 'https://remote.example/users/fresh' });
+
+      expect(bAllowed.status).toBe(200);
+    });
+
+    it('does not echo the username in the 429 body', async () => {
+      const max = config.get<number>('rateLimit.activitypub.user.max');
+
+      for (let i = 0; i < max; i++) {
+        await request(app)
+          .post('/users/secret-user/inbox')
+          .send({ type: 'Follow', actor: `https://remote.example/users/sender${i}` });
+      }
+
+      const blocked = await request(app)
+        .post('/users/secret-user/inbox')
+        .send({ type: 'Follow', actor: 'https://remote.example/users/senderN' });
+
+      expect(blocked.status).toBe(429);
+      expect(JSON.stringify(blocked.body)).not.toContain('secret-user');
+    });
+  });
+
+  describe('per-actor limiter', () => {
+    it('returns 429 once the per-actor threshold is exceeded', async () => {
+      // Config default: rateLimit.activitypub.actor.max = 60 per minute.
+      const max = config.get<number>('rateLimit.activitypub.actor.max');
+      const actor = 'https://remote.example/users/aggressor';
+
+      // Vary the username each request so the per-user limiter (max 120) does
+      // not fire first; this isolates the actor limiter as the cause of the 429.
+      for (let i = 0; i < max; i++) {
+        const response = await request(app)
+          .post(`/users/target${i}/inbox`)
+          .send({ type: 'Follow', actor });
+
+        expect(response.status).toBe(200);
+      }
+
+      const blocked = await request(app)
+        .post('/users/targetN/inbox')
+        .send({ type: 'Follow', actor });
+
+      expect(blocked.status).toBe(429);
+      expect(blocked.headers['retry-after']).toBeDefined();
+    });
+
+    it('keeps per-actor limits isolated: exhausting actor A does not affect actor B', async () => {
+      const max = config.get<number>('rateLimit.activitypub.actor.max');
+      const actorA = 'https://remote.example/users/actorA';
+      const actorB = 'https://remote.example/users/actorB';
+
+      // Exhaust actor A across distinct usernames to avoid the per-user cap.
+      for (let i = 0; i < max; i++) {
+        const response = await request(app)
+          .post(`/users/target${i}/inbox`)
+          .send({ type: 'Follow', actor: actorA });
+
+        expect(response.status).toBe(200);
+      }
+
+      const aBlocked = await request(app)
+        .post('/users/targetN/inbox')
+        .send({ type: 'Follow', actor: actorA });
+
+      expect(aBlocked.status).toBe(429);
+
+      // Actor B is unaffected by actor A's exhaustion.
+      const bAllowed = await request(app)
+        .post('/users/freshtarget/inbox')
+        .send({ type: 'Follow', actor: actorB });
+
+      expect(bAllowed.status).toBe(200);
+    });
+
+    it('does not echo the actor in the 429 body', async () => {
+      const max = config.get<number>('rateLimit.activitypub.actor.max');
+      const actor = 'https://remote.example/users/secret-actor';
+
+      for (let i = 0; i < max; i++) {
+        await request(app)
+          .post(`/users/target${i}/inbox`)
+          .send({ type: 'Follow', actor });
+      }
+
+      const blocked = await request(app)
+        .post('/users/targetN/inbox')
+        .send({ type: 'Follow', actor });
+
+      expect(blocked.status).toBe(429);
+      expect(JSON.stringify(blocked.body)).not.toContain('secret-actor');
+    });
+  });
+
+  describe('chain ordering', () => {
+    it('runs limiters before signature verification (both limits enforced on the same route)', async () => {
+      // The actor cap (60) is lower than the per-user cap (120). Holding both the
+      // username and actor constant, the actor limiter must trip first, proving
+      // the actor limiter is installed and reached on the user-inbox route.
+      const actorMax = config.get<number>('rateLimit.activitypub.actor.max');
+      const actor = 'https://remote.example/users/steady';
+
+      for (let i = 0; i < actorMax; i++) {
+        const response = await request(app)
+          .post('/users/alice/inbox')
+          .send({ type: 'Follow', actor });
+
+        expect(response.status).toBe(200);
+      }
+
+      const blocked = await request(app)
+        .post('/users/alice/inbox')
+        .send({ type: 'Follow', actor });
+
+      // 429 (not 401) confirms the limiter shed the request before signature
+      // verification ran, matching the calendar-inbox chain ordering.
+      expect(blocked.status).toBe(429);
+    });
+  });
+});

--- a/src/server/authentication/api/v1/auth.ts
+++ b/src/server/authentication/api/v1/auth.ts
@@ -15,8 +15,10 @@ const logger = createLogger('authentication');
 import {
   passwordResetByIp,
   passwordResetByEmail,
+  confirmPasswordResetByIp,
   loginByIp,
   loginByEmail,
+  emailChangeByAccount,
 } from '@/server/common/middleware/rate-limiters';
 
 export default class AuthenticationRouteHandlers {
@@ -35,8 +37,8 @@ export default class AuthenticationRouteHandlers {
     router.get('/token', ...ExpressHelper.loggedInOnly, this.getToken.bind(this) );
     router.get('/reset-password/:code', this.checkPasswordResetCode.bind(this) );
     router.post('/reset-password', passwordResetByIp, passwordResetByEmail, this.generatePasswordResetCode.bind(this) );
-    router.post('/reset-password/:code', this.setPassword.bind(this) );
-    router.post('/email', ...ExpressHelper.loggedInOnly, this.changeEmail.bind(this) );
+    router.post('/reset-password/:code', confirmPasswordResetByIp, this.setPassword.bind(this) );
+    router.post('/email', ...ExpressHelper.loggedInOnly, emailChangeByAccount, this.changeEmail.bind(this) );
     app.use(routePrefix, router);
   }
 

--- a/src/server/authentication/test/integration/rate_limiting.test.ts
+++ b/src/server/authentication/test/integration/rate_limiting.test.ts
@@ -6,6 +6,7 @@ import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 import AccountService from '@/server/accounts/service/account';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
+import ExpressHelper from '@/server/common/helper/express';
 import { EventEmitter } from 'events';
 
 /**
@@ -139,6 +140,42 @@ describeOrSkip('Authentication Rate Limiting Integration Tests', () => {
     });
   });
 
+  describe('Password Reset Confirm Rate Limiting', () => {
+    it('should enforce IP-based rate limit on password reset confirm (token brute-force defense)', async () => {
+      const maxAttempts = 20; // From config: rateLimit.passwordReset.confirm.byIp.max
+      const responses = [];
+
+      // Each request uses a distinct (invalid) code so the limiter, not the
+      // handler, is what stops us — the IP-keyed confirm limiter increments
+      // uniformly regardless of whether the token is valid.
+      for (let i = 0; i < maxAttempts + 5; i++) {
+        const response = await request(env.app)
+          .post(`/api/auth/v1/reset-password/invalid-code-${i}`)
+          .send({ password: 'newpassword123' });
+
+        responses.push(response);
+
+        if (response.status === 429) {
+          break;
+        }
+      }
+
+      // Should have at least one 429 response
+      const rateLimitedResponses = responses.filter(r => r.status === 429);
+      expect(rateLimitedResponses.length).toBeGreaterThan(0);
+
+      // Verify the rate limited response has the generic IP error message
+      const rateLimitedResponse = rateLimitedResponses[0];
+      expect(rateLimitedResponse.body.error).toBe('Too many password-reset-confirm requests from this IP, please try again later.');
+      expect(rateLimitedResponse.body.errorName).toBe('RateLimitError');
+
+      // Verify rate limit headers
+      expect(rateLimitedResponse.headers['ratelimit-limit']).toBe(String(maxAttempts));
+      expect(rateLimitedResponse.headers['ratelimit-remaining']).toBe('0');
+      expect(rateLimitedResponse.headers['retry-after']).toBeDefined();
+    });
+  });
+
   describe('Login Rate Limiting', () => {
     it('should include rate limit headers in login response', async () => {
       const response = await request(env.app)
@@ -223,6 +260,87 @@ describeOrSkip('Authentication Rate Limiting Integration Tests', () => {
     });
   });
 
+  describe('Email Change Rate Limiting', () => {
+    // The email-change limiter is account-keyed (createAccountRateLimiter), not
+    // IP-keyed, so each authenticated account gets its own independent window.
+    // changeEmail increments the limiter uniformly on every attempt
+    // (skipFailedRequests: false), so a deliberately-wrong password drives the
+    // counter to the threshold without mutating the account's email — and lets
+    // us assert the limiter, not the handler, is what produces the 429.
+    const emailChangeMax = 10; // From config: rateLimit.emailChange.byAccount.max
+
+    // Mint the JWT directly from the account model rather than via env.login():
+    // the login route is throttled by the shared IP login limiter (10/15m),
+    // which earlier tests in this file may have already exhausted. The
+    // email-change limiter is what we are exercising here, so we bypass login.
+    it('should enforce account-based rate limit on email change (429 at threshold)', async () => {
+      const email = `emailchange-a-${Date.now()}@pavillion.dev`;
+      const { account } = await accountService._setupAccount(email, testPassword);
+      const token = ExpressHelper.generateJWT(account);
+
+      const responses = [];
+      for (let i = 0; i < emailChangeMax + 5; i++) {
+        const response = await env.authPost(token, '/api/auth/v1/email', {
+          email: `new-${Date.now()}-${i}@example.com`,
+          password: 'wrongpassword', // fails the handler but still increments the limiter
+        });
+        responses.push(response);
+
+        if (response.status === 429) {
+          break;
+        }
+      }
+
+      // Should have at least one 429 once the account exhausts its window.
+      const rateLimitedResponses = responses.filter(r => r.status === 429);
+      expect(rateLimitedResponses.length).toBeGreaterThan(0);
+
+      // Verify the generic account-keyed error body (DEC-004: never echoes the
+      // account id).
+      const rateLimitedResponse = rateLimitedResponses[0];
+      expect(rateLimitedResponse.body.error).toBe('Too many email-change requests for this account, please try again later.');
+      expect(rateLimitedResponse.body.errorName).toBe('RateLimitError');
+      expect(rateLimitedResponse.body).not.toHaveProperty('accountId');
+
+      // Verify rate limit headers.
+      expect(rateLimitedResponse.headers['ratelimit-limit']).toBe(String(emailChangeMax));
+      expect(rateLimitedResponse.headers['ratelimit-remaining']).toBe('0');
+      expect(rateLimitedResponse.headers['retry-after']).toBeDefined();
+    });
+
+    it('should isolate the email-change limit per account (account A exhausted, account B unaffected)', async () => {
+      const emailA = `emailchange-isoA-${Date.now()}@pavillion.dev`;
+      const emailB = `emailchange-isoB-${Date.now()}@pavillion.dev`;
+      const { account: accountA } = await accountService._setupAccount(emailA, testPassword);
+      const { account: accountB } = await accountService._setupAccount(emailB, testPassword);
+      const tokenA = ExpressHelper.generateJWT(accountA);
+      const tokenB = ExpressHelper.generateJWT(accountB);
+
+      // Exhaust account A's window.
+      let accountARateLimited = false;
+      for (let i = 0; i < emailChangeMax + 5; i++) {
+        const response = await env.authPost(tokenA, '/api/auth/v1/email', {
+          email: `iso-a-${Date.now()}-${i}@example.com`,
+          password: 'wrongpassword',
+        });
+        if (response.status === 429) {
+          accountARateLimited = true;
+          break;
+        }
+      }
+      expect(accountARateLimited).toBe(true);
+
+      // Account B is a distinct key and must NOT be rate limited by A's
+      // exhaustion. Since this is account-keyed (not IP-keyed) and both requests
+      // share localhost, a non-429 response here proves the key isolation.
+      const responseB = await env.authPost(tokenB, '/api/auth/v1/email', {
+        email: `iso-b-${Date.now()}@example.com`,
+        password: 'wrongpassword',
+      });
+      expect(responseB.status).not.toBe(429);
+    });
+  });
+
   describe('Rate Limit Header Format', () => {
     it('should return standard rate limit headers format', async () => {
       const response = await request(env.app)
@@ -276,3 +394,4 @@ describeOrSkip('Authentication Rate Limiting Integration Tests', () => {
     });
   });
 });
+

--- a/src/server/common/middleware/rate-limit-by-account.ts
+++ b/src/server/common/middleware/rate-limit-by-account.ts
@@ -44,7 +44,11 @@ export function createAccountRateLimiter(
       const account = req.user as Account;
       const accountId = account?.id || 'unknown';
 
-      logger.warn({ accountId, endpoint: endpointName }, 'Rate limit exceeded');
+      // DEC-004: the account id is account-identifying; log rate-limit
+      // enforcement only at debug level, never at warn/info (which would build
+      // a per-account activity trail in standard log output). Mirrors the
+      // debug-level posture of the IP and credential limiters.
+      logger.debug({ accountId, endpoint: endpointName }, 'Rate limit exceeded');
 
       res.status(429).json({
         error: `Too many ${endpointName} requests for this account, please try again later.`,

--- a/src/server/common/middleware/rate-limit-by-credential.ts
+++ b/src/server/common/middleware/rate-limit-by-credential.ts
@@ -46,7 +46,10 @@ export function createCredentialRateLimiter(
       const credential = req.body?.[credentialField];
       const redactedCredential = redactEmail(credential);
 
-      logger.warn({ credential: redactedCredential, endpoint: endpointName }, 'Rate limit exceeded');
+      // DEC-004: even redacted, the credential is caller-identifying; log
+      // rate-limit enforcement at debug level only, matching the IP and account
+      // limiter factories, so standard log output carries no per-identity trail.
+      logger.debug({ credential: redactedCredential, endpoint: endpointName }, 'Rate limit exceeded');
 
       // Generate endpoint-specific error message
       const errorMessage = endpointName === 'password-reset'

--- a/src/server/common/middleware/rate-limit-by-ip.ts
+++ b/src/server/common/middleware/rate-limit-by-ip.ts
@@ -32,7 +32,10 @@ export function createIpRateLimiter(
     handler: (req: Request, res: Response) => {
       const ip = req.ip || req.socket.remoteAddress || 'unknown';
 
-      logger.warn({ ip, endpoint: endpointName }, 'Rate limit exceeded');
+      // DEC-004: raw visitor IP is logged only at debug level for rate-limit
+      // enforcement on anonymous/public endpoints, never at warn/info (which would
+      // build a browsing-history trail tied to IP in standard log output).
+      logger.debug({ ip, endpoint: endpointName }, 'Rate limit exceeded');
 
       // Generate endpoint-specific error message
       const errorMessage = endpointName === 'password-reset'

--- a/src/server/common/middleware/rate-limiters.ts
+++ b/src/server/common/middleware/rate-limiters.ts
@@ -202,6 +202,23 @@ export const checkoutSessionByAccount: RequestHandler = isRateLimitEnabled()
   : noOpMiddleware;
 
 /**
+ * Stripe funding webhook rate limiter by IP address.
+ * Limits: 300 requests per IP per minute (default config).
+ *
+ * Belt-and-braces behind Stripe signature verification (DEC-007), which is the
+ * primary defense for POST /api/funding/webhooks/stripe. Deliberately generous:
+ * Stripe can deliver many events per minute and retries failed deliveries for
+ * up to 72 hours, so this limiter must never gate legitimate provider traffic.
+ */
+export const fundingWebhookByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.fundingWebhook.byIp.max'),
+    config.get<number>('rateLimit.fundingWebhook.byIp.windowMs'),
+    'funding-webhook',
+  )
+  : noOpMiddleware;
+
+/**
  * Import source DNS verification rate limiter, keyed by the source's route
  * param (`id`). Each import source maps to a single hostname, so capping
  * per-source throttles DNS-verification load against the source's hostname
@@ -298,6 +315,35 @@ export const applicationByEmail: RequestHandler = isRateLimitEnabled()
   : noOpMiddleware;
 
 /**
+ * Public account registration rate limiter by IP address.
+ * Limits: 5 requests per IP per 15 minutes (default config).
+ */
+export const registerByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.register.byIp.max'),
+    config.get<number>('rateLimit.register.byIp.windowMs'),
+    'register',
+  )
+  : noOpMiddleware;
+
+/**
+ * Public account registration rate limiter by email address.
+ *
+ * Limits: 3 requests per email per 1 hour (default config). The limiter
+ * increments uniformly on every attempt regardless of whether the email
+ * already maps to an account, so the rate-limit signal cannot be used to
+ * enumerate registered accounts (DEC-004).
+ */
+export const registerByEmail: RequestHandler = isRateLimitEnabled()
+  ? createCredentialRateLimiter(
+    config.get<number>('rateLimit.register.byEmail.max'),
+    config.get<number>('rateLimit.register.byEmail.windowMs'),
+    'register',
+    'email',
+  )
+  : noOpMiddleware;
+
+/**
  * Application email-confirmation rate limiter by IP address.
  * Limits: 20 requests per IP per 15 minutes (default config).
  */
@@ -306,5 +352,60 @@ export const confirmApplicationByIp: RequestHandler = isRateLimitEnabled()
     config.get<number>('rateLimit.application.confirm.byIp.max'),
     config.get<number>('rateLimit.application.confirm.byIp.windowMs'),
     'application-confirm',
+  )
+  : noOpMiddleware;
+
+/**
+ * Password-reset confirmation rate limiter by IP address.
+ *
+ * Caps token-redemption attempts against POST /api/auth/v1/reset-password/:code
+ * to defend against brute-force guessing of reset codes.
+ *
+ * Limits: 20 requests per IP per 15 minutes (default config).
+ */
+export const confirmPasswordResetByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.passwordReset.confirm.byIp.max'),
+    config.get<number>('rateLimit.passwordReset.confirm.byIp.windowMs'),
+    'password-reset-confirm',
+  )
+  : noOpMiddleware;
+
+/**
+ * Invitation-acceptance rate limiter by IP address.
+ *
+ * Caps token-redemption attempts against POST /api/v1/invitations/:code to
+ * defend against brute-force guessing of invitation codes.
+ *
+ * Limits: 20 requests per IP per 15 minutes (default config).
+ */
+export const acceptInvitationByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.invitation.accept.byIp.max'),
+    config.get<number>('rateLimit.invitation.accept.byIp.windowMs'),
+    'invitation-accept',
+  )
+  : noOpMiddleware;
+
+/**
+ * Email-change rate limiter by authenticated account.
+ *
+ * Caps POST /api/auth/v1/email per account. Per the audit (pv-qqno.1, OQ2
+ * verdict), changeEmail verifies the password then writes the new email
+ * directly to the DB — there is no outbound email and no confirm route, so the
+ * original outbound-email amplifier rationale does not apply. This account-keyed
+ * limiter is probe/enumeration defense-in-depth: it bounds password-oracle
+ * probing (InvalidPasswordError) and email-existence enumeration
+ * (EmailAlreadyExistsError) attempt rate. It does NOT close the differential-
+ * response enumeration oracle itself. Keyed on the authenticated account, so it
+ * must be wired after loggedInOnly.
+ *
+ * Limits: 10 requests per account per 1 hour (default config).
+ */
+export const emailChangeByAccount: RequestHandler = isRateLimitEnabled()
+  ? createAccountRateLimiter(
+    config.get<number>('rateLimit.emailChange.byAccount.max'),
+    config.get<number>('rateLimit.emailChange.byAccount.windowMs'),
+    'email-change',
   )
   : noOpMiddleware;

--- a/src/server/common/test/rate-limit-coverage.test.ts
+++ b/src/server/common/test/rate-limit-coverage.test.ts
@@ -1,0 +1,539 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express, { Application } from 'express';
+import { EventEmitter } from 'events';
+
+import ConfigurationDomain from '@/server/configuration';
+import SetupDomain from '@/server/setup';
+import EmailDomain from '@/server/email';
+import AccountsDomain from '@/server/accounts';
+import AuthenticationDomain from '@/server/authentication';
+import FundingDomain from '@/server/funding';
+import CalendarDomain from '@/server/calendar';
+import ModerationDomain from '@/server/moderation';
+import HousekeepingDomain from '@/server/housekeeping';
+import ActivityPubDomain from '@/server/activitypub';
+import NotificationsDomain from '@/server/notifications';
+import PublicCalendarDomain from '@/server/public';
+import MediaDomain from '@/server/media';
+// Deliberate cross-domain test-time import. AP_RATE_LIMITER_MARKER and the
+// reset helpers are test-support infrastructure, not AP domain API — routing
+// them through the ActivityPub interface would pollute that interface with
+// test-only symbols. This common-domain guard reaches directly into the AP
+// middleware module for them, mirroring the backfill.ts "Exported for test
+// reset only" precedent. (The marker recognizes AP inbox limiters; the reset
+// helpers tear down the AP limiters' process-global singleton stores in afterAll.)
+import {
+  AP_RATE_LIMITER_MARKER,
+  resetActorRateLimitStore,
+  resetCalendarRateLimitStore,
+  resetUserRateLimitStore,
+} from '@/server/activitypub/middleware/rate-limit';
+
+/**
+ * =============================================================================
+ * RATE-LIMIT COVERAGE GUARD (epic pv-qqno capstone)
+ * =============================================================================
+ *
+ * This file is a CI guard, not a behavioral test. It introspects the REAL
+ * Express router stack of the fully-assembled application and enforces two
+ * invariants over the rate-limit posture of the route surface. It asserts
+ * PRESENCE of a rate-limit middleware, never thresholds or runtime behavior —
+ * per-limiter behavior is covered by the integration tests under each domain's
+ * `test/integration/rate_limiting.test.ts`.
+ *
+ * Two guards:
+ *
+ *   1. REGRESSION GUARD — every route on HIGH_ABUSE_RISK_ROUTES must carry at
+ *      least one rate-limit middleware in its layer stack. If a limiter is
+ *      removed from one of these high-value abuse surfaces, this guard fails.
+ *
+ *   2. COMPLETENESS GUARD — every registered MUTATING route (POST/PUT/PATCH/
+ *      DELETE) must be classified: it appears on HIGH_ABUSE_RISK_ROUTES OR on
+ *      the reviewed REVIEWED_NO_LIMITER_ROUTES allow-list. A new, unclassified
+ *      mutating route fails CI with an actionable message — forcing a human to
+ *      make an explicit rate-limit decision before the route can merge.
+ *
+ * -----------------------------------------------------------------------------
+ * MAINTENANCE PROTOCOL — read this before editing the lists below.
+ * -----------------------------------------------------------------------------
+ *
+ * The two lists in this file are the CANONICAL in-repo rate-limit risk taxonomy.
+ * The external audit (pv-qqno.1, pavillion-security route-rate-limit-audit.md)
+ * documents the original survey, but THIS FILE is the source of truth going
+ * forward. When you add a new mutating route and CI fails here, do ONE of:
+ *
+ *   A) The route is a high-value abuse surface (anonymous-reachable AND triggers
+ *      an amplifiable side effect: outbound email, row materialization, private-
+ *      surface enumeration, or unbounded federation fan-in). Attach a rate-limit
+ *      middleware to the route, then add it to HIGH_ABUSE_RISK_ROUTES. The
+ *      regression guard will then hold the limiter in place.
+ *
+ *   B) The route does NOT warrant a limiter (e.g. admin-only CRUD bounded by
+ *      ownership checks, or already gated by setup-mode middleware). Add it to
+ *      REVIEWED_NO_LIMITER_ROUTES with a one-line rationale. Allow-listing is a
+ *      reviewed decision — it records that a human looked at the route and judged
+ *      the residual abuse risk acceptable. Do NOT allow-list a route merely to
+ *      make CI pass; that defeats the guard's purpose.
+ *
+ * When you allow-list a route, mirror the rationale taxonomy already used below:
+ * "admin-only" (auth: adminOnly), "authenticated CRUD" (loggedInOnly, ownership-
+ * bounded), "setup-only" (gated by setup-mode middleware), or a specific note.
+ *
+ * -----------------------------------------------------------------------------
+ * LIMITER DETECTION STRATEGY (two-module split).
+ * -----------------------------------------------------------------------------
+ *
+ * Rate-limit middleware comes from two sources with different shapes, so we use
+ * two name-INDEPENDENT structural signals (function names are fragile and minify
+ * away under bundling):
+ *
+ *   - Common limiters (src/server/common/middleware/rate-limiters.ts) wrap
+ *     express-rate-limit. Every express-rate-limit middleware exposes `getKey`
+ *     and `resetKey` function properties; we detect those. (When config
+ *     rateLimit.enabled is false these collapse to no-op passthroughs and would
+ *     NOT be detected — which is exactly why this suite runs under
+ *     vitest.ratelimiting.config.ts with NODE_CONFIG rateLimit.enabled=true.)
+ *
+ *   - ActivityPub inbox limiters (src/server/activitypub/middleware/rate-limit.ts)
+ *     are plain closures over an in-memory LRU store with no express-rate-limit
+ *     signature. The factories tag each returned closure with a non-enumerable
+ *     AP_RATE_LIMITER_MARKER property; we detect that marker. This is why the AP
+ *     inbox routes are recognized despite carrying neither a named export nor a
+ *     getKey/resetKey method.
+ */
+
+// -----------------------------------------------------------------------------
+// HIGH_ABUSE_RISK_ROUTES — regression guard targets.
+//
+// Each of these MUST carry >=1 rate-limit middleware. These are the high-value
+// abuse surfaces from the pv-qqno threat model (A11/B4/C6): anonymous-reachable
+// routes that send outbound email, materialize rows, enumerate private surfaces,
+// or fan in federation traffic.
+// -----------------------------------------------------------------------------
+const HIGH_ABUSE_RISK_ROUTES: { method: string; path: string }[] = [
+  // Account signup (open-registration path) — IP + email limiters.
+  { method: 'POST', path: '/api/v1/register' },
+  // Application-gated signup path — IP + email limiters.
+  { method: 'POST', path: '/api/v1/applications' },
+  { method: 'POST', path: '/api/v1/applications/confirm/:token' },
+  // Calendar-editor invitation acceptance (noUserOnly) — IP limiter.
+  { method: 'POST', path: '/api/v1/invitations/:code' },
+  // Login — IP + email limiters.
+  { method: 'POST', path: '/api/auth/v1/login' },
+  // Password reset initiate — IP + email limiters.
+  { method: 'POST', path: '/api/auth/v1/reset-password' },
+  // Password reset confirm (reset-code brute-force surface) — IP limiter.
+  { method: 'POST', path: '/api/auth/v1/reset-password/:code' },
+  // Email change (credential-probe / enumeration hardening) — account limiter.
+  { method: 'POST', path: '/api/auth/v1/email' },
+  // Stripe funding webhook — IP limiter (defense in depth; signature is primary).
+  { method: 'POST', path: '/api/funding/webhooks/stripe' },
+  // Public moderation report submission — IP + email limiters.
+  { method: 'POST', path: '/api/public/v1/events/:eventId/reports' },
+  // Authenticated moderation report submission — IP + account limiters.
+  { method: 'POST', path: '/api/v1/reports' },
+  // ActivityPub federation inboxes — actor + calendar/user limiters (run before
+  // signature verification per DEC-013 ingest-boundary posture).
+  { method: 'POST', path: '/calendars/:urlname/inbox' },
+  { method: 'POST', path: '/users/:username/inbox' },
+];
+
+// -----------------------------------------------------------------------------
+// REVIEWED_NO_LIMITER_ROUTES — completeness guard allow-list.
+//
+// Mutating routes that have been reviewed and judged not to warrant a route-level
+// rate-limit middleware. Seeded from the pv-qqno.1 audit route table (all "low"
+// and reviewed "medium" verdicts). Rationale taxonomy:
+//   admin-only          — auth: adminOnly; bounded operator surface.
+//   authenticated CRUD  — loggedInOnly; ownership/tenant-bounded mutation.
+//   setup-only          — reachable only in first-run setup mode.
+//   per-account limited  — allow-listed as acceptable WITHOUT a guard-enforced
+//                          route-level limiter. These routes are documented as
+//                          carrying a per-account limiter (widget/funding/import),
+//                          but this guard does NOT verify that limiter's presence
+//                          — it only requires the route to be classified. The
+//                          per-account limiter, where present, is asserted by the
+//                          per-domain rate_limiting.test.ts integration tests, not
+//                          here. Treat this label as "reviewed, not a high-abuse
+//                          surface", not as a coverage guarantee.
+// -----------------------------------------------------------------------------
+const REVIEWED_NO_LIMITER_ROUTES: { method: string; path: string; reason: string }[] = [
+  // --- Accounts (admin / authenticated CRUD) ---
+  { method: 'PATCH', path: '/api/v1/accounts/me/profile', reason: 'authenticated CRUD (own profile)' },
+  { method: 'POST', path: '/api/v1/admin/applications/:id/approve', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/admin/applications/:id/deny', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/admin/invitations', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/applications/:id', reason: 'admin-only (application decision)' },
+  { method: 'POST', path: '/api/v1/invitations', reason: 'authenticated CRUD (outbound-email cost noted in audit; follow-up, not high-risk)' },
+  { method: 'POST', path: '/api/v1/invitations/:id/resend', reason: 'admin-only' },
+  { method: 'DELETE', path: '/api/v1/invitations/:id', reason: 'admin-only' },
+
+  // --- Authentication ---
+  // (all auth mutating routes are high-risk; none allow-listed)
+
+  // --- Configuration ---
+  { method: 'POST', path: '/api/config/v1/site', reason: 'admin-only' },
+
+  // --- Setup (first-run only) ---
+  { method: 'POST', path: '/api/v1/setup', reason: 'setup-only (gated by setup-mode middleware)' },
+
+  // --- Funding (admin + per-account limited) ---
+  { method: 'POST', path: '/api/funding/v1/admin/settings', reason: 'admin-only' },
+  { method: 'PUT', path: '/api/funding/v1/admin/providers/:providerType', reason: 'admin-only' },
+  { method: 'DELETE', path: '/api/funding/v1/admin/providers/:providerType', reason: 'admin-only' },
+  { method: 'POST', path: '/api/funding/v1/admin/providers/stripe/configure', reason: 'admin-only' },
+  { method: 'POST', path: '/api/funding/v1/admin/providers/paypal/configure', reason: 'admin-only' },
+  { method: 'POST', path: '/api/funding/v1/admin/funding-plans/:id/cancel', reason: 'admin-only' },
+  { method: 'POST', path: '/api/funding/v1/admin/grants', reason: 'admin-only' },
+  { method: 'DELETE', path: '/api/funding/v1/admin/grants/:id', reason: 'admin-only' },
+  { method: 'POST', path: '/api/funding/v1/cancel', reason: 'authenticated CRUD (own funding plan)' },
+  { method: 'POST', path: '/api/funding/v1/calendars', reason: 'per-account limited (calendarFundingPlanByAccount)' },
+  { method: 'DELETE', path: '/api/funding/v1/calendars/:calendarId', reason: 'per-account limited (calendarFundingPlanByAccount)' },
+  { method: 'POST', path: '/api/funding/v1/checkout-sessions', reason: 'per-account limited (checkoutSessionByAccount)' },
+
+  // --- Calendar (authenticated, ownership-bounded CRUD) ---
+  { method: 'POST', path: '/api/v1/calendars', reason: 'authenticated CRUD' },
+  { method: 'PATCH', path: '/api/v1/calendars/:calendarId/settings', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/editors', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/editors/remote', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/editors/:editorId', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/editors/:editorId/permissions', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/invitations/:invitationId', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/invitations/:invitationId/resend', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/categories', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/categories/merge', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/categories/:categoryId', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/categories/:categoryId', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/following/:actorId/category-mappings', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/locations', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/locations/:locationId', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/locations/:locationId', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/locations/:locationId/reassign-events', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/series', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/series/:seriesId', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/series/:seriesId', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/events/:id', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/events/:id', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events/bulk-assign-categories', reason: 'authenticated CRUD' },
+  { method: 'PUT', path: '/api/v1/events/:id/categories', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events/:eventId/occurrences/cancel', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/events/:eventId/occurrences/cancel', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events/:eventId/categories', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events/:eventId/categories/:categoryId', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/events/:eventId/categories/:categoryId', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/events/:eventId/series/:seriesId', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/events/:eventId/series/:seriesId', reason: 'authenticated CRUD' },
+  // Widget config + import-source routes carry widgetConfigByAccount / import limiters
+  // (per-account), classified here rather than as high-risk surfaces.
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/config', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/import-sources/:id', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify-issue', reason: 'per-account limited (widgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify', reason: 'per-source limited (importSourceVerifyBySource)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/sync', reason: 'per-source limited (importSourceSyncBySource)' },
+
+  // --- Media ---
+  { method: 'POST', path: '/api/v1/media/:calendarId', reason: 'authenticated CRUD (upload-abuse follow-up noted in audit; not high-risk)' },
+
+  // --- Notifications ---
+  { method: 'PATCH', path: '/api/v1/notification/:id', reason: 'authenticated CRUD (own notification)' },
+
+  // --- ActivityPub social (authenticated) ---
+  { method: 'POST', path: '/api/v1/social/follows', reason: 'authenticated CRUD' },
+  { method: 'PATCH', path: '/api/v1/social/follows/:id', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/social/follows/:id', reason: 'authenticated CRUD' },
+  { method: 'POST', path: '/api/v1/social/shares', reason: 'authenticated CRUD' },
+  { method: 'DELETE', path: '/api/v1/social/shares/:id', reason: 'authenticated CRUD' },
+
+  // --- Moderation (admin + authenticated calendar-scoped) ---
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/reports/:reportId', reason: 'authenticated CRUD (calendar-scoped moderation)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/reports/:reportId/resolve', reason: 'authenticated CRUD (calendar-scoped moderation)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/reports/:reportId/dismiss', reason: 'authenticated CRUD (calendar-scoped moderation)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/reports/:reportId/forward', reason: 'authenticated CRUD (calendar-scoped moderation)' },
+  { method: 'POST', path: '/api/v1/admin/reports', reason: 'admin-only' },
+  { method: 'PUT', path: '/api/v1/admin/reports/:reportId', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/admin/reports/:reportId/forward-to-admin', reason: 'admin-only' },
+  { method: 'PUT', path: '/api/v1/admin/moderation/settings', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/admin/moderation/block-instance', reason: 'admin-only' },
+  { method: 'DELETE', path: '/api/v1/admin/moderation/blocked-instances/:domain', reason: 'admin-only' },
+  { method: 'POST', path: '/api/v1/admin/moderation/blocked-reporters', reason: 'admin-only' },
+  { method: 'DELETE', path: '/api/v1/admin/moderation/blocked-reporters/:emailHash', reason: 'admin-only' },
+];
+
+// =============================================================================
+// Router-stack introspection (Express 4).
+// =============================================================================
+
+interface DiscoveredRoute {
+  method: string;
+  path: string;
+  hasRateLimiter: boolean;
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+/** express-rate-limit middleware exposes getKey/resetKey methods. */
+function isCommonRateLimiter(handle: any): boolean {
+  return !!handle && typeof handle.getKey === 'function' && typeof handle.resetKey === 'function';
+}
+
+/** AP inbox limiters carry the non-enumerable AP_RATE_LIMITER_MARKER. */
+function isApRateLimiter(handle: any): boolean {
+  return !!handle && (handle as any)[AP_RATE_LIMITER_MARKER] === true;
+}
+
+function isRateLimiter(handle: any): boolean {
+  return isCommonRateLimiter(handle) || isApRateLimiter(handle);
+}
+
+/**
+ * Reconstructs the mount-path fragment a router layer was mounted under from its
+ * compiled regexp + param keys. Express 4 stores `app.use('/x', router)` as a
+ * Layer whose regexp encodes '/x'; nested params become capture groups that map
+ * positionally to `layer.keys`.
+ *
+ * VALIDATED AGAINST EXPRESS 4.x (4.22.2 at time of writing). The hardcoded
+ * regexp-source patterns below depend on Express 4's internal path-to-regexp
+ * encoding. Express 5 (path-to-regexp v8) changes this encoding and stores
+ * layer matchers differently — under it these replacements would silently
+ * reconstruct wrong/empty paths. The positive-path sanity assertion in the
+ * "introspection sanity check" test guards against that: if reconstruction
+ * breaks, a KNOWN full path will go missing and that assertion fails loudly
+ * with a clear signal, rather than producing a cascade of misattributed
+ * "route not found" / "unclassified route" failures.
+ */
+function reconstructMountPath(layer: any): string {
+  if (layer.regexp && layer.regexp.fast_slash) return '';
+  const keys = layer.keys || [];
+  const src: string = layer.regexp && layer.regexp.source ? layer.regexp.source : '';
+  let path = src
+    .replace(/^\^/, '')
+    .replace(/\\\/\?\(\?=\\\/\|\$\)$/, '')
+    .replace(/\(\?=\\\/\|\$\)$/, '')
+    .replace(/\$$/, '')
+    .replace(/\\\//g, '/');
+  let ki = 0;
+  path = path.replace(/\(\?:\(\[\^\/\]\+\?\)\)/g, () => ':' + (keys[ki++]?.name ?? 'param'));
+  path = path.replace(/\(\?:\(\[\^\\\/\]\+\?\)\)/g, () => ':' + (keys[ki++]?.name ?? 'param'));
+  return path.replace(/\/\?$/, '');
+}
+
+/** Walks the full router stack and collects every terminal route. */
+function discoverRoutes(app: Application): DiscoveredRoute[] {
+  const routes: DiscoveredRoute[] = [];
+
+  function walk(stack: any[], prefix: string): void {
+    for (const layer of stack) {
+      if (layer.route) {
+        const methods = Object.keys(layer.route.methods).filter((m) => m !== '_all');
+        const hasRateLimiter = layer.route.stack.some((s: any) => isRateLimiter(s.handle));
+        for (const method of methods) {
+          routes.push({
+            method: method.toUpperCase(),
+            path: prefix + layer.route.path,
+            hasRateLimiter,
+          });
+        }
+      }
+      else if (layer.name === 'router' && layer.handle?.stack) {
+        walk(layer.handle.stack, prefix + reconstructMountPath(layer));
+      }
+    }
+  }
+
+  walk((app as any)._router.stack, '');
+  return routes;
+}
+
+interface BuiltApp {
+  app: Application;
+  /** Stops domain-level timers (funding scheduled jobs) started during init. */
+  teardown: () => void;
+}
+
+/**
+ * Builds the fully-assembled application, mirroring the domain wiring order in
+ * src/server/server.ts but skipping database initialization and `app.listen`.
+ * Route installation does not touch the database; the sqlite test dialect also
+ * skips the housekeeping job-queue wiring. This produces the real router stack.
+ *
+ * Returns a `teardown` that stops the funding domain's scheduled-job timers,
+ * which `FundingDomain.initialize` starts unconditionally. Without it those
+ * timers leak for the life of the worker.
+ */
+async function buildFullApp(): Promise<BuiltApp> {
+  const app: Application = express();
+  const eventBus = new EventEmitter();
+
+  const configurationDomain = new ConfigurationDomain(eventBus);
+  configurationDomain.initialize(app);
+
+  const setupDomain = new SetupDomain(configurationDomain.interface);
+  setupDomain.initialize(app);
+
+  const emailDomain = new EmailDomain();
+
+  const accountsDomain = new AccountsDomain(
+    eventBus, configurationDomain.interface, setupDomain.interface, emailDomain.interface,
+  );
+  accountsDomain.initialize(app);
+
+  const authenticationDomain = new AuthenticationDomain(
+    eventBus, accountsDomain.interface, emailDomain.interface,
+  );
+  authenticationDomain.initialize(app);
+
+  const fundingDomain = new FundingDomain(eventBus);
+  fundingDomain.initialize(app);
+
+  const calendarDomain = new CalendarDomain(
+    eventBus, accountsDomain.interface, emailDomain.interface, fundingDomain.interface,
+  );
+  calendarDomain.initialize(app);
+  fundingDomain.setCalendarInterface(calendarDomain.interface);
+
+  const moderationDomain = new ModerationDomain(
+    eventBus, calendarDomain.interface, accountsDomain.interface,
+    emailDomain.interface, configurationDomain.interface,
+  );
+  moderationDomain.initialize(app);
+  calendarDomain.interface.setModerationInterface(moderationDomain.interface);
+
+  const housekeepingDomain = new HousekeepingDomain(
+    eventBus, emailDomain.interface, accountsDomain.interface,
+  );
+  await housekeepingDomain.initialize(app);
+
+  const activityPubDomain = new ActivityPubDomain(
+    eventBus, calendarDomain.interface, accountsDomain.interface,
+    housekeepingDomain.interface, moderationDomain.interface,
+  );
+  activityPubDomain.initialize(app);
+  calendarDomain.interface.setActivityPubInterface(activityPubDomain.interface);
+
+  new NotificationsDomain(eventBus, calendarDomain.interface, accountsDomain.interface).initialize(app);
+  accountsDomain.interface.setCalendarInterface(calendarDomain.interface);
+
+  const publicDomain = new PublicCalendarDomain(eventBus, calendarDomain);
+  publicDomain.initialize(app);
+
+  const mediaDomain = new MediaDomain(eventBus, calendarDomain.interface);
+  mediaDomain.initialize(app);
+  calendarDomain.interface.setMediaInterface(mediaDomain.interface);
+
+  return {
+    app,
+    teardown: () => fundingDomain.shutdown(),
+  };
+}
+
+function routeKey(r: { method: string; path: string }): string {
+  return `${r.method} ${r.path}`;
+}
+
+describe('rate-limit coverage guard', () => {
+  let routes: DiscoveredRoute[];
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const built = await buildFullApp();
+    teardown = built.teardown;
+    routes = discoverRoutes(built.app);
+  });
+
+  afterAll(() => {
+    // Stop the funding domain's scheduled-job timers started during init.
+    teardown();
+    // The AP limiters share process-global singleton stores. Reset them (which
+    // also destroys their cleanup-interval timers) so this suite leaves no live
+    // handles for any test sharing the worker.
+    resetActorRateLimitStore();
+    resetCalendarRateLimitStore();
+    resetUserRateLimitStore();
+  });
+
+  it('discovers a non-trivial route surface (introspection sanity check)', () => {
+    expect(routes.length).toBeGreaterThan(50);
+    const mutating = routes.filter((r) => MUTATING_METHODS.has(r.method));
+    expect(mutating.length).toBeGreaterThan(20);
+
+    // Positive-path reconstruction check. POST /api/v1/register is a known,
+    // stably-registered route under a nested router (accounts domain). If
+    // reconstructMountPath breaks (e.g. an Express major bump changes the
+    // internal regexp encoding), this exact full path will fail to reconstruct
+    // and this assertion fails with a clear "path reconstruction failed" signal
+    // — instead of the breakage surfacing downstream as misleading "route not
+    // found" / "unclassified route" errors in the guards below.
+    expect(
+      routes.some((r) => r.method === 'POST' && r.path === '/api/v1/register'),
+      'Router introspection failed to reconstruct the known route POST /api/v1/register. '
+        + 'reconstructMountPath likely broke against the installed Express version '
+        + '(validated against Express 4.x) — fix path reconstruction before trusting the guards below.',
+    ).toBe(true);
+  });
+
+  describe('regression guard: high-abuse-risk routes carry a rate-limit middleware', () => {
+    it.each(HIGH_ABUSE_RISK_ROUTES)('$method $path is rate-limited', ({ method, path }) => {
+      const match = routes.find((r) => r.method === method && r.path === path);
+      expect(
+        match,
+        `High-abuse-risk route ${method} ${path} is not registered. The route was renamed or removed; update HIGH_ABUSE_RISK_ROUTES in this file to match.`,
+      ).toBeDefined();
+      expect(
+        match!.hasRateLimiter,
+        `High-abuse-risk route ${method} ${path} has NO rate-limit middleware. A limiter was removed from a high-value abuse surface. Re-attach a rate limiter (see src/server/common/middleware/rate-limiters.ts or the AP inbox limiters) before merging.`,
+      ).toBe(true);
+    });
+  });
+
+  describe('completeness guard: every mutating route is classified', () => {
+    it('no mutating route is left unclassified', () => {
+      const highRiskKeys = new Set(HIGH_ABUSE_RISK_ROUTES.map(routeKey));
+      const allowListKeys = new Set(REVIEWED_NO_LIMITER_ROUTES.map(routeKey));
+
+      const mutating = routes.filter((r) => MUTATING_METHODS.has(r.method));
+      const unclassified = mutating.filter(
+        (r) => !highRiskKeys.has(routeKey(r)) && !allowListKeys.has(routeKey(r)),
+      );
+
+      // De-duplicate (a route may appear once per registered method alias).
+      const unique = Array.from(new Set(unclassified.map(routeKey))).sort();
+
+      expect(
+        unique,
+        [
+          'Unclassified mutating route(s) detected. Every POST/PUT/PATCH/DELETE route must be',
+          'classified in src/server/common/test/rate-limit-coverage.test.ts. For each route below,',
+          'either (A) attach a rate-limit middleware and add it to HIGH_ABUSE_RISK_ROUTES if it is a',
+          'high-value abuse surface, or (B) add it to REVIEWED_NO_LIMITER_ROUTES with a one-line',
+          'rationale after a deliberate review. See the MAINTENANCE PROTOCOL docblock at the top of',
+          'the file.\n\nUnclassified:\n  ' + unique.join('\n  '),
+        ].join(' '),
+      ).toEqual([]);
+    });
+
+    it('the allow-list contains no stale entries (every entry maps to a real route)', () => {
+      const mutatingKeys = new Set(
+        routes.filter((r) => MUTATING_METHODS.has(r.method)).map(routeKey),
+      );
+      const stale = REVIEWED_NO_LIMITER_ROUTES
+        .map(routeKey)
+        .filter((k) => !mutatingKeys.has(k))
+        .sort();
+
+      expect(
+        stale,
+        'Stale allow-list entries: these routes are in REVIEWED_NO_LIMITER_ROUTES but no longer exist on the router. Remove them.\n  ' + stale.join('\n  '),
+      ).toEqual([]);
+    });
+
+    it('no route is both high-risk and allow-listed (lists are disjoint)', () => {
+      const allowListKeys = new Set(REVIEWED_NO_LIMITER_ROUTES.map(routeKey));
+      const overlap = HIGH_ABUSE_RISK_ROUTES.map(routeKey).filter((k) => allowListKeys.has(k));
+      expect(overlap, 'Routes appear on both HIGH_ABUSE_RISK_ROUTES and REVIEWED_NO_LIMITER_ROUTES: ' + overlap.join(', ')).toEqual([]);
+    });
+  });
+});

--- a/src/server/funding/api/v1/webhooks.ts
+++ b/src/server/funding/api/v1/webhooks.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, Application, Router } from 'express';
 import FundingInterface from '@/server/funding/interface';
 import { ProviderNotConfiguredError, WebhookSignatureError } from '@/common/exceptions/funding';
 import { logError } from '@/server/common/helper/error-logger';
+import { fundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
 
 /**
  * Webhook route handlers for payment provider events
@@ -25,9 +26,14 @@ export default class WebhookRoutes {
   installHandlers(app: Application, routePrefix: string): void {
     const router = Router();
 
-    // Stripe webhook endpoint - needs raw body for signature verification
+    // Stripe webhook endpoint - needs raw body for signature verification.
+    // The per-IP limiter runs before the raw-body parser so it cannot disturb
+    // body handling; it is belt-and-braces behind signature verification
+    // (DEC-007) and is tuned generously so it never gates legitimate Stripe
+    // delivery or retries.
     router.post(
       '/webhooks/stripe',
+      fundingWebhookByIp,
       express.raw({ type: 'application/json' }),
       this.handleStripeWebhook.bind(this),
     );

--- a/src/server/funding/test/integration/rate_limiting.test.ts
+++ b/src/server/funding/test/integration/rate_limiting.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import config from 'config';
+import express, { Express } from 'express';
+import request from 'supertest';
+
+import { fundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
+
+/**
+ * Integration tests for funding (Stripe webhook) rate limiting.
+ *
+ * The pre-configured limiter in rate-limiters.ts is computed at module-load
+ * time and reads the rateLimit.enabled flag once. This suite runs under
+ * vitest.ratelimiting.config.ts (NODE_CONFIG enables rate limiting), where the
+ * export resolves to real express-rate-limit middleware rather than the no-op.
+ *
+ * NOTE: requires rate limiting enabled. To run: npm run test:ratelimiting
+ *
+ * IMPORTANT: fundingWebhookByIp is a module-level singleton with its own
+ * in-memory store, keyed by IP. The whole suite shares the localhost IP, so the
+ * IP budget is exhausted exactly once in a single dedicated test. The webhook
+ * limiter is deliberately generous (DEC-007: belt-and-braces behind Stripe
+ * signature verification) and must never gate legitimate Stripe delivery or
+ * retries — the test only asserts that the configured ceiling is enforced.
+ */
+
+const rateLimitEnabled = config.get<boolean>('rateLimit.enabled');
+const describeOrSkip = rateLimitEnabled ? describe : describe.skip;
+
+describeOrSkip('Funding Webhook Rate Limiting Integration Tests', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    app.post('/webhook-ip-only', fundingWebhookByIp, (req, res) => {
+      res.json({ route: 'funding-webhook-ip' });
+    });
+  });
+
+  describe('fundingWebhookByIp', () => {
+    it('should return 429 once the per-IP limit is exhausted and wire the same singleton onto POST /api/funding/webhooks/stripe', async () => {
+      const ipMax = config.get<number>('rateLimit.fundingWebhook.byIp.max');
+
+      const responses = [];
+      for (let i = 0; i < ipMax + 1; i++) {
+        responses.push(
+          await request(app)
+            .post('/webhook-ip-only')
+            .send({ event: `funding-webhook-${i}` }),
+        );
+      }
+
+      // The first ipMax requests are under the ceiling and pass through.
+      for (let i = 0; i < ipMax; i++) {
+        expect(responses[i].status).toBe(200);
+      }
+
+      // The (ipMax + 1)th request must be blocked by the IP limiter with a
+      // generic 429 body and standard ratelimit-* headers.
+      const blocked = responses[ipMax];
+      expect(blocked.status).toBe(429);
+      expect(blocked.body.errorName).toBe('RateLimitError');
+      expect(blocked.body.error).toBe(
+        'Too many funding-webhook requests from this IP, please try again later.',
+      );
+      expect(blocked.headers['ratelimit-limit']).toBe(String(ipMax));
+      expect(blocked.headers['ratelimit-remaining']).toBe('0');
+      expect(blocked.headers['retry-after']).toBeDefined();
+
+      // Prove the same `fundingWebhookByIp` singleton is wired onto the real
+      // webhook route. The limiter is now exhausted for localhost, so a request
+      // to POST /api/funding/webhooks/stripe must short-circuit at 429 before
+      // the raw-body parser and signature-verification handler run.
+      // Imports are deferred so the full-server init cost is only paid here.
+      const { TestEnvironment } = await import('@/server/common/test/lib/test_environment');
+      const { EventEmitter } = await import('events');
+      const { default: AccountService } = await import('@/server/accounts/service/account');
+      const { default: ConfigurationInterface } = await import('@/server/configuration/interface');
+      const { default: SetupInterface } = await import('@/server/setup/interface');
+
+      const realEnv = new TestEnvironment();
+      await realEnv.init();
+
+      // Create an admin account so the setup-mode middleware (which returns 503
+      // for API requests while no admin exists) lets the request through to the
+      // funding route where the limiter is wired.
+      const accountService = new AccountService(
+        new EventEmitter(),
+        new ConfigurationInterface(),
+        new SetupInterface(),
+      );
+      await accountService._setupAccount('funding-ratelimit@pavillion.dev', 'testpassword123');
+
+      const webhookResponse = await request(realEnv.app)
+        .post('/api/funding/webhooks/stripe')
+        .set('stripe-signature', 'test-signature')
+        .send({ event: 'wired-check' });
+
+      expect(webhookResponse.status).toBe(429);
+      expect(webhookResponse.body.errorName).toBe('RateLimitError');
+      expect(webhookResponse.body.error).toBe(
+        'Too many funding-webhook requests from this IP, please try again later.',
+      );
+
+      await realEnv.cleanup();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,12 @@ export default defineConfig({
           include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
           exclude: [
             ...sharedExclude,
+            // Rate-limit coverage guard: transitively imports the full domain
+            // graph (reaching isomorphic-dompurify) AND only detects limiters
+            // when config rateLimit.enabled is true. It must run EXCLUSIVELY via
+            // vitest.ratelimiting.config.ts (NODE_CONFIG rateLimit.enabled=true,
+            // forks pool), exactly like the domain rate_limiting.test.ts files.
+            'src/server/common/test/rate-limit-coverage.test.ts',
             'src/common/test/utils/render-markdown.test.ts',
             'src/server/configuration/test/service_settings.test.ts',
             // Imports the full @/server/server entry module, whose graph reaches

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       '**/tests/e2e/**',
       '**/*.e2e.test.ts',
       // Exclude rate limiting tests - run separately with test:ratelimiting
-      '**/authentication/test/integration/rate_limiting.test.ts',
+      '**/test/integration/rate_limiting.test.ts',
       // Exclude widget tests - they need DOM and run with unit tests
       '**/widget/test/integration/**',
     ],

--- a/vitest.ratelimiting.config.ts
+++ b/vitest.ratelimiting.config.ts
@@ -4,7 +4,7 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig({
   plugins: [vue()],
   test: {
-    environment: 'happy-dom',
+    environment: 'node',
     globals: true,
     // Rate limiting tests use forks pool
     fileParallelism: true,
@@ -21,6 +21,9 @@ export default defineConfig({
     include: [
       '**/authentication/test/integration/rate_limiting.test.ts',
       '**/accounts/test/integration/rate_limiting.test.ts',
+      '**/funding/test/integration/rate_limiting.test.ts',
+      '**/activitypub/test/integration/rate_limiting.test.ts',
+      '**/common/test/rate-limit-coverage.test.ts',
     ],
     exclude: [
       '**/node_modules/**',


### PR DESCRIPTION
## Motivation

Several abuse-prone backend routes had no rate limiting — signup, password-reset confirm, invitation accept, email change, the ActivityPub user inbox, and the Stripe webhook — leaving them open to disposable-email calendar-spam, token brute-force, federation inbox flooding, and authenticated probe abuse. This closes the coverage gaps surfaced by a full route-table audit and adds a guard so they can't silently reopen.

## Approach

- New config-driven limiters wired at each gap: `registerByIp`/`registerByEmail`, `acceptInvitationByIp`, `confirmPasswordResetByIp`, `emailChangeByAccount`, `fundingWebhookByIp` (generous, sitting behind Stripe signature verification), and an ActivityPub user-inbox actor+user limiter that mirrors the calendar-inbox chain ordering (limiters run before HTTP-signature verification).
- The two-module boundary is preserved: HTTP-client-identity limiters (IP/email/account) live in common middleware; federation-identity limiters (actor/user) live in the ActivityPub module.
- Caddy gains `read_body`/`read_header`/`idle` timeouts for slowloris mitigation.
- A CI router-stack guard test enforces (a) a rate-limit limiter on every high-abuse-risk route and (b) classification of every mutating route against a reviewed allow-list — the build fails when a new route is unprotected or unclassified.
- Rate-limit keys stay in-memory and are logged only at debug level across all three limiter factories; 429 responses never echo the key.
- The password-reset-confirm threshold (20/15m) is traced to the reset code's 128-bit CSPRNG entropy. The email-change limiter is a per-account probe defense; closing the underlying email-existence enumeration oracle is a separate design change tracked as a follow-up.

## Validation

- Dedicated rate-limiting suite: 43 tests across 5 files — per-limiter 429-at-threshold, key-isolation for non-IP-keyed limiters, real-route wiring, and the coverage guard — all green.
- Full verification: lint clean, unit (8274) and integration (669) green, build clean, e2e green apart from pre-existing/environmental failures (admin UI selector timeouts, missing federation TLS cert).
- Caddy timeouts verified manually with a slow-drip smoke test.