### PR TITLE
refactor: prefix rate-limit middleware exports with "limit"

### DIFF
--- a/src/server/accounts/api/v1/accounts.ts
+++ b/src/server/accounts/api/v1/accounts.ts
@@ -6,7 +6,7 @@ import { Account } from '@/common/model/account';
 import { logError } from '@/server/common/helper/error-logger';
 import { ValidationError } from '@/common/exceptions/base';
 import { createLogger } from '@/server/common/helper/logger';
-import { registerByIp, registerByEmail } from '@/server/common/middleware/rate-limiters';
+import { limitRegisterByIp, limitRegisterByEmail } from '@/server/common/middleware/rate-limiters';
 
 const logger = createLogger('accounts');
 
@@ -25,7 +25,7 @@ export default class AccountRouteHandlers {
     // is disabled in config. The email limiter increments uniformly on every
     // attempt regardless of account existence, so it cannot leak which emails
     // are registered (DEC-004).
-    router.post('/register', registerByIp, registerByEmail, ...ExpressHelper.noUserOnly, this.registerHandler.bind(this));
+    router.post('/register', limitRegisterByIp, limitRegisterByEmail, ...ExpressHelper.noUserOnly, this.registerHandler.bind(this));
     router.get('/accounts/me', ...ExpressHelper.loggedInOnly, this.getCurrentUser.bind(this));
     router.patch('/accounts/me/profile', ...ExpressHelper.loggedInOnly, this.updateProfile.bind(this));
     app.use(routePrefix, router);

--- a/src/server/accounts/api/v1/applications.ts
+++ b/src/server/accounts/api/v1/applications.ts
@@ -10,9 +10,9 @@ import { ValidationError } from '@/common/exceptions/base';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
 import {
-  applicationByEmail,
-  applicationByIp,
-  confirmApplicationByIp,
+  limitApplicationByEmail,
+  limitApplicationByIp,
+  limitConfirmApplicationByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 const logger = createLogger('accounts');
@@ -32,8 +32,8 @@ export default class AccountApplicationRouteHandlers {
     // when rate limiting is disabled in config.
     router.post(
       '/applications',
-      applicationByIp,
-      applicationByEmail,
+      limitApplicationByIp,
+      limitApplicationByEmail,
       ...ExpressHelper.noUserOnly,
       this.applyToRegister.bind(this),
     );
@@ -44,7 +44,7 @@ export default class AccountApplicationRouteHandlers {
     // so no session middleware and no CSRF token are applied — either would
     // break the email-link flow. The SPA fires it automatically on mount so
     // the user-facing flow is single-click (the email link itself).
-    router.post('/applications/confirm/:token', confirmApplicationByIp, this.consumeConfirmationToken.bind(this));
+    router.post('/applications/confirm/:token', limitConfirmApplicationByIp, this.consumeConfirmationToken.bind(this));
     router.get('/applications', ...ExpressHelper.adminOnly, this.listApplications.bind(this));
     router.post('/applications/:id', ...ExpressHelper.adminOnly, this.processApplication.bind(this));
     app.use(routePrefix, router);

--- a/src/server/accounts/api/v1/invitations.ts
+++ b/src/server/accounts/api/v1/invitations.ts
@@ -5,7 +5,7 @@ import { ValidationError } from '@/common/exceptions/base';
 import AccountsInterface from '@/server/accounts/interface';
 import ExpressHelper from '@/server/common/helper/express';
 import { logError } from '@/server/common/helper/error-logger';
-import { acceptInvitationByIp } from '@/server/common/middleware/rate-limiters';
+import { limitAcceptInvitationByIp } from '@/server/common/middleware/rate-limiters';
 
 export default class AccountInvitationRouteHandlers {
   private service: AccountsInterface;
@@ -19,7 +19,7 @@ export default class AccountInvitationRouteHandlers {
     router.get('/invitations', ExpressHelper.loggedInOnly, this.listInvitations.bind(this));
     router.post('/invitations', ExpressHelper.loggedInOnly, this.inviteToRegister.bind(this));
     router.get('/invitations/:code', ...ExpressHelper.noUserOnly, this.checkInviteCode.bind(this));
-    router.post('/invitations/:code', acceptInvitationByIp, ...ExpressHelper.noUserOnly, this.acceptInvite.bind(this));
+    router.post('/invitations/:code', limitAcceptInvitationByIp, ...ExpressHelper.noUserOnly, this.acceptInvite.bind(this));
     router.delete('/invitations/:id', ExpressHelper.adminOnly, this.cancelInvite.bind(this));
     router.post('/invitations/:id/resend', ExpressHelper.adminOnly, this.resendInvite.bind(this));
     app.use(routePrefix, router);

--- a/src/server/accounts/test/integration/rate_limiting.test.ts
+++ b/src/server/accounts/test/integration/rate_limiting.test.ts
@@ -4,12 +4,12 @@ import express, { Express } from 'express';
 import request from 'supertest';
 
 import {
-  applicationByIp,
-  applicationByEmail,
-  confirmApplicationByIp,
-  registerByIp,
-  registerByEmail,
-  acceptInvitationByIp,
+  limitApplicationByIp,
+  limitApplicationByEmail,
+  limitConfirmApplicationByIp,
+  limitRegisterByIp,
+  limitRegisterByEmail,
+  limitAcceptInvitationByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 /**
@@ -50,27 +50,27 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     app = express();
     app.use(express.json());
 
-    app.post('/apply-ip-only', applicationByIp, (req, res) => {
+    app.post('/apply-ip-only', limitApplicationByIp, (req, res) => {
       res.json({ route: 'ip' });
     });
-    app.post('/apply-email-only', applicationByEmail, (req, res) => {
+    app.post('/apply-email-only', limitApplicationByEmail, (req, res) => {
       res.json({ route: 'email' });
     });
-    app.post('/confirm-ip-only', confirmApplicationByIp, (req, res) => {
+    app.post('/confirm-ip-only', limitConfirmApplicationByIp, (req, res) => {
       res.json({ route: 'confirm' });
     });
-    app.post('/register-ip-only', registerByIp, (req, res) => {
+    app.post('/register-ip-only', limitRegisterByIp, (req, res) => {
       res.json({ route: 'register-ip' });
     });
-    app.post('/register-email-only', registerByEmail, (req, res) => {
+    app.post('/register-email-only', limitRegisterByEmail, (req, res) => {
       res.json({ route: 'register-email' });
     });
-    app.post('/accept-invitation-ip-only', acceptInvitationByIp, (req, res) => {
+    app.post('/accept-invitation-ip-only', limitAcceptInvitationByIp, (req, res) => {
       res.json({ route: 'accept-invitation-ip' });
     });
   });
 
-  describe('applicationByEmail', () => {
+  describe('limitApplicationByEmail', () => {
     it('should return 429 once the per-email limit is exhausted', async () => {
       const maxRequests = config.get<number>('rateLimit.application.byEmail.max');
 
@@ -106,8 +106,8 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
 
   // The IP-keyed limiters share localhost across this whole file, so each is
   // exercised in a single dedicated test that consumes its full budget.
-  describe('applicationByIp', () => {
-    it('should return 429 once the per-IP limit is exhausted, remain in a distinct bucket from applicationByEmail, and the same singleton limiter is wired on POST /api/v1/applications', async () => {
+  describe('limitApplicationByIp', () => {
+    it('should return 429 once the per-IP limit is exhausted, remain in a distinct bucket from limitApplicationByEmail, and the same singleton limiter is wired on POST /api/v1/applications', async () => {
       const ipMax = config.get<number>('rateLimit.application.byIp.max');
       const emailMax = config.get<number>('rateLimit.application.byEmail.max');
 
@@ -162,7 +162,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
         'Too many application requests for this email, please try again later.',
       );
 
-      // Phase 2: prove the same `applicationByIp` and `applicationByEmail`
+      // Phase 2: prove the same `limitApplicationByIp` and `limitApplicationByEmail`
       // singletons are wired onto POST /api/v1/applications. Both limiters
       // are now exhausted (IP via `/apply-ip-only`; email via
       // `/apply-email-only` on `freshEmail`), so any request to the real
@@ -188,7 +188,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
       await accountService._setupAccount('rate-limit-apply-admin@pavillion.dev', 'testpassword!1');
 
       // Hit the real route with the same IP (localhost). Because
-      // `applicationByIp` runs first in the chain and is already exhausted,
+      // `limitApplicationByIp` runs first in the chain and is already exhausted,
       // we get 429 from it. This proves the IP limiter is mounted.
       const realPostIp = await request(realEnv.app)
         .post('/api/v1/applications')
@@ -203,7 +203,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     });
   });
 
-  describe('confirmApplicationByIp', () => {
+  describe('limitConfirmApplicationByIp', () => {
     it('should return 429 once the per-IP confirmation limit is exhausted, and route wiring on the real /api/v1/applications/confirm/:token endpoint is verified', async () => {
       const maxRequests = config.get<number>('rateLimit.application.confirm.byIp.max');
 
@@ -233,7 +233,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
       // public confirm endpoint. Because the limiter store is module-global
       // and the budget is already exhausted from Phase 1, a fresh request to
       // the real route (still on localhost) must short-circuit at 429. This
-      // confirms `confirmApplicationByIp` is mounted on the production
+      // confirms `limitConfirmApplicationByIp` is mounted on the production
       // POST /api/v1/applications/confirm/:token route.
       // Imports are deferred so we don't pay full-server init cost when this
       // file is loaded by other suites; Phase 2 only spins up the server when
@@ -268,7 +268,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     });
   });
 
-  describe('registerByEmail', () => {
+  describe('limitRegisterByEmail', () => {
     it('should return 429 once the per-email limit is exhausted, incrementing uniformly regardless of account existence', async () => {
       const maxRequests = config.get<number>('rateLimit.register.byEmail.max');
 
@@ -328,7 +328,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     });
   });
 
-  describe('registerByIp', () => {
+  describe('limitRegisterByIp', () => {
     it('should return 429 once the per-IP limit is exhausted, and the same singleton limiter is wired on POST /api/v1/register', async () => {
       const ipMax = config.get<number>('rateLimit.register.byIp.max');
 
@@ -357,7 +357,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
       expect(blocked.headers['ratelimit-remaining']).toBe('0');
       expect(blocked.headers['retry-after']).toBeDefined();
 
-      // Phase 2: prove the same `registerByIp` singleton is wired onto the
+      // Phase 2: prove the same `limitRegisterByIp` singleton is wired onto the
       // real POST /api/v1/register route. The IP limiter store is module-global
       // and already exhausted above, so a fresh request to the real route
       // (still on localhost) must short-circuit at 429 before the handler runs.
@@ -394,7 +394,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
     });
   });
 
-  describe('acceptInvitationByIp', () => {
+  describe('limitAcceptInvitationByIp', () => {
     it('should return 429 once the per-IP limit is exhausted, and the same singleton limiter is wired on POST /api/v1/invitations/:code', async () => {
       const ipMax = config.get<number>('rateLimit.invitation.accept.byIp.max');
 
@@ -425,7 +425,7 @@ describeOrSkip('Account Application Rate Limiting Integration Tests', () => {
       expect(blocked.headers['ratelimit-remaining']).toBe('0');
       expect(blocked.headers['retry-after']).toBeDefined();
 
-      // Phase 2: prove the same `acceptInvitationByIp` singleton is wired onto
+      // Phase 2: prove the same `limitAcceptInvitationByIp` singleton is wired onto
       // the real POST /api/v1/invitations/:code route. The IP limiter store is
       // module-global and already exhausted above, so a fresh request to the
       // real route (still on localhost) must short-circuit at 429 before the

--- a/src/server/authentication/api/v1/auth.ts
+++ b/src/server/authentication/api/v1/auth.ts
@@ -13,12 +13,12 @@ import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('authentication');
 import {
-  passwordResetByIp,
-  passwordResetByEmail,
-  confirmPasswordResetByIp,
-  loginByIp,
-  loginByEmail,
-  emailChangeByAccount,
+  limitPasswordResetByIp,
+  limitPasswordResetByEmail,
+  limitConfirmPasswordResetByIp,
+  limitLoginByIp,
+  limitLoginByEmail,
+  limitEmailChangeByAccount,
 } from '@/server/common/middleware/rate-limiters';
 
 export default class AuthenticationRouteHandlers {
@@ -33,12 +33,12 @@ export default class AuthenticationRouteHandlers {
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
 
-    router.post('/login', loginByIp, loginByEmail, ...ExpressHelper.noUserOnly, this.login.bind(this) );
+    router.post('/login', limitLoginByIp, limitLoginByEmail, ...ExpressHelper.noUserOnly, this.login.bind(this) );
     router.get('/token', ...ExpressHelper.loggedInOnly, this.getToken.bind(this) );
     router.get('/reset-password/:code', this.checkPasswordResetCode.bind(this) );
-    router.post('/reset-password', passwordResetByIp, passwordResetByEmail, this.generatePasswordResetCode.bind(this) );
-    router.post('/reset-password/:code', confirmPasswordResetByIp, this.setPassword.bind(this) );
-    router.post('/email', ...ExpressHelper.loggedInOnly, emailChangeByAccount, this.changeEmail.bind(this) );
+    router.post('/reset-password', limitPasswordResetByIp, limitPasswordResetByEmail, this.generatePasswordResetCode.bind(this) );
+    router.post('/reset-password/:code', limitConfirmPasswordResetByIp, this.setPassword.bind(this) );
+    router.post('/email', ...ExpressHelper.loggedInOnly, limitEmailChangeByAccount, this.changeEmail.bind(this) );
     app.use(routePrefix, router);
   }
 

--- a/src/server/calendar/api/v1/import_source.ts
+++ b/src/server/calendar/api/v1/import_source.ts
@@ -18,9 +18,9 @@ import {
 import ExpressHelper from '@/server/common/helper/express';
 import { logError } from '@/server/common/helper/error-logger';
 import {
-  widgetConfigByAccount,
-  importSourceVerifyBySource,
-  importSourceSyncBySource,
+  limitWidgetConfigByAccount,
+  limitImportSourceVerifyBySource,
+  limitImportSourceSyncBySource,
 } from '@/server/common/middleware/rate-limiters';
 import CalendarInterface from '../../interface';
 import type { SyncResult } from '../../service/import/sync';
@@ -39,10 +39,10 @@ import type { SyncResult } from '../../service/import/sync';
  *
  * Rate limiting:
  *  - list/create/get/delete/verify-issue: account-scoped limiter
- *    (`widgetConfigByAccount`) as a conservative default.
- *  - /verify: per-source limiter (`importSourceVerifyBySource`)
+ *    (`limitWidgetConfigByAccount`) as a conservative default.
+ *  - /verify: per-source limiter (`limitImportSourceVerifyBySource`)
  *    configured to 3 requests per source per hour.
- *  - /sync:   per-source limiter (`importSourceSyncBySource`)
+ *  - /sync:   per-source limiter (`limitImportSourceSyncBySource`)
  *    configured to 4 requests per source per hour, in addition to the
  *    service-level sliding window enforced by SyncService.
  *
@@ -61,43 +61,43 @@ class ImportSourceRoutes {
     router.get(
       '/calendars/:calendarId/import-sources',
       ExpressHelper.loggedInOnly,
-      widgetConfigByAccount,
+      limitWidgetConfigByAccount,
       this.listSources.bind(this),
     );
     router.post(
       '/calendars/:calendarId/import-sources',
       ExpressHelper.loggedInOnly,
-      widgetConfigByAccount,
+      limitWidgetConfigByAccount,
       this.createSource.bind(this),
     );
     router.get(
       '/calendars/:calendarId/import-sources/:id',
       ExpressHelper.loggedInOnly,
-      widgetConfigByAccount,
+      limitWidgetConfigByAccount,
       this.getSource.bind(this),
     );
     router.delete(
       '/calendars/:calendarId/import-sources/:id',
       ExpressHelper.loggedInOnly,
-      widgetConfigByAccount,
+      limitWidgetConfigByAccount,
       this.deleteSource.bind(this),
     );
     router.post(
       '/calendars/:calendarId/import-sources/:id/verify-issue',
       ExpressHelper.loggedInOnly,
-      widgetConfigByAccount,
+      limitWidgetConfigByAccount,
       this.issueChallenge.bind(this),
     );
     router.post(
       '/calendars/:calendarId/import-sources/:id/verify',
       ExpressHelper.loggedInOnly,
-      importSourceVerifyBySource,
+      limitImportSourceVerifyBySource,
       this.verifySource.bind(this),
     );
     router.post(
       '/calendars/:calendarId/import-sources/:id/sync',
       ExpressHelper.loggedInOnly,
-      importSourceSyncBySource,
+      limitImportSourceSyncBySource,
       this.syncSource.bind(this),
     );
 

--- a/src/server/calendar/api/v1/widget-config.ts
+++ b/src/server/calendar/api/v1/widget-config.ts
@@ -9,7 +9,7 @@ import { ValidationError } from '@/common/exceptions/base';
 import { CalendarNotFoundError, InvalidDomainFormatError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
 import { SubscriptionRequiredError } from '@/common/exceptions/subscription';
-import { widgetConfigByAccount } from '@/server/common/middleware/rate-limiters';
+import { limitWidgetConfigByAccount } from '@/server/common/middleware/rate-limiters';
 import CalendarInterface from '../../interface';
 
 /**
@@ -25,11 +25,11 @@ class WidgetConfigRoutes {
 
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
-    router.get('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.getDomain.bind(this));
-    router.put('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.setDomain.bind(this));
-    router.delete('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.clearDomain.bind(this));
-    router.get('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.getConfig.bind(this));
-    router.put('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, widgetConfigByAccount, this.setConfig.bind(this));
+    router.get('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, limitWidgetConfigByAccount, this.getDomain.bind(this));
+    router.put('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, limitWidgetConfigByAccount, this.setDomain.bind(this));
+    router.delete('/calendars/:calendarId/widget/domain', ExpressHelper.loggedInOnly, limitWidgetConfigByAccount, this.clearDomain.bind(this));
+    router.get('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, limitWidgetConfigByAccount, this.getConfig.bind(this));
+    router.put('/calendars/:calendarId/widget/config', ExpressHelper.loggedInOnly, limitWidgetConfigByAccount, this.setConfig.bind(this));
     app.use(routePrefix, router);
   }
 

--- a/src/server/calendar/api/v1/widget.ts
+++ b/src/server/calendar/api/v1/widget.ts
@@ -6,7 +6,7 @@ const logger = createLogger('calendar');
 import CalendarInterface from '../../interface';
 import WidgetDomainService from '../../service/widget_domain';
 import { SubscriptionRequiredError } from '@/common/exceptions/subscription';
-import { publicWidgetByIp } from '@/server/common/middleware/rate-limiters';
+import { limitPublicWidgetByIp } from '@/server/common/middleware/rate-limiters';
 
 /**
  * Widget-specific API routes with Origin validation and dynamic CSP headers.
@@ -28,7 +28,7 @@ class WidgetRoutes {
     router.use(this.validateOrigin.bind(this));
 
     // Widget calendar metadata endpoint with rate limiting
-    router.get('/calendars/:urlName', publicWidgetByIp, this.getCalendar.bind(this));
+    router.get('/calendars/:urlName', limitPublicWidgetByIp, this.getCalendar.bind(this));
 
     app.use(routePrefix, router);
   }

--- a/src/server/common/middleware/rate-limiters.ts
+++ b/src/server/common/middleware/rate-limiters.ts
@@ -12,11 +12,11 @@ import { createParamRateLimiter } from './rate-limit-by-param';
  * disabled globally via the rateLimit.enabled flag.
  *
  * @example
- * import { passwordResetByIp, passwordResetByEmail } from '@/server/common/middleware/rate-limiters';
+ * import { limitPasswordResetByIp, limitPasswordResetByEmail } from '@/server/common/middleware/rate-limiters';
  *
  * app.post('/api/auth/password-reset',
- *   passwordResetByIp,
- *   passwordResetByEmail,
+ *   limitPasswordResetByIp,
+ *   limitPasswordResetByEmail,
  *   passwordResetHandler
  * );
  */
@@ -37,7 +37,7 @@ function isRateLimitEnabled(): boolean {
  * Password reset rate limiter by IP address.
  * Limits: 5 requests per IP per 15 minutes (default config).
  */
-export const passwordResetByIp: RequestHandler = isRateLimitEnabled()
+export const limitPasswordResetByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.passwordReset.byIp.max'),
     config.get<number>('rateLimit.passwordReset.byIp.windowMs'),
@@ -49,7 +49,7 @@ export const passwordResetByIp: RequestHandler = isRateLimitEnabled()
  * Password reset rate limiter by email address.
  * Limits: 3 requests per email per 1 hour (default config).
  */
-export const passwordResetByEmail: RequestHandler = isRateLimitEnabled()
+export const limitPasswordResetByEmail: RequestHandler = isRateLimitEnabled()
   ? createCredentialRateLimiter(
     config.get<number>('rateLimit.passwordReset.byEmail.max'),
     config.get<number>('rateLimit.passwordReset.byEmail.windowMs'),
@@ -62,7 +62,7 @@ export const passwordResetByEmail: RequestHandler = isRateLimitEnabled()
  * Login rate limiter by IP address.
  * Limits: 10 requests per IP per 15 minutes (default config).
  */
-export const loginByIp: RequestHandler = isRateLimitEnabled()
+export const limitLoginByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.login.byIp.max'),
     config.get<number>('rateLimit.login.byIp.windowMs'),
@@ -74,7 +74,7 @@ export const loginByIp: RequestHandler = isRateLimitEnabled()
  * Login rate limiter by email address.
  * Limits: 5 requests per email per 1 hour (default config).
  */
-export const loginByEmail: RequestHandler = isRateLimitEnabled()
+export const limitLoginByEmail: RequestHandler = isRateLimitEnabled()
   ? createCredentialRateLimiter(
     config.get<number>('rateLimit.login.byEmail.max'),
     config.get<number>('rateLimit.login.byEmail.windowMs'),
@@ -87,7 +87,7 @@ export const loginByEmail: RequestHandler = isRateLimitEnabled()
  * Moderation report submission rate limiter by IP address.
  * Limits: 10 requests per IP per 15 minutes (default config).
  */
-export const reportSubmissionByIp: RequestHandler = isRateLimitEnabled()
+export const limitReportSubmissionByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.moderation.reportByIp.max'),
     config.get<number>('rateLimit.moderation.reportByIp.windowMs'),
@@ -99,7 +99,7 @@ export const reportSubmissionByIp: RequestHandler = isRateLimitEnabled()
  * Moderation report verification rate limiter by IP address.
  * Limits: 20 requests per IP per 15 minutes (default config).
  */
-export const reportVerificationByIp: RequestHandler = isRateLimitEnabled()
+export const limitReportVerificationByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.moderation.verifyByIp.max'),
     config.get<number>('rateLimit.moderation.verifyByIp.windowMs'),
@@ -111,7 +111,7 @@ export const reportVerificationByIp: RequestHandler = isRateLimitEnabled()
  * Moderation report submission rate limiter by email address.
  * Limits: 3 verification emails per email per 24 hours (default config).
  */
-export const reportSubmissionByEmail: RequestHandler = isRateLimitEnabled()
+export const limitReportSubmissionByEmail: RequestHandler = isRateLimitEnabled()
   ? createCredentialRateLimiter(
     config.get<number>('rateLimit.moderation.byEmail.max'),
     config.get<number>('rateLimit.moderation.byEmail.windowMs'),
@@ -124,7 +124,7 @@ export const reportSubmissionByEmail: RequestHandler = isRateLimitEnabled()
  * Moderation report submission rate limiter by authenticated account.
  * Limits: 20 reports per account per 1 hour (default config).
  */
-export const reportSubmissionByAccount: RequestHandler = isRateLimitEnabled()
+export const limitReportSubmissionByAccount: RequestHandler = isRateLimitEnabled()
   ? createAccountRateLimiter(
     config.get<number>('rateLimit.moderation.byAccount.max'),
     config.get<number>('rateLimit.moderation.byAccount.windowMs'),
@@ -137,7 +137,7 @@ export const reportSubmissionByAccount: RequestHandler = isRateLimitEnabled()
  * Limits: 300 requests per IP per 15 minutes (default config).
  * More permissive than auth endpoints due to legitimate embedded widget traffic.
  */
-export const publicWidgetByIp: RequestHandler = isRateLimitEnabled()
+export const limitPublicWidgetByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.publicWidget.byIp.max'),
     config.get<number>('rateLimit.publicWidget.byIp.windowMs'),
@@ -154,7 +154,7 @@ export const publicWidgetByIp: RequestHandler = isRateLimitEnabled()
  * permissive enough for legitimate share-link traffic from social crawlers
  * and search engines.
  */
-export const publicEventInstanceByIp: RequestHandler = isRateLimitEnabled()
+export const limitPublicEventInstanceByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.publicEventInstance.byIp.max'),
     config.get<number>('rateLimit.publicEventInstance.byIp.windowMs'),
@@ -167,7 +167,7 @@ export const publicEventInstanceByIp: RequestHandler = isRateLimitEnabled()
  * Limits: 100 requests per account per 15 minutes (default config).
  * Prevents abuse of widget configuration endpoints.
  */
-export const widgetConfigByAccount: RequestHandler = isRateLimitEnabled()
+export const limitWidgetConfigByAccount: RequestHandler = isRateLimitEnabled()
   ? createAccountRateLimiter(
     config.get<number>('rateLimit.widgetConfig.byAccount.max'),
     config.get<number>('rateLimit.widgetConfig.byAccount.windowMs'),
@@ -180,7 +180,7 @@ export const widgetConfigByAccount: RequestHandler = isRateLimitEnabled()
  * Limits: 30 requests per account per 15 minutes (default config).
  * Prevents abuse of calendar add/remove funding plan endpoints.
  */
-export const calendarFundingPlanByAccount: RequestHandler = isRateLimitEnabled()
+export const limitCalendarFundingPlanByAccount: RequestHandler = isRateLimitEnabled()
   ? createAccountRateLimiter(
     config.get<number>('rateLimit.calendarFundingPlan.byAccount.max'),
     config.get<number>('rateLimit.calendarFundingPlan.byAccount.windowMs'),
@@ -193,7 +193,7 @@ export const calendarFundingPlanByAccount: RequestHandler = isRateLimitEnabled()
  * Limits: 10 requests per account per 15 minutes (default config).
  * Prevents abuse of Stripe checkout session creation.
  */
-export const checkoutSessionByAccount: RequestHandler = isRateLimitEnabled()
+export const limitCheckoutSessionByAccount: RequestHandler = isRateLimitEnabled()
   ? createAccountRateLimiter(
     config.get<number>('rateLimit.checkoutSession.byAccount.max'),
     config.get<number>('rateLimit.checkoutSession.byAccount.windowMs'),
@@ -210,7 +210,7 @@ export const checkoutSessionByAccount: RequestHandler = isRateLimitEnabled()
  * Stripe can deliver many events per minute and retries failed deliveries for
  * up to 72 hours, so this limiter must never gate legitimate provider traffic.
  */
-export const fundingWebhookByIp: RequestHandler = isRateLimitEnabled()
+export const limitFundingWebhookByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.fundingWebhook.byIp.max'),
     config.get<number>('rateLimit.fundingWebhook.byIp.windowMs'),
@@ -226,7 +226,7 @@ export const fundingWebhookByIp: RequestHandler = isRateLimitEnabled()
  *
  * Limits: 3 verify attempts per source per hour (default config).
  */
-export const importSourceVerifyBySource: RequestHandler = isRateLimitEnabled()
+export const limitImportSourceVerifyBySource: RequestHandler = isRateLimitEnabled()
   ? createParamRateLimiter(
     config.get<number>('rateLimit.importSource.verifyBySource.max'),
     config.get<number>('rateLimit.importSource.verifyBySource.windowMs'),
@@ -245,7 +245,7 @@ export const importSourceVerifyBySource: RequestHandler = isRateLimitEnabled()
  *
  * Limits: 4 sync attempts per source per hour (default config).
  */
-export const importSourceSyncBySource: RequestHandler = isRateLimitEnabled()
+export const limitImportSourceSyncBySource: RequestHandler = isRateLimitEnabled()
   ? createParamRateLimiter(
     config.get<number>('rateLimit.importSource.syncBySource.max'),
     config.get<number>('rateLimit.importSource.syncBySource.windowMs'),
@@ -264,7 +264,7 @@ export const importSourceSyncBySource: RequestHandler = isRateLimitEnabled()
  * settings, and instance metadata. The limit is permissive enough for
  * legitimate page-render traffic while preventing scrape-style abuse.
  */
-export const configSiteByIp: RequestHandler = isRateLimitEnabled()
+export const limitConfigSiteByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.configSite.byIp.max'),
     config.get<number>('rateLimit.configSite.byIp.windowMs'),
@@ -281,7 +281,7 @@ export const configSiteByIp: RequestHandler = isRateLimitEnabled()
  * legitimate page-render and pagination traffic while preventing scrape-style
  * abuse of the listed-calendar enumeration surface.
  */
-export const publicCalendarListByIp: RequestHandler = isRateLimitEnabled()
+export const limitPublicCalendarListByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.publicCalendarList.byIp.max'),
     config.get<number>('rateLimit.publicCalendarList.byIp.windowMs'),
@@ -293,7 +293,7 @@ export const publicCalendarListByIp: RequestHandler = isRateLimitEnabled()
  * Public account application submission rate limiter by IP address.
  * Limits: 5 requests per IP per 15 minutes (default config).
  */
-export const applicationByIp: RequestHandler = isRateLimitEnabled()
+export const limitApplicationByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.application.byIp.max'),
     config.get<number>('rateLimit.application.byIp.windowMs'),
@@ -305,7 +305,7 @@ export const applicationByIp: RequestHandler = isRateLimitEnabled()
  * Public account application submission rate limiter by email address.
  * Limits: 3 requests per email per 1 hour (default config).
  */
-export const applicationByEmail: RequestHandler = isRateLimitEnabled()
+export const limitApplicationByEmail: RequestHandler = isRateLimitEnabled()
   ? createCredentialRateLimiter(
     config.get<number>('rateLimit.application.byEmail.max'),
     config.get<number>('rateLimit.application.byEmail.windowMs'),
@@ -318,7 +318,7 @@ export const applicationByEmail: RequestHandler = isRateLimitEnabled()
  * Public account registration rate limiter by IP address.
  * Limits: 5 requests per IP per 15 minutes (default config).
  */
-export const registerByIp: RequestHandler = isRateLimitEnabled()
+export const limitRegisterByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.register.byIp.max'),
     config.get<number>('rateLimit.register.byIp.windowMs'),
@@ -334,7 +334,7 @@ export const registerByIp: RequestHandler = isRateLimitEnabled()
  * already maps to an account, so the rate-limit signal cannot be used to
  * enumerate registered accounts (DEC-004).
  */
-export const registerByEmail: RequestHandler = isRateLimitEnabled()
+export const limitRegisterByEmail: RequestHandler = isRateLimitEnabled()
   ? createCredentialRateLimiter(
     config.get<number>('rateLimit.register.byEmail.max'),
     config.get<number>('rateLimit.register.byEmail.windowMs'),
@@ -347,7 +347,7 @@ export const registerByEmail: RequestHandler = isRateLimitEnabled()
  * Application email-confirmation rate limiter by IP address.
  * Limits: 20 requests per IP per 15 minutes (default config).
  */
-export const confirmApplicationByIp: RequestHandler = isRateLimitEnabled()
+export const limitConfirmApplicationByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.application.confirm.byIp.max'),
     config.get<number>('rateLimit.application.confirm.byIp.windowMs'),
@@ -363,7 +363,7 @@ export const confirmApplicationByIp: RequestHandler = isRateLimitEnabled()
  *
  * Limits: 20 requests per IP per 15 minutes (default config).
  */
-export const confirmPasswordResetByIp: RequestHandler = isRateLimitEnabled()
+export const limitConfirmPasswordResetByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.passwordReset.confirm.byIp.max'),
     config.get<number>('rateLimit.passwordReset.confirm.byIp.windowMs'),
@@ -379,7 +379,7 @@ export const confirmPasswordResetByIp: RequestHandler = isRateLimitEnabled()
  *
  * Limits: 20 requests per IP per 15 minutes (default config).
  */
-export const acceptInvitationByIp: RequestHandler = isRateLimitEnabled()
+export const limitAcceptInvitationByIp: RequestHandler = isRateLimitEnabled()
   ? createIpRateLimiter(
     config.get<number>('rateLimit.invitation.accept.byIp.max'),
     config.get<number>('rateLimit.invitation.accept.byIp.windowMs'),
@@ -402,7 +402,7 @@ export const acceptInvitationByIp: RequestHandler = isRateLimitEnabled()
  *
  * Limits: 10 requests per account per 1 hour (default config).
  */
-export const emailChangeByAccount: RequestHandler = isRateLimitEnabled()
+export const limitEmailChangeByAccount: RequestHandler = isRateLimitEnabled()
   ? createAccountRateLimiter(
     config.get<number>('rateLimit.emailChange.byAccount.max'),
     config.get<number>('rateLimit.emailChange.byAccount.windowMs'),

--- a/src/server/common/test/middleware/rate-limiters.test.ts
+++ b/src/server/common/test/middleware/rate-limiters.test.ts
@@ -4,19 +4,19 @@ import express, { Express } from 'express';
 import request from 'supertest';
 import { addRequestUser } from '@/server/common/test/lib/express';
 import {
-  passwordResetByIp,
-  passwordResetByEmail,
-  loginByIp,
-  loginByEmail,
-  reportSubmissionByIp,
-  reportSubmissionByEmail,
-  reportVerificationByIp,
-  reportSubmissionByAccount,
-  publicEventInstanceByIp,
-  publicCalendarListByIp,
-  applicationByIp,
-  applicationByEmail,
-  confirmApplicationByIp,
+  limitPasswordResetByIp,
+  limitPasswordResetByEmail,
+  limitLoginByIp,
+  limitLoginByEmail,
+  limitReportSubmissionByIp,
+  limitReportSubmissionByEmail,
+  limitReportVerificationByIp,
+  limitReportSubmissionByAccount,
+  limitPublicEventInstanceByIp,
+  limitPublicCalendarListByIp,
+  limitApplicationByIp,
+  limitApplicationByEmail,
+  limitConfirmApplicationByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 describe('rate-limiters', () => {
@@ -133,69 +133,69 @@ describe('rate-limiters', () => {
   });
 
   describe('limiter exports', () => {
-    it('should export passwordResetByIp limiter', () => {
-      expect(passwordResetByIp).toBeDefined();
-      expect(typeof passwordResetByIp).toBe('function');
+    it('should export limitPasswordResetByIp limiter', () => {
+      expect(limitPasswordResetByIp).toBeDefined();
+      expect(typeof limitPasswordResetByIp).toBe('function');
     });
 
-    it('should export passwordResetByEmail limiter', () => {
-      expect(passwordResetByEmail).toBeDefined();
-      expect(typeof passwordResetByEmail).toBe('function');
+    it('should export limitPasswordResetByEmail limiter', () => {
+      expect(limitPasswordResetByEmail).toBeDefined();
+      expect(typeof limitPasswordResetByEmail).toBe('function');
     });
 
-    it('should export loginByIp limiter', () => {
-      expect(loginByIp).toBeDefined();
-      expect(typeof loginByIp).toBe('function');
+    it('should export limitLoginByIp limiter', () => {
+      expect(limitLoginByIp).toBeDefined();
+      expect(typeof limitLoginByIp).toBe('function');
     });
 
-    it('should export loginByEmail limiter', () => {
-      expect(loginByEmail).toBeDefined();
-      expect(typeof loginByEmail).toBe('function');
+    it('should export limitLoginByEmail limiter', () => {
+      expect(limitLoginByEmail).toBeDefined();
+      expect(typeof limitLoginByEmail).toBe('function');
     });
 
-    it('should export reportSubmissionByIp limiter', () => {
-      expect(reportSubmissionByIp).toBeDefined();
-      expect(typeof reportSubmissionByIp).toBe('function');
+    it('should export limitReportSubmissionByIp limiter', () => {
+      expect(limitReportSubmissionByIp).toBeDefined();
+      expect(typeof limitReportSubmissionByIp).toBe('function');
     });
 
-    it('should export reportSubmissionByEmail limiter', () => {
-      expect(reportSubmissionByEmail).toBeDefined();
-      expect(typeof reportSubmissionByEmail).toBe('function');
+    it('should export limitReportSubmissionByEmail limiter', () => {
+      expect(limitReportSubmissionByEmail).toBeDefined();
+      expect(typeof limitReportSubmissionByEmail).toBe('function');
     });
 
-    it('should export reportVerificationByIp limiter', () => {
-      expect(reportVerificationByIp).toBeDefined();
-      expect(typeof reportVerificationByIp).toBe('function');
+    it('should export limitReportVerificationByIp limiter', () => {
+      expect(limitReportVerificationByIp).toBeDefined();
+      expect(typeof limitReportVerificationByIp).toBe('function');
     });
 
-    it('should export reportSubmissionByAccount limiter', () => {
-      expect(reportSubmissionByAccount).toBeDefined();
-      expect(typeof reportSubmissionByAccount).toBe('function');
+    it('should export limitReportSubmissionByAccount limiter', () => {
+      expect(limitReportSubmissionByAccount).toBeDefined();
+      expect(typeof limitReportSubmissionByAccount).toBe('function');
     });
 
-    it('should export publicEventInstanceByIp limiter', () => {
-      expect(publicEventInstanceByIp).toBeDefined();
-      expect(typeof publicEventInstanceByIp).toBe('function');
+    it('should export limitPublicEventInstanceByIp limiter', () => {
+      expect(limitPublicEventInstanceByIp).toBeDefined();
+      expect(typeof limitPublicEventInstanceByIp).toBe('function');
     });
 
-    it('should export publicCalendarListByIp limiter', () => {
-      expect(publicCalendarListByIp).toBeDefined();
-      expect(typeof publicCalendarListByIp).toBe('function');
+    it('should export limitPublicCalendarListByIp limiter', () => {
+      expect(limitPublicCalendarListByIp).toBeDefined();
+      expect(typeof limitPublicCalendarListByIp).toBe('function');
     });
 
-    it('should export applicationByIp limiter', () => {
-      expect(applicationByIp).toBeDefined();
-      expect(typeof applicationByIp).toBe('function');
+    it('should export limitApplicationByIp limiter', () => {
+      expect(limitApplicationByIp).toBeDefined();
+      expect(typeof limitApplicationByIp).toBe('function');
     });
 
-    it('should export applicationByEmail limiter', () => {
-      expect(applicationByEmail).toBeDefined();
-      expect(typeof applicationByEmail).toBe('function');
+    it('should export limitApplicationByEmail limiter', () => {
+      expect(limitApplicationByEmail).toBeDefined();
+      expect(typeof limitApplicationByEmail).toBe('function');
     });
 
-    it('should export confirmApplicationByIp limiter', () => {
-      expect(confirmApplicationByIp).toBeDefined();
-      expect(typeof confirmApplicationByIp).toBe('function');
+    it('should export limitConfirmApplicationByIp limiter', () => {
+      expect(limitConfirmApplicationByIp).toBeDefined();
+      expect(typeof limitConfirmApplicationByIp).toBe('function');
     });
   });
 
@@ -213,7 +213,7 @@ describe('rate-limiters', () => {
 
       // When disabled, limiters should act as no-op middleware
       // Multiple requests should all succeed without rate limiting
-      app.post('/test', passwordResetByIp, (req, res) => {
+      app.post('/test', limitPasswordResetByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -235,7 +235,7 @@ describe('rate-limiters', () => {
 
     it('should not add rate limit headers when disabled', async () => {
       // When rate limiting is disabled, no rate limit headers should be added
-      app.post('/test', passwordResetByIp, (req, res) => {
+      app.post('/test', limitPasswordResetByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -250,10 +250,10 @@ describe('rate-limiters', () => {
     it('should allow all limiter types to pass through when disabled', async () => {
       // Apply all four limiters - should all be no-ops
       app.post('/test',
-        passwordResetByIp,
-        passwordResetByEmail,
-        loginByIp,
-        loginByEmail,
+        limitPasswordResetByIp,
+        limitPasswordResetByEmail,
+        limitLoginByIp,
+        limitLoginByEmail,
         (req, res) => {
           res.json({ success: true });
         },
@@ -269,8 +269,8 @@ describe('rate-limiters', () => {
 
     it('should allow moderation limiters to pass through when disabled', async () => {
       app.post('/test',
-        reportSubmissionByIp,
-        reportSubmissionByEmail,
+        limitReportSubmissionByIp,
+        limitReportSubmissionByEmail,
         (req, res) => {
           res.json({ success: true });
         },
@@ -291,7 +291,7 @@ describe('rate-limiters', () => {
     it('should allow account limiter to pass through when disabled', async () => {
       app.post('/test',
         addRequestUser,
-        reportSubmissionByAccount,
+        limitReportSubmissionByAccount,
         (req, res) => {
           res.json({ success: true });
         },
@@ -310,7 +310,7 @@ describe('rate-limiters', () => {
     });
 
     it('should allow verification limiter to pass through when disabled', async () => {
-      app.get('/test', reportVerificationByIp, (req, res) => {
+      app.get('/test', limitReportVerificationByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -335,8 +335,8 @@ describe('rate-limiters', () => {
       app.use(express.json());
     });
 
-    it('should apply passwordResetByIp limiter to endpoint', async () => {
-      app.post('/reset', passwordResetByIp, (req, res) => {
+    it('should apply limitPasswordResetByIp limiter to endpoint', async () => {
+      app.post('/reset', limitPasswordResetByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -353,8 +353,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply passwordResetByEmail limiter to endpoint', async () => {
-      app.post('/reset', passwordResetByEmail, (req, res) => {
+    it('should apply limitPasswordResetByEmail limiter to endpoint', async () => {
+      app.post('/reset', limitPasswordResetByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -374,8 +374,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply loginByIp limiter to endpoint', async () => {
-      app.post('/login', loginByIp, (req, res) => {
+    it('should apply limitLoginByIp limiter to endpoint', async () => {
+      app.post('/login', limitLoginByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -392,8 +392,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply loginByEmail limiter to endpoint', async () => {
-      app.post('/login', loginByEmail, (req, res) => {
+    it('should apply limitLoginByEmail limiter to endpoint', async () => {
+      app.post('/login', limitLoginByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -413,8 +413,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply reportSubmissionByIp limiter to endpoint', async () => {
-      app.post('/report', reportSubmissionByIp, (req, res) => {
+    it('should apply limitReportSubmissionByIp limiter to endpoint', async () => {
+      app.post('/report', limitReportSubmissionByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -430,8 +430,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply reportVerificationByIp limiter to endpoint', async () => {
-      app.get('/verify', reportVerificationByIp, (req, res) => {
+    it('should apply limitReportVerificationByIp limiter to endpoint', async () => {
+      app.get('/verify', limitReportVerificationByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -447,8 +447,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply reportSubmissionByEmail limiter to endpoint', async () => {
-      app.post('/report', reportSubmissionByEmail, (req, res) => {
+    it('should apply limitReportSubmissionByEmail limiter to endpoint', async () => {
+      app.post('/report', limitReportSubmissionByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -467,8 +467,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply reportSubmissionByAccount limiter to endpoint', async () => {
-      app.post('/report', addRequestUser, reportSubmissionByAccount, (req, res) => {
+    it('should apply limitReportSubmissionByAccount limiter to endpoint', async () => {
+      app.post('/report', addRequestUser, limitReportSubmissionByAccount, (req, res) => {
         res.json({ success: true });
       });
 
@@ -488,7 +488,7 @@ describe('rate-limiters', () => {
     });
 
     it('should allow combining IP and credential limiters', async () => {
-      app.post('/reset', passwordResetByIp, passwordResetByEmail, (req, res) => {
+      app.post('/reset', limitPasswordResetByIp, limitPasswordResetByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -509,7 +509,7 @@ describe('rate-limiters', () => {
     });
 
     it('should allow combining report submission IP and email limiters', async () => {
-      app.post('/report', reportSubmissionByIp, reportSubmissionByEmail, (req, res) => {
+      app.post('/report', limitReportSubmissionByIp, limitReportSubmissionByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -528,8 +528,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply publicEventInstanceByIp limiter to endpoint', async () => {
-      app.get('/instance', publicEventInstanceByIp, (req, res) => {
+    it('should apply limitPublicEventInstanceByIp limiter to endpoint', async () => {
+      app.get('/instance', limitPublicEventInstanceByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -545,8 +545,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply publicCalendarListByIp limiter to endpoint', async () => {
-      app.get('/calendars', publicCalendarListByIp, (req, res) => {
+    it('should apply limitPublicCalendarListByIp limiter to endpoint', async () => {
+      app.get('/calendars', limitPublicCalendarListByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -563,7 +563,7 @@ describe('rate-limiters', () => {
     });
 
     it('should allow combining report submission IP and account limiters', async () => {
-      app.post('/report', addRequestUser, reportSubmissionByIp, reportSubmissionByAccount, (req, res) => {
+      app.post('/report', addRequestUser, limitReportSubmissionByIp, limitReportSubmissionByAccount, (req, res) => {
         res.json({ success: true });
       });
 
@@ -582,8 +582,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply applicationByIp limiter to endpoint', async () => {
-      app.post('/apply', applicationByIp, (req, res) => {
+    it('should apply limitApplicationByIp limiter to endpoint', async () => {
+      app.post('/apply', limitApplicationByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -599,8 +599,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply applicationByEmail limiter to endpoint', async () => {
-      app.post('/apply', applicationByEmail, (req, res) => {
+    it('should apply limitApplicationByEmail limiter to endpoint', async () => {
+      app.post('/apply', limitApplicationByEmail, (req, res) => {
         res.json({ success: true });
       });
 
@@ -619,8 +619,8 @@ describe('rate-limiters', () => {
       }
     });
 
-    it('should apply confirmApplicationByIp limiter to endpoint', async () => {
-      app.get('/confirm', confirmApplicationByIp, (req, res) => {
+    it('should apply limitConfirmApplicationByIp limiter to endpoint', async () => {
+      app.get('/confirm', limitConfirmApplicationByIp, (req, res) => {
         res.json({ success: true });
       });
 
@@ -637,7 +637,7 @@ describe('rate-limiters', () => {
     });
 
     it('should allow combining application IP and email limiters', async () => {
-      app.post('/apply', applicationByIp, applicationByEmail, (req, res) => {
+      app.post('/apply', limitApplicationByIp, limitApplicationByEmail, (req, res) => {
         res.json({ success: true });
       });
 

--- a/src/server/common/test/rate-limit-coverage.test.ts
+++ b/src/server/common/test/rate-limit-coverage.test.ts
@@ -187,9 +187,9 @@ const REVIEWED_NO_LIMITER_ROUTES: { method: string; path: string; reason: string
   { method: 'POST', path: '/api/funding/v1/admin/grants', reason: 'admin-only' },
   { method: 'DELETE', path: '/api/funding/v1/admin/grants/:id', reason: 'admin-only' },
   { method: 'POST', path: '/api/funding/v1/cancel', reason: 'authenticated CRUD (own funding plan)' },
-  { method: 'POST', path: '/api/funding/v1/calendars', reason: 'per-account limited (calendarFundingPlanByAccount)' },
-  { method: 'DELETE', path: '/api/funding/v1/calendars/:calendarId', reason: 'per-account limited (calendarFundingPlanByAccount)' },
-  { method: 'POST', path: '/api/funding/v1/checkout-sessions', reason: 'per-account limited (checkoutSessionByAccount)' },
+  { method: 'POST', path: '/api/funding/v1/calendars', reason: 'per-account limited (limitCalendarFundingPlanByAccount)' },
+  { method: 'DELETE', path: '/api/funding/v1/calendars/:calendarId', reason: 'per-account limited (limitCalendarFundingPlanByAccount)' },
+  { method: 'POST', path: '/api/funding/v1/checkout-sessions', reason: 'per-account limited (limitCheckoutSessionByAccount)' },
 
   // --- Calendar (authenticated, ownership-bounded CRUD) ---
   { method: 'POST', path: '/api/v1/calendars', reason: 'authenticated CRUD' },
@@ -224,16 +224,16 @@ const REVIEWED_NO_LIMITER_ROUTES: { method: string; path: string; reason: string
   { method: 'DELETE', path: '/api/v1/events/:eventId/categories/:categoryId', reason: 'authenticated CRUD' },
   { method: 'POST', path: '/api/v1/events/:eventId/series/:seriesId', reason: 'authenticated CRUD' },
   { method: 'DELETE', path: '/api/v1/events/:eventId/series/:seriesId', reason: 'authenticated CRUD' },
-  // Widget config + import-source routes carry widgetConfigByAccount / import limiters
+  // Widget config + import-source routes carry limitWidgetConfigByAccount / import limiters
   // (per-account), classified here rather than as high-risk surfaces.
-  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/config', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/import-sources/:id', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify-issue', reason: 'per-account limited (widgetConfigByAccount)' },
-  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify', reason: 'per-source limited (importSourceVerifyBySource)' },
-  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/sync', reason: 'per-source limited (importSourceSyncBySource)' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/widget/domain', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'PUT', path: '/api/v1/calendars/:calendarId/widget/config', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'DELETE', path: '/api/v1/calendars/:calendarId/import-sources/:id', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify-issue', reason: 'per-account limited (limitWidgetConfigByAccount)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/verify', reason: 'per-source limited (limitImportSourceVerifyBySource)' },
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/:id/sync', reason: 'per-source limited (limitImportSourceSyncBySource)' },
 
   // --- Media ---
   { method: 'POST', path: '/api/v1/media/:calendarId', reason: 'authenticated CRUD (upload-abuse follow-up noted in audit; not high-risk)' },

--- a/src/server/configuration/api/v1/site.ts
+++ b/src/server/configuration/api/v1/site.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express';
 import ExpressHelper from '../../../common/helper/express';
 import ConfigurationInterface from '@/server/configuration/interface';
 import { createLogger } from '@/server/common/helper/logger';
-import { configSiteByIp } from '@/server/common/middleware/rate-limiters';
+import { limitConfigSiteByIp } from '@/server/common/middleware/rate-limiters';
 
 const logger = createLogger('configuration');
 
@@ -20,7 +20,7 @@ export default class SiteRouteHandlers {
   }
   installHandlers(app: express.Application, routePrefix: string): void {
     const router = express.Router();
-    router.get('/site', configSiteByIp, this.getSettings.bind(this));
+    router.get('/site', limitConfigSiteByIp, this.getSettings.bind(this));
     router.post('/site', ExpressHelper.adminOnly, this.updateSettings.bind(this));
     app.use(routePrefix, router);
   }

--- a/src/server/funding/api/v1/calendar-funding-plan.ts
+++ b/src/server/funding/api/v1/calendar-funding-plan.ts
@@ -9,7 +9,7 @@ import {
   DuplicateCalendarFundingPlanError,
 } from '@/common/exceptions/funding';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
-import { calendarFundingPlanByAccount } from '@/server/common/middleware/rate-limiters';
+import { limitCalendarFundingPlanByAccount } from '@/server/common/middleware/rate-limiters';
 import { logError } from '@/server/common/helper/error-logger';
 
 /**
@@ -38,7 +38,7 @@ export default class CalendarFundingPlanRoutes {
     router.post(
       '/calendars',
       ...ExpressHelper.loggedInOnly,
-      calendarFundingPlanByAccount,
+      limitCalendarFundingPlanByAccount,
       this.addCalendar.bind(this),
     );
 
@@ -51,7 +51,7 @@ export default class CalendarFundingPlanRoutes {
     router.delete(
       '/calendars/:calendarId',
       ...ExpressHelper.loggedInOnly,
-      calendarFundingPlanByAccount,
+      limitCalendarFundingPlanByAccount,
       this.removeCalendar.bind(this),
     );
 

--- a/src/server/funding/api/v1/checkout-session.ts
+++ b/src/server/funding/api/v1/checkout-session.ts
@@ -9,7 +9,7 @@ import {
   InvalidSessionIdError,
   FundingPlanNotFoundError,
 } from '@/common/exceptions/funding';
-import { checkoutSessionByAccount } from '@/server/common/middleware/rate-limiters';
+import { limitCheckoutSessionByAccount } from '@/server/common/middleware/rate-limiters';
 import { logError } from '@/server/common/helper/error-logger';
 import { MAX_CALENDAR_IDS } from '@/server/funding/service/funding';
 
@@ -38,7 +38,7 @@ export default class CheckoutSessionRoutes {
     router.post(
       '/checkout-sessions',
       ...ExpressHelper.loggedInOnly,
-      checkoutSessionByAccount,
+      limitCheckoutSessionByAccount,
       this.createSession.bind(this),
     );
 

--- a/src/server/funding/api/v1/webhooks.ts
+++ b/src/server/funding/api/v1/webhooks.ts
@@ -2,7 +2,7 @@ import express, { Request, Response, Application, Router } from 'express';
 import FundingInterface from '@/server/funding/interface';
 import { ProviderNotConfiguredError, WebhookSignatureError } from '@/common/exceptions/funding';
 import { logError } from '@/server/common/helper/error-logger';
-import { fundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
+import { limitFundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
 
 /**
  * Webhook route handlers for payment provider events
@@ -33,7 +33,7 @@ export default class WebhookRoutes {
     // delivery or retries.
     router.post(
       '/webhooks/stripe',
-      fundingWebhookByIp,
+      limitFundingWebhookByIp,
       express.raw({ type: 'application/json' }),
       this.handleStripeWebhook.bind(this),
     );

--- a/src/server/funding/test/integration/rate_limiting.test.ts
+++ b/src/server/funding/test/integration/rate_limiting.test.ts
@@ -3,7 +3,7 @@ import config from 'config';
 import express, { Express } from 'express';
 import request from 'supertest';
 
-import { fundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
+import { limitFundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
 
 /**
  * Integration tests for funding (Stripe webhook) rate limiting.
@@ -15,7 +15,7 @@ import { fundingWebhookByIp } from '@/server/common/middleware/rate-limiters';
  *
  * NOTE: requires rate limiting enabled. To run: npm run test:ratelimiting
  *
- * IMPORTANT: fundingWebhookByIp is a module-level singleton with its own
+ * IMPORTANT: limitFundingWebhookByIp is a module-level singleton with its own
  * in-memory store, keyed by IP. The whole suite shares the localhost IP, so the
  * IP budget is exhausted exactly once in a single dedicated test. The webhook
  * limiter is deliberately generous (DEC-007: belt-and-braces behind Stripe
@@ -33,12 +33,12 @@ describeOrSkip('Funding Webhook Rate Limiting Integration Tests', () => {
     app = express();
     app.use(express.json());
 
-    app.post('/webhook-ip-only', fundingWebhookByIp, (req, res) => {
+    app.post('/webhook-ip-only', limitFundingWebhookByIp, (req, res) => {
       res.json({ route: 'funding-webhook-ip' });
     });
   });
 
-  describe('fundingWebhookByIp', () => {
+  describe('limitFundingWebhookByIp', () => {
     it('should return 429 once the per-IP limit is exhausted and wire the same singleton onto POST /api/funding/webhooks/stripe', async () => {
       const ipMax = config.get<number>('rateLimit.fundingWebhook.byIp.max');
 
@@ -68,7 +68,7 @@ describeOrSkip('Funding Webhook Rate Limiting Integration Tests', () => {
       expect(blocked.headers['ratelimit-remaining']).toBe('0');
       expect(blocked.headers['retry-after']).toBeDefined();
 
-      // Prove the same `fundingWebhookByIp` singleton is wired onto the real
+      // Prove the same `limitFundingWebhookByIp` singleton is wired onto the real
       // webhook route. The limiter is now exhausted for localhost, so a request
       // to POST /api/funding/webhooks/stripe must short-circuit at 429 before
       // the raw-body parser and signature-verification handler run.

--- a/src/server/moderation/api/v1/authenticated-report-routes.ts
+++ b/src/server/moderation/api/v1/authenticated-report-routes.ts
@@ -7,8 +7,8 @@ import { DuplicateReportError, ReportValidationError } from '@/common/exceptions
 import ExpressHelper from '@/server/common/helper/express';
 import ModerationInterface from '@/server/moderation/interface';
 import {
-  reportSubmissionByIp,
-  reportSubmissionByAccount,
+  limitReportSubmissionByIp,
+  limitReportSubmissionByAccount,
 } from '@/server/common/middleware/rate-limiters';
 import { logError } from '@/server/common/helper/error-logger';
 
@@ -40,8 +40,8 @@ export default class AuthenticatedReportRoutes {
     router.post(
       '/reports',
       ...ExpressHelper.loggedInOnly,
-      reportSubmissionByIp,
-      reportSubmissionByAccount,
+      limitReportSubmissionByIp,
+      limitReportSubmissionByAccount,
       this.submitReport.bind(this),
     );
     app.use(routePrefix, router);

--- a/src/server/moderation/api/v1/public-report-routes.ts
+++ b/src/server/moderation/api/v1/public-report-routes.ts
@@ -6,8 +6,8 @@ import { DuplicateReportError, ReportValidationError } from '@/common/exceptions
 import ModerationInterface from '@/server/moderation/interface';
 import { EmailRateLimitError, ReporterBlockedError } from '@/server/moderation/exceptions';
 import {
-  reportSubmissionByIp,
-  reportSubmissionByEmail,
+  limitReportSubmissionByIp,
+  limitReportSubmissionByEmail,
 } from '@/server/common/middleware/rate-limiters';
 import { logError } from '@/server/common/helper/error-logger';
 
@@ -34,8 +34,8 @@ export default class PublicReportRoutes {
     const router = express.Router();
     router.post(
       '/events/:eventId/reports',
-      reportSubmissionByIp,
-      reportSubmissionByEmail,
+      limitReportSubmissionByIp,
+      limitReportSubmissionByEmail,
       this.submitReport.bind(this),
     );
     app.use(routePrefix, router);

--- a/src/server/moderation/api/v1/verify-routes.ts
+++ b/src/server/moderation/api/v1/verify-routes.ts
@@ -2,7 +2,7 @@ import express, { Request, Response, Application } from 'express';
 
 import ModerationInterface from '@/server/moderation/interface';
 import { InvalidVerificationTokenError } from '@/server/moderation/exceptions';
-import { reportVerificationByIp } from '@/server/common/middleware/rate-limiters';
+import { limitReportVerificationByIp } from '@/server/common/middleware/rate-limiters';
 import { logError } from '@/server/common/helper/error-logger';
 
 /**
@@ -28,7 +28,7 @@ export default class VerifyRoutes {
     const router = express.Router();
     router.get(
       '/reports/verify/:token',
-      reportVerificationByIp,
+      limitReportVerificationByIp,
       this.verifyToken.bind(this),
     );
     app.use(routePrefix, router);

--- a/src/server/moderation/test/api/authenticated-report.test.ts
+++ b/src/server/moderation/test/api/authenticated-report.test.ts
@@ -426,7 +426,7 @@ describe('Authenticated Report API - POST /reports', () => {
       }
 
       // Route should have multiple handlers: loggedInOnly middleware(s),
-      // reportSubmissionByIp, reportSubmissionByAccount, and submitReport handler
+      // limitReportSubmissionByIp, limitReportSubmissionByAccount, and submitReport handler
       // With rate limiting disabled (test env), no-op middleware still counts
       expect(routeHandlerCount).toBeGreaterThanOrEqual(4);
     });

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -10,7 +10,7 @@ import { EventSeries } from '@/common/model/event_series';
 import { EventCategory } from '@/common/model/event_category';
 import { getRecurrenceSummary } from '@/common/utils/recurrence-text';
 import { parseInstanceSlug } from '@/common/utils/instance-slug';
-import { publicEventInstanceByIp, publicCalendarListByIp } from '@/server/common/middleware/rate-limiters';
+import { limitPublicEventInstanceByIp, limitPublicCalendarListByIp } from '@/server/common/middleware/rate-limiters';
 import ExpressHelper from '@/server/common/helper/express';
 
 /**
@@ -242,7 +242,7 @@ export default class CalendarRoutes {
 
   installHandlers(app: Application, routePrefix: string): void {
     const router = express.Router();
-    router.get('/calendars', publicCalendarListByIp, this.listPublicCalendars.bind(this));
+    router.get('/calendars', limitPublicCalendarListByIp, this.listPublicCalendars.bind(this));
     router.get('/calendar/:urlName', this.getCalendar.bind(this));
     router.get('/calendar/:urlName/categories', this.listCategories.bind(this));
     router.get('/calendar/:urlName/series', this.listSeries.bind(this));
@@ -251,7 +251,7 @@ export default class CalendarRoutes {
     router.get('/events/:id', this.getEvent.bind(this));
     router.get(
       '/events/:eventId/instances/:startTime',
-      publicEventInstanceByIp,
+      limitPublicEventInstanceByIp,
       this.getEventInstance.bind(this),
     );
     app.use(routePrefix, router);

--- a/src/server/public/test/calendars-api.test.ts
+++ b/src/server/public/test/calendars-api.test.ts
@@ -213,7 +213,7 @@ describe('Public Calendars Discovery API (pv-u4ew.3)', () => {
   describe('GET /api/public/v1/calendars - rate limiter wired', () => {
     it('registers a middleware ahead of the handler on the /calendars route', () => {
       // In the test environment `rateLimit.enabled = false` swaps the
-      // publicCalendarListByIp limiter for a no-op middleware (see
+      // limitPublicCalendarListByIp limiter for a no-op middleware (see
       // config/test.yaml), so we cannot assert on RateLimit-* response
       // headers. Instead, assert the route has TWO handlers: the rate
       // limiter (or its no-op stand-in) wired ahead of the bound


### PR DESCRIPTION
Stacked on #363.

## Motivation

The exported rate-limit middleware in `rate-limiters.ts` used bare noun names (`registerByEmail`, `loginByIp`, ...). At call sites these read as data, not behavior — a router line like `router.post('/register', registerByIp, registerByEmail, ...)` does not make clear that those middleware *enforce a limit*. Prefixing them with `limit` makes the action explicit.

## Approach

Rename all 26 exported limiter middleware in `src/server/common/middleware/rate-limiters.ts` to carry a `limit` prefix (`registerByEmail` → `limitRegisterByEmail`), and update every importer, test, and JSDoc reference across the accounts, authentication, calendar, configuration, funding, moderation, and public domains.

All 26 were renamed rather than only the limiters added in #363: a file mixing `limitRegisterByEmail` with an unprefixed `loginByEmail` would be less clear, not more — consistency is the point of the convention.

Out of scope by design:
- The `create…RateLimiter` factories in `activitypub/middleware/rate-limit.ts` keep their names; they already lead with a verb and are not the `xByY` pattern.
- The coverage guard detects limiters by their `getKey`/`resetKey` properties and the AP marker, not by function name, so the rename does not affect detection.

No behavior change.

## Validation

- `npm run lint` — clean on all 22 changed files.
- `tsc --noEmit` — no symbol-resolution errors for the renamed exports (pre-existing migration/client errors are unrelated).
- `npm run test:ratelimiting` — rate-limit unit, integration, and coverage-guard suites pass. (One failure in `activitypub/.../rate_limiting.test.ts` is a pre-existing parallel-run flake in a file this PR does not touch; it passes in isolation.)
- Verified no stale unprefixed limiter names remain anywhere in `src`, including comments.