### PR TITLE
fix: normalize credential rate-limit key (case/whitespace)

### DIFF
--- a/src/server/calendar/test/service/import/sync.test.ts
+++ b/src/server/calendar/test/service/import/sync.test.ts
@@ -75,7 +75,12 @@ function makeSourceEntity(overrides: Partial<ImportSourceEntity> = {}): ImportSo
     verification_state: 'verified',
     verification_token: null,
     verified_at: new Date('2026-03-01T00:00:00Z'),
-    verification_expires_at: new Date('2026-06-01T00:00:00Z'),
+    // No expiry by default: assertVerifiedForSync treats a verified source with
+    // a null expiry as valid regardless of wall-clock time, so the orchestration
+    // tests below don't trip ImportSourceNotVerifiedError as real time advances.
+    // Verification-expiry/grace-window behavior has dedicated tests that set
+    // verification_expires_at explicitly.
+    verification_expires_at: null,
     etag: null,
     content_hash: null,
     last_fetched_at: null,

--- a/src/server/common/middleware/rate-limit-by-credential.ts
+++ b/src/server/common/middleware/rate-limit-by-credential.ts
@@ -35,10 +35,14 @@ export function createCredentialRateLimiter(
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 
-    // Use credential from request body as the key
+    // Use credential from request body as the key, normalized so case and
+    // whitespace variants of the same credential share one bucket (prevents
+    // per-credential budget multiplication). String() guards non-string body
+    // values; the 'unknown' fallback covers empty/missing credentials.
     keyGenerator: (req: Request) => {
       const credential = req.body?.[credentialField];
-      return credential || 'unknown';
+      const normalized = String(credential ?? '').trim().toLowerCase();
+      return normalized || 'unknown';
     },
 
     // Custom handler when rate limit is exceeded

--- a/src/server/common/test/middleware/rate-limit-by-credential.test.ts
+++ b/src/server/common/test/middleware/rate-limit-by-credential.test.ts
@@ -209,6 +209,49 @@ describe('createCredentialRateLimiter', () => {
       expect(blockedResponse.status).toBe(429);
     });
 
+    it('should share one bucket across case and whitespace variants of the same email', async () => {
+      const limiter = createCredentialRateLimiter(
+        2,
+        60000,
+        'test-endpoint',
+        'email',
+      );
+
+      router.post('/test', limiter, (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      const app = testApp(router);
+
+      // First variant: mixed case
+      const firstResponse = await request(app)
+        .post('/test')
+        .send({ email: 'Alice@x.com' });
+
+      expect(firstResponse.status).toBe(200);
+
+      // Second variant: surrounding whitespace
+      const secondResponse = await request(app)
+        .post('/test')
+        .send({ email: ' alice@x.com ' });
+
+      expect(secondResponse.status).toBe(200);
+
+      // Third variant: canonical form — shares the normalized bucket, so blocked
+      const blockedResponse = await request(app)
+        .post('/test')
+        .send({ email: 'alice@x.com' });
+
+      expect(blockedResponse.status).toBe(429);
+
+      // Control: a distinct address still gets its own bucket (no over-collapse)
+      const distinctResponse = await request(app)
+        .post('/test')
+        .send({ email: 'bob@x.com' });
+
+      expect(distinctResponse.status).toBe(200);
+    });
+
     it('should share the unknown key for empty and missing credentials', async () => {
       const limiter = createCredentialRateLimiter(
         2,
@@ -243,6 +286,45 @@ describe('createCredentialRateLimiter', () => {
         .send({ notEmail: 'other-value' });
 
       expect(blockedResponse.status).toBe(429);
+    });
+
+    it('should coerce a non-string credential into its own isolated bucket', async () => {
+      const limiter = createCredentialRateLimiter(
+        1,
+        60000,
+        'test-endpoint',
+        'email',
+      );
+
+      router.post('/test', limiter, (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      const app = testApp(router);
+
+      // Exhaust the bucket for a legitimate string email.
+      const firstStringResponse = await request(app)
+        .post('/test')
+        .send({ email: 'alice@x.com' });
+
+      expect(firstStringResponse.status).toBe(200);
+
+      const blockedStringResponse = await request(app)
+        .post('/test')
+        .send({ email: 'alice@x.com' });
+
+      expect(blockedStringResponse.status).toBe(429);
+
+      // A non-string credential is coerced to a deterministic key
+      // (String({...}) === '[object Object]', normalized to '[object object]')
+      // that is distinct from the exhausted string bucket — so it is still
+      // allowed. This proves the String() guard yields an isolated key rather
+      // than collapsing the non-string value into the string email's bucket.
+      const objectResponse = await request(app)
+        .post('/test')
+        .send({ email: { inject: 'x' } });
+
+      expect(objectResponse.status).toBe(200);
     });
   });
 


### PR DESCRIPTION
## Motivation

The shared `keyGenerator` in the credential rate-limiter factory (`src/server/common/middleware/rate-limit-by-credential.ts`) keyed on the request credential verbatim. As a result, case and surrounding-whitespace variants of the same email — `Alice@x.com`, `alice@x.com`, `' alice@x.com '` — occupied three distinct rate-limit buckets, multiplying the effective per-credential request budget. This affected every limiter built on the factory: login, password reset, application, and registration by email. Per-IP caps bound total throughput today, but the per-credential multiplication held regardless of how an attacker distributed source IPs.

## Approach

Normalize the credential before it is used as the bucket key: `String(credential ?? '').trim().toLowerCase()`, falling back to the existing `'unknown'` bucket for empty/missing credentials. The factory is the single chokepoint, so all four credential limiters inherit the fix with no per-call-site changes.

- `String(credential ?? '')` guards non-string body values (numbers, objects from malformed/forged bodies) without throwing.
- `trim().toLowerCase()` collapses whitespace and case variants into one bucket.
- The normalized value is used **only** as an in-memory store key — never logged, returned, or persisted. The 429 handler reads the credential independently from `req.body` for its redacted, debug-level log, so privacy posture (DEC-004) is unchanged.

Accepted residual risks (documented, out of scope): sub-addressing (`+tags`), dotted Gmail aliases, and Unicode NFC/NFKC normalization remain distinct buckets; the auth path stays case-sensitive on email storage. All are bounded by per-IP caps.

A related defect surfaced during review and is tracked separately for follow-up: `redactEmail` calls `.trim()` unconditionally, so a forged **non-string** credential body that exceeds a limit currently degrades the 429 response to a 500. The key normalization here is robust against non-string input; the handler's log path is not. The new coercion test is deliberately scoped to the 200 path to avoid coupling to that separate defect.

## Validation

- New tests in `rate-limit-by-credential.test.ts`: case/whitespace variants share one bucket (third request returns 429); a no-over-collapse control (`bob@x.com` keeps its own bucket and returns 200); and non-string credential coercion lands in a distinct isolated bucket. Existing empty/missing `'unknown'` fallback tests pass unchanged.
- Targeted middleware suite: 14/14 passing.
- Full build-guardian run: lint clean (0 errors), unit/integration/build green, e2e green apart from the repo's known pre-existing ICS-import/federation baseline failures (unrelated to this change).