### PR TITLE
feat(authentication): defer email change behind a confirmation token

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -206,6 +206,26 @@ rateLimit:
       # (EmailAlreadyExistsError). This account-keyed cap bounds that probe rate;
       # it does not close the differential-response enumeration oracle itself.
       max: 10  # 10 email-change attempts per account per hour
+    byDestination:
+      windowMs: 86400000  # 24 hours in milliseconds
+      # Email-bombing defense (epic pv-91a3) for POST /api/auth/v1/email. Keyed
+      # on the NORMALIZED (trim + lowercase) requester-supplied destination
+      # address across ALL accounts, this caps how often any one address can be
+      # targeted as a pending email-change recipient, so a multi-account attacker
+      # cannot flood a victim address with confirmation emails — nor split the
+      # counter with case/whitespace variants of the same mailbox. Cannot become
+      # an enumeration oracle: the key is the attacker-supplied address, so a 429
+      # only reports the requester's own cap on an address they chose. Mirrors
+      # register.byEmail.
+      max: 2  # 2 email-change requests per destination address per 24 hours
+    confirm:
+      byIp:
+        windowMs: 900000  # 15 minutes in milliseconds
+        # Token brute-force defense for POST /api/auth/v1/email/confirm/:token.
+        # Mirrors passwordReset.confirm.byIp (20/15m): the email-change code is a
+        # randomBytes(16) = 128-bit CSPRNG token, so the keyspace is far too
+        # large to brute-force and this is an abuse cap, not a guessing wall.
+        max: 20  # 20 confirmation attempts per IP per 15 minutes
 
 # Housekeeping configuration for automated server maintenance
 housekeeping:

--- a/migrations/0038_add_email_change_columns.ts
+++ b/migrations/0038_add_email_change_columns.ts
@@ -1,0 +1,86 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import {
+  addColumnIfNotExists,
+  removeColumnIfExists,
+} from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Add email-change token columns to the `account_secrets` sidecar.
+ *
+ * Foundation migration for the email-change flow. The token lives on the
+ * existing per-account secrets sidecar alongside the password-reset token,
+ * mirroring the `password_reset_*` precedent exactly: the code is stored RAW
+ * (not hashed), with a nullable expiration timestamp. The pending new email
+ * address is held until the change is confirmed, after which the service
+ * layer nulls all three columns so they don't sit as long-lived noise.
+ *
+ * Schema changes (all on `account_secrets`):
+ * 1. `email_change_code` (STRING, nullable) — raw token generated at
+ *    request-time and consumed at confirm-time.
+ * 2. `email_change_expiration` (DATE, nullable) — expiry timestamp,
+ *    matching the `password_reset_expiration` naming style.
+ * 3. `email_change_new_email` (STRING, nullable) — the requested new email
+ *    address, applied to the account only on successful confirmation.
+ *
+ * No enum changes. Fully reversible: the down path removes each column with
+ * `removeColumnIfExists`.
+ *
+ * Reference: bead pv-91a3.1.1 (Migration + entity columns).
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await addColumnIfNotExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_code',
+      {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    );
+
+    await addColumnIfNotExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_expiration',
+      {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    );
+
+    await addColumnIfNotExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_new_email',
+      {
+        type: DataTypes.STRING,
+        allowNull: true,
+      },
+    );
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await removeColumnIfExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_new_email',
+    );
+
+    await removeColumnIfExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_expiration',
+    );
+
+    await removeColumnIfExists(
+      queryInterface,
+      'account_secrets',
+      'email_change_code',
+    );
+  },
+};

--- a/src/client/app.ts
+++ b/src/client/app.ts
@@ -21,6 +21,7 @@ import PasswordResetView from '@/client/components/logged_out/password_reset.vue
 import RegisterView from '@/client/components/logged_out/register.vue';
 import RegisterApplyView from '@/client/components/logged_out/register_apply.vue';
 import ApplyConfirmView from '@/client/components/logged_out/apply_confirm.vue';
+import EmailConfirmView from '@/client/components/logged_out/email_confirm.vue';
 import AcceptInviteView from '@/client/components/logged_out/accept_invite.vue';
 import SetupView from '@/client/components/logged_out/setup.vue';
 import InstancePolicyView from '@/client/components/logged_out/instance-policy.vue';
@@ -188,6 +189,7 @@ checkSetupMode().then((setupRequired) => {
           { path: 'invitation', component: AcceptInviteView, name: 'accept_invite', props: true, beforeEnter: authRouteGuard },
           { path: 'apply', component: RegisterApplyView, name: 'register-apply', props: true, beforeEnter: authRouteGuard },
           { path: 'apply/confirm/:token', component: ApplyConfirmView, name: 'apply-confirm', props: true, beforeEnter: authRouteGuard },
+          { path: 'email/confirm/:token', component: EmailConfirmView, name: 'email-confirm', props: true, beforeEnter: authRouteGuard },
           { path: 'forgot', component: PasswordForgotView, name: 'forgot_password', props: true, beforeEnter: authRouteGuard },
           { path: 'password', component: PasswordResetView, name: 'reset_password', props: true, beforeEnter: authRouteGuard },
         ],

--- a/src/client/components/logged_in/settings/email_modal.vue
+++ b/src/client/components/logged_in/settings/email_modal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { reactive, inject, ref, onMounted, computed } from 'vue';
+import { reactive, inject, ref, onMounted, computed, nextTick } from 'vue';
 import { useTranslation } from 'i18next-vue';
 import Modal from '@/client/components/common/modal.vue';
 
@@ -14,9 +14,11 @@ const state = reactive({
   email: '',
   password: '',
   err: '',
+  sent: false,
 });
 
 const firstInputRef = ref(null);
+const doneButtonRef = ref(null);
 
 onMounted(() => {
   // Focus first input when modal opens
@@ -30,7 +32,15 @@ onMounted(() => {
 const changeEmail = async () => {
   const ok = await authn.changeEmail(state.email, state.password);
   if (ok) {
-    emit('close', state.email);
+    // The address is NOT changed yet — a confirmation link was sent to the new
+    // inbox. Show the confirmation prompt rather than reporting an immediate
+    // change, and close without signalling a new address to the parent.
+    state.err = '';
+    state.sent = true;
+    // The previously-focused submit button is now removed from the DOM. Move
+    // focus to the Done button so keyboard/AT users aren't dropped to <body>.
+    await nextTick();
+    doneButtonRef.value?.focus();
   }
   else {
     state.err = t('change_email_failed_message');
@@ -46,7 +56,25 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
     @close="$emit('close', null)"
     modal-class="change-email-modal"
   >
-    <form @submit.prevent="changeEmail" class="modal-form">
+    <div v-if="state.sent" class="modal-form">
+      <p class="confirm-sent-text"
+         role="status"
+         aria-live="polite">
+        {{ t('confirm_sent_message', { defaultValue: 'Check your new inbox to confirm the change. Your email address will only update once you click the link we just sent.' }) }}
+      </p>
+      <div class="modal-footer">
+        <button
+          ref="doneButtonRef"
+          type="button"
+          class="btn-submit"
+          @click="$emit('close', null)"
+        >
+          {{ t('done_button', { defaultValue: 'Done' }) }}
+        </button>
+      </div>
+    </div>
+
+    <form v-else @submit.prevent="changeEmail" class="modal-form">
       <p class="current-email-text">
         {{ t('current_email_label', { defaultValue: 'Current email:' }) }}
         <span class="current-email-value">{{ authn.userEmail() }}</span>
@@ -145,6 +173,16 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
   }
 }
 
+.confirm-sent-text {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--pav-color-stone-700);
+
+  @media (prefers-color-scheme: dark) {
+    color: var(--pav-color-stone-300);
+  }
+}
+
 .error-message {
   padding: var(--pav-space-3);
   background: rgba(239, 68, 68, 0.1);
@@ -238,6 +276,12 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
 
   &:hover:not(:disabled) {
     background: var(--pav-color-orange-600);
+  }
+
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+    box-shadow: var(--pav-shadow-focus);
   }
 
   &:disabled {

--- a/src/client/components/logged_out/email_confirm.vue
+++ b/src/client/components/logged_out/email_confirm.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { reactive, ref, inject, nextTick, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { useTranslation } from 'i18next-vue';
+
+import type AuthenticationService from '@/client/service/authn';
+
+const { t } = useTranslation('authentication', {
+  keyPrefix: 'email_confirm',
+});
+
+const route = useRoute();
+const authn = inject('authn') as AuthenticationService;
+
+/**
+ * Render state for the email-change confirmation page.
+ *
+ * - 'confirming': consume in flight (also the initial state)
+ * - 'success':    token consumed; the email change is committed
+ * - 'invalid':    token rejected, expired, missing, or network failure
+ *
+ * Anti-enumeration posture (mirrors the backend collapse and apply-confirm):
+ * every failure mode — unknown / expired / already-consumed / address-now-taken
+ * / network error — renders the same single 'invalid' copy. The page never
+ * reveals which failure occurred.
+ */
+type RenderState = 'confirming' | 'success' | 'invalid';
+
+const state = reactive({
+  render: 'confirming' as RenderState,
+});
+
+// Template ref to the terminal-state heading. Only one terminal branch
+// (success or invalid) ever renders, so this resolves to whichever one is
+// shown. After the async consume settles we move focus here so the screen
+// reader announces the title + message on the freshly-swapped view
+// (WCAG 4.1.3 / 2.4.3) — the in-flight live region is unreliable.
+const resultHeading = ref<HTMLElement | null>(null);
+
+onMounted(async () => {
+  const token = route.params.token as string;
+  // Defensive: a missing token short-circuits to invalid without ever hitting
+  // the network. The router param is required, but be explicit.
+  if (!token) {
+    state.render = 'invalid';
+    await nextTick();
+    resultHeading.value?.focus();
+    return;
+  }
+
+  try {
+    const result = await authn.confirmEmailChange(token);
+    if (result?.valid === true) {
+      state.render = 'success';
+      // Propagate the new email into the current session, if one exists. This
+      // page may be opened anonymously or on a different device, so a missing
+      // or failed refresh is non-fatal — the change is already committed
+      // server-side and the success state must stand regardless.
+      await authn.refreshToken();
+    }
+    else {
+      state.render = 'invalid';
+    }
+  }
+  catch {
+    // Network or server failure: same anti-enumeration posture as the backend —
+    // collapse to the generic invalid copy.
+    state.render = 'invalid';
+  }
+  // Move focus to the terminal-state heading after the view swaps.
+  await nextTick();
+  resultHeading.value?.focus();
+});
+</script>
+
+<template>
+  <div>
+    <!-- Confirming state (initial + while the consume is in flight) -->
+    <div v-if="state.render === 'confirming'" class="welcome-card">
+      <h3>{{ t('title') }}</h3>
+      <p
+        class="status-message"
+        role="status"
+        aria-live="polite"
+      >
+        {{ t('confirming') }}
+      </p>
+    </div>
+
+    <!-- Success state -->
+    <div v-else-if="state.render === 'success'" class="welcome-card">
+      <h3
+        ref="resultHeading"
+        tabindex="-1"
+      >{{ t('title') }}</h3>
+      <p
+        class="success-message"
+        role="status"
+        aria-live="polite"
+      >{{ t('success_message') }}</p>
+      <router-link
+        class="forgot"
+        :to="{ name: 'login' }"
+      >{{ t('go_login') }}</router-link>
+    </div>
+
+    <!-- Invalid / expired / failed state -->
+    <div v-else class="welcome-card">
+      <h3
+        ref="resultHeading"
+        tabindex="-1"
+      >{{ t('title') }}</h3>
+      <p
+        class="invalid-message"
+        role="alert"
+      >{{ t('invalid_message') }}</p>
+      <router-link
+        class="forgot"
+        :to="{ name: 'login' }"
+      >{{ t('go_login') }}</router-link>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+h3 {
+  margin-block-end: var(--pav-space-4);
+}
+
+.status-message,
+.success-message,
+.invalid-message {
+  font-size: var(--pav-font-size-base);
+  color: var(--pav-text-secondary);
+  margin-block-end: var(--pav-space-6);
+}
+</style>

--- a/src/client/locales/en/authentication.json
+++ b/src/client/locales/en/authentication.json
@@ -67,5 +67,12 @@
   "session_expired": {
     "title": "Session expired",
     "description": "Your session has expired. Sign in again to continue where you left off."
+  },
+  "email_confirm": {
+    "title": "Confirm your email change",
+    "confirming": "Confirming your new email address…",
+    "success_message": "Your email address has been updated. You can now sign in with your new address.",
+    "go_login": "← back to sign in",
+    "invalid_message": "This confirmation link is invalid or has expired. Please request the email change again."
   }
 }

--- a/src/client/locales/en/profile.json
+++ b/src/client/locales/en/profile.json
@@ -28,7 +28,9 @@
     "password_help_text": "Enter your current password to confirm this change",
     "change_email_button": "Change Email",
     "close_button": "Cancel",
-    "change_email_failed_message": "Failed to change email address"
+    "done_button": "Done",
+    "change_email_failed_message": "Failed to change email address",
+    "confirm_sent_message": "Check your new inbox to confirm the change. Your email address will only update once you click the link we just sent."
   },
   "change_password_form": {
     "title": "Change your password",

--- a/src/client/locales/es/authentication.json
+++ b/src/client/locales/es/authentication.json
@@ -67,5 +67,12 @@
   "session_expired": {
     "title": "Sesión expirada",
     "description": "Tu sesión ha expirado. Inicia sesión nuevamente para continuar donde lo dejaste."
+  },
+  "email_confirm": {
+    "title": "Confirma el cambio de tu correo electrónico",
+    "confirming": "Confirmando tu nueva dirección de correo electrónico…",
+    "success_message": "Tu dirección de correo electrónico ha sido actualizada. Ya puedes iniciar sesión con tu nueva dirección.",
+    "go_login": "← volver a iniciar sesión",
+    "invalid_message": "Este enlace de confirmación es inválido o ha expirado. Por favor solicita el cambio de correo electrónico nuevamente."
   }
 }

--- a/src/client/locales/es/profile.json
+++ b/src/client/locales/es/profile.json
@@ -28,7 +28,9 @@
     "password_help_text": "Ingresa tu contraseña actual para confirmar este cambio",
     "change_email_button": "Cambiar Correo",
     "close_button": "Cancelar",
-    "change_email_failed_message": "No se pudo cambiar la dirección de correo electrónico"
+    "done_button": "Listo",
+    "change_email_failed_message": "No se pudo cambiar la dirección de correo electrónico",
+    "confirm_sent_message": "Revisa tu nueva bandeja de entrada para confirmar el cambio. Tu dirección de correo electrónico solo se actualizará cuando hagas clic en el enlace que acabamos de enviar."
   },
   "change_password_form": {
     "title": "Cambia tu contraseña",

--- a/src/client/locales/fr/authentication.json
+++ b/src/client/locales/fr/authentication.json
@@ -67,5 +67,12 @@
   "session_expired": {
     "title": "Session expirée",
     "description": "Votre session a expiré. Reconnectez-vous pour reprendre là où vous en étiez."
+  },
+  "email_confirm": {
+    "title": "Confirmez le changement de votre adresse e-mail",
+    "confirming": "Confirmation de votre nouvelle adresse e-mail…",
+    "success_message": "Votre adresse e-mail a été mise à jour. Vous pouvez désormais vous connecter avec votre nouvelle adresse.",
+    "go_login": "← retour à la connexion",
+    "invalid_message": "Ce lien de confirmation est invalide ou a expiré. Veuillez demander à nouveau le changement d'adresse e-mail."
   }
 }

--- a/src/client/locales/fr/profile.json
+++ b/src/client/locales/fr/profile.json
@@ -28,7 +28,9 @@
     "password_help_text": "Saisissez votre mot de passe actuel pour confirmer ce changement",
     "change_email_button": "Modifier l'e-mail",
     "close_button": "Annuler",
-    "change_email_failed_message": "Impossible de modifier l'adresse e-mail"
+    "done_button": "Terminé",
+    "change_email_failed_message": "Impossible de modifier l'adresse e-mail",
+    "confirm_sent_message": "Consultez votre nouvelle boîte de réception pour confirmer le changement. Votre adresse e-mail ne sera mise à jour qu'après avoir cliqué sur le lien que nous venons d'envoyer."
   },
   "change_password_form": {
     "title": "Modifier votre mot de passe",

--- a/src/client/service/authn.ts
+++ b/src/client/service/authn.ts
@@ -492,8 +492,7 @@ export default class AuthenticationService {
       return false;
     }
     try {
-      let response = await axios.get( this._authUrl('/token'), {} );
-      this._set_token(response.data);
+      await this._fetch_and_store_token();
       return true;
     }
     catch {
@@ -630,13 +629,7 @@ export default class AuthenticationService {
       try {
         this._refresh_timer = await this._wait( timer * 1000 );
         if ( this.jwt() ) {
-          let response = await axios.get( this._authUrl('/token'), {} );
-
-          if ( response.status >= 400 ) {
-            throw new Error(response.statusText);
-          }
-
-          this._set_token(response.data);
+          await this._fetch_and_store_token();
         }
       }
       catch (error) {
@@ -650,6 +643,27 @@ export default class AuthenticationService {
     else {
       this._unset_token();
     }
+  }
+
+  /**
+   * Fetches a fresh JWT from the server's /token endpoint and stores it (which
+   * also reschedules the silent-refresh timer via _set_token). This is the only
+   * point of contact with the refresh endpoint: both the scheduled
+   * _refresh_login() and the on-demand refreshToken() funnel through here and
+   * apply their own failure handling around it.
+   *
+   * @returns {Promise<void>}
+   * @throws Will throw on a non-2xx response or a network/axios error
+   * @private
+   */
+  async _fetch_and_store_token(): Promise<void> {
+    let response = await axios.get( this._authUrl('/token'), {} );
+
+    if ( response.status >= 400 ) {
+      throw new Error(response.statusText);
+    }
+
+    this._set_token(response.data);
   }
 
   /**

--- a/src/client/service/authn.ts
+++ b/src/client/service/authn.ts
@@ -2,6 +2,7 @@ import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ref, Ref } from 'vue';
 
 import { SessionExpiredError } from '@/common/exceptions/authentication';
+import { EmptyValueError } from '@/common/exceptions/base';
 
 interface JWTClaims {
   exp: number;
@@ -36,7 +37,7 @@ export default class AuthenticationService {
   constructor(localStore: Storage) {
 
     if ( localStore == null ) {
-      throw("Must provide a localStorage object");
+      throw new EmptyValueError('Must provide a localStorage object');
     }
 
     this.localStore = localStore;
@@ -239,7 +240,7 @@ export default class AuthenticationService {
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError;
         if (axiosError.response) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
       throw(error);
@@ -262,7 +263,7 @@ export default class AuthenticationService {
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError;
         if (axiosError.response) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
       throw(error);
@@ -278,7 +279,7 @@ export default class AuthenticationService {
    */
   async check_invite_token(code: string) {
     if (!code || code === '') {
-      throw("no_invite_code_provided");
+      throw new EmptyValueError('no_invite_code_provided');
     }
 
     try {
@@ -289,7 +290,7 @@ export default class AuthenticationService {
       if (axios.isAxiosError(error)) {
         const axiosError = error as AxiosError;
         if (axiosError.response) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
       throw(error);
@@ -402,7 +403,7 @@ export default class AuthenticationService {
   async reset_password( email: string ) {
 
     if ( email == undefined || email == '' ) {
-      throw("no_email_provided");
+      throw new EmptyValueError('no_email_provided');
     }
 
     try {
@@ -457,7 +458,7 @@ export default class AuthenticationService {
   async confirmEmailChange( token: string ): Promise<{valid: boolean}> {
 
     if ( token == null || token == '' ) {
-      throw("no_token_provided");
+      throw new EmptyValueError('no_token_provided');
     }
 
     try {
@@ -468,7 +469,7 @@ export default class AuthenticationService {
       if ( axios.isAxiosError(error) ) {
         const axiosError = error as AxiosError;
         if ( axiosError.response ) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
       return { valid: false };
@@ -513,7 +514,7 @@ export default class AuthenticationService {
   async check_password_reset_token( token: string ): Promise<{valid: boolean, isNewAccount?: boolean}> {
 
     if ( token == null || token == '' ) {
-      throw("Must provide a password reset token");
+      throw new EmptyValueError('Must provide a password reset token');
     }
 
     try {
@@ -530,7 +531,7 @@ export default class AuthenticationService {
       if ( axios.isAxiosError(error) ) {
         const axiosError = error as AxiosError;
         if ( axiosError.response ) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
       return { valid: false };
@@ -548,11 +549,11 @@ export default class AuthenticationService {
   async use_password_reset_token( token: string, password: string ) {
 
     if ( token == null || token == '' ) {
-      throw("no_token_provided");
+      throw new EmptyValueError('no_token_provided');
     }
 
     if ( password == null || password == '' ) {
-      throw("no_password_provided");
+      throw new EmptyValueError('no_password_provided');
     }
 
     try {
@@ -563,7 +564,7 @@ export default class AuthenticationService {
       if ( axios.isAxiosError(error) ) {
         const axiosError = error as AxiosError;
         if ( axiosError.response ) {
-          throw(axiosError.response.status);
+          throw new Error(`Request failed with status ${axiosError.response.status}`);
         }
       }
     }
@@ -632,7 +633,7 @@ export default class AuthenticationService {
           let response = await axios.get( this._authUrl('/token'), {} );
 
           if ( response.status >= 400 ) {
-            throw(response.statusText);
+            throw new Error(response.statusText);
           }
 
           this._set_token(response.data);

--- a/src/client/service/authn.ts
+++ b/src/client/service/authn.ts
@@ -420,21 +420,87 @@ export default class AuthenticationService {
     }
   }
 
+  /**
+   * Initiates an email change. This no longer changes the address immediately:
+   * the backend sends a confirmation link to the NEW address, and the change is
+   * only committed once confirmEmailChange consumes that token. The session is
+   * therefore NOT refreshed here — the logged-in email is unchanged until the
+   * user confirms from their new inbox.
+   *
+   * @param {string} email - Proposed new email address
+   * @param {string} password - Current password, confirming the request
+   * @returns {Promise<boolean>} true if the confirmation link was sent
+   */
   async changeEmail ( email: string, password: string ): Promise<boolean> {
     try {
       let response = await axios.post(
         this._authUrl('/email'),
         { email, password },
       );
-      if ( response.status === 200 ) {
-        await this._refresh_login( this.userSettings().exp );
-        return true;
-      }
+      return response.status === 200;
     }
     catch {
       // TODO: something more useful here
     }
     return false;
+  }
+
+  /**
+   * Confirms a pending email change by consuming the confirmation token sent to
+   * the new address. Every backend failure (bad format / unknown / expired /
+   * already-consumed / address-now-taken) collapses to { valid: false }.
+   *
+   * @param {string} token - Email-change confirmation token (path param)
+   * @returns {Promise<{valid: boolean}>} { valid: true } on success
+   * @throws Will throw if the token is null or empty, or on a non-2xx HTTP status
+   */
+  async confirmEmailChange( token: string ): Promise<{valid: boolean}> {
+
+    if ( token == null || token == '' ) {
+      throw("no_token_provided");
+    }
+
+    try {
+      let response = await axios.post( this._authUrl('/email/confirm/' + token) );
+      return { valid: response.data.success === true };
+    }
+    catch (error) {
+      if ( axios.isAxiosError(error) ) {
+        const axiosError = error as AxiosError;
+        if ( axiosError.response ) {
+          throw(axiosError.response.status);
+        }
+      }
+      return { valid: false };
+    }
+  }
+
+  /**
+   * Immediately refreshes the JWT from the server, replacing the stored token
+   * and rescheduling the silent refresh timer. Used after a confirmed email
+   * change so the new email propagates into the client session without forcing
+   * the user to log out and back in.
+   *
+   * No-op (returns false) when no session is present — the email-change confirm
+   * page may be opened anonymously or on a different device.
+   *
+   * @returns {Promise<boolean>} true if a fresh token was stored
+   */
+  async refreshToken(): Promise<boolean> {
+    if ( ! this.jwt() ) {
+      return false;
+    }
+    try {
+      let response = await axios.get( this._authUrl('/token'), {} );
+      this._set_token(response.data);
+      return true;
+    }
+    catch {
+      // A failed refresh must not mask a successful confirmation; the caller
+      // treats refresh failure as non-fatal. The next silent-refresh cycle or
+      // the response interceptor will surface session expiry if it occurs.
+      return false;
+    }
   }
 
   /**

--- a/src/client/test/components/logged_out/email_confirm.test.ts
+++ b/src/client/test/components/logged_out/email_confirm.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { flushPromises, VueWrapper } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, Router } from 'vue-router';
+import { RouteRecordRaw } from 'vue-router';
+
+import { mountComponent } from '@/client/test/lib/vue';
+import { initI18Next } from '@/client/service/locale';
+import EmailConfirm from '@/client/components/logged_out/email_confirm.vue';
+
+const TEST_TOKEN = 'abcdef0123456789abcdef0123456789';
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: { template: '<div />' }, name: 'app' },
+  { path: '/auth/login', component: { template: '<div />' }, name: 'login' },
+  { path: '/auth/email/confirm/:token', component: EmailConfirm, name: 'email-confirm' },
+];
+
+interface MockAuthn {
+  confirmEmailChange: ReturnType<typeof vi.fn>;
+  refreshToken: ReturnType<typeof vi.fn>;
+}
+
+function makeAuthn(overrides: Partial<MockAuthn> = {}): MockAuthn {
+  return {
+    confirmEmailChange: vi.fn().mockResolvedValue({ valid: true }),
+    refreshToken: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+async function mountEmailConfirm(
+  authn: MockAuthn,
+  token: string = TEST_TOKEN,
+): Promise<VueWrapper> {
+  const router: Router = createRouter({
+    history: createMemoryHistory(),
+    routes,
+  });
+  await router.push(`/auth/email/confirm/${token}`);
+  await router.isReady();
+  return mountComponent(EmailConfirm, router, { provide: { authn } });
+}
+
+describe('EmailConfirm Component (client logged_out)', () => {
+  beforeAll(() => {
+    initI18Next();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Confirming State', () => {
+    it('should render the in-progress message while the consume is in flight', async () => {
+      // A pending confirm keeps the component in the confirming state.
+      const authn = makeAuthn({
+        confirmEmailChange: vi.fn().mockReturnValueOnce(new Promise(() => {
+          // never resolves
+        })),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+
+      expect(wrapper.text()).toContain('Confirming your new email address');
+      // No button is ever rendered — the confirm fires automatically on mount.
+      expect(wrapper.find('button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should consume the token automatically on mount with the route token', async () => {
+      const authn = makeAuthn();
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(authn.confirmEmailChange).toHaveBeenCalledTimes(1);
+      expect(authn.confirmEmailChange).toHaveBeenCalledWith(TEST_TOKEN);
+      wrapper.unmount();
+    });
+  });
+
+  describe('Successful Confirmation', () => {
+    it('should render the success message after a successful confirm', async () => {
+      const authn = makeAuthn();
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Your email address has been updated');
+      expect(wrapper.find('button').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('should refresh the JWT after a successful confirm', async () => {
+      const authn = makeAuthn();
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(authn.refreshToken).toHaveBeenCalledTimes(1);
+      wrapper.unmount();
+    });
+
+    it('should still render success when the token refresh fails (non-fatal)', async () => {
+      // refreshToken returning false models the anonymous / no-session case and
+      // a failed refresh — neither must downgrade the committed change.
+      const authn = makeAuthn({
+        refreshToken: vi.fn().mockResolvedValue(false),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Your email address has been updated');
+      wrapper.unmount();
+    });
+
+    it('should render a router-link back to login in the success state', async () => {
+      const authn = makeAuthn();
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      const loginLink = wrapper.find('a.forgot');
+      expect(loginLink.exists()).toBe(true);
+      expect(loginLink.attributes('href')).toBe('/auth/login');
+      wrapper.unmount();
+    });
+  });
+
+  describe('Invalid / Expired Token State', () => {
+    it('should render the generic invalid/expired copy when confirm returns valid=false', async () => {
+      const authn = makeAuthn({
+        confirmEmailChange: vi.fn().mockResolvedValue({ valid: false }),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('confirmation link is invalid');
+      // The success copy must NOT appear.
+      expect(wrapper.text()).not.toContain('Your email address has been updated');
+      wrapper.unmount();
+    });
+
+    it('should not refresh the JWT when confirm fails', async () => {
+      const authn = makeAuthn({
+        confirmEmailChange: vi.fn().mockResolvedValue({ valid: false }),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(authn.refreshToken).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should render the same generic copy when confirm throws an error', async () => {
+      const authn = makeAuthn({
+        confirmEmailChange: vi.fn().mockRejectedValue(new Error('Network down')),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('confirmation link is invalid');
+      wrapper.unmount();
+    });
+
+    it('should short-circuit to invalid without calling confirm when the token is empty', async () => {
+      // The component's `if (!token)` guard renders the generic invalid copy
+      // without ever hitting the network.
+      const authn = makeAuthn();
+
+      const wrapper = await mountEmailConfirm(authn, '');
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('confirmation link is invalid');
+      expect(authn.confirmEmailChange).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should render a router-link back to login in the invalid state', async () => {
+      const authn = makeAuthn({
+        confirmEmailChange: vi.fn().mockResolvedValue({ valid: false }),
+      });
+
+      const wrapper = await mountEmailConfirm(authn);
+      await flushPromises();
+
+      const loginLink = wrapper.find('a.forgot');
+      expect(loginLink.exists()).toBe(true);
+      expect(loginLink.attributes('href')).toBe('/auth/login');
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/client/test/service/authn.test.ts
+++ b/src/client/test/service/authn.test.ts
@@ -4,6 +4,7 @@ import axios from 'axios';
 
 import AuthenticationService from '@/client/service/authn';
 import { SessionExpiredError } from '@/common/exceptions/authentication';
+import { EmptyValueError } from '@/common/exceptions/base';
 
 class LocalStore implements Storage {
 
@@ -225,7 +226,7 @@ describe('Invitation Management', () => {
     } as any);
     axios_delete.rejects(error);
 
-    await expect(authentication.revoke_invitation('inv-123')).rejects.toBe(404);
+    await expect(authentication.revoke_invitation('inv-123')).rejects.toThrow('Request failed with status 404');
   });
 });
 
@@ -508,7 +509,7 @@ describe('confirmEmailChange', () => {
   it('throws when given an empty token', async () => {
     let authentication = makeAuth();
 
-    await expect(() => authentication.confirmEmailChange('')).rejects.toBe('no_token_provided');
+    await expect(() => authentication.confirmEmailChange('')).rejects.toBeInstanceOf(EmptyValueError);
   });
 
   it('throws the HTTP status on a non-2xx response', async () => {
@@ -522,7 +523,7 @@ describe('confirmEmailChange', () => {
     } as any);
     sandbox.stub(axios, 'post').rejects(error);
 
-    await expect(authentication.confirmEmailChange('c'.repeat(32))).rejects.toBe(429);
+    await expect(authentication.confirmEmailChange('c'.repeat(32))).rejects.toThrow('Request failed with status 429');
   });
 });
 

--- a/src/client/test/service/authn.test.ts
+++ b/src/client/test/service/authn.test.ts
@@ -253,7 +253,7 @@ describe('Token Refresh', () => {
 
     let promise = authentication._refresh_login( Date.now() + 500)
       .then( () => {
-        expect( stub1.notCalled ).toBeFalsy;
+        expect( stub1.notCalled ).toBe(true);
       });
     sandbox.clock.runAll();
 
@@ -454,5 +454,111 @@ describe('lastKnownEmail', () => {
 
     await authentication.login('person@example.com', 'pw');
     expect(authentication.lastKnownEmail).toBeNull();
+  });
+});
+
+describe('changeEmail (initiate)', () => {
+  it('posts to /email and returns true on a 200, without refreshing the session', async () => {
+    let authentication = makeAuth();
+    const refresh = sandbox.stub(authentication, '_refresh_login');
+    const axios_post = sandbox.stub(axios, 'post');
+    axios_post.resolves({ status: 200, data: { success: true } });
+
+    const result = await authentication.changeEmail('new@example.com', 'pw');
+
+    expect(result).toBe(true);
+    expect(axios_post.calledOnceWith('/api/auth/v1/email', { email: 'new@example.com', password: 'pw' })).toBe(true);
+    // The address is not changed yet — no session refresh should occur.
+    expect(refresh.called).toBe(false);
+  });
+
+  it('returns false when the initiate request fails', async () => {
+    let authentication = makeAuth();
+    sandbox.stub(authentication, '_refresh_login');
+    sandbox.stub(axios, 'post').rejects({ response: { status: 401 } });
+
+    const result = await authentication.changeEmail('new@example.com', 'pw');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('confirmEmailChange', () => {
+  it('posts the token as a path param and returns valid:true on success', async () => {
+    let authentication = makeAuth();
+    const token = 'a'.repeat(32);
+    const axios_post = sandbox.stub(axios, 'post');
+    axios_post.resolves({ status: 200, data: { success: true } });
+
+    const result = await authentication.confirmEmailChange(token);
+
+    expect(result).toEqual({ valid: true });
+    expect(axios_post.calledOnceWith('/api/auth/v1/email/confirm/' + token)).toBe(true);
+  });
+
+  it('returns valid:false when the backend collapses to {valid:false}', async () => {
+    let authentication = makeAuth();
+    sandbox.stub(axios, 'post').resolves({ status: 200, data: { valid: false } });
+
+    const result = await authentication.confirmEmailChange('b'.repeat(32));
+
+    expect(result).toEqual({ valid: false });
+  });
+
+  it('throws when given an empty token', async () => {
+    let authentication = makeAuth();
+
+    await expect(() => authentication.confirmEmailChange('')).rejects.toBe('no_token_provided');
+  });
+
+  it('throws the HTTP status on a non-2xx response', async () => {
+    let authentication = makeAuth();
+    const error = new axios.AxiosError('Too Many Requests', '429', undefined, undefined, {
+      status: 429,
+      data: {},
+      statusText: 'Too Many Requests',
+      headers: {},
+      config: {} as any,
+    } as any);
+    sandbox.stub(axios, 'post').rejects(error);
+
+    await expect(authentication.confirmEmailChange('c'.repeat(32))).rejects.toBe(429);
+  });
+});
+
+describe('refreshToken', () => {
+  it('returns false without hitting the network when no session is present', async () => {
+    let authentication = makeAuth();
+    const axios_get = sandbox.stub(axios, 'get');
+
+    const result = await authentication.refreshToken();
+
+    expect(result).toBe(false);
+    expect(axios_get.called).toBe(false);
+  });
+
+  it('fetches a fresh token and stores it when a session is present', async () => {
+    let authentication = makeAuth();
+    authentication.localStore.setItem('jwt', fake_jwt);
+    const set_token = sandbox.stub(authentication, '_set_token');
+    const axios_get = sandbox.stub(axios, 'get');
+    axios_get.resolves({ status: 200, data: fake_jwt });
+
+    const result = await authentication.refreshToken();
+
+    expect(result).toBe(true);
+    expect(axios_get.calledOnceWith('/api/auth/v1/token')).toBe(true);
+    expect(set_token.calledOnceWith(fake_jwt)).toBe(true);
+  });
+
+  it('returns false (non-fatal) when the refresh request fails', async () => {
+    let authentication = makeAuth();
+    authentication.localStore.setItem('jwt', fake_jwt);
+    sandbox.stub(authentication, '_set_token');
+    sandbox.stub(axios, 'get').rejects({ response: { status: 401 } });
+
+    const result = await authentication.refreshToken();
+
+    expect(result).toBe(false);
   });
 });

--- a/src/server/accounts/test/integration/email-normalization-integration.test.ts
+++ b/src/server/accounts/test/integration/email-normalization-integration.test.ts
@@ -16,7 +16,6 @@ import AccountsInterface from '@/server/accounts/interface';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
 import EmailInterface from '@/server/email/interface';
-import { EmailAlreadyExistsError } from '@/server/authentication/exceptions';
 import { AccountAlreadyExistsError, AccountInviteAlreadyExistsError } from '@/server/accounts/exceptions';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 import { initI18Next } from '@/server/common/test/lib/i18next';
@@ -106,29 +105,48 @@ describe('Email normalization (integration, real SQLite DB)', () => {
     });
   });
 
-  describe('changeEmail', () => {
-    it('treats a change to a case-variant of an existing address as taken', async () => {
+  describe('email change (two-step confirm-by-token)', () => {
+    it('recognizes a case-variant of an existing address as taken and stores no pending change', async () => {
       await accountService._setupAccount('victim@x.com');
       const moverInfo = await accountService._setupAccount('user@x.com');
 
       // Password verification is exercised elsewhere; isolate the taken-check.
       sandbox.stub(authService, 'checkPassword').resolves(true);
 
-      await expect(authService.changeEmail(moverInfo.account, 'VICTIM@x.com', 'pw')).rejects
-        .toThrow(EmailAlreadyExistsError);
+      // The taken path returns the same uniform (void) response as the available
+      // path — it never throws (anti-enumeration). The normalization contract is
+      // what's under test: `VICTIM@x.com` must collapse to the existing
+      // `victim@x.com` row so the taken path is taken and nothing is stored.
+      await expect(authService.initiateEmailChange(moverInfo.account, 'VICTIM@x.com', 'pw'))
+        .resolves.toBeUndefined();
 
-      // The mover's address is unchanged and no row was added.
+      // No pending change was written for the mover, and no row was added.
+      const secret = await AccountSecretsEntity.findByPk(moverInfo.account.id);
+      expect(secret?.email_change_new_email ?? null).toBeNull();
+      expect(secret?.email_change_code ?? null).toBeNull();
+
+      // The mover's address is unchanged.
       const mover = await AccountEntity.findByPk(moverInfo.account.id);
       expect(mover!.email).toBe('user@x.com');
       expect(await countAccounts()).toBe(2);
     });
 
-    it('persists a normalized email on a successful change', async () => {
+    it('persists a normalized email after the change is confirmed', async () => {
       const moverInfo = await accountService._setupAccount('user@x.com');
       sandbox.stub(authService, 'checkPassword').resolves(true);
 
-      const updated = await authService.changeEmail(moverInfo.account, 'New@X.COM', 'pw');
-      expect(updated.email).toBe('new@x.com');
+      // Initiate stores a pending, normalized address plus a confirmation token;
+      // it does not write the new address to the account yet.
+      await authService.initiateEmailChange(moverInfo.account, 'New@X.COM', 'pw');
+
+      const pending = await AccountSecretsEntity.findByPk(moverInfo.account.id);
+      expect(pending!.email_change_new_email).toBe('new@x.com');
+      const beforeConfirm = await AccountEntity.findByPk(moverInfo.account.id);
+      expect(beforeConfirm!.email).toBe('user@x.com');
+
+      // Confirming the token commits the normalized address.
+      const committed = await authService.confirmEmailChange(pending!.email_change_code!);
+      expect(committed).toBe(true);
 
       const stored = await AccountEntity.findByPk(moverInfo.account.id);
       expect(stored!.email).toBe('new@x.com');

--- a/src/server/authentication/api/v1/auth.ts
+++ b/src/server/authentication/api/v1/auth.ts
@@ -6,7 +6,7 @@ import { validatePassword } from '@/common/validation/password';
 import ExpressHelper from '@/server/common/helper/express';
 import { noAccountExistsError } from '@/server/accounts/exceptions';
 import AccountsInterface from '@/server/accounts/interface';
-import { EmailAlreadyExistsError, InvalidPasswordError } from '@/server/authentication/exceptions';
+import { InvalidPasswordError } from '@/server/authentication/exceptions';
 import AuthenticationInterface from '@/server/authentication/interface';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
@@ -19,6 +19,8 @@ import {
   limitLoginByIp,
   limitLoginByEmail,
   limitEmailChangeByAccount,
+  limitEmailChangeByDestination,
+  limitConfirmEmailChangeByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 export default class AuthenticationRouteHandlers {
@@ -38,7 +40,15 @@ export default class AuthenticationRouteHandlers {
     router.get('/reset-password/:code', this.checkPasswordResetCode.bind(this) );
     router.post('/reset-password', limitPasswordResetByIp, limitPasswordResetByEmail, this.generatePasswordResetCode.bind(this) );
     router.post('/reset-password/:code', limitConfirmPasswordResetByIp, this.setPassword.bind(this) );
-    router.post('/email', ...ExpressHelper.loggedInOnly, limitEmailChangeByAccount, this.changeEmail.bind(this) );
+    // CRITICAL: the confirm route is registered BEFORE `/email` so the static
+    // `confirm` segment can never be shadowed by a future `/email/:param` or
+    // `/email/*` wildcard (Express matches in registration order; mirrors the
+    // applications.ts confirm/:token discipline). This endpoint is anonymous:
+    // the URL-path token IS the bearer credential, so no session middleware and
+    // no CSRF token are applied — either would break the email-link flow. Only
+    // an IP limiter guards it (epic pv-91a3).
+    router.post('/email/confirm/:token', limitConfirmEmailChangeByIp, this.confirmEmailChange.bind(this) );
+    router.post('/email', ...ExpressHelper.loggedInOnly, limitEmailChangeByAccount, limitEmailChangeByDestination, this.changeEmail.bind(this) );
     app.use(routePrefix, router);
   }
 
@@ -144,20 +154,49 @@ export default class AuthenticationRouteHandlers {
     }
 
     try {
-      await this.service.changeEmail(req.user as Account, email, password);
+      // initiateEmailChange NEVER throws EmailAlreadyExistsError: the available,
+      // taken, and no-op outcomes all resolve to the same uniform 200
+      // {success:true} below, so the response carries no signal about which
+      // emails are already registered. This closes the 409-vs-200 enumeration
+      // oracle the old synchronous changeEmail exposed (epic pv-91a3, DEC-004).
+      await this.service.initiateEmailChange(req.user as Account, email, password);
       res.json({ success: true });
     }
     catch (error) {
-      if (error instanceof EmailAlreadyExistsError) {
-        res.status(409).json({ error: 'email_exists', errorName: 'EmailAlreadyExistsError' });
-      }
-      else if (error instanceof InvalidPasswordError) {
+      // InvalidPasswordError is the only retained throw: the caller is probing
+      // with their OWN password, so a password-validity signal leaks no email
+      // existence (epic pv-91a3, out-of-scope OQ2).
+      if (error instanceof InvalidPasswordError) {
         res.status(401).json({ error: 'invalid_password', errorName: 'InvalidPasswordError' });
       }
       else {
         logError(error, 'Error changing email');
         res.status(500).json({ error: 'server_error', errorName: 'UnknownError' });
       }
+    }
+  }
+
+  /**
+   * POST /api/auth/v1/email/confirm/:token
+   * Anonymous endpoint that consumes an email-change confirmation token and
+   * commits the pending address. The path token IS the bearer credential, so
+   * the route carries no session and no CSRF guard. Every terminal failure
+   * (bad format / unknown / expired / already-consumed / address-now-taken /
+   * DB error) collapses to a single uniform `{ valid: false }` (HTTP 200) so a
+   * caller cannot distinguish them — the address-now-taken branch is explicitly
+   * indistinguishable from token-expiry (anti-enumeration; epic pv-91a3,
+   * DEC-004). The collapse lives in the service (confirmEmailChange returns a
+   * boolean) to avoid a handler catch block that would enumerate the error set;
+   * tokens are never logged. Mirrors accounts/api/v1/applications.ts
+   * consumeConfirmationToken.
+   */
+  async confirmEmailChange(req: Request, res: Response) {
+    const success = await this.service.confirmEmailChange(req.params.token);
+    if (success) {
+      res.json({ success: true });
+    }
+    else {
+      res.json({ valid: false });
     }
   }
 }

--- a/src/server/authentication/interface/index.ts
+++ b/src/server/authentication/interface/index.ts
@@ -40,7 +40,11 @@ export default class AuthenticationInterface {
     return this.authenticationService.resetPassword(code, password);
   }
 
-  async changeEmail(account: Account, newEmail: string, password: string): Promise<Account> {
-    return this.authenticationService.changeEmail(account, newEmail, password);
+  async initiateEmailChange(account: Account, newEmail: string, password: string): Promise<void> {
+    return this.authenticationService.initiateEmailChange(account, newEmail, password);
+  }
+
+  async confirmEmailChange(token: string): Promise<boolean> {
+    return this.authenticationService.confirmEmailChange(token);
   }
 }

--- a/src/server/authentication/model/email_change_confirmation_email.ts
+++ b/src/server/authentication/model/email_change_confirmation_email.ts
@@ -1,0 +1,43 @@
+import config from 'config';
+import { Account } from '@/common/model/account';
+import { MailData } from '@/server/email/model/types';
+import { EmailMessage, compileTemplate } from '@/server/email/model/message';
+
+const textTemplate = compileTemplate('src/server/authentication', 'email_change_confirmation_email.text.hbs');
+const htmlTemplate = compileTemplate('src/server/authentication', 'email_change_confirmation_email.html.hbs');
+
+export default class EmailChangeConfirmationEmail extends EmailMessage {
+  account: Account;
+  newEmail: string;
+  token: string;
+
+  constructor(account: Account, newEmail: string, token: string) {
+    super('email_change_confirmation_email', textTemplate, htmlTemplate);
+    this.account = account;
+    this.newEmail = newEmail;
+    this.token = token;
+  }
+
+  buildMessage(language: string): MailData {
+    // confirmUrl is the base path; the templates append `/{{token}}` so the
+    // emitted link is `<domain>/auth/email/confirm/<token>` — the path-param
+    // form that matches the API route POST /api/auth/v1/email/confirm/:token
+    // and the client confirm route /auth/email/confirm/:token (epic pv-91a3,
+    // :token is the forward standard). Do NOT switch this back to `?code=`
+    // without realigning the route and the client page.
+    return {
+      emailAddress: this.newEmail,
+      subject: this.renderSubject(language,{}),
+      textMessage: this.renderPlaintext(language, {
+        token: this.token,
+        language: language,
+        confirmUrl: config.get('domain') + '/auth/email/confirm',
+      }),
+      htmlMessage: this.renderHtml(language, {
+        token: this.token,
+        language: language,
+        confirmUrl: config.get('domain') + '/auth/email/confirm',
+      }),
+    };
+  }
+}

--- a/src/server/authentication/service/auth.ts
+++ b/src/server/authentication/service/auth.ts
@@ -1,14 +1,19 @@
-import { scryptSync } from 'crypto';
+import { randomBytes, scryptSync } from 'crypto';
 import { DateTime } from 'luxon';
 
 import { Account } from "@/common/model/account";
 import { AccountEntity, AccountSecretsEntity } from "@/server/common/entity/account";
 import { noAccountExistsError } from '@/server/accounts/exceptions';
 import { normalizeEmail } from '@/common/validation/email';
-import { EmailAlreadyExistsError, InvalidPasswordError } from '@/server/authentication/exceptions';
+import { InvalidPasswordError } from '@/server/authentication/exceptions';
+import { logError } from '@/server/common/helper/error-logger';
 import EmailInterface from '@/server/email/interface';
 import PasswordResetEmail from '@/server/authentication/model/password_reset_email';
+import EmailChangeConfirmationEmail from '@/server/authentication/model/email_change_confirmation_email';
 import AccountsInterface from '@/server/accounts/interface';
+
+/** Confirmation tokens are 16 random bytes rendered as lowercase hex. */
+const EMAIL_CHANGE_TOKEN_PATTERN = /^[0-9a-f]{32}$/;
 
 /**
  * Service class for managing accounts
@@ -24,47 +29,143 @@ export default class AuthenticationService {
   ) {}
 
   /**
-   * Changes the email address for an account after verifying the password
+   * Begins a two-step email change after verifying the caller's password.
    *
-   * @param {Account} account - The account to change email for
-   * @param {string} newEmail - The new email address
+   * The immediate response is uniform across every outcome (available, taken,
+   * no-op) so it carries no information about which emails are already
+   * registered — closing the differential-response enumeration oracle that the
+   * old synchronous changeEmail exposed via its 409-vs-200 split (epic pv-91a3,
+   * DEC-004 anti-enumeration). The new address is never written here; it is
+   * stored pending and committed only when a token sent to that address is
+   * consumed via {@link confirmEmailChange}.
+   *
+   * @param {Account} account - The authenticated account requesting the change
+   * @param {string} newEmail - The new email address (normalized to lowercase)
    * @param {string} password - The current password for verification
-   * @returns {Promise<Account>} The updated account
-   * @throws {InvalidPasswordError} If the provided password is incorrect
-   * @throws {EmailAlreadyExistsError} If the new email is already in use by another account
+   * @returns {Promise<void>}
+   * @throws {InvalidPasswordError} If the provided password is incorrect. This
+   *   is the ONLY throw retained: the caller is probing with their own
+   *   password, so a password-validity signal leaks no email existence
+   *   (epic pv-91a3, out-of-scope OQ2). EmailAlreadyExistsError is NEVER thrown
+   *   from this path.
    */
-  async changeEmail(account: Account, newEmail: string, password: string): Promise<Account> {
-    // Verify the password first
+  async initiateEmailChange(account: Account, newEmail: string, password: string): Promise<void> {
+    // Verify the password first.
     const passwordValid = await this.checkPassword(account, password);
     if (!passwordValid) {
       throw new InvalidPasswordError();
     }
 
-    // Normalize the email address for case-insensitive comparison
+    // Normalize the email address for case-insensitive comparison.
     const normalizedNewEmail = normalizeEmail(newEmail);
 
-    // If the new email is the same as current (case-insensitive), just return the account
+    // No-op if the new email matches the current one. Returns the same uniform
+    // (void) response as the available/taken paths.
     if (normalizeEmail(account.email) === normalizedNewEmail) {
-      return account;
+      return;
     }
 
-    // Check if email is already in use by another account
+    // Availability check. If the address is taken by another account, write
+    // nothing and send nothing — the response is identical to the available
+    // path, so the requester cannot distinguish the two (anti-enumeration).
     const existingAccount = await this.accountService.getAccountByEmail(normalizedNewEmail);
     if (existingAccount && existingAccount.id !== account.id) {
-      throw new EmailAlreadyExistsError();
+      return;
     }
 
-    // Update the email in the database
-    const accountEntity = await AccountEntity.findByPk(account.id);
-    if (accountEntity) {
-      accountEntity.email = normalizedNewEmail;
-      await accountEntity.save();
+    // Available: stash a pending change on the secrets sidecar (mirrors the
+    // password_reset_* lifecycle) and send a confirmation link to the NEW
+    // address. The address is not written to AccountEntity until confirm.
+    let secret = await AccountSecretsEntity.findByPk(account.id);
+    if (!secret) {
+      secret = AccountSecretsEntity.build({ id: account.id });
+    }
+    secret.email_change_code = randomBytes(16).toString('hex');
+    secret.email_change_expiration = DateTime.now().plus({ hours: 1 }).toJSDate();
+    secret.email_change_new_email = normalizedNewEmail;
+    await secret.save();
 
-      // Return the updated account
-      return await this.accountService.getAccountById(account.id) as Account;
+    const message = new EmailChangeConfirmationEmail(account, normalizedNewEmail, secret.email_change_code);
+    await this.emailInterface.sendEmail(message.buildMessage(account.language));
+  }
+
+  /**
+   * Consumes an email-change confirmation token and commits the pending
+   * address.
+   *
+   * Returns a boolean rather than throwing BY DESIGN: every terminal failure
+   * (bad token format, unknown token, expired, address-now-taken) collapses to
+   * the same `false` so a caller cannot distinguish them. Keeping the collapse
+   * in the service avoids a handler catch block that would re-expand the error
+   * set (anti-enumeration; mirrors accounts' consumeConfirmationToken). Tokens
+   * and the pending address are NEVER logged, including on the error path
+   * (DEC-004).
+   *
+   * @param {string} token - The confirmation token from the email link
+   * @returns {Promise<boolean>} true once the pending address is committed;
+   *   false on any terminal failure state
+   */
+  async confirmEmailChange(token: string): Promise<boolean> {
+    // Validate the token shape before touching the database (mirrors the
+    // reset-password / UUID pre-check). A malformed token has no row to match.
+    if (!EMAIL_CHANGE_TOKEN_PATTERN.test(token)) {
+      return false;
     }
 
-    throw new noAccountExistsError();
+    try {
+      const secret = await AccountSecretsEntity.findOne({
+        where: { email_change_code: token },
+        include: AccountEntity,
+      });
+
+      // Unknown token: no row to clear, uniform negative.
+      if (!secret || !secret.account) {
+        return false;
+      }
+
+      const pendingEmail = secret.email_change_new_email;
+      const expired = !secret.email_change_expiration
+        || DateTime.now() >= DateTime.fromJSDate(secret.email_change_expiration);
+
+      // Expired: clear the three fields (no retry, no orphaned PII) and fail.
+      if (expired || !pendingEmail) {
+        await this.clearEmailChangeFields(secret);
+        return false;
+      }
+
+      // Re-check the pending address is still available at consume time. If it
+      // was claimed since initiate, clear the fields and fail — explicitly
+      // indistinguishable from token-expiry to the caller.
+      const existingAccount = await this.accountService.getAccountByEmail(pendingEmail);
+      if (existingAccount && existingAccount.id !== secret.account.id) {
+        await this.clearEmailChangeFields(secret);
+        return false;
+      }
+
+      // Commit: write the pending address to the account and clear the fields.
+      secret.account.email = pendingEmail;
+      await secret.account.save();
+      await this.clearEmailChangeFields(secret);
+      return true;
+    }
+    catch (error) {
+      // A transient failure must not produce a distinguishable result. Collapse
+      // to the uniform negative. The token and pending address are never
+      // included in the log (DEC-004).
+      logError(error, 'Error confirming email change');
+      return false;
+    }
+  }
+
+  /**
+   * Clears the pending email-change fields on a secrets row. Used on every
+   * terminal failure and on success so no orphaned token or PII is left behind.
+   */
+  private async clearEmailChangeFields(secret: AccountSecretsEntity): Promise<void> {
+    secret.email_change_code = null;
+    secret.email_change_expiration = null;
+    secret.email_change_new_email = null;
+    await secret.save();
   }
 
   /**

--- a/src/server/authentication/templates/email_change_confirmation_email.html.hbs
+++ b/src/server/authentication/templates/email_change_confirmation_email.html.hbs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{t 'title'}}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #4A90E2;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+            margin: 20px 0;
+        }
+        .footer {
+            margin-top: 30px;
+            font-size: 12px;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>{{t 'title'}}</h1>
+        <p>{{t 'greeting'}}</p>
+        <p>{{t 'instructions'}}</p>
+
+        <p><a href="{{confirmUrl}}/{{token}}" class="button">{{t 'button'}}</a></p>
+
+        <p>{{t 'copy_link_text'}} <br>
+        {{confirmUrl}}/{{token}}</p>
+
+        <p>{{t 'ignore_message'}}</p>
+
+        <p>{{t 'expiry_notice'}}</p>
+
+        <p>{{t 'signature'}}<br>
+        {{t 'team_name'}}</p>
+
+        <div class="footer">
+            <p>{{t 'footer_text'}}</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/server/authentication/templates/email_change_confirmation_email.text.hbs
+++ b/src/server/authentication/templates/email_change_confirmation_email.text.hbs
@@ -1,0 +1,17 @@
+{{t 'title'}}
+
+{{t 'greeting'}}
+
+{{t 'instructions'}}
+
+{{confirmUrl}}/{{token}}
+
+{{t 'ignore_message'}}
+
+{{t 'expiry_notice'}}
+
+{{t 'signature'}}
+{{t 'team_name'}}
+
+----
+{{t 'footer_text'}}

--- a/src/server/authentication/test/auth_service.test.ts
+++ b/src/server/authentication/test/auth_service.test.ts
@@ -5,10 +5,15 @@ import { DateTime } from 'luxon';
 import { Account } from '@/common/model/account';
 import { AccountEntity, AccountSecretsEntity } from '@/server/common/entity/account';
 import AuthenticationService from '@/server/authentication/service/auth';
+import { InvalidPasswordError } from '@/server/authentication/exceptions';
+import EmailInterface from '@/server/email/interface';
 import AccountsDomain from '@/server/accounts';
 import { EventEmitter } from 'events';
 import ConfigurationDomain from '@/server/configuration';
 import SetupDomain from '@/server/setup';
+import { initI18Next } from '@/server/common/test/lib/i18next';
+
+initI18Next();
 
 
 describe( 'checkPassword', async () => {
@@ -131,5 +136,217 @@ describe('resetPassword', async () => {
     }
     expect(secrets.password_reset_code).toBe('');
     expect(secrets.password_reset_expiration).toBe(null);
+  });
+});
+
+describe('initiateEmailChange', async () => {
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+  let service: AuthenticationService;
+  let accountDomain: AccountsDomain;
+  let emailInterface: EmailInterface;
+  let sendEmailStub: sinon.SinonStub;
+
+  beforeEach( () => {
+    const eventBus = new EventEmitter();
+    const configurationDomain = new ConfigurationDomain(eventBus);
+    const setupDomain = new SetupDomain();
+    accountDomain = new AccountsDomain(eventBus, configurationDomain.interface, setupDomain.interface);
+    emailInterface = new EmailInterface();
+    sendEmailStub = sandbox.stub(emailInterface, 'sendEmail').resolves(null);
+    service = new AuthenticationService(eventBus, accountDomain.interface, emailInterface);
+    // checkPassword succeeds by default; specific tests override.
+    sandbox.stub(service, 'checkPassword').resolves(true);
+  });
+
+  afterEach( () => {
+    sandbox.restore();
+  });
+
+  it('should store pending change and send one email to the new address when available', async () => {
+    const account = new Account('1234', 'testme', 'old@example.com');
+    const accountEntity = AccountEntity.build({ id: '1234', username: 'testme', email: 'old@example.com' });
+    const secrets = AccountSecretsEntity.build({ id: '1234' });
+
+    sandbox.stub(accountDomain.interface, 'getAccountByEmail').resolves(undefined);
+    sandbox.stub(AccountSecretsEntity, 'findByPk').resolves(secrets);
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+    const accountSaveStub = sandbox.stub(AccountEntity.prototype, 'save').resolves();
+
+    await service.initiateEmailChange(account, 'New@Example.com', 'password');
+
+    // Pending fields written on the secrets sidecar.
+    expect(secretSaveStub.called).toBe(true);
+    expect(secrets.email_change_code).toMatch(/^[0-9a-f]{32}$/);
+    expect(secrets.email_change_new_email).toBe('new@example.com');
+    expect(secrets.email_change_expiration).not.toBe(null);
+
+    // Mailer called exactly once, addressed to the new (normalized) address.
+    expect(sendEmailStub.calledOnce).toBe(true);
+    expect(sendEmailStub.firstCall.args[0].emailAddress).toBe('new@example.com');
+
+    // The account's own email is NOT mutated at initiate time.
+    expect(account.email).toBe('old@example.com');
+    expect(accountEntity.email).toBe('old@example.com');
+    expect(accountSaveStub.called).toBe(false);
+  });
+
+  it('should write nothing and send nothing when the address is taken', async () => {
+    const account = new Account('1234', 'testme', 'old@example.com');
+    const secrets = AccountSecretsEntity.build({ id: '1234' });
+
+    const otherAccount = new Account('9999', 'other', 'new@example.com');
+    sandbox.stub(accountDomain.interface, 'getAccountByEmail').resolves(otherAccount);
+    const findSecretStub = sandbox.stub(AccountSecretsEntity, 'findByPk').resolves(secrets);
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+
+    // Must not throw — uniform with the available path.
+    await expect(service.initiateEmailChange(account, 'new@example.com', 'password')).resolves.toBeUndefined();
+
+    // Nothing written, nothing sent.
+    expect(findSecretStub.called).toBe(false);
+    expect(secretSaveStub.called).toBe(false);
+    expect(secrets.email_change_code).toBe(undefined);
+    expect(sendEmailStub.called).toBe(false);
+    expect(account.email).toBe('old@example.com');
+  });
+
+  it('should be a no-op when the new email equals the current email', async () => {
+    const account = new Account('1234', 'testme', 'old@example.com');
+    const getByEmailStub = sandbox.stub(accountDomain.interface, 'getAccountByEmail');
+    const findSecretStub = sandbox.stub(AccountSecretsEntity, 'findByPk');
+
+    await expect(service.initiateEmailChange(account, 'OLD@example.com', 'password')).resolves.toBeUndefined();
+
+    expect(getByEmailStub.called).toBe(false);
+    expect(findSecretStub.called).toBe(false);
+    expect(sendEmailStub.called).toBe(false);
+    expect(account.email).toBe('old@example.com');
+  });
+
+  it('should throw InvalidPasswordError when the password is wrong', async () => {
+    (service.checkPassword as sinon.SinonStub).resolves(false);
+    const account = new Account('1234', 'testme', 'old@example.com');
+
+    await expect(service.initiateEmailChange(account, 'new@example.com', 'wrong'))
+      .rejects.toBeInstanceOf(InvalidPasswordError);
+    expect(sendEmailStub.called).toBe(false);
+  });
+});
+
+describe('confirmEmailChange', async () => {
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+  let service: AuthenticationService;
+  let accountDomain: AccountsDomain;
+  const validToken = 'a'.repeat(32);
+
+  beforeEach( () => {
+    const eventBus = new EventEmitter();
+    const configurationDomain = new ConfigurationDomain(eventBus);
+    const setupDomain = new SetupDomain();
+    accountDomain = new AccountsDomain(eventBus, configurationDomain.interface, setupDomain.interface);
+    const emailInterface = new EmailInterface();
+    service = new AuthenticationService(eventBus, accountDomain.interface, emailInterface);
+  });
+
+  afterEach( () => {
+    sandbox.restore();
+  });
+
+  it('should apply the pending address, clear fields, and return true on a valid token', async () => {
+    const accountEntity = AccountEntity.build({ id: '1234', username: 'testme', email: 'old@example.com' });
+    const secrets = AccountSecretsEntity.build({
+      id: '1234',
+      email_change_code: validToken,
+      email_change_expiration: DateTime.now().plus({ minutes: 30 }).toJSDate(),
+      email_change_new_email: 'new@example.com',
+    });
+    secrets.account = accountEntity;
+
+    sandbox.stub(AccountSecretsEntity, 'findOne').resolves(secrets);
+    sandbox.stub(accountDomain.interface, 'getAccountByEmail').resolves(undefined);
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+    const accountSaveStub = sandbox.stub(AccountEntity.prototype, 'save').resolves();
+
+    const result = await service.confirmEmailChange(validToken);
+
+    expect(result).toBe(true);
+    expect(accountEntity.email).toBe('new@example.com');
+    expect(accountSaveStub.called).toBe(true);
+    expect(secretSaveStub.called).toBe(true);
+    expect(secrets.email_change_code).toBe(null);
+    expect(secrets.email_change_expiration).toBe(null);
+    expect(secrets.email_change_new_email).toBe(null);
+  });
+
+  it('should return false, clear fields, and leave email unchanged when the token is expired', async () => {
+    const accountEntity = AccountEntity.build({ id: '1234', username: 'testme', email: 'old@example.com' });
+    const secrets = AccountSecretsEntity.build({
+      id: '1234',
+      email_change_code: validToken,
+      email_change_expiration: DateTime.now().minus({ minutes: 1 }).toJSDate(),
+      email_change_new_email: 'new@example.com',
+    });
+    secrets.account = accountEntity;
+
+    sandbox.stub(AccountSecretsEntity, 'findOne').resolves(secrets);
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+    const accountSaveStub = sandbox.stub(AccountEntity.prototype, 'save').resolves();
+
+    const result = await service.confirmEmailChange(validToken);
+
+    expect(result).toBe(false);
+    expect(accountEntity.email).toBe('old@example.com');
+    expect(accountSaveStub.called).toBe(false);
+    expect(secretSaveStub.called).toBe(true);
+    expect(secrets.email_change_code).toBe(null);
+    expect(secrets.email_change_expiration).toBe(null);
+    expect(secrets.email_change_new_email).toBe(null);
+  });
+
+  it('should return false, clear fields, and leave email unchanged when the address is now taken', async () => {
+    const accountEntity = AccountEntity.build({ id: '1234', username: 'testme', email: 'old@example.com' });
+    const secrets = AccountSecretsEntity.build({
+      id: '1234',
+      email_change_code: validToken,
+      email_change_expiration: DateTime.now().plus({ minutes: 30 }).toJSDate(),
+      email_change_new_email: 'new@example.com',
+    });
+    secrets.account = accountEntity;
+
+    sandbox.stub(AccountSecretsEntity, 'findOne').resolves(secrets);
+    sandbox.stub(accountDomain.interface, 'getAccountByEmail')
+      .resolves(new Account('9999', 'other', 'new@example.com'));
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+    const accountSaveStub = sandbox.stub(AccountEntity.prototype, 'save').resolves();
+
+    const result = await service.confirmEmailChange(validToken);
+
+    expect(result).toBe(false);
+    expect(accountEntity.email).toBe('old@example.com');
+    expect(accountSaveStub.called).toBe(false);
+    expect(secretSaveStub.called).toBe(true);
+    expect(secrets.email_change_code).toBe(null);
+    expect(secrets.email_change_expiration).toBe(null);
+    expect(secrets.email_change_new_email).toBe(null);
+  });
+
+  it('should return false for an unknown token without clearing any row', async () => {
+    const findOneStub = sandbox.stub(AccountSecretsEntity, 'findOne').resolves(undefined);
+    const secretSaveStub = sandbox.stub(AccountSecretsEntity.prototype, 'save').resolves();
+
+    const result = await service.confirmEmailChange(validToken);
+
+    expect(result).toBe(false);
+    expect(findOneStub.calledOnce).toBe(true);
+    expect(secretSaveStub.called).toBe(false);
+  });
+
+  it('should return false for a malformed token without querying the database', async () => {
+    const findOneStub = sandbox.stub(AccountSecretsEntity, 'findOne');
+
+    expect(await service.confirmEmailChange('not-hex')).toBe(false);
+    expect(await service.confirmEmailChange('A'.repeat(32))).toBe(false); // uppercase rejected
+    expect(await service.confirmEmailChange('a'.repeat(31))).toBe(false); // too short
+    expect(findOneStub.called).toBe(false);
   });
 });

--- a/src/server/authentication/test/integration/email_change.test.ts
+++ b/src/server/authentication/test/integration/email_change.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import request from 'supertest';
+import sinon from 'sinon';
+import { EventEmitter } from 'events';
+import { DateTime } from 'luxon';
+import { randomBytes } from 'crypto';
+
+import { AccountEntity, AccountSecretsEntity } from '@/server/common/entity/account';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import EmailInterface from '@/server/email/interface';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+
+/**
+ * Integration tests for the email-change endpoints (epic pv-91a3):
+ *   - POST /api/auth/v1/email (initiate; authenticated)
+ *   - POST /api/auth/v1/email/confirm/:token (confirm; anonymous)
+ *
+ * The governing decision is DEC-004 (privacy-first: no enumeration of
+ * registered accounts). The initiate endpoint MUST be non-differential for an
+ * already-registered target versus a brand-new target — same status, byte-equal
+ * body, and no confirmation email dispatched on the taken path — so an
+ * authenticated caller cannot probe which addresses are registered. The confirm
+ * endpoint collapses every terminal failure to a single uniform
+ * `{ valid: false }` (HTTP 200), mirroring accounts/api/v1/applications.ts
+ * consumeConfirmationToken.
+ *
+ * Bead: pv-91a3.4.2
+ */
+describe('Email change endpoints (integration)', () => {
+  let env: TestEnvironment;
+  let accountService: AccountService;
+
+  const requesterEmail = 'requester@pavillion.dev';
+  const requesterPassword = 'testpassword!1';
+  // A second, already-registered account whose email is the "taken" target.
+  const takenEmail = 'taken@pavillion.dev';
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    const eventBus = new EventEmitter();
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    // First account exits setup mode; both accounts back the initiate tests.
+    await accountService._setupAccount(requesterEmail, requesterPassword);
+    await accountService._setupAccount(takenEmail, 'testpassword!2');
+  });
+
+  afterAll(async () => {
+    if (env) {
+      await env.cleanup();
+    }
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    // Reset any pending email-change state left on the requester's secrets row.
+    const requester = await accountService.getAccountByEmail(requesterEmail);
+    if (requester) {
+      const secret = await AccountSecretsEntity.findByPk(requester.id);
+      if (secret) {
+        secret.email_change_code = null;
+        secret.email_change_expiration = null;
+        secret.email_change_new_email = null;
+        await secret.save();
+      }
+      // Ensure the requester's email was not mutated by a prior test.
+      const entity = await AccountEntity.findByPk(requester.id);
+      if (entity && entity.email !== requesterEmail) {
+        entity.email = requesterEmail;
+        await entity.save();
+      }
+    }
+  });
+
+  /**
+   * REQUIRED non-differential regression test (epic pv-91a3, DEC-004).
+   *
+   * Drives POST /api/auth/v1/email for an already-registered target and a
+   * brand-new target and asserts the responses are indistinguishable:
+   *   (1) identical HTTP status (200) for both,
+   *   (2) byte-equal {success:true} body with no differing keys,
+   *   (3) the mailer is NOT called on the taken path.
+   * If any of these diverge, the 409-vs-200 enumeration oracle the epic closes
+   * would have crept back in.
+   */
+  describe('POST /email is non-differential for taken vs new target (DEC-004)', () => {
+    it('returns identical 200 + byte-equal {success:true} and sends no email on the taken path', async () => {
+      const token = await env.login(requesterEmail, requesterPassword);
+
+      // Taken target: the email belongs to the second registered account.
+      const takenSend = sinon.stub(EmailInterface.prototype, 'sendEmail').resolves(null);
+      const takenResponse = await env.authPost(token, '/api/auth/v1/email', {
+        email: takenEmail,
+        password: requesterPassword,
+      });
+      const takenMailerCalled = takenSend.called;
+      const takenStatus = takenResponse.status;
+      const takenRawBody = JSON.stringify(takenResponse.body);
+      sinon.restore();
+
+      // New target: an address that belongs to no account.
+      const newSend = sinon.stub(EmailInterface.prototype, 'sendEmail').resolves(null);
+      const newResponse = await env.authPost(token, '/api/auth/v1/email', {
+        email: 'brand-new-target@pavillion.dev',
+        password: requesterPassword,
+      });
+
+      // (1) Identical status.
+      expect(takenStatus).toBe(200);
+      expect(newResponse.status).toBe(200);
+
+      // (2) Byte-equal body with no differing keys.
+      expect(takenRawBody).toBe(JSON.stringify(newResponse.body));
+      expect(takenResponse.body).toEqual({ success: true });
+      expect(newResponse.body).toEqual({ success: true });
+
+      // (3) No email dispatched on the taken path; the available path does send.
+      expect(takenMailerCalled).toBe(false);
+      expect(newSend.calledOnce).toBe(true);
+      expect(newSend.firstCall.args[0].emailAddress).toBe('brand-new-target@pavillion.dev');
+    });
+
+    it('returns 401 InvalidPasswordError when the password is wrong (out of scope: own-password probe)', async () => {
+      const token = await env.login(requesterEmail, requesterPassword);
+      sinon.stub(EmailInterface.prototype, 'sendEmail').resolves(null);
+
+      const response = await env.authPost(token, '/api/auth/v1/email', {
+        email: 'whatever@pavillion.dev',
+        password: 'wrong-password',
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.body.errorName).toBe('InvalidPasswordError');
+    });
+
+    it('returns 400 when email or password is missing', async () => {
+      const token = await env.login(requesterEmail, requesterPassword);
+
+      const response = await env.authPost(token, '/api/auth/v1/email', { email: 'only-email@pavillion.dev' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+    });
+  });
+
+  describe('POST /email/confirm/:token', () => {
+    /** Seed a pending email change on the requester's secrets row. */
+    async function seedPendingChange(overrides: Partial<{
+      token: string;
+      expiresAt: Date;
+      newEmail: string;
+    }> = {}): Promise<string> {
+      const requester = await accountService.getAccountByEmail(requesterEmail);
+      if (!requester) {
+        throw new Error('requester account not found');
+      }
+      const token = overrides.token ?? randomBytes(16).toString('hex');
+      const secret = await AccountSecretsEntity.findByPk(requester.id);
+      if (!secret) {
+        throw new Error('requester secrets row not found');
+      }
+      secret.email_change_code = token;
+      secret.email_change_expiration = overrides.expiresAt ?? DateTime.now().plus({ hours: 1 }).toJSDate();
+      secret.email_change_new_email = overrides.newEmail ?? 'confirmed-target@pavillion.dev';
+      await secret.save();
+      return token;
+    }
+
+    it('happy path: a valid token commits the pending address and returns {success:true}', async () => {
+      const token = await seedPendingChange({ newEmail: 'confirmed-target@pavillion.dev' });
+
+      const response = await request(env.app).post(`/api/auth/v1/email/confirm/${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ success: true });
+
+      // The account's email is now the confirmed address and the fields cleared.
+      const updated = await accountService.getAccountByEmail('confirmed-target@pavillion.dev');
+      expect(updated).toBeDefined();
+      const secret = await AccountSecretsEntity.findByPk(updated!.id);
+      expect(secret!.email_change_code).toBeNull();
+      expect(secret!.email_change_expiration).toBeNull();
+      expect(secret!.email_change_new_email).toBeNull();
+
+      // Restore the requester email so afterEach/other tests see a clean state.
+      const entity = await AccountEntity.findByPk(updated!.id);
+      entity!.email = requesterEmail;
+      await entity!.save();
+    });
+
+    it('unknown token: collapses to 200 {valid:false}', async () => {
+      // Well-formed (32-hex) but matches no row.
+      const response = await request(env.app).post(`/api/auth/v1/email/confirm/${randomBytes(16).toString('hex')}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ valid: false });
+    });
+
+    it('expired token: collapses to 200 {valid:false}', async () => {
+      const token = await seedPendingChange({ expiresAt: DateTime.now().minus({ hours: 1 }).toJSDate() });
+
+      const response = await request(env.app).post(`/api/auth/v1/email/confirm/${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ valid: false });
+    });
+
+    it('malformed token (not 32-hex): collapses to 200 {valid:false} with NO DB query', async () => {
+      // The service validates the token shape before touching the database, so
+      // a malformed token must short-circuit before any AccountSecretsEntity
+      // lookup (anti-enumeration; no timing/DB signal).
+      const findOneSpy = sinon.spy(AccountSecretsEntity, 'findOne');
+      const findByPkSpy = sinon.spy(AccountSecretsEntity, 'findByPk');
+
+      const response = await request(env.app).post('/api/auth/v1/email/confirm/not-a-valid-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ valid: false });
+      expect(findOneSpy.called).toBe(false);
+      expect(findByPkSpy.called).toBe(false);
+    });
+
+    it('anonymous: confirm sets no Set-Cookie header', async () => {
+      const token = await seedPendingChange();
+
+      const response = await request(env.app).post(`/api/auth/v1/email/confirm/${token}`);
+
+      expect(response.headers['set-cookie']).toBeUndefined();
+    });
+
+    it('route ordering: confirm path is not shadowed by /email', async () => {
+      // /email is authenticated (loggedInOnly) and would reject an anonymous
+      // POST. A 200 with the anti-enumeration body proves the confirm route
+      // matched first.
+      const response = await request(env.app).post(`/api/auth/v1/email/confirm/${randomBytes(16).toString('hex')}`);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ valid: false });
+    });
+  });
+});

--- a/src/server/common/entity/account.ts
+++ b/src/server/common/entity/account.ts
@@ -138,6 +138,15 @@ class AccountSecretsEntity extends Model {
   @Column({ type: DataType.DATE })
   declare password_reset_expiration: Date | null;
 
+  @Column({ type: DataType.STRING })
+  declare email_change_code: string | null;
+
+  @Column({ type: DataType.DATE })
+  declare email_change_expiration: Date | null;
+
+  @Column({ type: DataType.STRING })
+  declare email_change_new_email: string | null;
+
   @BelongsTo(() => AccountEntity)
   declare account: AccountEntity;
 };

--- a/src/server/common/middleware/rate-limiters.ts
+++ b/src/server/common/middleware/rate-limiters.ts
@@ -409,3 +409,55 @@ export const limitEmailChangeByAccount: RequestHandler = isRateLimitEnabled()
     'email-change',
   )
   : noOpMiddleware;
+
+/**
+ * Email-change rate limiter by destination (candidate) address.
+ *
+ * Sits alongside limitEmailChangeByAccount on POST /api/auth/v1/email. Keyed on
+ * the requester-supplied destination email (req.body.email) across ALL accounts,
+ * it caps how often any single address can be targeted as a pending email-change
+ * recipient — the email-bombing defense (epic pv-91a3): a multi-account attacker
+ * cannot flood a victim address with confirmation emails, because the per-address
+ * window is shared regardless of which account initiates.
+ *
+ * Cannot become an enumeration oracle: the key is the attacker-supplied address,
+ * so a 429 only tells the requester they hit their own cap on an address they
+ * chose — it reveals nothing about whether that address maps to an account.
+ *
+ * Keyed on the NORMALIZED destination (trim + lowercase), mirroring the
+ * normalization initiateEmailChange applies before using the address
+ * (src/server/authentication/service/auth.ts). Without this, an attacker could
+ * split the per-address counter with case/whitespace variants (Victim@x.com vs
+ * victim@x.com) and bomb the same mailbox past the cap. Normalization happens in
+ * createCredentialRateLimiter's keyGenerator, so every credential limiter
+ * (including this one) shares one bucket across case/whitespace variants. Uses
+ * the same credential factory and 'email' field as limitRegisterByEmail.
+ *
+ * Limits: 2 requests per destination address per 24 hours (default config).
+ */
+export const limitEmailChangeByDestination: RequestHandler = isRateLimitEnabled()
+  ? createCredentialRateLimiter(
+    config.get<number>('rateLimit.emailChange.byDestination.max'),
+    config.get<number>('rateLimit.emailChange.byDestination.windowMs'),
+    'email-change',
+    'email',
+  )
+  : noOpMiddleware;
+
+/**
+ * Email-change confirmation rate limiter by IP address.
+ *
+ * Caps token-redemption attempts against POST /api/auth/v1/email/confirm/:token
+ * to defend against brute-force guessing of email-change codes. Mirrors
+ * limitConfirmPasswordResetByIp: the confirmation code is a randomBytes(16)
+ * CSPRNG token, so this is an abuse cap rather than a guessing wall.
+ *
+ * Limits: 20 requests per IP per 15 minutes (default config).
+ */
+export const limitConfirmEmailChangeByIp: RequestHandler = isRateLimitEnabled()
+  ? createIpRateLimiter(
+    config.get<number>('rateLimit.emailChange.confirm.byIp.max'),
+    config.get<number>('rateLimit.emailChange.confirm.byIp.windowMs'),
+    'email-change-confirm',
+  )
+  : noOpMiddleware;

--- a/src/server/common/test/middleware/rate-limiters.test.ts
+++ b/src/server/common/test/middleware/rate-limiters.test.ts
@@ -3,6 +3,7 @@ import config from 'config';
 import express, { Express } from 'express';
 import request from 'supertest';
 import { addRequestUser } from '@/server/common/test/lib/express';
+import { createCredentialRateLimiter } from '@/server/common/middleware/rate-limit-by-credential';
 import {
   limitPasswordResetByIp,
   limitPasswordResetByEmail,
@@ -17,6 +18,8 @@ import {
   limitApplicationByIp,
   limitApplicationByEmail,
   limitConfirmApplicationByIp,
+  limitEmailChangeByDestination,
+  limitConfirmEmailChangeByIp,
 } from '@/server/common/middleware/rate-limiters';
 
 describe('rate-limiters', () => {
@@ -125,6 +128,22 @@ describe('rate-limiters', () => {
       expect(windowMs).toBe(900000); // 15 minutes
     });
 
+    it('should use correct config values for email change by destination', () => {
+      const maxRequests = config.get<number>('rateLimit.emailChange.byDestination.max');
+      const windowMs = config.get<number>('rateLimit.emailChange.byDestination.windowMs');
+
+      expect(maxRequests).toBe(2);
+      expect(windowMs).toBe(86400000); // 24 hours
+    });
+
+    it('should use correct config values for email change confirm by IP', () => {
+      const maxRequests = config.get<number>('rateLimit.emailChange.confirm.byIp.max');
+      const windowMs = config.get<number>('rateLimit.emailChange.confirm.byIp.windowMs');
+
+      expect(maxRequests).toBe(20);
+      expect(windowMs).toBe(900000); // 15 minutes
+    });
+
     it('should check if rate limiting is enabled in config', () => {
       const enabled = config.get<boolean>('rateLimit.enabled');
       // In test environment, rate limiting is disabled
@@ -196,6 +215,16 @@ describe('rate-limiters', () => {
     it('should export limitConfirmApplicationByIp limiter', () => {
       expect(limitConfirmApplicationByIp).toBeDefined();
       expect(typeof limitConfirmApplicationByIp).toBe('function');
+    });
+
+    it('should export limitEmailChangeByDestination limiter', () => {
+      expect(limitEmailChangeByDestination).toBeDefined();
+      expect(typeof limitEmailChangeByDestination).toBe('function');
+    });
+
+    it('should export limitConfirmEmailChangeByIp limiter', () => {
+      expect(limitConfirmEmailChangeByIp).toBeDefined();
+      expect(typeof limitConfirmEmailChangeByIp).toBe('function');
     });
   });
 
@@ -636,6 +665,43 @@ describe('rate-limiters', () => {
       }
     });
 
+    it('should apply limitEmailChangeByDestination limiter to endpoint', async () => {
+      app.post('/email', limitEmailChangeByDestination, (req, res) => {
+        res.json({ success: true });
+      });
+
+      const response = await request(app)
+        .post('/email')
+        .send({ email: 'new@example.com', password: 'pw' });
+
+      expect(response.status).toBe(200);
+
+      if (config.get<boolean>('rateLimit.enabled')) {
+        expect(response.headers['ratelimit-limit']).toBeDefined();
+        expect(response.headers['ratelimit-remaining']).toBeDefined();
+      }
+      else {
+        expect(response.headers['ratelimit-limit']).toBeUndefined();
+      }
+    });
+
+    it('should apply limitConfirmEmailChangeByIp limiter to endpoint', async () => {
+      app.post('/email/confirm', limitConfirmEmailChangeByIp, (req, res) => {
+        res.json({ success: true });
+      });
+
+      const response = await request(app).post('/email/confirm');
+      expect(response.status).toBe(200);
+
+      if (config.get<boolean>('rateLimit.enabled')) {
+        expect(response.headers['ratelimit-limit']).toBeDefined();
+        expect(response.headers['ratelimit-remaining']).toBeDefined();
+      }
+      else {
+        expect(response.headers['ratelimit-limit']).toBeUndefined();
+      }
+    });
+
     it('should allow combining application IP and email limiters', async () => {
       app.post('/apply', limitApplicationByIp, limitApplicationByEmail, (req, res) => {
         res.json({ success: true });
@@ -654,6 +720,56 @@ describe('rate-limiters', () => {
       else {
         expect(response.headers['ratelimit-limit']).toBeUndefined();
       }
+    });
+  });
+
+  // The pre-configured limitEmailChangeByDestination export is a no-op under the
+  // test config (rateLimit.enabled: false), so real counting cannot be driven
+  // through it. To prove the destination limiter keys on the NORMALIZED address,
+  // build a limiter directly from the factory with the email-change endpoint name
+  // and a small max, then drive real requests through it. The factory's
+  // keyGenerator normalizes (trim + lowercase) unconditionally, and counting is
+  // unconditional too — only the export gate is config-dependent — so requests
+  // here are actually counted.
+  //
+  // This is the email-bombing regression guard for pv-91a3: if the limiter
+  // keyed on the RAW body (the pre-fix defect), case-variant requests would
+  // split into separate counters and both succeed, letting an attacker exceed
+  // the per-mailbox cap. With normalized keying they share one counter, so the
+  // second request is rejected.
+  describe('limitEmailChangeByDestination normalization', () => {
+    function appWithDestinationLimiter(max: number): Express {
+      const app = express();
+      app.use(express.json());
+      const limiter = createCredentialRateLimiter(max, 60000, 'email-change', 'email');
+      app.post('/email', limiter, (req, res) => res.json({ success: true }));
+      return app;
+    }
+
+    it('shares one counter across case/whitespace variants of the same address', async () => {
+      const app = appWithDestinationLimiter(1); // allow a single request per key
+
+      const first = await request(app).post('/email').send({ email: 'Victim@Example.com' });
+      const second = await request(app).post('/email').send({ email: '  victim@example.com  ' });
+
+      // First request consumes the only allowed hit on the canonical key.
+      expect(first.status).toBe(200);
+      // Second request is a case/whitespace variant of the SAME mailbox, so it
+      // hits the same counter and is rejected. Pre-fix (raw keying) it would be
+      // a 200, splitting the counter and defeating the cap.
+      expect(second.status).toBe(429);
+      expect(second.body.errorName).toBe('RateLimitError');
+    });
+
+    it('keeps distinct addresses on separate counters', async () => {
+      const app = appWithDestinationLimiter(1);
+
+      const first = await request(app).post('/email').send({ email: 'victim@example.com' });
+      const other = await request(app).post('/email').send({ email: 'someone-else@example.com' });
+
+      // A genuinely different address must not be throttled by the first.
+      expect(first.status).toBe(200);
+      expect(other.status).toBe(200);
     });
   });
 });

--- a/src/server/common/test/rate-limit-coverage.test.ts
+++ b/src/server/common/test/rate-limit-coverage.test.ts
@@ -126,6 +126,8 @@ const HIGH_ABUSE_RISK_ROUTES: { method: string; path: string }[] = [
   { method: 'POST', path: '/api/auth/v1/reset-password/:code' },
   // Email change (credential-probe / enumeration hardening) — account limiter.
   { method: 'POST', path: '/api/auth/v1/email' },
+  // Email change confirm (confirmation-token brute-force surface) — IP limiter.
+  { method: 'POST', path: '/api/auth/v1/email/confirm/:token' },
   // Stripe funding webhook — IP limiter (defense in depth; signature is primary).
   { method: 'POST', path: '/api/funding/webhooks/stripe' },
   // Public moderation report submission — IP + email limiters.

--- a/src/server/locales/en/email_change_confirmation_email.json
+++ b/src/server/locales/en/email_change_confirmation_email.json
@@ -1,0 +1,13 @@
+{
+  "subject": "Confirm Your New Email Address",
+  "title": "Confirm Your New Email Address",
+  "greeting": "Hello,",
+  "instructions": "We received a request to change the email address for your account. To confirm this new email address, please click the link below or copy and paste it into your browser:",
+  "button": "Confirm Email Address",
+  "copy_link_text": "Or copy this link:",
+  "ignore_message": "If you did not request an email address change, you can safely ignore this email.",
+  "expiry_notice": "This confirmation link will expire in 1 hour.",
+  "signature": "Thank you,",
+  "team_name": "The Pavillion Team",
+  "footer_text": "This is an automated message, please do not reply to this email."
+}

--- a/src/server/locales/es/email_change_confirmation_email.json
+++ b/src/server/locales/es/email_change_confirmation_email.json
@@ -1,0 +1,13 @@
+{
+  "subject": "Confirma tu nueva dirección de correo electrónico",
+  "title": "Confirma tu nueva dirección de correo electrónico",
+  "greeting": "Hola,",
+  "instructions": "Hemos recibido una solicitud para cambiar la dirección de correo electrónico de tu cuenta. Para confirmar esta nueva dirección de correo electrónico, haz clic en el enlace que aparece a continuación o cópialo y pégalo en tu navegador:",
+  "button": "Confirmar dirección de correo electrónico",
+  "copy_link_text": "O copia este enlace:",
+  "ignore_message": "Si no solicitaste un cambio de dirección de correo electrónico, puedes ignorar este mensaje de forma segura.",
+  "expiry_notice": "Este enlace de confirmación caducará en 1 hora.",
+  "signature": "Gracias,",
+  "team_name": "El equipo de Pavillion",
+  "footer_text": "Este es un mensaje automático, por favor no respondas a este correo electrónico."
+}

--- a/src/server/locales/fr/email_change_confirmation_email.json
+++ b/src/server/locales/fr/email_change_confirmation_email.json
@@ -1,0 +1,13 @@
+{
+  "subject": "Confirmez votre nouvelle adresse e-mail",
+  "title": "Confirmez votre nouvelle adresse e-mail",
+  "greeting": "Bonjour,",
+  "instructions": "Nous avons reçu une demande de modification de l'adresse e-mail de votre compte. Pour confirmer cette nouvelle adresse e-mail, veuillez cliquer sur le lien ci-dessous ou le copier et le coller dans votre navigateur :",
+  "button": "Confirmer l'adresse e-mail",
+  "copy_link_text": "Ou copiez ce lien :",
+  "ignore_message": "Si vous n'avez pas demandé de modification de votre adresse e-mail, vous pouvez ignorer cet e-mail en toute sécurité.",
+  "expiry_notice": "Ce lien de confirmation expirera dans 1 heure.",
+  "signature": "Merci,",
+  "team_name": "L'équipe Pavillion",
+  "footer_text": "Ceci est un message automatique, veuillez ne pas répondre à cet e-mail."
+}


### PR DESCRIPTION
## Motivation

`POST /api/auth/v1/email` updated the account email synchronously and returned `409 EmailAlreadyExistsError` when the target was already registered, versus `200 {success:true}` when it wasn't. That 409-vs-200 split is a differential-response oracle: an authenticated user who knows their own password could probe which email addresses are registered on the instance. This violates the privacy-first / no-account-enumeration posture and was a tracked residual from a prior red-team finding.

## Approach

Email change is now a two-step confirm-by-token flow, mirroring the existing password-reset, application-confirmation, and invitation patterns — and adding real value by verifying ownership of the new address before committing it.

- **Initiate** (authenticated): verifies the password, normalizes the new address, and returns an identical `200 {success:true}` for the available, taken, and no-op (same-as-current) cases. On *available* it stores a raw token + 1h expiry + pending address on the `account_secrets` sidecar and sends a confirmation email to the **new address only**; on *taken* it writes nothing and sends nothing. `EmailAlreadyExistsError` is no longer thrown from this path (the class is retained for registration). The `400` missing-fields and `401` invalid-password branches are kept — the caller probes with their own password, so that signal leaks no email existence.
- **Confirm** (anonymous, `POST /email/confirm/:token`): validates the `/^[0-9a-f]{32}$/` token format before any DB query, then collapses every terminal failure — bad-format, unknown, expired, address-now-taken, DB error — to a uniform `{valid:false}` 200. On success it writes the new address and clears the three token fields. Fields are cleared on every terminal path so no orphaned pending-email PII or reusable token lingers. Tokens and the pending address are never logged.
- **Abuse limits**: a per-destination limiter (keyed on the normalized attacker-supplied address, so it cannot become an oracle) caps email-bombing a victim across accounts; the confirm route is IP-limited.
- **Frontend**: the settings email modal now tells the user to check their new inbox; a new client SPA page at `/auth/email/confirm/:token` consumes the token, reports a uniform success/invalid state, and refreshes the session JWT on success. The confirmation email and client copy ship in en, es, and fr.
- **Data model**: migration `0038` adds three nullable `email_change_*` columns to `account_secrets` (raw token storage mirroring `password_reset_*`), fully reversible.

The anti-enumeration collapse deliberately lives in the service layer (returning a boolean) so no handler `catch` block can re-expand the error set. The emailed confirmation link uses the path-param `:token` form end-to-end (email → API route → client route).

## Validation

- Full `build-guardian` suite green: `npm run lint` (0 errors), unit, integration, and `npm run build` all pass; migration 0038 applies cleanly on DB reset-and-reseed.
- New tests pass: service unit (initiate/confirm), the required **non-differential regression** integration test (existing-vs-new target → identical 200 status, byte-equal `{success:true}` body, mailer not called on the taken path), confirm-route integration cases (happy path; unknown/expired/malformed → `{valid:false}`, malformed asserts no DB query; no Set-Cookie; route ordering), rate-limiter unit tests (including normalized-key counter-sharing), and client unit/component tests for the service, modal, and confirm page.
- Reviewed across waves for security, privacy (DEC-004), architecture, consistency, testing, i18n, accessibility, and stylesheet, plus an end-to-end security + privacy sweep confirming the oracle is closed across the full initiate → email → confirm → JWT-refresh chain.
- Pre-existing/environmental test failures (import-source unit suite; admin-login and TLS-cert e2e) are unrelated to this change.

Two pre-existing issues were surfaced (not introduced) by this work and are tracked separately for follow-up: the shared email service logs the recipient address (a DEC-004 concern across all email flows), and `getAccountByEmail` is case-sensitive while emails are stored verbatim (a duplicate-by-case integrity risk). Neither affects the oracle closure.