### PR TITLE
fix(email): log recipient domain instead of full address

### DIFF
--- a/src/server/email/service/email.ts
+++ b/src/server/email/service/email.ts
@@ -169,7 +169,11 @@ class EmailServiceClass {
    * @returns Promise resolving to the message info or null if sending failed
    */
   public async sendEmail(data: MailData): Promise<SentMessageInfo | null> {
-    logger.info({ transport: this.transportType, to: data.emailAddress, subject: data.subject }, 'Sending email');
+    // Log only the recipient domain, never the full address: recipient addresses
+    // are PII (DEC-004, privacy-playbook/logging.md). The domain aids ops
+    // diagnostics (e.g. a whole domain bouncing) without identifying an individual.
+    const recipientDomain = data.emailAddress.split('@')[1] ?? 'unknown';
+    logger.info({ transport: this.transportType, recipientDomain, subject: data.subject }, 'Sending email');
     try {
       const info = await this.transportInstance.sendMail({
         from: process.env.MAIL_FROM || this.mailConfig.from,
@@ -183,7 +187,7 @@ class EmailServiceClass {
       return info;
     }
     catch (error) {
-      logError(error, `[Email] Failed to send via ${this.transportType} to=${data.emailAddress}, subject="${data.subject}"`);
+      logError(error, `[Email] Failed to send via ${this.transportType} to domain=${recipientDomain}, subject="${data.subject}"`);
       return null;
     }
   }

--- a/src/server/email/test/email-service.test.ts
+++ b/src/server/email/test/email-service.test.ts
@@ -8,7 +8,49 @@ import sinon from 'sinon';
  * - Transport selection logic (test vs development vs mailpit vs smtp)
  * - EmailService.sendEmail() method with mock transport
  * - MailConfig type validation
+ * - Recipient address never reaches logs (DEC-004, privacy-playbook/logging.md)
  */
+
+// Module-scope mocks so the logger/error-logger seams are stubbed before email.ts
+// captures its module-scoped `logger`/`logError` references. A post-import spy
+// after vi.resetModules() would be disconnected and pass vacuously.
+const mockLoggerInfo = vi.fn();
+const mockLoggerWarn = vi.fn();
+const mockLoggerError = vi.fn();
+const mockLogError = vi.fn();
+
+vi.mock('@/server/common/helper/logger', () => ({
+  createLogger: () => ({
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+  }),
+}));
+
+vi.mock('@/server/common/helper/error-logger', () => ({
+  logError: mockLogError,
+}));
+
+/**
+ * Collects every argument passed to a mocked function across all calls into a
+ * single string, so a test can assert that a substring appears in (or is absent
+ * from) anything the function was ever handed.
+ */
+function flattenCallArgs(mockFn: ReturnType<typeof vi.fn>): string {
+  return mockFn.mock.calls
+    .flat()
+    .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+    .join(' || ');
+}
+
+// Clear logger mock call history before every test so accumulated calls from
+// one describe block can't leak into another's assertions.
+beforeEach(() => {
+  mockLoggerInfo.mockClear();
+  mockLoggerWarn.mockClear();
+  mockLoggerError.mockClear();
+  mockLogError.mockClear();
+});
 
 describe('EmailService Transport Selection', () => {
   let sandbox: sinon.SinonSandbox;
@@ -207,6 +249,69 @@ describe('EmailService.sendEmail', () => {
 
     // Cleanup
     delete process.env.MAIL_FROM;
+  });
+});
+
+describe('EmailService.sendEmail recipient-address log safety', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    vi.resetModules();
+    mockLoggerInfo.mockClear();
+    mockLoggerWarn.mockClear();
+    mockLoggerError.mockClear();
+    mockLogError.mockClear();
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should not log the full recipient address on the pre-send info log, but should log the domain', async () => {
+    // Arrange
+    const { createEmailService } = await import('../service/email');
+    const { EmailStore } = await import('../transport/testing-transport');
+    const service = createEmailService();
+    EmailStore.getInstance().clear();
+
+    // Act
+    await service.sendEmail({
+      emailAddress: 'recipient@example.com',
+      subject: 'Test Subject',
+      textMessage: 'Test content',
+      htmlMessage: '<p>Test content</p>',
+    });
+
+    // Assert: the full address never appears in any logger.info argument,
+    // but the domain does (so the test can't pass by the log being removed/empty).
+    const infoArgs = flattenCallArgs(mockLoggerInfo);
+    expect(infoArgs).not.toContain('recipient@example.com');
+    expect(infoArgs).toContain('example.com');
+  });
+
+  it('should not log the full recipient address on the failure log, but should keep it diagnosable', async () => {
+    // Arrange
+    const { createEmailService } = await import('../service/email');
+    const service = createEmailService();
+
+    const sendMailStub = sandbox.stub(service.transportInstance, 'sendMail');
+    sendMailStub.rejects(new Error('Sending failed'));
+
+    // Act
+    const result = await service.sendEmail({
+      emailAddress: 'recipient@example.com',
+      subject: 'Test Subject',
+      textMessage: 'Test content',
+    });
+
+    // Assert
+    expect(result).toBeNull();
+    const errorArgs = flattenCallArgs(mockLogError);
+    expect(errorArgs).not.toContain('recipient@example.com');
+    expect(errorArgs).toContain('example.com');
+    expect(errorArgs).toContain('Test Subject');
   });
 });
 


### PR DESCRIPTION
## Motivation

The shared `sendEmail()` method in `src/server/email/service/email.ts` logged the full recipient email address in two places — the pre-send `logger.info` "Sending email" line and the failure-path `logError` context. This is shared infrastructure used by every email flow (password reset, application confirmation, invitation, moderation, email-change), so the leak was broad. Recipient addresses are PII; under DEC-004 (privacy-first public access) they must not appear in logs, even on failure. For the email-change flow the recipient is an unconfirmed pending new address, making the exposure especially sensitive.

## Approach

Compute `recipientDomain = data.emailAddress.split('@')[1] ?? 'unknown'` once and log it in place of the full address on both the info and failure lines. The domain alone is not individual PII and preserves operational diagnostics (e.g. spotting a whole recipient domain bouncing). The `?? 'unknown'` guard keeps the failure message accurate if a malformed address with no `@` is ever passed.

The transport `sendMail()` call still uses the real full address — only the log output changed. The success log (messageId only) was already clean and is untouched.

## Validation

- Added two regression tests in `email-service.test.ts`. They mock the logger and error-logger at module scope (before `email.ts` captures its module-scoped references) and assert both the **absence** of the full address and the **presence** of the domain (plus subject on the failure path), so they cannot pass vacuously by the log call being deleted, emptied, or a field misspelled.
- `npx vitest run src/server/email/test/email-service.test.ts`: 16/16 pass.
- `npm run lint`: 0 errors.
- Reviewed by privacy, testing, consistency, and architecture auditors; full unit/integration/build suite verified green for this change (the only suite failures observed were unrelated and pre-existing).