### PR TITLE
fix: harden redactEmail against non-string credential bodies

### DIFF
--- a/src/server/common/helpers/redact-email.ts
+++ b/src/server/common/helpers/redact-email.ts
@@ -1,7 +1,9 @@
 /**
  * Redacts an email address for safe logging while preserving some context.
  *
- * @param email - The email address to redact, or undefined
+ * @param email - The email address to redact. Accepts unknown so forged
+ *   non-string request-body values can be passed safely; any non-string
+ *   input redacts to 'unknown' rather than throwing or leaking its shape.
  * @returns Redacted email in format: first2chars***@domain, or 'unknown' if invalid
  *
  * @example
@@ -9,10 +11,15 @@
  * redactEmail('a@example.com')     // Returns: 'a***@example.com'
  * redactEmail('invalid')           // Returns: 'unknown'
  * redactEmail(undefined)           // Returns: 'unknown'
+ * redactEmail({ x: 1 })            // Returns: 'unknown'
+ * redactEmail(42)                  // Returns: 'unknown'
  */
-export function redactEmail(email: string | undefined): string {
-  // Handle undefined, null, or empty string
-  if (!email || email.trim() === '') {
+export function redactEmail(email: unknown): string {
+  // Reject non-string input (including null/undefined) and empty/whitespace
+  // strings. Guarding on typeof keeps forged non-string credential bodies from
+  // throwing on .trim() and from leaking their shape into logs (e.g. an
+  // array-wrapped address would otherwise coerce back to a real email).
+  if (typeof email !== 'string' || email.trim() === '') {
     return 'unknown';
   }
 

--- a/src/server/common/test/helpers/redact-email.test.ts
+++ b/src/server/common/test/helpers/redact-email.test.ts
@@ -77,6 +77,29 @@ describe('redactEmail', () => {
     });
   });
 
+  describe('non-string values', () => {
+    // Forged request bodies can carry non-string credential values. redactEmail
+    // must redact these to 'unknown' rather than throwing on .trim() (which
+    // would degrade an over-limit 429 into a 500) or leaking the forged shape.
+    it('should return "unknown" for an object', () => {
+      expect(redactEmail({ x: 1 })).toBe('unknown');
+    });
+
+    it('should return "unknown" for a number', () => {
+      expect(redactEmail(42)).toBe('unknown');
+    });
+
+    it('should return "unknown" for null', () => {
+      expect(redactEmail(null)).toBe('unknown');
+    });
+
+    it('should return "unknown" for an array (no redaction bypass)', () => {
+      // String(['x@y.com']) coerces to 'x@y.com'; the typeof guard prevents
+      // an array-wrapped address from bypassing redaction.
+      expect(redactEmail(['x@y.com'])).toBe('unknown');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle email with very long domain', () => {
       const longDomain = 'a'.repeat(50) + '.com';

--- a/src/server/common/test/middleware/rate-limit-by-credential.test.ts
+++ b/src/server/common/test/middleware/rate-limit-by-credential.test.ts
@@ -326,6 +326,40 @@ describe('createCredentialRateLimiter', () => {
 
       expect(objectResponse.status).toBe(200);
     });
+
+    it('should return a clean 429 (not 500) when a non-string credential exceeds the limit', async () => {
+      // Regression for pv-43x4: the 429 handler logs redactEmail(credential).
+      // A forged non-string credential body must not crash that handler — the
+      // over-limit response must stay a clean 429, never degrade to a 500.
+      const limiter = createCredentialRateLimiter(
+        1,
+        60000,
+        'test-endpoint',
+        'email',
+      );
+
+      router.post('/test', limiter, (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      const app = testApp(router);
+
+      // First request fills the non-string credential's bucket.
+      const firstResponse = await request(app)
+        .post('/test')
+        .send({ email: { x: 1 } });
+
+      expect(firstResponse.status).toBe(200);
+
+      // Second request exceeds the limit and runs the 429 handler, which logs
+      // redactEmail(credential) on the same non-string body.
+      const blockedResponse = await request(app)
+        .post('/test')
+        .send({ email: { x: 1 } });
+
+      expect(blockedResponse.status).toBe(429);
+      expect(blockedResponse.body).toHaveProperty('errorName', 'RateLimitError');
+    });
   });
 
   describe('error response format', () => {


### PR DESCRIPTION
## Motivation

On any credential-limited route (login, password reset, application, register, moderation-report — anything built with `createCredentialRateLimiter`), a forged non-string `email` body such as `{"email":{"x":1}}` or `{"email":42}` crashed the over-limit handler. The 429 response handler logs a redacted credential via `redactEmail`, which called `.trim()` unconditionally; a non-string value threw `TypeError: email.trim is not a function`, degrading a clean **429 into a 500**.

Impact is low-to-medium: the request is still counted against the rate-limit bucket (the keyGenerator coerces with `String(...)` and runs first), so this is not an auth bypass or data leak — only the over-limit response degrades for forged non-string bodies.

## Approach

Hardened `redactEmail` at its single chokepoint rather than the call site, so every present and future caller is protected:

- Widened the parameter type `string | undefined` → `unknown`.
- Replaced the guard with `typeof email !== 'string' || email.trim() === ''`, returning `'unknown'` for any non-string input — consistent with the function's existing "invalid input → 'unknown'" contract.

The `typeof` guard is chosen over `String(value ?? '')` deliberately: `String(['x@y.com'])` coerces back to a real address and would **bypass redaction entirely**, leaking a real email into logs. The typeof guard rejects arrays/objects/numbers before any coercion, closing that vector. The call site in `rate-limit-by-credential.ts` is unchanged.

## Validation

- New unit tests in `redact-email.test.ts`: object, number, null, and array inputs all redact to `'unknown'`; all existing string-redaction cases unchanged.
- New integration test in `rate-limit-by-credential.test.ts`: a non-string `email` body that exceeds the limit returns **429** with `errorName: 'RateLimitError'`, not 500 — the assertion that was previously impossible because of this bug.
- Full suite via build-guardian: lint (0 errors), unit (8346 passed), integration (669 passed), and frontend/widget build all green. Pre-existing e2e failures (federation SSL cert missing, a login-navigation timeout, an admin-moderation persistence test) are unrelated to this backend logging change.

Post-code auditors (security, privacy, complexity, consistency, testing) all returned PASS. Consistency raised two LOW non-blocking notes about test-describe-group placement labels.