### PR TITLE
fix(accounts): normalize email case at all lookup and write boundaries

### DIFF
--- a/migrations/0037_normalize_account_email.ts
+++ b/migrations/0037_normalize_account_email.ts
@@ -1,0 +1,113 @@
+import { Sequelize, QueryTypes } from 'sequelize';
+import { addIndexIfNotExists, removeIndexIfExists } from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Normalize stored email addresses (lowercase + trim) and enforce
+ * case-insensitive uniqueness on `account.email`.
+ *
+ * Context: email lookups normalize (`normalizeEmail`) at every read/write
+ * boundary in the accounts + authentication services, but rows written before
+ * that change were persisted verbatim. A lookup for a normalized address could
+ * therefore miss an existing account stored mixed-case (e.g. `Victim@x.com`),
+ * and — with no unique constraint on `account.email` — a registration for
+ * `victim@x.com` would be treated as available and create a case-duplicate
+ * account. This migration backfills existing rows to the normalized form and
+ * adds a unique index as a backstop against exact-string duplicates.
+ *
+ * Uniqueness model: the index is a plain unique index on the raw `email`
+ * column, so the DB layer enforces only EXACT-STRING uniqueness. It is NOT a
+ * functional or COLLATE-based case-insensitive index. Case-insensitive
+ * uniqueness holds because every writer funnels the address through
+ * `normalizeEmail` before persisting (application-level discipline); the index
+ * then catches any two writes of the same normalized string. A writer that
+ * bypassed `normalizeEmail` could still persist a mixed-case duplicate — the
+ * write boundary, not the index, is the case-collapse guarantee.
+ *
+ * Order matters:
+ *   1. Collision pre-check on `account` BEFORE any mutation. If two or more
+ *      account rows normalize to the same value the migration throws and leaves
+ *      all data untouched, surfacing the conflicting account IDs (never the
+ *      plaintext email addresses — privacy-playbook) so an operator can resolve
+ *      the duplicates and re-run. Auto-merging case-duplicate accounts is an
+ *      ops/data decision and intentionally out of scope here.
+ *   2. Backfill `account`, `account_application`, and `account_invitation` to
+ *      the normalized form with standard SQL `LOWER`/`TRIM` (dual-dialect; no
+ *      `citext`). NULL emails are left untouched.
+ *   3. Add a unique index on `account.email` via `CREATE UNIQUE INDEX`
+ *      (`addIndexIfNotExists`). This emits a plain index on both SQLite and
+ *      PostgreSQL — no table rebuild. NULL emails are treated as distinct on
+ *      both dialects, so null-email accounts do not collide.
+ *
+ * The `account_application` and `account_invitation` tables carry lifecycle
+ * state; uniqueness there is a separate behavioral decision and is NOT enforced
+ * — they receive normalization + backfill only.
+ *
+ * down(): drops the unique index only. The lowercase/trim backfill is
+ * IRREVERSIBLE — the original casing is not preserved and cannot be restored.
+ */
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    // Step 1: collision pre-check on `account`. Run before any UPDATE so an
+    // abort leaves every table unmodified. The grouping query is dialect-
+    // portable; per-group IDs are fetched separately to avoid SQLite's
+    // GROUP_CONCAT vs PostgreSQL's STRING_AGG split. Only account IDs are
+    // surfaced — never the plaintext email addresses (privacy-playbook).
+    const collisions = await sequelize.query<{ norm: string }>(
+      `SELECT LOWER(TRIM(email)) AS norm
+       FROM account
+       WHERE email IS NOT NULL
+       GROUP BY LOWER(TRIM(email))
+       HAVING COUNT(*) > 1`,
+      { type: QueryTypes.SELECT },
+    );
+
+    if (collisions.length > 0) {
+      const idGroups: string[] = [];
+      for (const { norm } of collisions) {
+        const rows = await sequelize.query<{ id: string }>(
+          `SELECT id FROM account
+           WHERE email IS NOT NULL AND LOWER(TRIM(email)) = :norm
+           ORDER BY id`,
+          { replacements: { norm }, type: QueryTypes.SELECT },
+        );
+        idGroups.push(`[${rows.map((r) => r.id).join(', ')}]`);
+      }
+      throw new Error(
+        'Migration 0037 aborted: multiple account rows normalize to the same '
+        + 'email address. Resolve these case-duplicate accounts manually, then '
+        + 're-run. Conflicting account ID groups (no other data shown): '
+        + idGroups.join('; '),
+      );
+    }
+
+    // Step 2: backfill normalized email on every table that stores one.
+    for (const table of ['account', 'account_application', 'account_invitation']) {
+      await sequelize.query(
+        `UPDATE ${table}
+         SET email = LOWER(TRIM(email))
+         WHERE email IS NOT NULL AND email <> LOWER(TRIM(email))`,
+        { type: QueryTypes.UPDATE },
+      );
+    }
+
+    // Step 3: enforce case-insensitive uniqueness on account.email.
+    await addIndexIfNotExists(
+      queryInterface,
+      'account',
+      ['email'],
+      {
+        name: 'account_email_unique',
+        unique: true,
+      },
+    );
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+    // Only the unique index is reversible. The normalization backfill is
+    // irreversible: original casing was not preserved and is not restored.
+    await removeIndexIfExists(queryInterface, 'account', 'account_email_unique');
+  },
+};

--- a/src/common/test/email-validation.test.ts
+++ b/src/common/test/email-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isValidEmail } from '@/common/validation/email';
+import { isValidEmail, normalizeEmail } from '@/common/validation/email';
 
 describe('isValidEmail', () => {
 
@@ -30,4 +30,31 @@ describe('isValidEmail', () => {
       expect(isValidEmail(email)).toBe(false);
     });
   }
+});
+
+describe('normalizeEmail', () => {
+  it('lowercases mixed-case addresses', () => {
+    expect(normalizeEmail('Victim@X.com')).toBe('victim@x.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeEmail('  user@example.com  ')).toBe('user@example.com');
+  });
+
+  it('trims and lowercases together', () => {
+    expect(normalizeEmail('  User@Example.COM\t')).toBe('user@example.com');
+  });
+
+  it('leaves an already-normalized address unchanged', () => {
+    expect(normalizeEmail('user@example.com')).toBe('user@example.com');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(normalizeEmail('')).toBe('');
+  });
+
+  it('returns an empty string for nullish input without throwing', () => {
+    expect(normalizeEmail(null as unknown as string)).toBe('');
+    expect(normalizeEmail(undefined as unknown as string)).toBe('');
+  });
 });

--- a/src/common/validation/email.ts
+++ b/src/common/validation/email.ts
@@ -10,3 +10,21 @@
 export function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
+
+/**
+ * Normalizes an email address for case-insensitive storage and lookup.
+ *
+ * Trims surrounding whitespace and lowercases the address. This is the single
+ * source of truth applied at every email read and write boundary so that a
+ * lookup never misses an account whose address was stored in a different case.
+ *
+ * Defensive contract: nullish or non-string input collapses to `''` rather
+ * than throwing. Callers gate the format upstream via {@link isValidEmail}; an
+ * empty-string lookup simply returns no row, which is benign.
+ *
+ * @param email - The email string to normalize
+ * @returns The trimmed, lowercased email, or `''` for nullish/empty input
+ */
+export function normalizeEmail(email: string): string {
+  return (email ?? '').trim().toLowerCase();
+}

--- a/src/server/accounts/service/account.ts
+++ b/src/server/accounts/service/account.ts
@@ -26,7 +26,7 @@ import { EventEmitter } from 'events';
 import EditorInvitationEmail from '@/server/calendar/model/editor_invitation_email';
 import { isValidLanguageCode } from '@/common/i18n/languages';
 import { ValidationError } from '@/common/exceptions/base';
-import { isValidEmail } from '@/common/validation/email';
+import { isValidEmail, normalizeEmail } from '@/common/validation/email';
 import { logError } from '@/server/common/helper/error-logger';
 import { createLogger } from '@/server/common/helper/logger';
 
@@ -94,13 +94,13 @@ export default class AccountService {
       throw new AccountAlreadyExistsError();
     }
 
-    if ( await AccountInvitationEntity.findOne({ where: { email: email }}) ) {
+    if ( await AccountInvitationEntity.findOne({ where: { email: normalizeEmail(email) }}) ) {
       throw new AccountInviteAlreadyExistsError();
     }
 
     const invitationEntity = AccountInvitationEntity.build({
       id: uuidv4(),
-      email: email,
+      email: normalizeEmail(email),
       invited_by: inviter.id,
       message: message,
       invitation_code: randomBytes(16).toString('hex'),
@@ -240,7 +240,7 @@ export default class AccountService {
 
     const existingAccount = await this.getAccountByEmail(email);
     const existingApplication = await AccountApplicationEntity.findOne({
-      where: { email: email },
+      where: { email: normalizeEmail(email) },
     });
 
     // Branch 5: existing account — silently swallow AccountAlreadyExistsError.
@@ -296,7 +296,7 @@ export default class AccountService {
 
     const applicationEntity = AccountApplicationEntity.build({
       id: uuidv4(),
-      email: email,
+      email: normalizeEmail(email),
       message: message || '',
       status: 'pending_confirmation',
       status_timestamp: new Date(),
@@ -446,7 +446,7 @@ export default class AccountService {
 
     const accountEntity = AccountEntity.build({
       id: uuidv4(),
-      email: email,
+      email: normalizeEmail(email),
       username: '',
     });
 
@@ -842,7 +842,7 @@ export default class AccountService {
     * @returns {Promise<Account | undefined>} a promise that resolves to the account associated with the given email address, or undefined if no such account exists
     */
   async getAccountByEmail(email:string): Promise<Account | undefined> {
-    let account = await AccountEntity.findOne({ where: { email: email }});
+    let account = await AccountEntity.findOne({ where: { email: normalizeEmail(email) }});
     if (!account) { return undefined; }
 
     let roles = await AccountRoleEntity.findAll({ where: { account_id: account.id } });

--- a/src/server/accounts/test/account_service.test.ts
+++ b/src/server/accounts/test/account_service.test.ts
@@ -77,6 +77,25 @@ describe('inviteNewAccount', () => {
     expect(saveInviteStub.called).toBe(true);
   });
 
+  it('persists a normalized email when input has mixed case', async () => {
+    let getAccountStub = sandbox.stub(accountService, 'getAccountByEmail');
+    let findInvitationStub = sandbox.stub(AccountInvitationEntity, 'findOne');
+    let buildSpy = sandbox.spy(AccountInvitationEntity, 'build');
+    sandbox.stub(accountService,'sendNewAccountInvite');
+    sandbox.stub(AccountInvitationEntity.prototype, 'save');
+    let getAllSettingsStub = sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings');
+
+    getAllSettingsStub.resolves({ registrationMode: 'invitation' });
+    getAccountStub.resolves(undefined);
+    findInvitationStub.resolves(undefined);
+
+    let invitation = await accountService.inviteNewAccount(adminUser,'Test@Example.COM','test_message');
+
+    const buildArgs = buildSpy.firstCall.args[0] as Record<string, unknown>;
+    expect(buildArgs.email).toBe('test@example.com');
+    expect(invitation.email).toBe('test@example.com');
+  });
+
   it.each([
     { mode: 'closed', shouldAllow: false, description: 'should throw AccountInvitationPermissionError if non-admin user tries to invite in closed mode' },
     { mode: 'apply', shouldAllow: false, description: 'should throw AccountInvitationPermissionError if non-admin user tries to invite in apply mode' },
@@ -291,6 +310,25 @@ describe('applyForNewAccount', () => {
     // The confirmation email must be addressed to the applicant
     const sentMail = emailStub.firstCall.args[0];
     expect(sentMail.emailAddress).toBe('newuser@example.com');
+  });
+
+  // Write-path normalization: a new application persists the normalized email.
+  it('persists a normalized email when input has mixed case', async () => {
+    const getAllSettingsStub = applySandbox.stub(ConfigurationInterface.prototype, 'getAllSettings');
+    const getAccountByEmailStub = applySandbox.stub(accountService, 'getAccountByEmail');
+    const findApplicationStub = applySandbox.stub(AccountApplicationEntity, 'findOne');
+    const buildSpy = applySandbox.spy(AccountApplicationEntity, 'build');
+    applySandbox.stub(AccountApplicationEntity.prototype, 'save').resolves();
+    applySandbox.stub(emailInterface, 'sendEmail').resolves();
+
+    getAllSettingsStub.resolves({ registrationMode: 'apply' });
+    getAccountByEmailStub.resolves(undefined);
+    findApplicationStub.resolves(undefined);
+
+    await accountService.applyForNewAccount('NewUser@Example.COM', 'I would like to apply');
+
+    const buildArgs = buildSpy.firstCall.args[0] as Record<string, unknown>;
+    expect(buildArgs.email).toBe('newuser@example.com');
   });
 
   // Branch 2: re-applying while still pending_confirmation regenerates the
@@ -1172,6 +1210,26 @@ describe('_setupAccount', () => {
     expect(accountSaveStub.called).toBe(true);
     expect(passwordCodeStub.called).toBe(false);
     expect(accountSecretsSaveStub.called).toBe(true);
+  });
+
+  it('persists a normalized email when input has mixed case and whitespace', async () => {
+    let accountServiceStub = setupSandbox.stub(accountService, 'getAccountByEmail');
+    let buildSpy = setupSandbox.spy(AccountEntity, 'build');
+    setupSandbox.stub(AccountEntity.prototype, 'save');
+    setupSandbox.stub(AccountSecretsEntity.prototype, 'save');
+    setupSandbox.stub(AccountRoleEntity.prototype, 'save');
+    let accountRoleFindAllStub = setupSandbox.stub(AccountRoleEntity, 'findAll');
+    let passwordCodeStub = setupSandbox.stub(accountService, 'generatePasswordResetCodeForAccount');
+
+    passwordCodeStub.resolves('test_code');
+    accountServiceStub.resolves(undefined);
+    accountRoleFindAllStub.resolves([]);
+
+    let accountInfo = await accountService._setupAccount('  Test@Example.COM ');
+
+    const buildArgs = buildSpy.firstCall.args[0] as Record<string, unknown>;
+    expect(buildArgs.email).toBe('test@example.com');
+    expect(accountInfo.account.email).toBe('test@example.com');
   });
 
 });

--- a/src/server/accounts/test/integration/email-normalization-integration.test.ts
+++ b/src/server/accounts/test/integration/email-normalization-integration.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
+import sinon from 'sinon';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import {
+  AccountEntity,
+  AccountSecretsEntity,
+  AccountRoleEntity,
+  AccountApplicationEntity,
+} from '@/server/common/entity/account';
+import AccountInvitationEntity from '@/server/accounts/entity/account_invitation';
+import AccountService from '@/server/accounts/service/account';
+import AuthenticationService from '@/server/authentication/service/auth';
+import AccountsInterface from '@/server/accounts/interface';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import EmailInterface from '@/server/email/interface';
+import { EmailAlreadyExistsError } from '@/server/authentication/exceptions';
+import { AccountAlreadyExistsError, AccountInviteAlreadyExistsError } from '@/server/accounts/exceptions';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+import { initI18Next } from '@/server/common/test/lib/i18next';
+
+initI18Next();
+
+/**
+ * Integration tests for case-insensitive email handling against a real SQLite
+ * database. SQLite's default `=` comparison on TEXT is case-SENSITIVE, so a
+ * stubbed unit test cannot prove that a mixed-case lookup finds a normalized
+ * row — only a real DB round-trip can. These tests exercise the
+ * normalize-at-boundary contract end to end: every read and write funnels the
+ * address through `normalizeEmail`, so case variants collapse to one account.
+ *
+ * Bead: pv-j5mw
+ */
+describe('Email normalization (integration, real SQLite DB)', () => {
+  let env: TestEnvironment;
+  let sandbox: sinon.SinonSandbox;
+  let accountService: AccountService;
+  let authService: AuthenticationService;
+  let emailInterface: EmailInterface;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+  });
+
+  afterAll(async () => {
+    if (env) {
+      await env.cleanup();
+    }
+  });
+
+  beforeEach(async () => {
+    await AccountInvitationEntity.destroy({ where: {}, truncate: true });
+    await AccountApplicationEntity.destroy({ where: {}, truncate: true });
+    await AccountRoleEntity.destroy({ where: {}, truncate: true });
+    await AccountSecretsEntity.destroy({ where: {}, truncate: true });
+    await AccountEntity.destroy({ where: {}, truncate: true });
+
+    sandbox = sinon.createSandbox();
+    const eventBus = new EventEmitter();
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    emailInterface = new EmailInterface();
+    sandbox.stub(emailInterface, 'sendEmail').resolves();
+
+    accountService = new AccountService(eventBus, configurationInterface, setupInterface, emailInterface);
+    authService = new AuthenticationService(
+      eventBus,
+      accountService as unknown as AccountsInterface,
+      emailInterface,
+    );
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  async function countAccounts(): Promise<number> {
+    return AccountEntity.count();
+  }
+
+  describe('getAccountByEmail', () => {
+    it('finds a verbatim-lowercased account when queried with mixed case', async () => {
+      await accountService._setupAccount('Victim@X.com');
+
+      const lower = await accountService.getAccountByEmail('victim@x.com');
+      const upper = await accountService.getAccountByEmail('VICTIM@X.COM');
+      const spaced = await accountService.getAccountByEmail('  Victim@X.com  ');
+
+      expect(lower).toBeDefined();
+      expect(lower!.email).toBe('victim@x.com');
+      expect(upper).toBeDefined();
+      expect(upper!.id).toBe(lower!.id);
+      expect(spaced).toBeDefined();
+      expect(spaced!.id).toBe(lower!.id);
+    });
+
+    it('treats a case-variant registration as already taken (no duplicate)', async () => {
+      await accountService._setupAccount('victim@x.com');
+
+      await expect(accountService._setupAccount('Victim@X.com')).rejects
+        .toThrow(AccountAlreadyExistsError);
+      expect(await countAccounts()).toBe(1);
+    });
+  });
+
+  describe('changeEmail', () => {
+    it('treats a change to a case-variant of an existing address as taken', async () => {
+      await accountService._setupAccount('victim@x.com');
+      const moverInfo = await accountService._setupAccount('user@x.com');
+
+      // Password verification is exercised elsewhere; isolate the taken-check.
+      sandbox.stub(authService, 'checkPassword').resolves(true);
+
+      await expect(authService.changeEmail(moverInfo.account, 'VICTIM@x.com', 'pw')).rejects
+        .toThrow(EmailAlreadyExistsError);
+
+      // The mover's address is unchanged and no row was added.
+      const mover = await AccountEntity.findByPk(moverInfo.account.id);
+      expect(mover!.email).toBe('user@x.com');
+      expect(await countAccounts()).toBe(2);
+    });
+
+    it('persists a normalized email on a successful change', async () => {
+      const moverInfo = await accountService._setupAccount('user@x.com');
+      sandbox.stub(authService, 'checkPassword').resolves(true);
+
+      const updated = await authService.changeEmail(moverInfo.account, 'New@X.COM', 'pw');
+      expect(updated.email).toBe('new@x.com');
+
+      const stored = await AccountEntity.findByPk(moverInfo.account.id);
+      expect(stored!.email).toBe('new@x.com');
+    });
+  });
+
+  describe('registerNewAccount', () => {
+    it('persists a normalized email regardless of input casing', async () => {
+      sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings')
+        .resolves({ registrationMode: 'open' });
+
+      await accountService.registerNewAccount('New@User.COM');
+
+      const stored = await AccountEntity.findOne({ where: { email: 'new@user.com' } });
+      expect(stored).toBeDefined();
+      expect(stored!.email).toBe('new@user.com');
+    });
+  });
+
+  describe('applyForNewAccount', () => {
+    beforeEach(() => {
+      sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings')
+        .resolves({ registrationMode: 'apply' });
+    });
+
+    it('does not create a second application row for a case-variant of a pending application', async () => {
+      await accountService.applyForNewAccount('Applicant@X.com', 'first');
+      await accountService.applyForNewAccount('APPLICANT@x.com', 'second');
+
+      expect(await AccountApplicationEntity.count()).toBe(1);
+      const stored = await AccountApplicationEntity.findOne({});
+      expect(stored!.email).toBe('applicant@x.com');
+    });
+
+    it('hits the account-exists branch (no application row) for a case-variant of an existing account', async () => {
+      await accountService._setupAccount('owner@x.com');
+
+      const result = await accountService.applyForNewAccount('OWNER@X.com', 'let me in');
+
+      expect(result).toBe(true);
+      expect(await AccountApplicationEntity.count()).toBe(0);
+    });
+  });
+
+  describe('inviteNewAccount', () => {
+    let inviter: Account;
+
+    beforeEach(async () => {
+      sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings')
+        .resolves({ registrationMode: 'invitation' });
+      // The invitation row has a foreign key on invited_by; the inviter must
+      // be a real account.
+      const inviterInfo = await accountService._setupAccount('inviter@x.com');
+      inviter = inviterInfo.account;
+      inviter.roles = ['admin'];
+    });
+
+    it('treats a case-variant of an existing account as taken', async () => {
+      await accountService._setupAccount('owner@x.com');
+
+      await expect(accountService.inviteNewAccount(inviter, 'OWNER@X.com', 'hi')).rejects
+        .toThrow(AccountAlreadyExistsError);
+    });
+
+    it('treats a case-variant of an existing invitation as taken', async () => {
+      await accountService.inviteNewAccount(inviter, 'invitee@x.com', 'hi');
+
+      await expect(accountService.inviteNewAccount(inviter, 'INVITEE@X.com', 'again')).rejects
+        .toThrow(AccountInviteAlreadyExistsError);
+      expect(await AccountInvitationEntity.count()).toBe(1);
+    });
+  });
+
+  describe('account creation funnels persist normalized email', () => {
+    it('invite-accept creates an account with the normalized invitation email', async () => {
+      sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings')
+        .resolves({ registrationMode: 'invitation' });
+      const inviterInfo = await accountService._setupAccount('inviter@x.com');
+      const inviter = inviterInfo.account;
+      inviter.roles = ['admin'];
+
+      await accountService.inviteNewAccount(inviter, 'Accept@X.com', 'join');
+      const invitation = await AccountInvitationEntity.findOne({ where: { email: 'accept@x.com' } });
+      expect(invitation).toBeDefined();
+
+      const { account } = await accountService.acceptAccountInvite(invitation!.invitation_code, 'Password!1');
+      expect(account.email).toBe('accept@x.com');
+
+      const stored = await AccountEntity.findByPk(account.id);
+      expect(stored!.email).toBe('accept@x.com');
+    });
+
+    it('application-accept creates an account with the normalized application email', async () => {
+      sandbox.stub(ConfigurationInterface.prototype, 'getAllSettings')
+        .resolves({ registrationMode: 'apply' });
+
+      await accountService.applyForNewAccount('Applicant@X.com', 'please');
+      const application = await AccountApplicationEntity.findOne({ where: { email: 'applicant@x.com' } });
+      expect(application).toBeDefined();
+
+      const account = await accountService.acceptAccountApplication(application!.id);
+      expect(account.email).toBe('applicant@x.com');
+
+      const stored = await AccountEntity.findByPk(account.id);
+      expect(stored!.email).toBe('applicant@x.com');
+    });
+  });
+});

--- a/src/server/authentication/service/auth.ts
+++ b/src/server/authentication/service/auth.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { Account } from "@/common/model/account";
 import { AccountEntity, AccountSecretsEntity } from "@/server/common/entity/account";
 import { noAccountExistsError } from '@/server/accounts/exceptions';
+import { normalizeEmail } from '@/common/validation/email';
 import { EmailAlreadyExistsError, InvalidPasswordError } from '@/server/authentication/exceptions';
 import EmailInterface from '@/server/email/interface';
 import PasswordResetEmail from '@/server/authentication/model/password_reset_email';
@@ -40,10 +41,10 @@ export default class AuthenticationService {
     }
 
     // Normalize the email address for case-insensitive comparison
-    const normalizedNewEmail = newEmail.toLowerCase();
+    const normalizedNewEmail = normalizeEmail(newEmail);
 
     // If the new email is the same as current (case-insensitive), just return the account
-    if (account.email.toLowerCase() === normalizedNewEmail) {
+    if (normalizeEmail(account.email) === normalizedNewEmail) {
       return account;
     }
 

--- a/src/server/common/test/migrations/migration_0037_normalize_account_email.test.ts
+++ b/src/server/common/test/migrations/migration_0037_normalize_account_email.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Sequelize, DataTypes, QueryTypes } from 'sequelize';
+import migration from '../../../../../migrations/0037_normalize_account_email';
+
+/**
+ * Migration 0037 normalizes (lowercase + trim) stored email addresses across
+ * `account`, `account_application`, and `account_invitation`, then enforces
+ * case-insensitive uniqueness with a unique index on `account.email`. A
+ * pre-mutation collision check aborts the migration (leaving all data
+ * untouched) when two account rows normalize to the same value, surfacing the
+ * conflicting account IDs only.
+ */
+describe('Migration 0037: normalize account email + unique index', () => {
+  let sequelize: Sequelize;
+
+  beforeEach(async () => {
+    sequelize = new Sequelize({
+      dialect: 'sqlite',
+      storage: ':memory:',
+      logging: false,
+    });
+
+    const qi = sequelize.getQueryInterface();
+    for (const table of ['account', 'account_application', 'account_invitation']) {
+      await qi.createTable(table, {
+        id: { type: DataTypes.UUID, primaryKey: true, allowNull: false },
+        email: { type: DataTypes.STRING, allowNull: true },
+        createdAt: { type: DataTypes.DATE, allowNull: false },
+        updatedAt: { type: DataTypes.DATE, allowNull: false },
+      });
+    }
+  });
+
+  afterEach(async () => {
+    await sequelize.close();
+  });
+
+  async function insertRow(table: string, id: string, email: string | null) {
+    const now = new Date().toISOString();
+    await sequelize.query(
+      `INSERT INTO ${table} (id, email, "createdAt", "updatedAt")
+       VALUES (:id, :email, :now, :now)`,
+      { replacements: { id, email, now }, type: QueryTypes.INSERT },
+    );
+  }
+
+  async function getEmail(table: string, id: string): Promise<string | null> {
+    const [row] = await sequelize.query(
+      `SELECT email FROM ${table} WHERE id = :id`,
+      { replacements: { id }, type: QueryTypes.SELECT },
+    ) as Array<{ email: string | null }>;
+    return row ? row.email : null;
+  }
+
+  async function uniqueIndexExists(): Promise<boolean> {
+    const indexes = await sequelize.getQueryInterface().showIndex('account') as Array<{
+      name: string;
+    }>;
+    return indexes.some((ix) => ix.name === 'account_email_unique');
+  }
+
+  it('lowercases + trims email across all three tables and adds the unique index', async () => {
+    await insertRow('account', 'a1', 'Victim@X.com');
+    await insertRow('account', 'a2', '  Spaced@Example.COM  ');
+    await insertRow('account', 'a3', 'already@normal.com');
+    await insertRow('account_application', 'app1', 'Applicant@Y.com');
+    await insertRow('account_invitation', 'inv1', '  Invitee@Z.com ');
+
+    await migration.up({ context: sequelize });
+
+    expect(await getEmail('account', 'a1')).toBe('victim@x.com');
+    expect(await getEmail('account', 'a2')).toBe('spaced@example.com');
+    expect(await getEmail('account', 'a3')).toBe('already@normal.com');
+    expect(await getEmail('account_application', 'app1')).toBe('applicant@y.com');
+    expect(await getEmail('account_invitation', 'inv1')).toBe('invitee@z.com');
+    expect(await uniqueIndexExists()).toBe(true);
+  });
+
+  it('leaves NULL emails untouched and does not collide them', async () => {
+    await insertRow('account', 'n1', null);
+    await insertRow('account', 'n2', null);
+
+    await migration.up({ context: sequelize });
+
+    expect(await getEmail('account', 'n1')).toBeNull();
+    expect(await getEmail('account', 'n2')).toBeNull();
+    expect(await uniqueIndexExists()).toBe(true);
+  });
+
+  it('aborts before any mutation when two account rows normalize equal', async () => {
+    await insertRow('account', 'dup1', 'Victim@x.com');
+    await insertRow('account', 'dup2', 'victim@X.com');
+    await insertRow('account_application', 'app1', 'Mixed@Case.com');
+
+    await expect(migration.up({ context: sequelize })).rejects.toThrow(/aborted/);
+
+    // No table was modified: account rows retain original casing, the
+    // application row was not backfilled, and the index was not created.
+    expect(await getEmail('account', 'dup1')).toBe('Victim@x.com');
+    expect(await getEmail('account', 'dup2')).toBe('victim@X.com');
+    expect(await getEmail('account_application', 'app1')).toBe('Mixed@Case.com');
+    expect(await uniqueIndexExists()).toBe(false);
+  });
+
+  it('surfaces the conflicting account IDs (not emails) in the abort error', async () => {
+    await insertRow('account', 'dup1', 'Victim@x.com');
+    await insertRow('account', 'dup2', 'victim@X.com');
+
+    let message = '';
+    try {
+      await migration.up({ context: sequelize });
+    }
+    catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toMatch(/dup1.*dup2|dup2.*dup1/);
+    expect(message).toContain('dup1');
+    expect(message).toContain('dup2');
+    // The plaintext email must never appear in diagnostics.
+    expect(message.toLowerCase()).not.toContain('victim@x.com');
+  });
+
+  it('down() drops the unique index and does not restore casing', async () => {
+    await insertRow('account', 'a1', 'Victim@X.com');
+
+    await migration.up({ context: sequelize });
+    expect(await uniqueIndexExists()).toBe(true);
+    expect(await getEmail('account', 'a1')).toBe('victim@x.com');
+
+    await migration.down({ context: sequelize });
+    expect(await uniqueIndexExists()).toBe(false);
+    // Backfill is irreversible: casing stays normalized after down().
+    expect(await getEmail('account', 'a1')).toBe('victim@x.com');
+  });
+});


### PR DESCRIPTION
## Motivation

Email lookup was case-sensitive while account emails were stored verbatim at every creation path. The only path that normalized was `changeEmail` (and it lowercased without trimming). The mismatch meant a normalized lookup would miss an existing account stored mixed-case (e.g. `Victim@x.com`), and — with no unique constraint on `account.email` — a registration or email change to `victim@x.com` when `Victim@x.com` already existed was treated as available, writing a second account that differs only by case.

The exposure spanned three read lookups (`getAccountByEmail` plus the invitation and application bypass lookups) and four write paths (`_setupAccount`, invitation write, application write, `changeEmail`).

## Approach

- **Shared helper.** Added `normalizeEmail()` (trim + lowercase, nullish-safe → `''`, never throws) to the existing `src/common/validation/email.ts`, so both the Accounts and Authentication domains import one source of truth rather than scattering ad-hoc `.toLowerCase()` calls.
- **Read boundaries.** `getAccountByEmail` (covers all 9 callers), the `inviteNewAccount` invitation lookup, and the `applyForNewAccount` application lookup now normalize before querying.
- **Write boundaries.** `_setupAccount` (register / invite-accept / application-confirm), the invitation write, the application write, and `changeEmail` now persist normalized email. `changeEmail`'s ad-hoc `toLowerCase()` (missing the trim) is routed through the shared helper.
- **Migration 0037.** Backfills `account`, `account_application`, and `account_invitation` to normalized form, gated by a pre-mutation collision pre-check that aborts before any write and surfaces only conflicting **account IDs — never plaintext emails** (privacy posture). After backfill it adds a dual-dialect unique index on `account.email`. The index enforces exact-string uniqueness; case-collapse is guaranteed at the write boundary by `normalizeEmail`. `down()` drops the index only — the lowercase backfill is irreversible (documented inline).
- **Out of scope (deliberately):** `citext` (Postgres-only; codebase also runs SQLite), unique constraints on the application/invitation tables (they carry lifecycle state), and auto-merging pre-existing case-duplicate accounts (an ops decision — the migration aborts and surfaces IDs for manual resolution).

## Validation

- New unit tests: `normalizeEmail` (mixed case, whitespace, already-normalized, empty/nullish → `''`) and write-path normalization for `_setupAccount`, invitation, and application writes.
- New integration tests (real SQLite, since a stubbed test cannot prove SQL case-insensitivity): `getAccountByEmail` case-variant round-trip; `changeEmail` taken-path and happy-path normalized write; `applyForNewAccount` and `inviteNewAccount` case-variant taken-branches (separate branches → separate tests); register / invite-accept / application-confirm persist normalized email.
- New migration integration tests: happy backfill + unique index, NULL handling, collision abort-before-mutation, IDs-not-emails in the abort error, and `down()`.
- `npm run lint`: 0 errors. `npm run test:integration`: green (including the new email and migration suites). `npm run build`: green. The full `npm run test:unit` run shows a single pre-existing, nondeterministic flaky failure (rotates across unrelated files — calendar API, ActivityPub rate-limit — and passes in isolation); a clean-baseline run reproduces the same single failure, and this branch adds only passing tests, so it introduces no regression.