### PR TITLE
fix(client): wrap long image-upload error messages

### DIFF
--- a/src/client/components/common/media/image-upload.vue
+++ b/src/client/components/common/media/image-upload.vue
@@ -873,6 +873,8 @@ $transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   color: $error-color;
   font-size: 13px;
   text-align: center;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 // Validation error


### PR DESCRIPTION
## Motivation

Long upload-error messages — especially those containing file paths — overflowed the `.error-banner` container horizontally instead of wrapping.

## Approach

Add `word-break: break-word` and `overflow-wrap: anywhere` to the `.error-banner` SCSS block in image-upload.vue.

## Validation

- `npx eslint` clean on the changed file
- Targeted: `image-upload.test.ts` — 12 passed
- Combined batch: build-guardian lint/integration/build PASS