### PR TITLE
fix(client): parameterize provider name in connection warning

### DIFF
--- a/src/client/components/admin/add-provider-wizard.vue
+++ b/src/client/components/admin/add-provider-wizard.vue
@@ -588,7 +588,7 @@ function handleSuccess() {
           <div class="warning-icon">!</div>
           <h3 class="step-title">{{ t('step3.connection_warning_title') }}</h3>
           <p class="warning-message">
-            {{ t('step3.connection_warning_message') }}
+            {{ t('step3.connection_warning_message', { provider: selectedProviderName }) }}
           </p>
         </div>
       </div>

--- a/src/client/locales/en/admin.json
+++ b/src/client/locales/en/admin.json
@@ -523,7 +523,7 @@
         "success_message": "{{provider}} has been successfully connected.",
         "ready_message": "You can now accept payments through this provider.",
         "connection_warning_title": "Credentials saved",
-        "connection_warning_message": "Stripe was saved, but the connection test failed. Please check that your API keys are correct.",
+        "connection_warning_message": "{{provider}} was saved, but the connection test failed. Please check that your API keys are correct.",
         "close_button": "Close"
       },
       "errors": {

--- a/src/client/locales/es/admin.json
+++ b/src/client/locales/es/admin.json
@@ -523,7 +523,7 @@
         "success_message": "{{provider}} se ha conectado correctamente.",
         "ready_message": "Ya puedes aceptar pagos a través de este proveedor.",
         "connection_warning_title": "Credenciales guardadas",
-        "connection_warning_message": "Stripe se guardó, pero la prueba de conexión falló. Comprueba que tus claves de API son correctas.",
+        "connection_warning_message": "{{provider}} se guardó, pero la prueba de conexión falló. Comprueba que tus claves de API son correctas.",
         "close_button": "Cerrar"
       },
       "errors": {

--- a/src/client/locales/fr/admin.json
+++ b/src/client/locales/fr/admin.json
@@ -523,7 +523,7 @@
         "success_message": "{{provider}} a été connecté avec succès.",
         "ready_message": "Vous pouvez désormais accepter des paiements via ce prestataire.",
         "connection_warning_title": "Identifiants enregistrés",
-        "connection_warning_message": "Stripe a été enregistré, mais le test de connexion a échoué. Veuillez vérifier que vos clés API sont correctes.",
+        "connection_warning_message": "{{provider}} a été enregistré, mais le test de connexion a échoué. Veuillez vérifier que vos clés API sont correctes.",
         "close_button": "Fermer"
       },
       "errors": {


### PR DESCRIPTION
## Motivation

The funding wizard's `connection_warning_message` hardcoded "Stripe". A future PayPal verification would surface the wrong provider name to users.

## Approach

Replace the hardcoded provider with a `{{provider}}` interpolation param across en/es/fr admin locales, and pass the selected provider name at the call site, mirroring `step3.success_message`.

## Validation

- `npx eslint` clean on the call-site component; all three locale JSON files parse
- i18n-auditor confirmed placeholder consistency across locales and correct call-site param
- Combined batch: build-guardian lint/integration/build PASS