### PR TITLE
fix(client): use strict boolean for connectionVerified

### DIFF
--- a/src/client/service/funding.ts
+++ b/src/client/service/funding.ts
@@ -256,7 +256,7 @@ export default class FundingService {
       const response = await axios.post('/api/funding/v1/admin/providers/stripe/configure', credentials);
       return {
         success: response.status === 200,
-        connectionVerified: response.data?.connectionVerified ?? false,
+        connectionVerified: response.data?.connectionVerified === true,
       };
     }
     catch (error) {


### PR DESCRIPTION
## Motivation

`connectionVerified` used nullish coalescing (`?? false`), which would pass a truthy non-boolean server value through unchanged.

## Approach

Use `response.data?.connectionVerified === true` so the flag is always a strict boolean.

## Validation

- `npx eslint` clean
- Targeted: `funding.test.ts` — 33 passed
- Combined batch: build-guardian lint/integration/build PASS