### PR TITLE
chore(client): add i18n key for calendar URL fallback

### DIFF
--- a/src/client/components/logged_in/calendar/calendars.vue
+++ b/src/client/components/logged_in/calendar/calendars.vue
@@ -52,7 +52,7 @@ const audience = computed(() => audienceForRoute(route?.name));
  */
 function getDescription(info: CalendarInfo): string {
   const desc = info.calendar.content('en').description;
-  return desc || `/${info.calendar.urlName}`;
+  return desc || t('url_path', { urlName: info.calendar.urlName });
 }
 
 onBeforeMount(async () => {

--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -27,6 +27,7 @@
     "role_editor": "Editor",
     "aria_navigate_calendar": "Navigate to calendar: {{calendarName}}, role: {{role}}",
     "aria_view_public_calendar": "View public calendar: {{name}} (opens in new tab)",
+    "url_path": "/{{urlName}}",
     "error_loading_calendars": "Failed to load calendars",
     "menu_label": "Calendar list actions",
     "documentation": "Documentation",

--- a/src/client/locales/es/calendars.json
+++ b/src/client/locales/es/calendars.json
@@ -27,6 +27,7 @@
     "role_editor": "Editor",
     "aria_navigate_calendar": "Ir al calendario: {{calendarName}}, rol: {{role}}",
     "aria_view_public_calendar": "Ver calendario público: {{name}} (se abre en una pestaña nueva)",
+    "url_path": "/{{urlName}}",
     "error_loading_calendars": "Error al cargar los calendarios",
     "guide_link": "Cómo crear un calendario"
   },

--- a/src/client/locales/fr/calendars.json
+++ b/src/client/locales/fr/calendars.json
@@ -27,6 +27,7 @@
     "role_editor": "Éditeur",
     "aria_navigate_calendar": "Aller au calendrier : {{calendarName}}, rôle : {{role}}",
     "aria_view_public_calendar": "Voir le calendrier public : {{name}} (s'ouvre dans un nouvel onglet)",
+    "url_path": "/{{urlName}}",
     "error_loading_calendars": "Échec du chargement des calendriers",
     "guide_link": "Comment créer un calendrier"
   },


### PR DESCRIPTION
## Motivation

The My Calendars list rendered a hardcoded `/` prefix for the no-description fallback, bypassing i18n.

## Approach

Add a `list.url_path` key (`/{{urlName}}`) across en/es/fr calendars locales and render the fallback through it.

## Validation

- `npx eslint` clean; all three locale JSON files parse
- i18n-auditor confirmed key resolves via the component's `list` keyPrefix with the `urlName` param
- Combined batch: build-guardian lint/integration/build PASS