### PR TITLE
fix(federation): guard null apObject in processUpdateEvent

### DIFF
--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -1521,6 +1521,20 @@ class ProcessInboxService {
       }
     }
 
+    // SAFETY: apObject can be null on the Person-actor path. An authorized
+    // remote editor may resolve a locally-owned event via
+    // message.object.eventParams.id (local UUID lookup) that was never
+    // federated and therefore has no EventObjectEntity row, leaving apObject
+    // null after the re-lookup. The eventParams build below and the
+    // SharedEventEntity / Note cascade all dereference apObject.event_id, so
+    // without an AP object record there is nothing to update remotely. No-op
+    // rather than crash, and emit no Note and no eventUpdated. The
+    // calendar-actor path already returned above on !apObject (ownership check).
+    if (!apObject) {
+      logger.debug({ apObjectId, actorUri }, '[INBOX] Update activity has no AP object record — no-op');
+      return null;
+    }
+
     // Create event params with local UUID for database.
     // Pass actorUri so fromActivityPubObject can origin-gate privileged fields
     // (hideFromPublic on schedules). For the Person-actor path (remote editor),

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -1617,6 +1617,47 @@ describe('ProcessInboxService - inbox-originated lifecycle Note cascade (pv-taf2
     expect(enqueued.filter(a => a.type === 'Update').length).toBe(0);
   });
 
+  // Lock-in (pv-vq8z): a Person-actor Update resolving a locally-owned event via
+  // eventParams.id that has NO EventObjectEntity row leaves apObject null. The
+  // eventParams build dereferenced apObject.event_id, crashing with a TypeError.
+  // The guard must no-op: no crash, no updateRemoteEvent, no eventUpdated, no Note.
+  it('no-ops without crashing on a Person-actor Update when no AP object record exists', async () => {
+    const personActorUri = 'https://user.instance/users/editor';
+    const eventApId = 'https://remote.instance/events/never-federated';
+    const eventId = uuidv4();
+    // Deliberately NO EventObjectEntity row → apObject stays null on the
+    // Person-actor path after both the ap_id and event_id re-lookups miss.
+
+    sandbox.stub(inboxService as any, 'isPersonActorUri').resolves(true);
+    sandbox.stub(inboxService as any, 'isAuthorizedRemoteEditor').resolves(true);
+    // Event resolves only via the eventParams.id local UUID lookup.
+    sandbox.stub(calendarInterface, 'getEventById').resolves(buildReconstitutedEvent(eventId));
+    const updateRemoteEvent = sandbox.stub(calendarInterface, 'updateRemoteEvent').resolves(buildReconstitutedEvent(eventId));
+
+    const enqueued: any[] = [];
+    eventBus.on('outboxMessageAdded', (activity) => enqueued.push(activity));
+    let eventUpdatedEmitted = false;
+    eventBus.on('eventUpdated', () => { eventUpdatedEmitted = true; });
+
+    const updateMessage = UpdateActivity.fromObject({
+      type: 'Update',
+      actor: personActorUri,
+      object: {
+        id: eventApId,
+        type: 'Event',
+        name: 'Editor Updated Event',
+        eventParams: { id: eventId, name: 'Editor Updated Event' },
+      },
+    });
+
+    const result = await inboxService.processUpdateEvent(testCalendar, updateMessage!);
+
+    expect(result).toBeNull();
+    expect(updateRemoteEvent.called).toBe(false);
+    expect(eventUpdatedEmitted).toBe(false);
+    expect(enqueued.length).toBe(0);
+  });
+
   it('emits no Note on a Person-actor delete of a locally-owned event with no share row', async () => {
     const personActorUri = 'https://user.instance/users/editor';
     const eventApId = 'https://remote.instance/events/owned-event-2';


### PR DESCRIPTION
## Motivation

In `processUpdateEvent`, the eventParams build dereferenced `apObject.event_id` unconditionally. On the Person-actor path `apObject` can be null — when an authorized remote editor sends an Update that resolves a locally-owned event via local UUID lookup and that event has no `EventObjectEntity` row — causing a TypeError. (The calendar-actor path was already safe via an early return.)

## Approach

Guard `apObject` before the eventParams build so the null path is a clean no-op: no crash, no Note creation, no `eventUpdated` emission. The guard was chosen over resolving `event_id` from `existingEvent.id` because the latter would let the update proceed and emit `eventUpdated`, which this path must not do.

## Validation

- `npx eslint` clean on both files
- Targeted: `inbox.test.ts` — 55 passed, including a new lock-in test for the null-apObject Person-actor path
- Combined batch: build-guardian lint/unit/integration/build PASS