### PR TITLE
fix(calendar): validate media focal point and zoom ranges

### DIFF
--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -99,6 +99,40 @@ function validateExternalUrlPair(externalUrl: string | null, urlPrompt: UrlPromp
 }
 
 /**
+ * Validates the media-transform parameters (focal point and zoom) before they
+ * are persisted. `mediaFocalPointX` and `mediaFocalPointY` must be finite
+ * numbers in [0,1]; `mediaZoom` must be a finite number >= 1. Values that are
+ * undefined or null are skipped (no transform supplied / cleared). Out-of-range
+ * or non-numeric inputs are rejected with a {@link ValidationError} whose
+ * `fields` map flags the offending input.
+ *
+ * Shared by createEvent and updateEvent so both persistence paths enforce the
+ * same bounds.
+ */
+export function validateMediaTransform(eventParams: Record<string, any>): void {
+  const checkFocal = (key: 'mediaFocalPointX' | 'mediaFocalPointY') => {
+    const value = eventParams[key];
+    if (value === undefined || value === null) return;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+      throw new ValidationError(`${key} must be a number between 0 and 1`, {
+        [key]: ['must be a number between 0 and 1'],
+      });
+    }
+  };
+  checkFocal('mediaFocalPointX');
+  checkFocal('mediaFocalPointY');
+
+  const zoom = eventParams.mediaZoom;
+  if (zoom !== undefined && zoom !== null) {
+    if (typeof zoom !== 'number' || !Number.isFinite(zoom) || zoom < 1) {
+      throw new ValidationError('mediaZoom must be a number greater than or equal to 1', {
+        mediaZoom: ['must be a number greater than or equal to 1'],
+      });
+    }
+  }
+}
+
+/**
  * Scrubs an external URL for safe inclusion in structured logs.
  *
  * External URLs may contain sensitive material in their query string or
@@ -659,6 +693,9 @@ class EventService {
     tx?: Transaction,
   ): Promise<CalendarEvent> {
 
+    // Bounds-check media transform values before any persistence.
+    validateMediaTransform(eventParams);
+
     const calendar = await this.calendarService.getCalendar(eventParams.calendarId);
     const calendars = await this.calendarService.editableCalendarsForUser(account);
 
@@ -912,6 +949,9 @@ class EventService {
     if (!this.isValidUUID(eventId)) {
       throw new ValidationError('Invalid UUID format in event ID');
     }
+
+    // Bounds-check media transform values before any persistence.
+    validateMediaTransform(eventParams);
 
     const eventEntity = await EventEntity.findByPk(eventId);
 

--- a/src/server/calendar/test/service/events-validation.test.ts
+++ b/src/server/calendar/test/service/events-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import EventsService from '@/server/calendar/service/events';
+import EventsService, { validateMediaTransform } from '@/server/calendar/service/events';
 import { ValidationError } from '@/common/exceptions/base';
 import { Account } from '@/common/model/account';
 import { EventEmitter } from 'events';
@@ -120,6 +120,72 @@ describe('EventsService - Validation', () => {
       await expect(
         service.bulkAssignCategories(mockAccount, ['event-1'], [123 as any, 'cat-2']),
       ).rejects.toThrow('all categoryIds must be strings');
+    });
+  });
+
+  describe('validateMediaTransform', () => {
+    it('accepts boundary focal point values 0 and 1 and zoom 1', () => {
+      expect(() => validateMediaTransform({ mediaFocalPointX: 0, mediaFocalPointY: 1, mediaZoom: 1 })).not.toThrow();
+      expect(() => validateMediaTransform({ mediaFocalPointX: 1, mediaFocalPointY: 0 })).not.toThrow();
+      expect(() => validateMediaTransform({ mediaFocalPointX: 0.5, mediaFocalPointY: 0.25, mediaZoom: 2.5 })).not.toThrow();
+    });
+
+    it('skips undefined and null values', () => {
+      expect(() => validateMediaTransform({})).not.toThrow();
+      expect(() => validateMediaTransform({ mediaFocalPointX: undefined, mediaFocalPointY: null, mediaZoom: null })).not.toThrow();
+    });
+
+    it('rejects focal point X below 0', () => {
+      expect(() => validateMediaTransform({ mediaFocalPointX: -0.1 })).toThrow(ValidationError);
+    });
+
+    it('rejects focal point X above 1', () => {
+      expect(() => validateMediaTransform({ mediaFocalPointX: 1.1 })).toThrow(ValidationError);
+    });
+
+    it('rejects focal point Y out of range', () => {
+      expect(() => validateMediaTransform({ mediaFocalPointY: 2 })).toThrow(ValidationError);
+      expect(() => validateMediaTransform({ mediaFocalPointY: -1 })).toThrow(ValidationError);
+    });
+
+    it('rejects zoom below 1', () => {
+      expect(() => validateMediaTransform({ mediaZoom: 0.5 })).toThrow(ValidationError);
+    });
+
+    it('rejects non-numeric and non-finite values', () => {
+      expect(() => validateMediaTransform({ mediaFocalPointX: 'x' })).toThrow(ValidationError);
+      expect(() => validateMediaTransform({ mediaZoom: NaN })).toThrow(ValidationError);
+      expect(() => validateMediaTransform({ mediaZoom: Infinity })).toThrow(ValidationError);
+    });
+  });
+
+  describe('createEvent media transform validation', () => {
+    it('rejects out-of-range focal point before any persistence', async () => {
+      await expect(
+        service.createEvent(mockAccount, { calendarId: 'cal-1', mediaFocalPointX: 5 }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('rejects out-of-range zoom before any persistence', async () => {
+      await expect(
+        service.createEvent(mockAccount, { calendarId: 'cal-1', mediaZoom: 0 }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('updateEvent media transform validation', () => {
+    const validUuid = '11111111-1111-4111-8111-111111111111';
+
+    it('rejects out-of-range focal point before any persistence', async () => {
+      await expect(
+        service.updateEvent(mockAccount, validUuid, { mediaFocalPointY: -2 }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('rejects out-of-range zoom before any persistence', async () => {
+      await expect(
+        service.updateEvent(mockAccount, validUuid, { mediaZoom: 0.2 }),
+      ).rejects.toThrow(ValidationError);
     });
   });
 });


### PR DESCRIPTION
## Motivation

`mediaFocalPointX`/`mediaFocalPointY` and `mediaZoom` were persisted without bounds checking (flagged by the security auditor). Out-of-range values could reach the database.

## Approach

Add a shared `validateMediaTransform` helper (matching the service's existing `ValidationError` validators) enforcing focal points in [0,1] and zoom >= 1. Wire it into both the create path (`createEvent`) and the update path (`updateEvent`), which are separate assignment sites. Undefined/null values are skipped; out-of-range and non-finite values are rejected.

## Validation

- `npx eslint` clean on both files
- Targeted: `events-validation.test.ts` — 21 passed (boundary 0/1 and zoom=1 accepted; out-of-range rejected on both create and update)
- Combined batch: build-guardian lint/unit/integration/build PASS