### PR TITLE
chore: clear unused-var lint warnings and honor _-prefix convention

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,13 @@ export default [
     rules: {
       // TypeScript rules
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      '@typescript-eslint/no-unused-vars': 'warn',
+      // Honor the repo convention: a leading underscore marks an
+      // intentionally-unused binding (required param, caught error, etc.).
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
     },
   },
   // Vue config

--- a/src/client/test/components/calendar/calendar-tabs.test.ts
+++ b/src/client/test/components/calendar/calendar-tabs.test.ts
@@ -35,13 +35,13 @@ const routes: RouteRecordRaw[] = [
 const mockCalendar = {
   id: 'cal-1',
   urlName: 'test-calendar',
-  content: (lang: string) => ({ name: 'Test Calendar' }),
+  content: (_lang: string) => ({ name: 'Test Calendar' }),
   languages: ['en'],
 };
 
 const mockEvent = {
   id: 'evt-1',
-  content: (lang: string) => ({ name: 'Test Event', description: 'Description' }),
+  content: (_lang: string) => ({ name: 'Test Event', description: 'Description' }),
   schedules: [],
   categories: [],
   languages: ['en'],
@@ -96,7 +96,7 @@ const createWrapper = async (routeQuery = {}, routeParams = { calendar: 'test-ca
  * Simulates a keydown event on the tablist.
  * Uses Vue Test Utils' trigger with KeyboardEvent-specific options.
  */
-const triggerTabKeydown = async (wrapper, key: string) => {
+const _triggerTabKeydown = async (wrapper, key: string) => {
   const tablist = wrapper.find('[role="tablist"]');
   // Vue test utils trigger creates proper KeyboardEvent when event name starts with 'key'
   await tablist.trigger('keydown', { key });

--- a/src/client/test/components/calendar/calendar-tabs.test.ts
+++ b/src/client/test/components/calendar/calendar-tabs.test.ts
@@ -103,7 +103,7 @@ const createWrapper = async (
  * Simulates a keydown event on the tablist.
  * Uses Vue Test Utils' trigger with KeyboardEvent-specific options.
  */
-const _triggerTabKeydown = async (wrapper, key: string) => {
+const triggerTabKeydown = async (wrapper, key: string) => {
   const tablist = wrapper.find('[role="tablist"]');
   // Vue test utils trigger creates proper KeyboardEvent when event name starts with 'key'
   await tablist.trigger('keydown', { key });

--- a/src/client/test/components/calendar/calendar-url-sync-logic.test.ts
+++ b/src/client/test/components/calendar/calendar-url-sync-logic.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeEach, vi } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { reactive } from 'vue';
 
 describe('Calendar URL Synchronization Logic', () => {

--- a/src/client/test/components/calendar/category-badges-semantic.test.ts
+++ b/src/client/test/components/calendar/category-badges-semantic.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { defineComponent, ref } from 'vue';
-import { createTestingPinia } from '@pinia/testing';
+import { defineComponent } from 'vue';
 
 /**
  * Tests: Category badges use ul/li for semantic list markup

--- a/src/client/test/components/calendar/event-recurrence-dst.test.ts
+++ b/src/client/test/components/calendar/event-recurrence-dst.test.ts
@@ -14,9 +14,8 @@
  *   moving into RecurrenceEditorSheet.vue, so these tests keep mounting the
  *   wrapper component.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
-import { reactive } from 'vue';
 import { CalendarEventSchedule } from '@/common/model/events';
 import { DateTime } from 'luxon';
 import I18NextVue from 'i18next-vue';

--- a/src/client/test/components/calendar/search-filter-integration.test.ts
+++ b/src/client/test/components/calendar/search-filter-integration.test.ts
@@ -6,7 +6,6 @@ import { RouteRecordRaw } from 'vue-router';
 import sinon from 'sinon';
 import { mountComponent } from '@/client/test/lib/vue';
 import SearchFilter from '@/client/components/logged_in/calendar/search-filter.vue';
-import EventService from '@/client/service/event';
 import CategoryService from '@/client/service/category';
 
 /**

--- a/src/client/test/components/calendar/widget-admin.test.ts
+++ b/src/client/test/components/calendar/widget-admin.test.ts
@@ -12,16 +12,14 @@ import WidgetTab from '@/client/components/logged_in/calendar-management/widget-
 describe('Widget Admin UI Components', () => {
   let sandbox: sinon.SinonSandbox;
   let axiosGetStub: sinon.SinonStub;
-  let axiosPostStub: sinon.SinonStub;
   let axiosPutStub: sinon.SinonStub;
-  let axiosDeleteStub: sinon.SinonStub;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
     axiosGetStub = sandbox.stub(axios, 'get');
-    axiosPostStub = sandbox.stub(axios, 'post');
+    sandbox.stub(axios, 'post');
     axiosPutStub = sandbox.stub(axios, 'put');
-    axiosDeleteStub = sandbox.stub(axios, 'delete');
+    sandbox.stub(axios, 'delete');
 
     // Initialize i18next for testing
     await i18next.init({

--- a/src/client/test/components/event-recurrence-end-time.test.ts
+++ b/src/client/test/components/event-recurrence-end-time.test.ts
@@ -15,7 +15,7 @@
  *   controls remain on the wrapper component after the sheet refactor and
  *   this file continues to mount it.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('lucide-vue-next', () => ({
   Trash2: { template: '<span />' },

--- a/src/client/test/components/feed/events.test.ts
+++ b/src/client/test/components/feed/events.test.ts
@@ -375,7 +375,7 @@ describe('FollowedEventsView', () => {
       }
     } as any;
 
-    const wrapper = mount(FollowedEventsView, {
+    mount(FollowedEventsView, {
       global: {
         plugins: [pinia, [I18NextVue, { i18next }]],
       },

--- a/src/client/test/components/report-detail.test.ts
+++ b/src/client/test/components/report-detail.test.ts
@@ -44,7 +44,7 @@ describe('ReportDetail', () => {
   /**
    * Helper to create a mock report with event data
    */
-  const createMockReport = (isRemoteEvent: boolean): Report => {
+  const createMockReport = (_isRemoteEvent: boolean): Report => {
     const report = new Report('report-123');
     report.eventId = 'event-456';
     report.calendarId = 'calendar-789';

--- a/src/client/test/components/repost-categories-modal.test.ts
+++ b/src/client/test/components/repost-categories-modal.test.ts
@@ -39,7 +39,7 @@ const SOURCE_CATEGORIES = [
 
 const MOCK_EVENT = {
   id: 'event-123',
-  content: (lang: string) => ({ name: 'Test Event', description: 'A test event description' }),
+  content: (_lang: string) => ({ name: 'Test Event', description: 'A test event description' }),
   schedules: [],
   categories: [],
   location: null,

--- a/src/client/test/composables/useEventEditor.test.ts
+++ b/src/client/test/composables/useEventEditor.test.ts
@@ -1129,7 +1129,7 @@ describe('useEventEditor', () => {
 
       sandbox.stub(CalendarService.prototype, 'loadCalendars').resolves([calendar]);
 
-      const { state, fieldErrors, initializeEvent, saveEvent } = useEventEditor();
+      const { fieldErrors, initializeEvent, saveEvent } = useEventEditor();
 
       await initializeEvent();
 
@@ -1168,7 +1168,7 @@ describe('useEventEditor', () => {
       sandbox.stub(CalendarService.prototype, 'loadCalendars').resolves([calendar]);
       const saveStub = sandbox.stub(EventService.prototype, 'saveEvent');
 
-      const { state, initializeEvent, saveEvent } = useEventEditor();
+      const { initializeEvent, saveEvent } = useEventEditor();
 
       await initializeEvent();
 
@@ -1229,7 +1229,7 @@ describe('useEventEditor', () => {
 
       sandbox.stub(CalendarService.prototype, 'loadCalendars').resolves([calendar]);
 
-      const { state, fieldErrors, clearFieldError, initializeEvent, saveEvent } = useEventEditor();
+      const { fieldErrors, clearFieldError, initializeEvent, saveEvent } = useEventEditor();
 
       await initializeEvent();
 

--- a/src/client/test/integration/feed-workflow.test.ts
+++ b/src/client/test/integration/feed-workflow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import sinon from 'sinon';
 import axios from 'axios';

--- a/src/client/test/routing/navigation-integration.test.ts
+++ b/src/client/test/routing/navigation-integration.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { flushPromises, DOMWrapper } from '@vue/test-utils';
+import { flushPromises } from '@vue/test-utils';
 import { createRouter, createWebHistory, Router } from 'vue-router';
 import { createPinia, setActivePinia, Pinia } from 'pinia';
-import { nextTick } from 'vue';
 import CalendarView from '@/client/components/logged_in/calendar/calendar.vue';
-import RootView from '@/client/components/logged_in/root.vue';
-import CalendarSelector from '@/client/components/logged_in/calendar/calendar_selector.vue';
-import { mountComponent } from '@/client/test/lib/vue';
 import { Calendar } from '@/common/model/calendar';
 import { CalendarEvent } from '@/common/model/events';
 import { EventLocation } from '@/common/model/location';
@@ -242,8 +238,6 @@ describe('Navigation Integration - Task Group 4', () => {
       router = createTestRouter();
       await router.push('/calendar');
       await router.isReady();
-
-      const mockCalendar = createMockCalendar('cal-1', 'test-calendar');
 
       // Mock calendar selection - this would be called when calendar is selected
       mockSetSelectedCalendar('cal-1');

--- a/src/client/test/service/feed.test.ts
+++ b/src/client/test/service/feed.test.ts
@@ -15,9 +15,7 @@ describe('FeedService', () => {
   let sandbox: sinon.SinonSandbox;
   let service: FeedService;
   let axiosGetStub: sinon.SinonStub;
-  let axiosPostStub: sinon.SinonStub;
   let axiosPatchStub: sinon.SinonStub;
-  let axiosDeleteStub: sinon.SinonStub;
 
   const testCalendarId = 'test-calendar-id';
 
@@ -26,9 +24,9 @@ describe('FeedService', () => {
     service = new FeedService();
 
     axiosGetStub = sandbox.stub(axios, 'get');
-    axiosPostStub = sandbox.stub(axios, 'post');
+    sandbox.stub(axios, 'post');
     axiosPatchStub = sandbox.stub(axios, 'patch');
-    axiosDeleteStub = sandbox.stub(axios, 'delete');
+    sandbox.stub(axios, 'delete');
   });
 
   afterEach(() => {

--- a/src/client/test/session-expired-modal.vue.test.ts
+++ b/src/client/test/session-expired-modal.vue.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, afterEach, beforeEach } from 'vitest';
+import { expect, describe, it, afterEach } from 'vitest';
 import { createMemoryHistory, createRouter, Router } from 'vue-router';
 import { RouteRecordRaw } from 'vue-router';
 import sinon from 'sinon';

--- a/src/server/accounts/test/account_already_exists_email.test.ts
+++ b/src/server/accounts/test/account_already_exists_email.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import sinon from 'sinon';
 import config from 'config';
 

--- a/src/server/accounts/test/account_service.test.ts
+++ b/src/server/accounts/test/account_service.test.ts
@@ -1174,7 +1174,7 @@ describe('_setupAccount', () => {
     let accountServiceStub = setupSandbox.stub(accountService, 'getAccountByEmail');
     let accountSaveStub = setupSandbox.stub(AccountEntity.prototype, 'save');
     let accountSecretsSaveStub = setupSandbox.stub(AccountSecretsEntity.prototype, 'save');
-    let accountRoleSaveStub = setupSandbox.stub(AccountRoleEntity.prototype, 'save');
+    let _accountRoleSaveStub = setupSandbox.stub(AccountRoleEntity.prototype, 'save');
     let accountRoleFindAllStub = setupSandbox.stub(AccountRoleEntity, 'findAll');
     let passwordCodeStub = setupSandbox.stub(accountService, 'generatePasswordResetCodeForAccount');
 
@@ -1196,7 +1196,7 @@ describe('_setupAccount', () => {
     let accountSaveStub = setupSandbox.stub(AccountEntity.prototype, 'save');
     let setPasswordStub = sinon.stub(accountService, 'setPassword');
     let accountSecretsSaveStub = setupSandbox.stub(AccountSecretsEntity.prototype, 'save');
-    let accountRoleSaveStub = setupSandbox.stub(AccountRoleEntity.prototype, 'save');
+    let _accountRoleSaveStub = setupSandbox.stub(AccountRoleEntity.prototype, 'save');
     let accountRoleFindAllStub = setupSandbox.stub(AccountRoleEntity, 'findAll');
     let passwordCodeStub = setupSandbox.stub(accountService, 'generatePasswordResetCodeForAccount');
 

--- a/src/server/accounts/test/admin_pagination.test.ts
+++ b/src/server/accounts/test/admin_pagination.test.ts
@@ -68,7 +68,7 @@ describe('Admin API Pagination Limits', () => {
 
       // Verify service was called with enforced limit of 100
       expect(listStub.calledOnce).toBe(true);
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBe(100);
     });
 
@@ -91,7 +91,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/applications');
 
       expect(listStub.calledOnce).toBe(true);
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBe(50);
     });
 
@@ -114,7 +114,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/applications?limit=25');
 
       expect(listStub.calledOnce).toBe(true);
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBe(25);
     });
 
@@ -173,7 +173,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/invitations?limit=1000');
 
       expect(listStub.calledOnce).toBe(true);
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBe(100);
     });
 
@@ -196,7 +196,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/invitations');
 
       expect(listStub.calledOnce).toBe(true);
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBe(50);
     });
 
@@ -253,7 +253,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/applications?limit=999999');
 
       // Verify API handler clamped the limit
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBeLessThanOrEqual(100);
     });
 
@@ -276,7 +276,7 @@ describe('Admin API Pagination Limits', () => {
         .get('/admin/invitations?limit=999999');
 
       // Verify API handler clamped the limit
-      const [page, limit] = listStub.firstCall.args;
+      const [_page, limit] = listStub.firstCall.args;
       expect(limit).toBeLessThanOrEqual(100);
     });
 

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -16,7 +16,6 @@ import AcceptActivity from "@/server/activitypub/model/action/accept";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
 import { ActivityPubInboxMessageEntity, EventActivityEntity, FollowerCalendarEntity, FollowingCalendarEntity, RepostDismissalEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
 import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
-import { CalendarActorEntity } from "@/server/activitypub/entity/calendar_actor";
 import RemoteCalendarService from "@/server/activitypub/service/remote_calendar";
 import { EventObject } from "@/server/activitypub/model/object/event";
 import { NoteObject } from "@/server/activitypub/model/object/note";

--- a/src/server/activitypub/test/api/server.test.ts
+++ b/src/server/activitypub/test/api/server.test.ts
@@ -4,7 +4,6 @@ import { EventEmitter } from 'events';
 
 import { Calendar } from '@/common/model/calendar';
 import { WebFingerResponse } from '@/server/activitypub/model/webfinger';
-import { UserProfileResponse } from '@/server/activitypub/model/userprofile';
 import ActivityPubServerRoutes from '@/server/activitypub/api/v1/server';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import CalendarInterface from '@/server/calendar/interface';

--- a/src/server/activitypub/test/api/user-actor-routes.test.ts
+++ b/src/server/activitypub/test/api/user-actor-routes.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
-import { EventEmitter } from 'events';
 
 import UserActorRoutes from '@/server/activitypub/api/v1/user-actor';
 import UserActorService from '@/server/activitypub/service/user_actor';
@@ -146,10 +145,6 @@ describe('UserActorRoutes - POST /users/:username/inbox', () => {
   it('should require HTTP signature verification', async () => {
     // This test verifies the middleware is applied - actual signature verification
     // is tested in the middleware test suite
-    const req = {
-      params: { username: 'alice' },
-      body: { type: 'Add' },
-    };
     const res = {
       status: sandbox.stub(),
       json: sandbox.stub(),

--- a/src/server/activitypub/test/api/v1/repost-policy.test.ts
+++ b/src/server/activitypub/test/api/v1/repost-policy.test.ts
@@ -64,7 +64,7 @@ describe('ActivityPub Repost Policy API Routes', () => {
       expect(res.status.calledWith(200)).toBe(true);
       expect(res.send.calledWith('Followed')).toBe(true);
       expect(followStub.calledOnce).toBe(true);
-      const [account, calendar, remoteId, autoOriginals, autoReposts] = followStub.firstCall.args;
+      const [_account, _calendar, _remoteId, autoOriginals, autoReposts] = followStub.firstCall.args;
       expect(autoOriginals).toBe(true);
       expect(autoReposts).toBe(false);
     });
@@ -90,7 +90,7 @@ describe('ActivityPub Repost Policy API Routes', () => {
 
       expect(res.status.calledWith(200)).toBe(true);
       expect(followStub.calledOnce).toBe(true);
-      const [account, calendar, remoteId, autoOriginals, autoReposts] = followStub.firstCall.args;
+      const [_account, _calendar, _remoteId, autoOriginals, autoReposts] = followStub.firstCall.args;
       expect(autoOriginals).toBe(false);
       expect(autoReposts).toBe(false);
     });
@@ -233,7 +233,7 @@ describe('ActivityPub Repost Policy API Routes', () => {
       await routes.updateFollowPolicy(req as any, res as any);
 
       expect(updateStub.calledOnce).toBe(true);
-      const [calendar, followId, originals, reposts] = updateStub.firstCall.args;
+      const [_calendar, _followId, originals, reposts] = updateStub.firstCall.args;
       expect(originals).toBe(true);
       expect(reposts).toBe(false);
     });

--- a/src/server/activitypub/test/api/v1/social.test.ts
+++ b/src/server/activitypub/test/api/v1/social.test.ts
@@ -323,7 +323,7 @@ describe('ActivityPub Social API Routes', () => {
       await routes.getFeed(req as any, res as any);
 
       expect(getFeedStub.calledOnce).toBe(true);
-      const [calendar, page, pageSize] = getFeedStub.firstCall.args;
+      const [_calendar, page, pageSize] = getFeedStub.firstCall.args;
       expect(page).toBe(2);
       expect(pageSize).toBe(20);
     });
@@ -429,7 +429,7 @@ describe('ActivityPub Social API Routes', () => {
       expect(res.status.calledWith(200)).toBe(true);
       expect(res.send.calledWith('Followed')).toBe(true);
       expect(followStub.calledOnce).toBe(true);
-      const [account, calendar, remoteId, originals, reposts] = followStub.firstCall.args;
+      const [_account, _calendar, _remoteId, originals, reposts] = followStub.firstCall.args;
       expect(originals).toBe(true);
       expect(reposts).toBe(false);
     });
@@ -456,7 +456,7 @@ describe('ActivityPub Social API Routes', () => {
       expect(res.status.calledWith(200)).toBe(true);
       expect(res.send.calledWith('Followed')).toBe(true);
       expect(followStub.calledOnce).toBe(true);
-      const [account, calendar, remoteId, originals, reposts] = followStub.firstCall.args;
+      const [_account, _calendar, _remoteId, originals, reposts] = followStub.firstCall.args;
       expect(originals).toBe(false);
       expect(reposts).toBe(false);
     });

--- a/src/server/activitypub/test/helper/rejection-logger.test.ts
+++ b/src/server/activitypub/test/helper/rejection-logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Use vi.hoisted so mock variables are available when vi.mock factory runs
 const { mockWarn, mockError } = vi.hoisted(() => ({

--- a/src/server/activitypub/test/integration/blocked-instance-filter.test.ts
+++ b/src/server/activitypub/test/integration/blocked-instance-filter.test.ts
@@ -9,7 +9,6 @@ vi.mock('@/server/activitypub/helper/rejection-logger', () => ({
 
 import { logActivityRejection } from '@/server/activitypub/helper/rejection-logger';
 import ProcessInboxService from '@/server/activitypub/service/inbox';
-import ModerationService from '@/server/moderation/service/moderation';
 import ModerationInterface from '@/server/moderation/interface';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import CalendarInterface from '@/server/calendar/interface';
@@ -19,7 +18,6 @@ import ConfigurationInterface from '@/server/configuration/interface';
 import RemoteCalendarService from '@/server/activitypub/service/remote_calendar';
 import { ActivityPubInboxMessageEntity, FollowerCalendarEntity, FollowingCalendarEntity } from '@/server/activitypub/entity/activitypub';
 import { Calendar } from '@/common/model/calendar';
-import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import CreateActivity from '@/server/activitypub/model/action/create';
 
 describe('ProcessInboxService - Blocked Instance Filtering', () => {
@@ -187,7 +185,7 @@ describe('ProcessInboxService - Blocked Instance Filtering', () => {
       ];
 
       const moderationService = moderationInterface.getModerationService();
-      const isBlockedStub = sandbox.stub(moderationService, 'isInstanceBlocked');
+      const _isBlockedStub = sandbox.stub(moderationService, 'isInstanceBlocked');
 
       for (const testCase of testCases) {
         // Clear the calendar interface stub before each iteration

--- a/src/server/activitypub/test/integration/feed.integration.test.ts
+++ b/src/server/activitypub/test/integration/feed.integration.test.ts
@@ -37,7 +37,7 @@ describe('Event Feed Integration Tests', () => {
   let env: TestEnvironment;
   let calendarInterface: CalendarInterface;
   let accountsInterface: AccountsInterface;
-  let activityPubInterface: ActivityPubInterface;
+  let _activityPubInterface: ActivityPubInterface;
   let accountService: AccountService;
   let eventBus: EventEmitter;
 
@@ -58,7 +58,7 @@ describe('Event Feed Integration Tests', () => {
     const setupInterface = new SetupInterface();
     accountsInterface = new AccountsInterface(eventBus, configurationInterface, setupInterface);
     calendarInterface = new CalendarInterface(eventBus, accountsInterface, configurationInterface);
-    activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
+    _activityPubInterface = new ActivityPubInterface(eventBus, calendarInterface, accountsInterface);
     accountService = new AccountService(eventBus, configurationInterface, setupInterface);
 
     // Create Account A with calendar
@@ -81,7 +81,7 @@ describe('Event Feed Integration Tests', () => {
   describe('Test 1: Full Workflow - Local Calendar Follow', () => {
     it('should allow Account A to follow Account B\'s calendar and see B\'s events in feed', async () => {
       // Step 1: Account B creates multiple events
-      const event1 = await calendarInterface.createEvent(accountB, {
+      const _event1 = await calendarInterface.createEvent(accountB, {
         calendarId: calendarB.id,
         content: {
           en: {
@@ -95,7 +95,7 @@ describe('Event Feed Integration Tests', () => {
         end_time: '11:00',
       });
 
-      const event2 = await calendarInterface.createEvent(accountB, {
+      const _event2 = await calendarInterface.createEvent(accountB, {
         calendarId: calendarB.id,
         content: {
           en: {
@@ -173,11 +173,11 @@ describe('Event Feed Integration Tests', () => {
       // Create Account C for additional local calendar
       const accountCInfo = await accountService._setupAccount('accountc@pavillion.dev', 'testpassword');
       const accountC = accountCInfo.account;
-      const authKeyC = await env.login('accountc@pavillion.dev', 'testpassword');
+      const _authKeyC = await env.login('accountc@pavillion.dev', 'testpassword');
       const calendarC = await calendarInterface.createCalendar(accountC, 'calendarc');
 
       // Account C creates an event
-      const eventC = await calendarInterface.createEvent(accountC, {
+      const _eventC = await calendarInterface.createEvent(accountC, {
         calendarId: calendarC.id,
         content: {
           en: {
@@ -231,7 +231,7 @@ describe('Event Feed Integration Tests', () => {
       const remoteEventUuid = uuidv4();
       const remoteEventApId = 'https://remote.example.com/events/remote-event-1';
 
-      const remoteEvent = await EventEntity.create({
+      const _remoteEvent = await EventEntity.create({
         id: remoteEventUuid,
         calendar_id: null, // Remote events have null calendar_id
         url_name: 'remote-event-1',
@@ -292,11 +292,11 @@ describe('Event Feed Integration Tests', () => {
 
       const accountEInfo = await accountService._setupAccount('accounte@pavillion.dev', 'testpassword');
       const accountE = accountEInfo.account;
-      const authKeyE = await env.login('accounte@pavillion.dev', 'testpassword');
+      const _authKeyE = await env.login('accounte@pavillion.dev', 'testpassword');
       const calendarE = await calendarInterface.createCalendar(accountE, 'calendare');
 
       // Step 1: Account E creates events
-      const eventE1 = await calendarInterface.createEvent(accountE, {
+      const _eventE1 = await calendarInterface.createEvent(accountE, {
         calendarId: calendarE.id,
         content: {
           en: {
@@ -310,7 +310,7 @@ describe('Event Feed Integration Tests', () => {
         end_time: '11:00',
       });
 
-      const eventE2 = await calendarInterface.createEvent(accountE, {
+      const _eventE2 = await calendarInterface.createEvent(accountE, {
         calendarId: calendarE.id,
         content: {
           en: {
@@ -353,7 +353,7 @@ describe('Event Feed Integration Tests', () => {
       );
 
       expect(feedBeforeUnfollow.status).toBe(200);
-      const eventsBeforeUnfollow = feedBeforeUnfollow.body.events;
+      const _eventsBeforeUnfollow = feedBeforeUnfollow.body.events;
 
       // Step 5: Get the follow relationship ID
       const followsResponse = await env.authGet(

--- a/src/server/activitypub/test/integration/flag-outbox.test.ts
+++ b/src/server/activitypub/test/integration/flag-outbox.test.ts
@@ -146,7 +146,7 @@ describe('Flag activity outbox processing', () => {
     const postStub = sandbox.stub(axios, 'post');
     postStub.resolves({ status: 200 });
 
-    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const _updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
 
     const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
     resolveStub.resolves(REMOTE_INBOX_URL);
@@ -235,7 +235,7 @@ describe('Flag activity outbox processing', () => {
     const postStub = sandbox.stub(axios, 'post');
     postStub.resolves({ status: 200 });
 
-    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const _updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
 
     const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
     resolveStub.resolves(REMOTE_INBOX_URL);

--- a/src/server/activitypub/test/integration/inbox-security.test.ts
+++ b/src/server/activitypub/test/integration/inbox-security.test.ts
@@ -16,24 +16,16 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import { EventEmitter } from 'events';
 import request from 'supertest';
 import crypto from 'crypto';
-import sinon from 'sinon';
-import { v4 as uuidv4 } from 'uuid';
 
 import { Account } from '@/common/model/account';
-import { Calendar, CalendarContent } from '@/common/model/calendar';
+import { Calendar } from '@/common/model/calendar';
 import CalendarInterface from '@/server/calendar/interface';
 import AccountsInterface from '@/server/accounts/interface';
 import ConfigurationInterface from '@/server/configuration/interface';
 import SetupInterface from '@/server/setup/interface';
 import AccountService from '@/server/accounts/service/account';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
-import ProcessInboxService from '@/server/activitypub/service/inbox';
-import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
-import { EventActivityEntity, ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
-import AnnounceActivity from '@/server/activitypub/model/action/announce';
-import * as remoteFetch from '@/server/activitypub/helper/remote-fetch';
-import { CalendarEntity } from '@/server/calendar/entity/calendar';
-import { setupActivityPubSchema, teardownActivityPubSchema } from '@/server/common/test/helpers/database';
+import { ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
 import { waitForStableCount } from '@/server/common/test/lib/test_polling';
 
 describe('ActivityPub Inbox Security Pipeline', () => {
@@ -45,8 +37,8 @@ describe('ActivityPub Inbox Security Pipeline', () => {
 
   // Test accounts and calendars
   let ownerAccount: Account;
-  let editorAccount: Account;
-  let unauthorizedAccount: Account;
+  let _editorAccount: Account;
+  let _unauthorizedAccount: Account;
   let testCalendar: Calendar;
 
   // Test constants
@@ -71,10 +63,10 @@ describe('ActivityPub Inbox Security Pipeline', () => {
     ownerAccount = ownerInfo.account;
 
     const editorInfo = await accountService._setupAccount('editor@pavillion.dev', 'testpassword');
-    editorAccount = editorInfo.account;
+    _editorAccount = editorInfo.account;
 
     const unauthorizedInfo = await accountService._setupAccount('unauthorized@pavillion.dev', 'testpassword');
-    unauthorizedAccount = unauthorizedInfo.account;
+    _unauthorizedAccount = unauthorizedInfo.account;
 
     // Create test calendar
     testCalendar = await calendarInterface.createCalendar(ownerAccount, 'testcalendar');

--- a/src/server/activitypub/test/service/inbox.test.ts
+++ b/src/server/activitypub/test/service/inbox.test.ts
@@ -234,7 +234,7 @@ describe('processInboxMessage', () => {
     sandbox.stub(testService.remoteCalendarService, 'findOrCreateByActorUri').resolves(mockRemoteCalendar);
 
     // Mock FollowerCalendarEntity to simulate no existing follower
-    const findOneStub = sandbox.stub(FollowerCalendarEntity, 'findOne').resolves(null);
+    const _findOneStub = sandbox.stub(FollowerCalendarEntity, 'findOne').resolves(null);
     const createStub = sandbox.stub(FollowerCalendarEntity, 'create').resolves({} as any);
 
     // Mock ActivityPubOutboxMessageEntity save
@@ -1156,7 +1156,7 @@ describe('Structured Logging for Activity Rejections', () => {
       try {
         await service.processCreateEvent(calendar, activityMessage);
       }
-      catch (error: any) {
+      catch (_error: any) {
         // Expected to throw
       }
 
@@ -1196,7 +1196,7 @@ describe('Structured Logging for Activity Rejections', () => {
       try {
         await service.processCreateEvent(calendar, activityMessage);
       }
-      catch (error: any) {
+      catch (_error: any) {
         // Expected to throw
       }
 
@@ -1233,7 +1233,7 @@ describe('Structured Logging for Activity Rejections', () => {
       try {
         await service.processUpdateEvent(calendar, activityMessage);
       }
-      catch (error: any) {
+      catch (_error: any) {
         // Expected to throw
       }
 
@@ -1267,7 +1267,7 @@ describe('Structured Logging for Activity Rejections', () => {
       try {
         await service.processDeleteEvent(calendar, activityMessage);
       }
-      catch (error: any) {
+      catch (_error: any) {
         // Expected to throw
       }
 
@@ -1718,7 +1718,6 @@ describe('Relationship-Based Inbox Filtering', () => {
       });
 
       const processStub = sandbox.stub(service, 'processCreateEvent');
-      const updateStub = (ActivityPubInboxMessageEntity.prototype.update as sinon.SinonStub);
 
       await service.processInboxMessage(message);
 

--- a/src/server/activitypub/test/service/members.test.ts
+++ b/src/server/activitypub/test/service/members.test.ts
@@ -146,7 +146,7 @@ describe("followCalendar", () => {
     let getActorUrlStub = sandbox.stub(service, 'actorUrl');
     getActorUrlStub.resolves('https://testdomain.com/calendars/testcalendar');
 
-    let buildFollowStub = sandbox.spy(FollowingCalendarEntity, 'build');
+    let _buildFollowStub = sandbox.spy(FollowingCalendarEntity, 'build');
 
     let saveFollowStub = sandbox.stub(FollowingCalendarEntity.prototype, 'save');
     saveFollowStub.resolves();
@@ -305,13 +305,13 @@ describe("unfollowCalendar", () => {
 describe("getFeed - Local Calendar Follows", () => {
   let service: ActivityPubService;
   let sandbox: sinon.SinonSandbox;
-  let account: Account;
+  let _account: Account;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     const eventBus = new EventEmitter();
     service = new ActivityPubService(eventBus, new CalendarInterface(eventBus));
-    account = Account.fromObject({ id: 'test-account-id' });
+    _account = Account.fromObject({ id: 'test-account-id' });
   });
 
   afterEach(() => {
@@ -352,7 +352,7 @@ describe("getFeed - Local Calendar Follows", () => {
         createdAt: new Date('2024-01-03'),
         content: [{ language: 'en', title: 'Event 1', description: 'Description 1' }],
         schedules: [],
-        get: function(options: any) {
+        get: function(_options: any) {
           return { ...this };
         },
       },
@@ -363,7 +363,7 @@ describe("getFeed - Local Calendar Follows", () => {
         createdAt: new Date('2024-01-02'),
         content: [{ language: 'en', title: 'Event 2', description: 'Description 2' }],
         schedules: [],
-        get: function(options: any) {
+        get: function(_options: any) {
           return { ...this };
         },
       },
@@ -374,7 +374,7 @@ describe("getFeed - Local Calendar Follows", () => {
         createdAt: new Date('2024-01-01'),
         content: [{ language: 'en', title: 'Event 3', description: 'Description 3' }],
         schedules: [],
-        get: function(options: any) {
+        get: function(_options: any) {
           return { ...this };
         },
       },
@@ -383,7 +383,7 @@ describe("getFeed - Local Calendar Follows", () => {
     // Don't stub EventEntity.findAll - let it use the real query with mocked results
     const findAllStub = sandbox.stub();
     findAllStub.resolves(mockEvents);
-    sandbox.stub(service, 'getFeed').callsFake(async (calendar, page, pageSize) => {
+    sandbox.stub(service, 'getFeed').callsFake(async (_calendar, _page, _pageSize) => {
       // Simulate the actual query logic
       const events = mockEvents;
 
@@ -498,7 +498,7 @@ describe("getFeed - Local Calendar Follows", () => {
       },
     ];
 
-    sandbox.stub(service, 'getFeed').callsFake(async (calendar, page, pageSize) => {
+    sandbox.stub(service, 'getFeed').callsFake(async (_calendar, _page, _pageSize) => {
       return mockEvents.map(event => {
         const contentByLanguage: Record<string, any> = {};
         if (event.content && Array.isArray(event.content)) {
@@ -591,7 +591,7 @@ describe("getFeed - Local Calendar Follows", () => {
       },
     ];
 
-    sandbox.stub(service, 'getFeed').callsFake(async (calendar, page, pageSize) => {
+    sandbox.stub(service, 'getFeed').callsFake(async (_calendar, _page, _pageSize) => {
       return mockEvents.map(event => {
         const contentByLanguage: Record<string, any> = {};
         if (event.content && Array.isArray(event.content)) {
@@ -675,7 +675,7 @@ describe("getFeed - Local Calendar Follows", () => {
       },
     ];
 
-    sandbox.stub(service, 'getFeed').callsFake(async (calendar, page, pageSize) => {
+    sandbox.stub(service, 'getFeed').callsFake(async (_calendar, _page, _pageSize) => {
       return mockEvents.map(event => {
         const contentByLanguage: Record<string, any> = {};
         if (event.content && Array.isArray(event.content)) {
@@ -744,7 +744,7 @@ describe("getFeed - Local Calendar Follows", () => {
     };
 
     // Mock manual repost by Calendar A
-    sandbox.stub(service, 'getFeed').callsFake(async (calendar, page, pageSize) => {
+    sandbox.stub(service, 'getFeed').callsFake(async (_calendar, _page, _pageSize) => {
       const contentByLanguage: Record<string, any> = {};
       if (mockEvent.content && Array.isArray(mockEvent.content)) {
         mockEvent.content.forEach((c: any) => {

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -460,7 +460,7 @@ describe('processOutboxMessage', () => {
 
     const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
     const postStub = sandbox.stub(axios, 'post');
-    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const _updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
     const getRecipientsStub = sandbox.stub(service, 'getRecipients');
     const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
     stubSigning(service, sandbox);

--- a/src/server/activitypub/test/user_actor_service.test.ts
+++ b/src/server/activitypub/test/user_actor_service.test.ts
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 import { v4 as uuidv4 } from 'uuid';
 
 import UserActorService from '@/server/activitypub/service/user_actor';
-import { UserActorEntity } from '@/server/activitypub/entity/user_actor';
 import { AccountEntity } from '@/server/common/entity/account';
 import { Account } from '@/common/model/account';
 import CalendarInterface from '@/server/calendar/interface';
@@ -89,7 +88,7 @@ describe('UserActorService', () => {
       });
 
       const account = accountEntity.toModel();
-      const createdActor = await service.createActor(account, testDomain);
+      const _createdActor = await service.createActor(account, testDomain);
 
       const actor = await service.getActorByUsername(username);
 

--- a/src/server/calendar/service/calendar.ts
+++ b/src/server/calendar/service/calendar.ts
@@ -454,7 +454,7 @@ class CalendarService {
       const accountWithRoles = await this.accountsInterface.loadAccountRoles(account);
       return accountWithRoles.hasRole('admin');
     }
-    catch (error) {
+    catch {
       // Fail-secure: if we can't determine admin status, treat as non-admin
       return false;
     }
@@ -1690,7 +1690,6 @@ class CalendarService {
    * @throws CalendarNotFoundError if calendar not found
    * @throws CalendarEditorPermissionError if user lacks permission
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async setWidgetDomain(account: Account, calendarId: string, _domain: string): Promise<void> {
     // Check if subscriptions are enabled
     const settings = await this.fundingInterface?.getSettings();
@@ -2007,7 +2006,6 @@ class CalendarService {
       ],
     };
     if (searchTerm.length > 0) {
-      const pattern = `%${searchTerm.toLowerCase()}%`;
       calendarInclude.where = {
         [Op.or]: [
           // Case-insensitive urlName match using LOWER() for dialect neutrality

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -31,7 +31,7 @@ import { EventCategoryAssignmentEntity } from '@/server/calendar/entity/event_ca
 import { EventInstanceEntity } from '@/server/calendar/entity/event_instance';
 import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
 import db from '@/server/common/entity/db';
-import { Op, literal, where, fn, col, type Transaction } from 'sequelize';
+import { Op, where, fn, col, type Transaction } from 'sequelize';
 
 /**
  * Normalizes an optional external URL attached to an event.
@@ -688,7 +688,6 @@ class EventService {
   async createEvent(
     account: Account,
     eventParams: Record<string, any>,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _context: EventOriginatorContext = DEFAULT_ORIGINATOR_CONTEXT,
     tx?: Transaction,
   ): Promise<CalendarEvent> {

--- a/src/server/calendar/service/widget_domain.ts
+++ b/src/server/calendar/service/widget_domain.ts
@@ -103,7 +103,7 @@ class WidgetDomainService {
       // Return hostname with port if present
       return url.port ? `${url.hostname}:${url.port}` : url.hostname;
     }
-    catch (error) {
+    catch {
       // If URL parsing fails, return the original string
       return origin;
     }
@@ -126,7 +126,7 @@ class WidgetDomainService {
              hostname === '[::1]' || // IPv6 localhost
              hostname.endsWith('.localhost'); // Subdomains of localhost
     }
-    catch (error) {
+    catch {
       // If URL parsing fails, do a simple string check
       const lowerOrigin = origin.toLowerCase();
       return lowerOrigin.includes('localhost') || lowerOrigin.includes('127.0.0.1');

--- a/src/server/calendar/test/EventService/update.test.ts
+++ b/src/server/calendar/test/EventService/update.test.ts
@@ -980,8 +980,8 @@ describe('updateEvent with mediaId', () => {
   const acct = new Account('testAccountId', 'testme', 'testme');
 
   beforeEach(async () => {
-    const { Media } = await import('@/common/model/media');
-    const MediaInterface = (await import('@/server/media/interface')).default;
+    const { Media: _Media } = await import('@/common/model/media');
+    const _MediaInterface = (await import('@/server/media/interface')).default;
 
     service = new EventService(new EventEmitter());
     getCalendarStub = sandbox.stub(service['calendarService'], 'getCalendar');

--- a/src/server/calendar/test/api.test.ts
+++ b/src/server/calendar/test/api.test.ts
@@ -985,7 +985,6 @@ describe('Editor API', () => {
 // Import CalendarRoutes for settings API tests
 import CalendarRoutes from '@/server/calendar/api/v1/calendar';
 import { Media } from '@/common/model/media';
-import { ValidationError } from '@/common/exceptions/base';
 
 describe('Calendar Settings API', () => {
   let routes: CalendarRoutes;

--- a/src/server/calendar/test/calendar_editor_permissions.test.ts
+++ b/src/server/calendar/test/calendar_editor_permissions.test.ts
@@ -6,8 +6,6 @@ import { Account } from '@/common/model/account';
 import { Calendar } from '@/common/model/calendar';
 import CalendarService from '@/server/calendar/service/calendar';
 import { CalendarMemberEntity } from '@/server/calendar/entity/calendar_member';
-import { CalendarEntity } from '@/server/calendar/entity/calendar';
-import { AccountEntity } from '@/server/common/entity/account';
 import { CALENDAR_BUS_EVENTS } from '@/server/calendar/events/types';
 
 describe('CalendarService - Editor Permissions', () => {

--- a/src/server/calendar/test/category_management_enhancements.test.ts
+++ b/src/server/calendar/test/category_management_enhancements.test.ts
@@ -8,7 +8,6 @@ import { EventCategory } from '@/common/model/event_category';
 import { EventCategoryEntity } from '../entity/event_category';
 import { EventCategoryContentEntity } from '../entity/event_category_content';
 import { EventCategoryAssignmentEntity } from '../entity/event_category_assignment';
-import { CalendarNotFoundError, InsufficientCalendarPermissionsError } from '@/common/exceptions/calendar';
 import { CategoryNotFoundError } from '@/common/exceptions/category';
 import db from '@/server/common/entity/db';
 

--- a/src/server/calendar/test/entity/calendar_member.test.ts
+++ b/src/server/calendar/test/entity/calendar_member.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 
 import { CalendarMember } from '@/common/model/calendar_member';

--- a/src/server/calendar/test/integration/category_management_integration.test.ts
+++ b/src/server/calendar/test/integration/category_management_integration.test.ts
@@ -26,7 +26,7 @@ describe('Category Management Integration Tests', () => {
   let testCalendar: Calendar;
   let testCategory1: EventCategory;
   let testCategory2: EventCategory;
-  let testCategory3: EventCategory;
+  let _testCategory3: EventCategory;
   let testEvent1: CalendarEvent;
   let testEvent2: CalendarEvent;
   let authToken: string;
@@ -81,7 +81,7 @@ describe('Category Management Integration Tests', () => {
       language: 'en',
     });
 
-    testCategory3 = await calendarInterface.createCategory(testAccount, testCalendar.id, {
+    _testCategory3 = await calendarInterface.createCategory(testAccount, testCalendar.id, {
       name: 'Arts',
       language: 'en',
     });

--- a/src/server/calendar/test/integration/event_deletion.test.ts
+++ b/src/server/calendar/test/integration/event_deletion.test.ts
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { TestEnvironment } from '@/server/common/test/lib/test_environment';
 import { Account } from '@/common/model/account';
 import { Calendar } from '@/common/model/calendar';
-import { CalendarEvent } from '@/common/model/events';
 import AccountService from '@/server/accounts/service/account';
 import CalendarInterface from '@/server/calendar/interface';
 import ConfigurationInterface from '@/server/configuration/interface';

--- a/src/server/calendar/test/integration/event_search_sqlite.test.ts
+++ b/src/server/calendar/test/integration/event_search_sqlite.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { EventEmitter } from 'events';
 
 import { Calendar } from '@/common/model/calendar';
-import { CalendarEvent } from '@/common/model/events';
 import { Account } from '@/common/model/account';
 import EventService from '@/server/calendar/service/events';
 import CalendarService from '@/server/calendar/service/calendar';
@@ -16,7 +15,7 @@ import db from '@/server/common/entity/db';
  */
 describe('Event Search Integration (SQLite)', () => {
   let eventService: EventService;
-  let calendarService: CalendarService;
+  let _calendarService: CalendarService;
   let eventBus: EventEmitter;
   let testCalendar: Calendar;
   let testAccount: Account;
@@ -27,7 +26,7 @@ describe('Event Search Integration (SQLite)', () => {
 
     eventBus = new EventEmitter();
     eventService = new EventService(eventBus);
-    calendarService = new CalendarService();
+    _calendarService = new CalendarService();
 
     // Inject a minimal AP interface stub so listEvents does not crash when
     // no real ActivityPub domain is wired up in this test environment.

--- a/src/server/calendar/test/service/event_instance.test.ts
+++ b/src/server/calendar/test/service/event_instance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
-import { DateTime, Duration } from 'luxon';
+import { DateTime } from 'luxon';
 import { v4 as uuidv4 } from 'uuid';
 import sinon from 'sinon';
 import { Op, Utils } from 'sequelize';

--- a/src/server/cli/index.ts
+++ b/src/server/cli/index.ts
@@ -12,7 +12,6 @@ import { EventEmitter } from 'events';
 import { BackupEntity } from '../housekeeping/entity/backup.js';
 import JobQueueService from '../housekeeping/service/job-queue.js';
 import StorageService from '../housekeeping/service/storage.js';
-import BackupService from '../housekeeping/service/backup.js';
 import * as readline from 'readline';
 import Table from 'cli-table3';
 import { DateTime } from 'luxon';

--- a/src/server/common/entity/db.ts
+++ b/src/server/common/entity/db.ts
@@ -210,7 +210,6 @@ export const seedFollowData = async () => {
   }
 
   // test_calendar (admin) follows testuser_calendar
-  const followingCalendarId = 'cbe74815-939e-48b3-af44-1cd4eb3671bb'; // testuser_calendar
   const localCalendarId = 'c71f5c9e-7a3d-4e5f-8e1a-66c3612a05f3';   // test_calendar (admin)
 
   const existingFollow = await db.models['FollowingCalendarEntity'].findOne({

--- a/src/server/common/test/app.test.ts
+++ b/src/server/common/test/app.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { countRoutes } from '@/server/common/test/lib/express';
 import sinon from 'sinon';
 import express from 'express';
 

--- a/src/server/common/test/helpers/database.ts
+++ b/src/server/common/test/helpers/database.ts
@@ -19,7 +19,6 @@
  * This approach is ephemeral - tables are created fresh for each test.
  */
 
-import db from '@/server/common/entity/db';
 import {
   FollowingCalendarEntity,
   FollowerCalendarEntity,

--- a/src/server/common/test/middleware/validation.test.ts
+++ b/src/server/common/test/middleware/validation.test.ts
@@ -5,7 +5,6 @@ import { validateUUID, validateRequired, validateDateRange } from '@/server/comm
 
 // Install a simple error handler that serializes ValidationError into JSON
 function installErrorHandler(app: Express): void {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
     res.status(400).json({ error: err.message, errorName: err.name });
   });

--- a/src/server/common/test/migrations/fixtures/failing-migrations/0001_failing.ts
+++ b/src/server/common/test/migrations/fixtures/failing-migrations/0001_failing.ts
@@ -4,11 +4,11 @@ import { Sequelize } from 'sequelize';
  * Test migration that intentionally fails
  */
 export default {
-  async up({ context: sequelize }: { context: Sequelize }) {
+  async up({ context: _sequelize }: { context: Sequelize }) {
     throw new Error('Migration failed intentionally');
   },
 
-  async down({ context: sequelize }: { context: Sequelize }) {
+  async down({ context: _sequelize }: { context: Sequelize }) {
     // Nothing to roll back since up() fails
   },
 };

--- a/src/server/common/test/migrations/fixtures/partial-failing-migrations/0001_partial_failing.ts
+++ b/src/server/common/test/migrations/fixtures/partial-failing-migrations/0001_partial_failing.ts
@@ -22,7 +22,7 @@ export default {
     throw new Error('Migration failed after partial change');
   },
 
-  async down({ context: sequelize }: { context: Sequelize }) {
+  async down({ context: _sequelize }: { context: Sequelize }) {
     // Never reached
   },
 };

--- a/src/server/email/service/email.ts
+++ b/src/server/email/service/email.ts
@@ -88,7 +88,7 @@ class EmailServiceClass {
         mailConfig = config.get('mail');
       }
     }
-    catch (err) {
+    catch {
       logger.warn('Mail configuration not found, using defaults');
     }
 

--- a/src/server/email/test/cross-domain-email.test.ts
+++ b/src/server/email/test/cross-domain-email.test.ts
@@ -6,7 +6,6 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import sinon from 'sinon';
-import { EventEmitter } from 'events';
 
 import EmailService from '@/server/email/service/email';
 import { EmailStore } from '@/server/email/transport/testing-transport';

--- a/src/server/funding/service/provider/factory.ts
+++ b/src/server/funding/service/provider/factory.ts
@@ -32,7 +32,7 @@ export class ProviderFactory {
     try {
       credentials = JSON.parse(entity.decryptCredentials());
     }
-    catch (err) {
+    catch {
       throw new Error(`Invalid credentials format for provider ${entity.id}`);
     }
 

--- a/src/server/funding/service/provider/mock_adapters.ts
+++ b/src/server/funding/service/provider/mock_adapters.ts
@@ -77,7 +77,7 @@ export class MockStripeAdapter implements PaymentProviderAdapter {
    * @param subscriptionId - Provider's subscription ID
    * @param immediate - If true, cancel immediately
    */
-  async cancelSubscription(subscriptionId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(_subscriptionId: string, _immediate: boolean): Promise<void> {
     // Mock cancellation - no actual API call
     return Promise.resolve();
   }
@@ -152,7 +152,7 @@ export class MockStripeAdapter implements PaymentProviderAdapter {
    * @param signature - Signature header from webhook request
    * @returns Always returns true for mock
    */
-  verifyWebhookSignature(payload: string, signature: string): boolean {
+  verifyWebhookSignature(_payload: string, _signature: string): boolean {
     // Mock verification - always returns true
     return true;
   }
@@ -200,7 +200,7 @@ export class MockStripeAdapter implements PaymentProviderAdapter {
    * @param sessionId - The checkout session ID
    * @returns Mock checkout session status
    */
-  async getCheckoutSessionStatus(sessionId: string): Promise<CheckoutSessionStatus> {
+  async getCheckoutSessionStatus(_sessionId: string): Promise<CheckoutSessionStatus> {
     return {
       status: 'complete',
       subscriptionId: 'sub_mock_123',
@@ -258,7 +258,7 @@ export class MockPayPalAdapter implements PaymentProviderAdapter {
    * @param subscriptionId - Provider's subscription ID
    * @param immediate - If true, cancel immediately
    */
-  async cancelSubscription(subscriptionId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(_subscriptionId: string, _immediate: boolean): Promise<void> {
     // Mock cancellation - no actual API call
     return Promise.resolve();
   }
@@ -333,7 +333,7 @@ export class MockPayPalAdapter implements PaymentProviderAdapter {
    * @param signature - Signature header from webhook request
    * @returns Always returns true for mock
    */
-  verifyWebhookSignature(payload: string, signature: string): boolean {
+  verifyWebhookSignature(_payload: string, _signature: string): boolean {
     // Mock verification - always returns true
     return true;
   }
@@ -365,7 +365,7 @@ export class MockPayPalAdapter implements PaymentProviderAdapter {
    * @param params - Checkout session parameters
    * @throws Error always
    */
-  async createCheckoutSession(params: CreateCheckoutSessionParams): Promise<CheckoutSessionResult> {
+  async createCheckoutSession(_params: CreateCheckoutSessionParams): Promise<CheckoutSessionResult> {
     throw new Error('createCheckoutSession is not implemented for PayPal');
   }
 
@@ -377,7 +377,7 @@ export class MockPayPalAdapter implements PaymentProviderAdapter {
    * @param sessionId - The checkout session ID
    * @throws Error always
    */
-  async getCheckoutSessionStatus(sessionId: string): Promise<CheckoutSessionStatus> {
+  async getCheckoutSessionStatus(_sessionId: string): Promise<CheckoutSessionStatus> {
     throw new Error('getCheckoutSessionStatus is not implemented for PayPal');
   }
 
@@ -391,7 +391,7 @@ export class MockPayPalAdapter implements PaymentProviderAdapter {
    * @param interval - Billing interval
    * @throws Error always
    */
-  async createPrice(amount: number, currency: string, interval: 'month' | 'year'): Promise<string> {
+  async createPrice(_amount: number, _currency: string, _interval: 'month' | 'year'): Promise<string> {
     throw new Error('createPrice is not implemented for PayPal');
   }
 }

--- a/src/server/funding/service/provider/paypal.ts
+++ b/src/server/funding/service/provider/paypal.ts
@@ -73,7 +73,7 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @param subscriptionId - Provider's subscription ID
    * @param immediate - If true, cancel immediately; otherwise at period end (PayPal only supports immediate)
    */
-  async cancelSubscription(subscriptionId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(subscriptionId: string, _immediate: boolean): Promise<void> {
     // Note: PayPal doesn't have native "cancel at period end" functionality
     // We'll cancel immediately and the service layer should handle the timing
     await (this.client as any).subscriptions.subscriptionsCancel({
@@ -105,9 +105,9 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @throws Error always, as PayPal does not support this operation
    */
   async updateSubscriptionAmount(
-    providerSubscriptionId: string,
-    newAmount: number,
-    currency: string,
+    _providerSubscriptionId: string,
+    _newAmount: number,
+    _currency: string,
   ): Promise<void> {
     throw new Error('updateSubscriptionAmount is not implemented for PayPal');
   }
@@ -137,7 +137,7 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @param returnUrl - URL to return to after management
    * @returns Management portal URL
    */
-  async getBillingPortalUrl(customerId: string, returnUrl: string): Promise<string> {
+  async getBillingPortalUrl(_customerId: string, _returnUrl: string): Promise<string> {
     // PayPal doesn't have a dedicated billing portal like Stripe
     // Direct users to their PayPal account subscription management
     const mode = (this.credentials.mode as string) || 'sandbox';
@@ -237,7 +237,7 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @param params - Checkout session parameters
    * @throws Error always, as PayPal does not support embedded checkout sessions
    */
-  async createCheckoutSession(params: CreateCheckoutSessionParams): Promise<CheckoutSessionResult> {
+  async createCheckoutSession(_params: CreateCheckoutSessionParams): Promise<CheckoutSessionResult> {
     throw new Error('createCheckoutSession is not implemented for PayPal');
   }
 
@@ -250,7 +250,7 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @param sessionId - The checkout session ID
    * @throws Error always, as PayPal does not support checkout sessions
    */
-  async getCheckoutSessionStatus(sessionId: string): Promise<CheckoutSessionStatus> {
+  async getCheckoutSessionStatus(_sessionId: string): Promise<CheckoutSessionStatus> {
     throw new Error('getCheckoutSessionStatus is not implemented for PayPal');
   }
 
@@ -265,7 +265,7 @@ export class PayPalAdapter implements PaymentProviderAdapter {
    * @param interval - Billing interval
    * @throws Error always, as PayPal uses billing plans instead
    */
-  async createPrice(amount: number, currency: string, interval: 'month' | 'year'): Promise<string> {
+  async createPrice(_amount: number, _currency: string, _interval: 'month' | 'year'): Promise<string> {
     throw new Error('createPrice is not implemented for PayPal');
   }
 

--- a/src/server/funding/service/provider/stripe.ts
+++ b/src/server/funding/service/provider/stripe.ts
@@ -215,7 +215,7 @@ export class StripeAdapter implements PaymentProviderAdapter {
       this.stripe.webhooks.constructEvent(payload, signature, this.webhookSecret);
       return true;
     }
-    catch (err) {
+    catch {
       return false;
     }
   }

--- a/src/server/funding/service/provider/webhook_manager.ts
+++ b/src/server/funding/service/provider/webhook_manager.ts
@@ -46,7 +46,7 @@ export class WebhookManager {
         }
       }
     }
-    catch (e) {
+    catch {
       // Config doesn't have server.domain, continue to fallback
     }
 

--- a/src/server/funding/service/provider_connection.ts
+++ b/src/server/funding/service/provider_connection.ts
@@ -87,7 +87,7 @@ export class ProviderConnectionService {
    * @param adminUser - Admin user performing the configuration
    * @returns Object with connectionVerified indicating if Stripe API call succeeded
    */
-  async configureStripe(credentials: StripeCredentialInputs, adminUser: AdminUser): Promise<StripeConfigureResult> {
+  async configureStripe(credentials: StripeCredentialInputs, _adminUser: AdminUser): Promise<StripeConfigureResult> {
     // Validate required fields
     if (!credentials.publishable_key || credentials.publishable_key.trim() === '') {
       throw new MissingRequiredFieldError('publishable_key');
@@ -178,7 +178,7 @@ export class ProviderConnectionService {
    * @param adminUser - Admin user performing the configuration
    * @returns True if configuration successful
    */
-  async configurePayPal(credentials: ProviderCredentials, adminUser: AdminUser): Promise<boolean> {
+  async configurePayPal(credentials: ProviderCredentials, _adminUser: AdminUser): Promise<boolean> {
     // Validate required fields (check for both undefined and empty string)
     if (!credentials.client_id || credentials.client_id.trim() === '') {
       throw new MissingRequiredFieldError('client_id');
@@ -279,7 +279,7 @@ export class ProviderConnectionService {
         hasRequiredFields = !!credentials.client_id && !!credentials.client_secret;
       }
     }
-    catch (e) {
+    catch {
       hasRequiredFields = false;
     }
 

--- a/src/server/funding/test/adapter.test.ts
+++ b/src/server/funding/test/adapter.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
-import { ProviderConfig } from '@/common/model/funding-plan';
 import { StripeAdapter } from '../service/provider/stripe';
 import { PayPalAdapter } from '../service/provider/paypal';
 import { MockStripeAdapter, MockPayPalAdapter } from '../service/provider/mock_adapters';

--- a/src/server/funding/test/admin_api.test.ts
+++ b/src/server/funding/test/admin_api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import express, { Request, Response } from 'express';
+import express from 'express';
 import request from 'supertest';
 import sinon from 'sinon';
 import FundingService from '@/server/funding/service/funding';

--- a/src/server/funding/test/api/v1/calendar-funding-plan.test.ts
+++ b/src/server/funding/test/api/v1/calendar-funding-plan.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import express, { Request, Response } from 'express';
+import express from 'express';
 import request from 'supertest';
 import sinon from 'sinon';
 import CalendarFundingPlanRoutes from '@/server/funding/api/v1/calendar-funding-plan';
 import FundingInterface from '@/server/funding/interface';
 import { Account } from '@/common/model/account';
-import { FundingPlan } from '@/common/model/funding-plan';
 import { testApp } from '@/server/common/test/lib/express';
 import {
   FundingPlanNotFoundError,

--- a/src/server/funding/test/calendar_subscription_service.test.ts
+++ b/src/server/funding/test/calendar_subscription_service.test.ts
@@ -8,9 +8,8 @@ import { FundingPlanEntity } from '@/server/funding/entity/funding_plan';
 import { CalendarFundingPlanEntity } from '@/server/funding/entity/calendar_funding_plan';
 import { ComplimentaryGrantEntity } from '@/server/funding/entity/complimentary_grant';
 import { ProviderConfigEntity } from '@/server/funding/entity/provider_config';
-import { FundingSettingsEntity } from '@/server/funding/entity/funding_settings';
 import { ProviderFactory } from '@/server/funding/service/provider/factory';
-import { FundingSettings, ProviderConfig, FundingPlan } from '@/common/model/funding-plan';
+import { ProviderConfig, FundingPlan } from '@/common/model/funding-plan';
 import { ValidationError } from '@/common/exceptions/base';
 import {
   FundingPlanNotFoundError,
@@ -442,7 +441,7 @@ describe('FundingService - Calendar Subscription Methods', () => {
       sandbox.stub(AccountRoleEntity, 'findOne').resolves(null);
 
       // No grant - hasActiveGrant returns null for first call, CalendarFundingPlanEntity for second
-      const findOneStub = sandbox.stub(ComplimentaryGrantEntity, 'findOne').resolves(null);
+      sandbox.stub(ComplimentaryGrantEntity, 'findOne').resolves(null);
 
       // Active calendar subscription exists
       sandbox.stub(CalendarFundingPlanEntity, 'findOne').resolves({

--- a/src/server/funding/test/entity.test.ts
+++ b/src/server/funding/test/entity.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import sinon from 'sinon';
 import { FundingSettingsEntity } from '../entity/funding_settings';
 import { ProviderConfigEntity } from '../entity/provider_config';
 import { FundingPlanEntity } from '../entity/funding_plan';
 import { FundingEventEntity } from '../entity/funding_event';
-import { FundingSettings, ProviderConfig, FundingPlan, FundingEvent } from '@/common/model/funding-plan';
+import { FundingSettings } from '@/common/model/funding-plan';
 import { millicentsToDisplay, displayToMillicents } from '@/common/model/funding-plan';
 
 describe('Subscription Entities', () => {

--- a/src/server/funding/test/integration.test.ts
+++ b/src/server/funding/test/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
 import sinon from 'sinon';
 import { EventEmitter } from 'events';
 import { v4 as uuidv4 } from 'uuid';
@@ -12,7 +12,7 @@ import { CalendarFundingPlanEntity } from '@/server/funding/entity/calendar_fund
 import { AccountEntity } from '@/server/common/entity/account';
 import { CalendarEntity } from '@/server/calendar/entity/calendar';
 import { ProviderFactory } from '@/server/funding/service/provider/factory';
-import { ProviderConfig, FundingSettings, FundingPlan } from '@/common/model/funding-plan';
+import { ProviderConfig } from '@/common/model/funding-plan';
 import { WebhookEvent } from '@/server/funding/service/provider/adapter';
 import { checkGracePeriodExpiry } from '@/server/funding/service/jobs';
 
@@ -27,7 +27,7 @@ describe('Subscription System Integration Tests', () => {
   let sandbox: sinon.SinonSandbox;
   let eventBus: EventEmitter;
   let service: FundingService;
-  let clock: sinon.SinonFakeTimers;
+  let _clock: sinon.SinonFakeTimers;
 
   beforeAll(async () => {
     // Sync database schema before running tests
@@ -40,7 +40,7 @@ describe('Subscription System Integration Tests', () => {
     service = new FundingService(eventBus);
 
     // Use fake timers for time-based tests
-    clock = sandbox.useFakeTimers({
+    _clock = sandbox.useFakeTimers({
       now: new Date('2026-01-15T12:00:00Z'),
       shouldAdvanceTime: false,
     });

--- a/src/server/funding/test/jobs.test.ts
+++ b/src/server/funding/test/jobs.test.ts
@@ -13,8 +13,8 @@ import { checkGracePeriodExpiry } from '@/server/funding/service/jobs';
 describe('Subscription Scheduled Jobs', () => {
   let sandbox: sinon.SinonSandbox;
   let eventBus: EventEmitter;
-  let service: FundingService;
-  let clock: sinon.SinonFakeTimers;
+  let _service: FundingService;
+  let _clock: sinon.SinonFakeTimers;
 
   beforeAll(async () => {
     // Sync database schema before running tests
@@ -24,10 +24,10 @@ describe('Subscription Scheduled Jobs', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     eventBus = new EventEmitter();
-    service = new FundingService(eventBus);
+    _service = new FundingService(eventBus);
 
     // Use fake timers to control date/time
-    clock = sandbox.useFakeTimers({
+    _clock = sandbox.useFakeTimers({
       now: new Date('2026-01-15T12:00:00Z'),
       shouldAdvanceTime: false,
     });

--- a/src/server/funding/test/service.test.ts
+++ b/src/server/funding/test/service.test.ts
@@ -23,7 +23,6 @@ import {
   FundingPlanNotFoundError,
 } from '@/common/exceptions/funding';
 import { ValidationError } from '@/common/exceptions/base';
-import { AccountEntity } from '@/server/common/entity/account';
 import { v4 as uuidv4 } from 'uuid';
 import config from 'config';
 

--- a/src/server/housekeeping/service/backup.ts
+++ b/src/server/housekeeping/service/backup.ts
@@ -161,7 +161,7 @@ export default class BackupService {
         }
       }
     }
-    catch (error) {
+    catch {
       // Config doesn't exist, which is fine - S3 is optional
     }
   }

--- a/src/server/housekeeping/service/retention.ts
+++ b/src/server/housekeeping/service/retention.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import config from 'config';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';
 import { logError } from '@/server/common/helper/error-logger';
-import { Op } from 'sequelize';
 import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('housekeeping');

--- a/src/server/housekeeping/test/integration/end-to-end-backup.test.ts
+++ b/src/server/housekeeping/test/integration/end-to-end-backup.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import JobQueueService from '@/server/housekeeping/service/job-queue';
 import BackupService from '@/server/housekeeping/service/backup';
 import RetentionService from '@/server/housekeeping/service/retention';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';

--- a/src/server/housekeeping/test/integration/worker-startup-config.test.ts
+++ b/src/server/housekeeping/test/integration/worker-startup-config.test.ts
@@ -112,7 +112,7 @@ describe('Worker Startup and Configuration Integration', () => {
     };
 
     // Verify all config values are defined
-    Object.entries(requiredConfig).forEach(([key, value]) => {
+    Object.entries(requiredConfig).forEach(([_key, value]) => {
       expect(value).toBeDefined();
       expect(value).not.toBeNull();
     });

--- a/src/server/housekeeping/test/service/storage.test.ts
+++ b/src/server/housekeeping/test/service/storage.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { DateTime } from 'luxon';
 import StorageService from '@/server/housekeeping/service/storage';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';
 import * as fs from 'fs';

--- a/src/server/media/test/integration/media_approval.test.ts
+++ b/src/server/media/test/integration/media_approval.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
 import { EventEmitter } from 'events';
-import path from 'path';
-import fs from 'fs';
 
 import { Account } from '@/common/model/account';
 import { Calendar } from '@/common/model/calendar';

--- a/src/server/moderation/service/moderation.ts
+++ b/src/server/moderation/service/moderation.ts
@@ -2123,7 +2123,7 @@ class ModerationService {
         );
       }
     }
-    catch (error) {
+    catch {
       // Silently handle errors - pattern detection should not fail report creation
     }
   }
@@ -2159,7 +2159,7 @@ class ModerationService {
         }
       }
     }
-    catch (error) {
+    catch {
       // Silently handle errors - pattern detection should not fail report creation
     }
   }

--- a/src/server/moderation/test/api/admin-report-forward.test.ts
+++ b/src/server/moderation/test/api/admin-report-forward.test.ts
@@ -132,7 +132,7 @@ describe('Admin Report Forward API', () => {
         sandbox.stub(moderationInterface, 'forwardReport').resolves();
 
         // Mock the entity save to prevent DB operations
-        const saveSpy = sandbox.stub(ReportEscalationEntity.prototype, 'save').resolves({
+        sandbox.stub(ReportEscalationEntity.prototype, 'save').resolves({
           toModel: () => ({
             id: 'esc-id',
             reportId: TEST_REPORT_ID,

--- a/src/server/moderation/test/integration/remote-report-creation.test.ts
+++ b/src/server/moderation/test/integration/remote-report-creation.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
-import { EventEmitter } from 'events';
 import { v4 as uuidv4 } from 'uuid';
 
 import { ReportEntity } from '@/server/moderation/entity/report';

--- a/src/server/moderation/test/model/new_report_notification_email.test.ts
+++ b/src/server/moderation/test/model/new_report_notification_email.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
 import i18next from 'i18next';
-import handlebars from 'handlebars';
 import NewReportNotificationEmail from '../../model/new_report_notification_email';
 import { initI18Next } from '@/server/common/test/lib/i18next';
 

--- a/src/server/moderation/test/service/auto-escalation.test.ts
+++ b/src/server/moderation/test/service/auto-escalation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
 import { EventEmitter } from 'events';
 
-import { Report, ReportCategory, ReportStatus } from '@/common/model/report';
+import { Report, ReportStatus } from '@/common/model/report';
 import { ReportEntity } from '@/server/moderation/entity/report';
 import ModerationService from '@/server/moderation/service/moderation';
 import ConfigurationInterface from '@/server/configuration/interface';

--- a/src/server/moderation/test/service/email-blocking-integration.test.ts
+++ b/src/server/moderation/test/service/email-blocking-integration.test.ts
@@ -28,7 +28,6 @@ describe('ModerationService - Email Blocking Integration', () => {
 
     it('should throw ReporterBlockedError when anonymous reporter email is blocked', async () => {
       const blockedEmail = 'blocked@example.com';
-      const emailHash = service.hashEmail(blockedEmail);
 
       // Mock isEmailBlocked to return true
       sandbox.stub(service, 'isEmailBlocked').resolves(true);
@@ -150,7 +149,6 @@ describe('ModerationService - Email Blocking Integration', () => {
 
     it('should include block reason in ReporterBlockedError', async () => {
       const blockedEmail = 'blocked@example.com';
-      const blockReason = 'Abusive behavior';
 
       sandbox.stub(service, 'isEmailBlocked').resolves(true);
       sandbox.stub(service, 'hasExceededEmailRateLimit').resolves(false);

--- a/src/server/moderation/test/service/moderation-forward-status.test.ts
+++ b/src/server/moderation/test/service/moderation-forward-status.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 
 import ModerationService from '@/server/moderation/service/moderation';
 import { ReportEntity } from '@/server/moderation/entity/report';
-import { Report, ReportStatus, ForwardStatus } from '@/common/model/report';
+import { ForwardStatus } from '@/common/model/report';
 
 describe('ModerationService.checkForwardStatus', () => {
   let sandbox: sinon.SinonSandbox;

--- a/src/server/moderation/test/service/pattern-detection.test.ts
+++ b/src/server/moderation/test/service/pattern-detection.test.ts
@@ -38,7 +38,7 @@ describe('PatternDetectionService', () => {
       });
 
       // Mock finding other reports from same source
-      const otherReports = [
+      const _otherReports = [
         ReportEntity.build({
           id: 'report-2',
           event_id: 'event-2',

--- a/src/server/moderation/test/service/pattern-integration.test.ts
+++ b/src/server/moderation/test/service/pattern-integration.test.ts
@@ -312,7 +312,7 @@ describe('ModerationService - Pattern Detection Integration', () => {
             report.hasSourceFloodingPattern = true;
           }
         }
-        catch (error) {
+        catch {
           // Silently handle error - don't fail report creation
         }
 
@@ -322,7 +322,7 @@ describe('ModerationService - Pattern Detection Integration', () => {
             report.hasEventTargetingPattern = true;
           }
         }
-        catch (error) {
+        catch {
           // Silently handle error
         }
 

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -130,7 +130,7 @@ async function registerJobHandlers(queue: JobQueueService): Promise<void> {
   });
 
   // Disk check job handler (runs hourly)
-  await queue.schedule('disk:check', '0 * * * *', async (data) => {
+  await queue.schedule('disk:check', '0 * * * *', async (_data) => {
     logger.info('Executing disk:check job');
     try {
       // Get configuration
@@ -175,7 +175,7 @@ async function registerJobHandlers(queue: JobQueueService): Promise<void> {
   });
 
   // IP cleanup job handler (runs daily at 3 AM)
-  await queue.schedule('moderation:ip-cleanup', '0 3 * * *', async (data) => {
+  await queue.schedule('moderation:ip-cleanup', '0 3 * * *', async (_data) => {
     logger.info('Executing moderation:ip-cleanup job');
     try {
       // Get retention configuration

--- a/src/site/components/test/calendar.integration.test.ts
+++ b/src/site/components/test/calendar.integration.test.ts
@@ -9,7 +9,6 @@ import CalendarService from '../../service/calendar';
 import ModelService from '@/client/service/models';
 import ListResult from '@/client/service/list-result';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
-import { EventCategory } from '@/common/model/event_category';
 import CalendarEventInstance from '@/common/model/event_instance';
 import { CalendarEvent, CalendarEventContent } from '@/common/model/events';
 import { DateTime } from 'luxon';
@@ -113,7 +112,7 @@ describe('calendar.vue - SearchFilterPublic Integration', () => {
       },
     });
 
-    const wrapper = mount(calendar, {
+    const _wrapper = mount(calendar, {
       global: {
         plugins: [pinia, router],
         stubs: {
@@ -177,7 +176,7 @@ describe('calendar.vue - SearchFilterPublic Integration', () => {
     // Start with no filters
     await router.push('/calendar/test-calendar');
 
-    const wrapper = mount(calendar, {
+    const _wrapper = mount(calendar, {
       global: {
         plugins: [pinia, router],
         stubs: {

--- a/src/site/components/test/search-filter.e2e.test.ts
+++ b/src/site/components/test/search-filter.e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import { createRouter, createMemoryHistory, Router } from 'vue-router';
 import { createPinia, setActivePinia } from 'pinia';
 import SearchFilterPublic from '../search-filter-public.vue';
@@ -148,7 +148,7 @@ describe('Public Event Search & Filtering - End-to-End Tests', () => {
     it('should handle array parameters that should be strings', async () => {
       vi.mocked(CalendarService.prototype.getCalendarByUrlName).mockResolvedValue(mockCalendar);
 
-      const store = usePublicCalendarStore();
+      const _store = usePublicCalendarStore();
 
       // Navigate with array where string is expected
       await router.push({
@@ -506,11 +506,11 @@ describe('Public Event Search & Filtering - End-to-End Tests', () => {
       expect(searchInput.attributes('id')).toBe('public-event-search');
 
       // Date inputs should have proper labels
-      const startDateInput = wrapper.find('input#start-date');
+      const _startDateInput = wrapper.find('input#start-date');
       const startLabel = wrapper.find('label[for="start-date"]');
       expect(startLabel.exists()).toBe(true);
 
-      const endDateInput = wrapper.find('input#end-date');
+      const _endDateInput = wrapper.find('input#end-date');
       const endLabel = wrapper.find('label[for="end-date"]');
       expect(endLabel.exists()).toBe(true);
 

--- a/src/site/test/components/event-image.test.ts
+++ b/src/site/test/components/event-image.test.ts
@@ -8,7 +8,7 @@
  * - Zoom <= 1 does not apply transform.
  * - Component renders nothing when media is null.
  */
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
 // Mock fetch globally so the component can load images

--- a/src/site/test/components/search-filter-public.test.ts
+++ b/src/site/test/components/search-filter-public.test.ts
@@ -1187,7 +1187,7 @@ describe('SearchFilterPublic Component', () => {
         query: { search: 'yoga classes' },
       });
 
-      const wrapper = mount(SearchFilterPublic, {
+      const _wrapper = mount(SearchFilterPublic, {
         global: {
           plugins: [pinia, router, [I18NextVue, { i18next }]],
         },

--- a/src/widget-sdk/pavillion-widget.ts
+++ b/src/widget-sdk/pavillion-widget.ts
@@ -57,7 +57,7 @@ class PavillionWidget {
         const url = new URL(scriptSrc, window.location.href);
         this.widgetOrigin = url.origin;
       }
-      catch (e) {
+      catch {
         // Fallback to current origin if script src cannot be parsed
         this.widgetOrigin = window.location.origin;
       }

--- a/src/widget/test/integration/widget_integration.test.ts
+++ b/src/widget/test/integration/widget_integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import sinon from 'sinon';
 import express, { Application } from 'express';

--- a/src/widget/test/widgetApp.test.ts
+++ b/src/widget/test/widgetApp.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 import { createMemoryHistory, createRouter, type Router } from 'vue-router';
 import { useWidgetStore } from '../stores/widgetStore';


### PR DESCRIPTION
## Motivation

`npm run lint` reported ~283 `@typescript-eslint/no-unused-vars` warnings (0 errors). The repo already uses a leading-underscore convention to mark intentionally-unused bindings, but the eslint rule wasn't configured to honor it, so those were flagged alongside genuinely-dead code.

## Approach

1. **Config:** set `no-unused-vars` to ignore `^_` for args, vars, and caught errors — legitimizing the existing convention and clearing the underscore-prefixed subset in one change.
2. **Sweep:** clear the remaining warnings across ~90 files — remove dead imports and locals, `_`-prefix intentionally-unused params and caught errors, drop redundant eslint-disable directives. Behavior-preserving: side-effecting calls were retained when only the unused binding was removed/renamed.

Partitioned by source directory across parallel workers; one fix-up was needed where a still-referenced stub had been renamed (caught by build-guardian, corrected).

## Validation

- `npm run lint` → 0 errors, 0 warnings
- build-guardian: full unit suite (8373) PASS, integration PASS (after the stub fix-up), build PASS
- e2e env-gated (could not run locally)