### PR TITLE
test(client): cover calendar tab keyboard-navigation wiring

### DIFF
--- a/src/client/test/components/calendar/calendar-tabs.test.ts
+++ b/src/client/test/components/calendar/calendar-tabs.test.ts
@@ -49,7 +49,11 @@ const mockEvent = {
   isRepost: false,
 };
 
-const createWrapper = async (routeQuery = {}, routeParams = { calendar: 'test-calendar' }) => {
+const createWrapper = async (
+  routeQuery = {},
+  routeParams = { calendar: 'test-calendar' },
+  { attach = false } = {},
+) => {
   const router: Router = createRouter({
     history: createMemoryHistory(),
     routes,
@@ -65,6 +69,9 @@ const createWrapper = async (routeQuery = {}, routeParams = { calendar: 'test-ca
 
   const wrapper = mountComponent(CalendarView, router, {
     pinia,
+    // Keyboard navigation focuses tabs via document.getElementById, which only
+    // resolves when the component is attached to a live document.
+    attachTo: attach ? document.body : undefined,
     stubs: {
       SearchFilter: { template: '<div class="search-filter-stub" />' },
       BulkOperationsMenu: { template: '<div />' },
@@ -202,18 +209,27 @@ describe('Calendar View Tabs', () => {
   });
 
   describe('Arrow Key Navigation', () => {
-    it('should have a keydown handler on the tablist', async () => {
-      const { wrapper } = await createWrapper();
+    it('should activate the next tab when ArrowRight is pressed on the tablist', async () => {
+      // Exercises the real @keydown="handleTabKeydown" binding end-to-end.
+      // The arrow-key semantics themselves (wrapping, Home/End, preventDefault)
+      // are covered exhaustively in useTabNavigation.test.ts; this asserts only
+      // that calendar.vue wires that composable to the tablist with ORDERED_TABS.
+      // Requires a DOM-attached mount because the handler focuses the target tab
+      // via document.getElementById; unmount afterward to detach from body.
+      const { wrapper, router } = await createWrapper({}, { calendar: 'test-calendar' }, { attach: true });
 
-      // Verify the tablist element has the @keydown binding by checking
-      // that it renders properly with the handler attached
-      const tablist = wrapper.find('[role="tablist"]');
-      expect(tablist.exists()).toBe(true);
+      try {
+        expect(wrapper.find('#events-tab').attributes('aria-selected')).toBe('true');
 
-      // The keydown handler is verified by confirming the ORDERED_TABS
-      // constant drives tab ordering, and the activateTab function works
-      // via click. Arrow key behavior is tested functionally via click
-      // equivalents below.
+        await triggerTabKeydown(wrapper, 'ArrowRight');
+
+        expect(wrapper.find('#places-tab').attributes('aria-selected')).toBe('true');
+        expect(wrapper.find('#events-tab').attributes('aria-selected')).toBe('false');
+        expect(router.currentRoute.value.query.tab).toBe('places');
+      }
+      finally {
+        wrapper.unmount();
+      }
     });
 
     it('should navigate through tabs in correct order via sequential clicks', async () => {

--- a/src/client/test/lib/vue.ts
+++ b/src/client/test/lib/vue.ts
@@ -10,6 +10,10 @@ interface MountConfig {
   props?: Record<string, any>;
   stubs?: Record<string, any>;
   pinia?: Pinia;
+  // Attach the component to a live DOM node. Required for behavior that reads
+  // the document (e.g. document.getElementById / element focus); omit it for
+  // the common detached-mount case. Remember to unmount() to detach again.
+  attachTo?: Element | string;
 }
 
 const mountComponent = (component: any, router: Router, config: MountConfig = {}) => {
@@ -43,6 +47,7 @@ const mountComponent = (component: any, router: Router, config: MountConfig = {}
       stubs: config.stubs || {},
     },
     props: config.props,
+    ...(config.attachTo ? { attachTo: config.attachTo } : {}),
   });
 
   return wrapper;


### PR DESCRIPTION
## Motivation

`calendar-tabs.test.ts` had an `Arrow Key Navigation` suite whose `triggerTabKeydown` helper was never invoked. Its one keydown-named test (`should have a keydown handler on the tablist`) asserted only that the tablist element renders — it never dispatched a key event. The arrow-key behavior was instead approximated with click-based tests.

Root cause: `mountComponent` leaves the component detached from the document, so the `useTabNavigation` handler's `document.getElementById(...).focus()` path silently no-ops in jsdom. A keydown integration test would have passed vacuously, so the original author fell back to clicks and left the helper dead.

The composable's key semantics (ArrowLeft/Right wrapping, Home/End, `preventDefault`, unhandled keys, ref/computed inputs) are already covered exhaustively in `useTabNavigation.test.ts`. What was missing was the **wiring contract**: that `calendar.vue` binds `@keydown="handleTabKeydown"` to the tablist with `ORDERED_TABS`, so a real key press moves the active tab.

PR #381 (lint sweep) silenced the dead helper by renaming it to `_triggerTabKeydown`. That suppressed the warning but preserved the coverage gap. This PR closes the gap instead, removing the dead helper by using it.

## Approach

- Thread an optional `attachTo` through the shared `mountComponent` test helper (`src/client/test/lib/vue.ts`); applied only when set, so every existing detached-mount caller is unaffected.
- Give `createWrapper` an `{ attach }` option and, for one `ArrowRight` case, mount attached to `document.body` so the focus path resolves. Assert the active tab moves from events→places (aria-selected) and the URL query syncs to `tab=places`, then `unmount()` to detach.
- Replace the vacuous `should have a keydown handler` test with this real end-to-end binding test.

Verified non-vacuous by mutation: with the DOM attachment removed the new test fails (handler no-ops); with it, it passes.

## Validation

- New test passes; full file 19/19.
- `npm run lint` → 0 errors (the two pre-existing `'lang'` unused-var warnings in this file are out of scope and cleared separately by #381).
- `npm run test:unit` → 8373 passed (confirms the shared `mountComponent` change breaks no existing caller).
- `npm run test:integration` → 680 passed / 2 skipped.
- `npm run build` → pass.
- e2e env-gated; not run locally.