### PR TITLE
chore(client): drop stale role="dialog" from modal test stubs and CSS

### DIFF
--- a/src/client/assets/style/base/_accessibility.scss
+++ b/src/client/assets/style/base/_accessibility.scss
@@ -224,7 +224,7 @@ button:disabled,
     outline-offset: var(--pav-space-0_5);
   }
   
-  [role="dialog"], [role="complementary"] {
+  [role="complementary"] {
     border-width: var(--pav-border-width-2);
   }
 }
@@ -250,10 +250,6 @@ button:disabled,
     &:hover, &:active {
       transform: none;
     }
-  }
-  
-  [role="dialog"]::before {
-    backdrop-filter: none;
   }
 }
 

--- a/src/client/test/components/add-space-sheet.test.ts
+++ b/src/client/test/components/add-space-sheet.test.ts
@@ -25,7 +25,7 @@ vi.mock('@/client/service/location', () => ({
 const SheetStub = {
   props: ['title'],
   template: `
-    <dialog role="dialog" aria-modal="true">
+    <dialog aria-modal="true">
       <h2>{{ title }}</h2>
       <slot/>
     </dialog>
@@ -112,7 +112,7 @@ describe('AddSpaceSheet', () => {
         },
       });
 
-      expect(wrapper.find('[role="dialog"]').exists()).toBe(true);
+      expect(wrapper.find('dialog').exists()).toBe(true);
       expect(wrapper.find('h2').text()).toBe('Add a space to Community Center');
     });
 

--- a/src/client/test/components/admin/blocked-instances.test.ts
+++ b/src/client/test/components/admin/blocked-instances.test.ts
@@ -46,7 +46,7 @@ describe('BlockedInstances', () => {
           // in happy-dom. Expose the slot content so tests can still
           // assert against dialog body markup.
           Modal: {
-            template: '<div class="modal-overlay" role="dialog" aria-modal="true" :aria-labelledby="titleId"><h2 :id="titleId" class="modal">{{ title }}</h2><slot/></div>',
+            template: '<dialog class="modal-overlay" aria-modal="true" :aria-labelledby="titleId"><h2 :id="titleId" class="modal">{{ title }}</h2><slot/></dialog>',
             props: ['title', 'modalClass', 'size', 'initiallyOpen'],
             data() {
               return { titleId: 'confirm-title' };

--- a/src/client/test/components/admin/funding_provider_ui.test.ts
+++ b/src/client/test/components/admin/funding_provider_ui.test.ts
@@ -113,12 +113,12 @@ describe('Funding Provider UI Components', () => {
   const ModalStub = {
     props: ['title', 'modalClass', 'size', 'initiallyOpen'],
     template: `
-      <div class="modal-overlay" role="dialog" aria-modal="true">
+      <dialog class="modal-overlay" aria-modal="true">
         <div class="modal-container">
           <h2>{{ title }}</h2>
           <slot/>
         </div>
-      </div>
+      </dialog>
     `,
     emits: ['close'],
   };

--- a/src/client/test/components/calendar/edit-place.test.ts
+++ b/src/client/test/components/calendar/edit-place.test.ts
@@ -180,7 +180,7 @@ const ModalLayoutStub = {
   name: 'ModalLayout',
   props: ['title', 'modalClass', 'initiallyOpen', 'size'],
   emits: ['close'],
-  template: '<div role="dialog" aria-modal="true" :class="[\'modal\', modalClass]"><h2>{{ title }}</h2><slot /></div>',
+  template: '<dialog aria-modal="true" :class="[\'modal\', modalClass]"><h2>{{ title }}</h2><slot /></dialog>',
 };
 
 const createWrapper = async (

--- a/src/client/test/components/calendar/recurrence-editor-sheet.test.ts
+++ b/src/client/test/components/calendar/recurrence-editor-sheet.test.ts
@@ -34,7 +34,7 @@ const mountSheet = (schedule: CalendarEventSchedule) => {
         // inside a role=dialog element so ARIA-oriented assertions still
         // work.
         Sheet: {
-          template: '<div role="dialog" aria-modal="true"><slot /></div>',
+          template: '<dialog aria-modal="true"><slot /></dialog>',
           props: ['title'],
           emits: ['close'],
         },
@@ -59,7 +59,7 @@ describe('RecurrenceEditorSheet.vue — smoke tests', () => {
     const schedule = new CalendarEventSchedule();
     const wrapper = mountSheet(schedule);
 
-    const dialog = wrapper.find('[role="dialog"]');
+    const dialog = wrapper.find('dialog');
     expect(dialog.exists()).toBe(true);
     expect(dialog.attributes('aria-modal')).toBe('true');
     wrapper.unmount();

--- a/src/client/test/components/common/doc-link.test.ts
+++ b/src/client/test/components/common/doc-link.test.ts
@@ -20,7 +20,7 @@ const routes: RouteRecordRaw[] = [
 // HelpPanel still mounts, so its props remain assertable.
 const sheetStub = {
   Sheet: {
-    template: '<div role="dialog"><slot /></div>',
+    template: '<dialog aria-modal="true"><slot /></dialog>',
     props: ['title'],
     emits: ['close'],
   },

--- a/src/client/test/components/common/empty-state.test.ts
+++ b/src/client/test/components/common/empty-state.test.ts
@@ -12,7 +12,7 @@ const routes: RouteRecordRaw[] = [{ path: '/', component: {}, name: 'calendars' 
 
 const sheetStub = {
   Sheet: {
-    template: '<div role="dialog"><slot /></div>',
+    template: '<dialog aria-modal="true"><slot /></dialog>',
     props: ['title'],
     emits: ['close'],
   },

--- a/src/client/test/components/create-location-form.test.ts
+++ b/src/client/test/components/create-location-form.test.ts
@@ -12,7 +12,7 @@ import enEventEditor from '@/client/locales/en/event_editor.json';
 const SheetStub = {
   props: ['title'],
   template: `
-    <dialog role="dialog" aria-modal="true">
+    <dialog aria-modal="true">
       <h2>{{ title }}</h2>
       <slot/>
     </dialog>
@@ -94,7 +94,7 @@ describe('CreateLocationForm', () => {
         },
       });
 
-      expect(wrapper.find('[role="dialog"]').exists()).toBe(true);
+      expect(wrapper.find('dialog').exists()).toBe(true);
       expect(wrapper.find('h2').text()).toBe('Create Location');
     });
 

--- a/src/client/test/components/location-picker-modal.test.ts
+++ b/src/client/test/components/location-picker-modal.test.ts
@@ -17,7 +17,7 @@ import enCalendars from '@/client/locales/en/calendars.json';
 const SheetStub = {
   props: ['title'],
   template: `
-    <dialog role="dialog" aria-modal="true">
+    <dialog aria-modal="true">
       <h2>{{ title }}</h2>
       <slot/>
     </dialog>

--- a/src/client/test/components/moderation/blocked-reporters.test.ts
+++ b/src/client/test/components/moderation/blocked-reporters.test.ts
@@ -22,12 +22,12 @@ const routes = [
 const ModalStub = {
   props: ['title', 'modalClass', 'size', 'initiallyOpen'],
   template: `
-    <div class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <dialog class="modal-overlay" aria-modal="true" aria-labelledby="modal-title">
       <div class="modal">
         <h2 id="modal-title" class="modal-title">{{ title }}</h2>
         <slot/>
       </div>
-    </div>
+    </dialog>
   `,
   emits: ['close'],
 };
@@ -775,8 +775,10 @@ describe('BlockedReporters.vue', () => {
       await wrapper.find('.block-reporter-button').trigger('click');
       await wrapper.vm.$nextTick();
 
-      const modal = wrapper.find('[role="dialog"]');
-      expect(modal.attributes('role')).toBe('dialog');
+      // Native <dialog> provides the dialog role implicitly; existence of the
+      // element is the correct assertion, not an explicit role attribute.
+      const modal = wrapper.find('dialog');
+      expect(modal.exists()).toBe(true);
       expect(modal.attributes('aria-modal')).toBe('true');
       expect(modal.attributes('aria-labelledby')).toBeTruthy();
     });

--- a/src/client/test/components/repost-categories-modal.test.ts
+++ b/src/client/test/components/repost-categories-modal.test.ts
@@ -54,7 +54,7 @@ const mountModal = (props: Record<string, any> = {}): VueWrapper => {
         // Stub the Modal wrapper to render slot content directly, bypassing
         // native <dialog> showModal() which is not supported in happy-dom.
         Modal: {
-          template: '<div role="dialog" aria-modal="true"><slot /></div>',
+          template: '<dialog aria-modal="true"><slot /></dialog>',
           props: ['title'],
           emits: ['close'],
         },


### PR DESCRIPTION
## Motivation

When the modal and sheet components moved to the native `<dialog>` element, the explicit `role="dialog"` attribute was removed from production code (native `<dialog>` carries the dialog role implicitly). Two kinds of stale artifacts were left behind:

- Unit-test stubs that modeled `<Modal>`/`<Sheet>` as `<div role="dialog">`, no longer matching the real components' ARIA signature.
- Two high-contrast / reduced-motion CSS rules in `_accessibility.scss` keyed on `[role="dialog"]`, which no longer match any rendered dialog.

## Approach

- Converted the affected test stubs to native `<dialog>` elements and updated the queries (`find('[role="dialog"]')` → `find('dialog')`) and ARIA assertions that depended on the explicit attribute. Class-based assertions (`.modal-overlay`, `.modal`) were preserved by keeping those classes on the converted elements.
- Removed the dead `[role="dialog"]` selector from the `forced-colors` border rule (keeping `[role="complementary"]`, still in use; native dialogs are already covered by the `article, aside, dialog` element selector) and deleted the dead `[role="dialog"]::before` reduced-motion rule (the live rule is `dialog::backdrop`).

No production behavior changes — this aligns tests and styles with what the components already render.

## Validation

- Full unit suite green: 479 files / 8373 tests.
- `npm run build` passes (compiles the SCSS).
- Changed files lint clean.
- Integration/e2e tiers not run: the change surface is client unit-test stubs and one dead CSS rule, with no backend or federation reach.