### PR TITLE
chore: remove dead code and dedupe across server and frontend

### DIFF
--- a/src/client/service/locale.ts
+++ b/src/client/service/locale.ts
@@ -38,7 +38,6 @@ import esSeries from '@/client/locales/es/series.json';
 import esSetup from '@/client/locales/es/setup.json';
 import esFunding from '@/client/locales/es/funding.json';
 import esPolicy from '@/client/locales/es/policy.json';
-import esEditEvent from '@/client/locales/es/event_editor.json';
 
 // Import French translation resources
 import frSystem from '@/client/locales/fr/system.json';
@@ -56,7 +55,6 @@ import frSeries from '@/client/locales/fr/series.json';
 import frSetup from '@/client/locales/fr/setup.json';
 import frFunding from '@/client/locales/fr/funding.json';
 import frPolicy from '@/client/locales/fr/policy.json';
-import frEditEvent from '@/client/locales/fr/event_editor.json';
 
 /**
  * Detects the best language for the client from available signals.
@@ -147,7 +145,6 @@ export const initI18Next = (serverLanguage?: string) => {
         setup: esSetup,
         funding: esFunding,
         policy: esPolicy,
-        event_editor: esEditEvent,
       },
       fr: {
         system: frSystem,
@@ -165,7 +162,6 @@ export const initI18Next = (serverLanguage?: string) => {
         setup: frSetup,
         funding: frFunding,
         policy: frPolicy,
-        event_editor: frEditEvent,
       },
     },
   });

--- a/src/server/activitypub/helper/url-sanitizer.ts
+++ b/src/server/activitypub/helper/url-sanitizer.ts
@@ -1,0 +1,25 @@
+/**
+ * Sanitizes an untrusted href value from a federated peer. Returns a parsed
+ * http(s) URL string or null for any anomaly (non-string, empty/whitespace,
+ * too long, malformed, or non-http(s) scheme).
+ *
+ * Security-critical: this is the authoritative barrier against malicious peers
+ * injecting javascript:, data:, ftp:, or other dangerous URL schemes into
+ * stored event data. Shared by the inbound Event and Note object parsers so the
+ * scheme allowlist has a single source of truth. NEVER throws — a throw would
+ * cause the inbox to reject the entire activity, which is not the correct
+ * posture for a single bad field.
+ */
+export function sanitizeExternalUrlHref(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed.length > 2048) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  }
+  catch {
+    return null;
+  }
+}

--- a/src/server/activitypub/interface/index.ts
+++ b/src/server/activitypub/interface/index.ts
@@ -432,20 +432,6 @@ export default class ActivityPubInterface {
   }
 
   /**
-   * Gets the IDs of all events shared (reposted) to a given calendar.
-   *
-   * @param calendarId - The calendar UUID
-   * @returns Array of event ID strings
-   */
-  async getSharedEventIds(calendarId: string): Promise<string[]> {
-    const sharedEvents = await SharedEventEntity.findAll({
-      where: { calendar_id: calendarId },
-      attributes: ['event_id'],
-    });
-    return sharedEvents.map((se) => se.event_id);
-  }
-
-  /**
    * Gets a map of shared event IDs to their repost status ('auto' or 'manual')
    * for a given calendar. Derived from SharedEventEntity.auto_posted.
    *

--- a/src/server/activitypub/model/object/event.ts
+++ b/src/server/activitypub/model/object/event.ts
@@ -9,6 +9,7 @@ import { EventLocation, EventLocationSpace } from '@/common/model/location';
 import { ActivityPubObject } from '@/server/activitypub/model/base';
 import { SeriesObject } from '@/server/activitypub/model/object/series';
 import { createLogger } from '@/server/common/helper/logger';
+import { sanitizeExternalUrlHref } from '@/server/activitypub/helper/url-sanitizer';
 
 const logger = createLogger('activitypub');
 
@@ -30,30 +31,6 @@ const URL_PROMPT_EN_LABELS: Record<UrlPrompt, string> = {
  */
 function stripHtmlTags(html: string): string {
   return striptags(he.decode(html)).trim();
-}
-
-/**
- * Sanitizes an untrusted href value from a federated peer. Returns a parsed
- * http(s) URL string or null for any anomaly (non-string, empty/whitespace,
- * too long, malformed, or non-http(s) scheme).
- *
- * Security-critical: This is the authoritative barrier against malicious peers
- * injecting javascript:, data:, ftp:, or other dangerous URL schemes into
- * stored event data. NEVER throws — a throw would cause the inbox to reject
- * the entire activity, which is not the correct posture for a single bad field.
- */
-function sanitizeExternalUrlHref(raw: unknown): string | null {
-  if (typeof raw !== 'string') return null;
-  const trimmed = raw.trim();
-  if (trimmed === '' || trimmed.length > 2048) return null;
-  try {
-    const parsed = new URL(trimmed);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed.toString();
-  }
-  catch {
-    return null;
-  }
 }
 
 class EventObject extends ActivityPubObject {

--- a/src/server/activitypub/model/object/note.ts
+++ b/src/server/activitypub/model/object/note.ts
@@ -7,29 +7,7 @@ import { CalendarEvent } from '@/common/model/events';
 import { ActivityPubObject, ActivityPubActor } from '@/server/activitypub/model/base';
 import { EventObject } from '@/server/activitypub/model/object/event';
 
-/**
- * Sanitizes an untrusted href value from a federated peer. Returns a parsed
- * http(s) URL string or null for any anomaly (non-string, empty/whitespace,
- * too long, malformed, or non-http(s) scheme).
- *
- * Mirrors the helper in `event.ts` — duplicated here rather than re-exported
- * to keep `event.ts`'s helper private to that module. The two implementations
- * MUST stay in sync; both are the authoritative barrier against malicious
- * peers injecting javascript:, data:, ftp:, or other dangerous URL schemes.
- */
-function sanitizeExternalUrlHref(raw: unknown): string | null {
-  if (typeof raw !== 'string') return null;
-  const trimmed = raw.trim();
-  if (trimmed === '' || trimmed.length > 2048) return null;
-  try {
-    const parsed = new URL(trimmed);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
-    return parsed.toString();
-  }
-  catch {
-    return null;
-  }
-}
+import { sanitizeExternalUrlHref } from '@/server/activitypub/helper/url-sanitizer';
 
 /**
  * Wraps a CalendarEvent as an ActivityStreams `Note` for Mastodon-class

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -509,6 +509,13 @@ class ProcessOutboxService {
    * but have no CalendarActorEntity row. WebFinger handles (user@domain) and
    * malformed URIs return false.
    *
+   * Invariant this guard defends: recipients are sourced from
+   * FollowerCalendarEntity rows joined against CalendarActorEntity, so a
+   * local-looking recipient with no CalendarActorEntity row is FK-impossible
+   * under normal DB state. The guard exists only to fail safe against a
+   * missing/stale row (e.g. mid-migration or manual DB surgery) rather than
+   * HTTP-looping a delivery back to this instance.
+   *
    * @private
    */
   private isSameHostAsActor(recipient: string, actorUrl: string): boolean {

--- a/src/server/activitypub/test/integration/event_external_url_federation.test.ts
+++ b/src/server/activitypub/test/integration/event_external_url_federation.test.ts
@@ -41,7 +41,6 @@ describe('Event externalUrl + urlPrompt — AP federation round-trip (integratio
     calendarInterface = new CalendarInterface(eventBus);
 
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);

--- a/src/server/activitypub/test/integration/hide_from_public_federation.test.ts
+++ b/src/server/activitypub/test/integration/hide_from_public_federation.test.ts
@@ -44,7 +44,6 @@ describe('hideFromPublic federation — origin-actor gate (integration)', () => 
     calendarInterface = new CalendarInterface(eventBus);
 
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);

--- a/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
+++ b/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
@@ -36,7 +36,6 @@ function buildMockApInterface(
     return calendarIdsForEvent[eventId] ?? [];
   });
   return {
-    getSharedEventIds: sinon.stub().resolves(sharedEventIds),
     getSharedEventStatusMap: sinon.stub().resolves(statusMap),
     getCalendarIdsForSharedEvent,
   } as any;

--- a/src/server/calendar/test/EventService/event_service.test.ts
+++ b/src/server/calendar/test/EventService/event_service.test.ts
@@ -9,8 +9,7 @@ import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
 import EventService from '@/server/calendar/service/events';
 
 /**
- * Creates a mock ActivityPubInterface with getSharedEventIds and
- * getSharedEventStatusMap stubbed.
+ * Creates a mock ActivityPubInterface with getSharedEventStatusMap stubbed.
  *
  * @param sharedEventIds - Array of event IDs reposted to the calendar.
  * @param statusOverrides - Optional map of eventId -> 'auto'|'manual' to
@@ -26,7 +25,6 @@ function buildMockApInterface(
     statusMap.set(id, statusOverrides[id] ?? 'manual');
   }
   return {
-    getSharedEventIds: sinon.stub().resolves(sharedEventIds),
     getSharedEventStatusMap: sinon.stub().resolves(statusMap),
   } as any;
 }

--- a/src/server/calendar/test/EventService/local_event_ap_identifier.test.ts
+++ b/src/server/calendar/test/EventService/local_event_ap_identifier.test.ts
@@ -31,7 +31,6 @@ describe('EventService - Calendar ID Storage', () => {
     // Inject a minimal AP interface stub so listEvents does not crash when
     // no real ActivityPub domain is wired up in these unit tests.
     (eventService as any).activityPubInterface = {
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
     };
 

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -35,7 +35,6 @@ function buildMockApInterface(
     return calendarIdsForEvent[eventId] ?? [];
   });
   return {
-    getSharedEventIds: sinon.stub().resolves(sharedEventIds),
     getSharedEventStatusMap: sinon.stub().resolves(statusMap),
     getCalendarIdsForSharedEvent,
   } as any;

--- a/src/server/calendar/test/integration/bulk_category_assignment.test.ts
+++ b/src/server/calendar/test/integration/bulk_category_assignment.test.ts
@@ -33,7 +33,6 @@ describe('CalendarInterface.bulkAssignCategories', () => {
     eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
       getCalendarIdsForSharedEvent: async () => [],
       getEventSourceActorUris: async () => new Map<string, string>(),

--- a/src/server/calendar/test/integration/create_event_transaction.test.ts
+++ b/src/server/calendar/test/integration/create_event_transaction.test.ts
@@ -54,7 +54,6 @@ describe('EventService.createEvent — transaction-aware emit (integration)', ()
     // Minimal AP interface stub: integration tests here do not wire the AP
     // domain, so we return shapes that keep local-only code paths correct.
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as never);

--- a/src/server/calendar/test/integration/event_accessibility_info.test.ts
+++ b/src/server/calendar/test/integration/event_accessibility_info.test.ts
@@ -31,7 +31,6 @@ describe('Event content accessibilityInfo — API round-trip (integration)', () 
     calendarInterface = new CalendarInterface(eventBus);
 
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);

--- a/src/server/calendar/test/integration/event_deletion_authorization.test.ts
+++ b/src/server/calendar/test/integration/event_deletion_authorization.test.ts
@@ -56,7 +56,6 @@ describe('Event Deletion and Update Authorization - IDOR Prevention', () => {
     // Inject a minimal AP interface stub. No AP domain is wired in this test
     // environment; returning null/[] keeps local-only code paths correct.
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);

--- a/src/server/calendar/test/integration/event_external_url.test.ts
+++ b/src/server/calendar/test/integration/event_external_url.test.ts
@@ -37,7 +37,6 @@ describe('Event externalUrl + urlPrompt — API round-trip (integration)', () =>
     // Minimal AP interface stub: integration tests here do not wire the AP
     // domain, so we return shapes that keep local-only code paths correct.
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       findCalendarActorByCalendarId: async () => null,
     } as any);

--- a/src/server/calendar/test/integration/event_location_integration.test.ts
+++ b/src/server/calendar/test/integration/event_location_integration.test.ts
@@ -43,7 +43,6 @@ describe('EventService - Location Integration', () => {
     // Inject a minimal AP interface stub so listEvents does not crash when
     // no real ActivityPub domain is wired up in this test environment.
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     } as any);
 
@@ -319,7 +318,6 @@ describe('EventService - Space persistence integration', () => {
     const eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     } as any);
 
@@ -458,7 +456,6 @@ describe('EventInstanceService - Space eager-loading on listing endpoints', () =
     const eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
       getEventSourceActorUris: async () => new Map<string, string>(),
       findCalendarActorByCalendarId: async () => null,
@@ -580,7 +577,6 @@ describe('EventEntity - space_id FK ON DELETE SET NULL', () => {
     const eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     } as any);
 

--- a/src/server/calendar/test/integration/event_search_sqlite.test.ts
+++ b/src/server/calendar/test/integration/event_search_sqlite.test.ts
@@ -31,7 +31,6 @@ describe('Event Search Integration (SQLite)', () => {
     // Inject a minimal AP interface stub so listEvents does not crash when
     // no real ActivityPub domain is wired up in this test environment.
     (eventService as any).activityPubInterface = {
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     };
 

--- a/src/server/calendar/test/integration/import_sync.test.ts
+++ b/src/server/calendar/test/integration/import_sync.test.ts
@@ -52,7 +52,6 @@ describe('SyncService integration', () => {
     calendarInterface = new CalendarInterface(eventBus);
 
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     } as never);
 

--- a/src/server/calendar/test/integration/listing_with_reposts.test.ts
+++ b/src/server/calendar/test/integration/listing_with_reposts.test.ts
@@ -74,13 +74,6 @@ describe('Listing union for reposted events (pv-hr72.4)', () => {
     // can return an empty map because all events here have a non-null
     // calendar_id (no remote-origin events under test).
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async (calendarId: string) => {
-        const rows = await SharedEventEntity.findAll({
-          where: { calendar_id: calendarId },
-          attributes: ['event_id'],
-        });
-        return rows.map(r => r.event_id);
-      },
       getSharedEventStatusMap: async (calendarId: string) => {
         const rows = await SharedEventEntity.findAll({
           where: { calendar_id: calendarId },

--- a/src/server/calendar/test/integration/place_atomic_save.test.ts
+++ b/src/server/calendar/test/integration/place_atomic_save.test.ts
@@ -61,7 +61,6 @@ describe('Place + Spaces atomic-save - Integration', () => {
     const eventBus = new EventEmitter();
     calendarInterface = new CalendarInterface(eventBus);
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map(),
     } as any);
 

--- a/src/server/calendar/test/integration/replace_event_categories.test.ts
+++ b/src/server/calendar/test/integration/replace_event_categories.test.ts
@@ -54,10 +54,9 @@ describe('replaceEventCategories calendar-scoped destroy (pv-bv78)', () => {
     calendarInterface = new CalendarInterface(eventBus);
     // Minimal AP interface stub. resolveEffectiveCalendarId consults
     // getCalendarIdsForSharedEvent; the post-commit repostStatus lookup uses
-    // getSharedEventIds / getSharedEventStatusMap. The repost link under test
-    // is an EventRepostEntity row (legacy table), so all AP stubs return empty.
+    // getSharedEventStatusMap. The repost link under test is an
+    // EventRepostEntity row (legacy table), so all AP stubs return empty.
     calendarInterface.setActivityPubInterface({
-      getSharedEventIds: async () => [],
       getSharedEventStatusMap: async () => new Map<string, 'auto' | 'manual'>(),
       getCalendarIdsForSharedEvent: async () => [],
       getEventSourceActorUris: async () => new Map<string, string>(),

--- a/src/site/components/EventDetailBody.vue
+++ b/src/site/components/EventDetailBody.vue
@@ -11,12 +11,10 @@ import EventImage from '@/site/components/event-image.vue';
 import AddToCalendar from '@/site/components/add-to-calendar.vue';
 import { URL_PROMPT_VALUES, type UrlPrompt } from '@/common/model/events';
 import type CalendarEventInstance from '@/common/model/event_instance';
-import type { Calendar as CalendarModel } from '@/common/model/calendar';
 import type { EventCategory } from '@/common/model/event_category';
 
 const props = defineProps<{
   instance: CalendarEventInstance;
-  calendar: CalendarModel;
   categoryHrefBuilder?: (category: EventCategory) => string;
 }>();
 

--- a/src/site/components/event-instance.vue
+++ b/src/site/components/event-instance.vue
@@ -125,7 +125,6 @@ onBeforeMount(async () => {
 
       <EventDetailBody
         :instance="state.instance"
-        :calendar="state.calendar"
         :category-href-builder="categoryHrefBuilder"
       />
     </main>

--- a/src/site/test/components/EventDetailBody.test.ts
+++ b/src/site/test/components/EventDetailBody.test.ts
@@ -25,7 +25,6 @@ import I18NextVue from 'i18next-vue';
 import i18next from 'i18next';
 import { DateTime } from 'luxon';
 
-import { Calendar as CalendarModel, CalendarContent } from '@/common/model/calendar';
 import { EventCategory } from '@/common/model/event_category';
 import { EventCategoryContent } from '@/common/model/event_category_content';
 
@@ -138,14 +137,6 @@ function makeCategory(id: string, name: string): EventCategory {
   return cat;
 }
 
-function makeCalendar(): CalendarModel {
-  const cal = new CalendarModel('cal-1', 'test_calendar');
-  const content = new CalendarContent('en');
-  content.name = 'Test Calendar';
-  cal.addContent(content);
-  return cal;
-}
-
 function makeInstance(overrides: InstanceOverrides = {}): any {
   const start = DateTime.fromISO('2026-05-08T18:00:00.000Z');
   const end = overrides.end === undefined ? null : overrides.end;
@@ -181,7 +172,6 @@ function makeInstance(overrides: InstanceOverrides = {}): any {
 
 function mountBody(props: {
   instance: any;
-  calendar?: CalendarModel;
   categoryHrefBuilder?: (cat: EventCategory) => string;
 }): VueWrapper {
   const pinia = createPinia();
@@ -194,7 +184,6 @@ function mountBody(props: {
     },
     props: {
       instance: props.instance,
-      calendar: props.calendar ?? makeCalendar(),
       categoryHrefBuilder: props.categoryHrefBuilder,
     },
   });

--- a/src/widget/components/event-detail-overlay.vue
+++ b/src/widget/components/event-detail-overlay.vue
@@ -149,7 +149,6 @@ onBeforeMount(async () => {
       <main class="instance-main">
         <EventDetailBody
           :instance="state.instance"
-          :calendar="state.calendar"
           :category-href-builder="categoryHrefBuilder"
         />
       </main>

--- a/src/widget/test/event-detail-overlay.test.ts
+++ b/src/widget/test/event-detail-overlay.test.ts
@@ -98,7 +98,7 @@ vi.mock('@/site/components/not-found.vue', () => ({
 vi.mock('@/site/components/EventDetailBody.vue', () => ({
   default: {
     name: 'EventDetailBody',
-    props: ['instance', 'calendar', 'categoryHrefBuilder'],
+    props: ['instance', 'categoryHrefBuilder'],
     template: '<div data-test="event-detail-body" class="event-detail-body-stub"></div>',
   },
 }));
@@ -236,14 +236,13 @@ describe('widget event-detail-overlay shell', () => {
     wrapper.unmount();
   });
 
-  it('passes the loaded instance, calendar, and a category href builder to EventDetailBody', async () => {
+  it('passes the loaded instance and a category href builder to EventDetailBody', async () => {
     const { wrapper } = await mountOverlay('/widget/test_calendar/events/evt-1');
 
     const body = wrapper.findComponent({ name: 'EventDetailBody' });
     expect(body.exists()).toBe(true);
     expect(body.props('instance')).toBeTruthy();
     expect((body.props('instance') as any).id).toBe('inst-1');
-    expect((body.props('calendar') as any).urlName).toBe('test_calendar');
     // Widget shell supplies a categoryHrefBuilder so categories render as
     // clickable <a> badges that filter the widget calendar list.
     const builder = body.props('categoryHrefBuilder') as ((c: { id: string }) => string) | undefined;


### PR DESCRIPTION
## Motivation

Five independent low-risk cleanups, each previously surfaced by post-code audits and deferred. Bundled into one PR since each is small and none changes behavior.

## Approach

- **Dedupe a security barrier** — `sanitizeExternalUrlHref` (the URL-scheme allowlist rejecting `javascript:`/`data:`/`ftp:`/`file:`) existed as byte-identical copies in the inbound `Note` and `Event` AS object parsers, with a hand-maintained "MUST stay in sync" comment. Extracted to `src/server/activitypub/helper/url-sanitizer.ts` and imported by both; existing XSS tests continue to cover both call sites.
- **Remove a dead interface method** — `ActivityPubInterface.getSharedEventIds` was superseded by `getSharedEventStatusMap` and has no production caller. Removed it and dropped its now-orphaned stubs from the calendar/AP test mocks (all loosely cast `as any`, so no type coupling).
- **Locale dedupe** — removed duplicate `event_editor` imports and resource keys in the client locale loader that produced build-time duplicate-key warnings.
- **Document a defensive guard** — added the FK-invariant rationale to the `isSameHostAsActor` outbox delivery guard, explaining why the missing-`CalendarActorEntity` path it defends is FK-impossible under normal DB state.
- **Remove an unused prop** — the site `EventDetailBody` declared a required `calendar` prop it never read; removed it, the two shell callers (`event-instance.vue`, widget `event-detail-overlay.vue`) that forwarded it, and the test scaffolding/assertions that checked the forwarding.

## Validation

- `npm run build` passes.
- `npm run test:unit` — 479 files / 8373 tests pass.
- `npm run test:integration` — 82 files / 680 pass (2 pre-existing skips).
- Lint clean on all changed files and the new helper.