### PR TITLE
feat(calendar): add cancel capability for single non-recurring events

### DIFF
--- a/docs/guides/calendar-owners/cancel-event.md
+++ b/docs/guides/calendar-owners/cancel-event.md
@@ -20,18 +20,18 @@ Deletion does none of these things. A deleted event is gone — from your calend
 
 ## How to cancel an event
 
-The cancellation tool is currently available for recurring events. When you edit a recurring event — a weekly meeting, a monthly meetup, a Tuesday-night open mic — the editor shows a <Btn>Manage cancellations</Btn> button below the schedule. Click it and a panel opens with a card for each upcoming occurrence. Each card has a <Btn>Cancel</Btn> button that marks just that one date as cancelled.
+You cancel an event from its editor. What you see there depends on whether the event recurs.
 
-The confirmation that opens has one decision worth thinking about — a **Hide from public** toggle:
+**A single, non-recurring event.** The editor shows a <Btn>Cancel event</Btn> control. Use it and the event is marked **Cancelled** — it stays on your public calendar, on the same date and time, and the cancellation propagates to any calendar reposting from yours, exactly as the section above describes. The control then changes to <Btn>Restore</Btn>, so reversing the call is one click if plans change again. Single events are show-as-cancelled only: there's no hide-from-public option. A one-off event you'd want to remove from the page entirely is almost always one to delete instead — see below.
+
+**A recurring event** — a weekly meeting, a monthly meetup, a Tuesday-night open mic. The editor shows a <Btn>Manage cancellations</Btn> button below the schedule. Click it and a panel opens with a card for each upcoming occurrence. Each card has a <Btn>Cancel</Btn> button that marks just that one date as cancelled.
+
+For a recurring occurrence, the confirmation that opens has one decision worth thinking about — a **Hide from public** toggle:
 
 - **Off (the default): show as cancelled.** The occurrence stays on the calendar. Visitors and any calendar reposting from yours still see the listing, but it's marked **Cancelled**. Use this when the event *was* announced and people might be planning to attend — cancelling-but-showing tells them the meeting they had on their calendar isn't happening.
 - **On: hide from public.** The occurrence is removed from the public page and from any calendar reposting from yours. Use this when the occurrence hasn't been visible long enough for anyone to be planning around it — for example, a brand-new recurring event where you want to skip a holiday week before the public page has had time to surface those occurrences.
 
 After you confirm, the card shows a **Cancelled** or **Hidden** badge, and its button changes to <Btn>Restore</Btn>. Restoring is immediate and needs no confirmation — useful if you changed your mind, or if a cancellation was made in error.
-
-::: tip <Lightbulb /> A note on single, non-recurring events.
-Pavillion's cancellation tool is built around occurrences of recurring events. A single event that isn't part of a recurrence doesn't get a cancel button in the editor — you have two options instead. If the event was announced and people may be planning to attend, edit the title to mark it cancelled (a prefix like *Cancelled —* on the front of the title is the convention) and update the description to explain. The listing stays where visitors expect to find it, and any calendar reposting from yours picks up the edit. If the event was never made public or only briefly visible, deletion is the cleaner move — see below.
-:::
 
 ## When deletion is the right tool
 

--- a/src/client/components/logged_in/calendar/EventCancelConfirmModal.vue
+++ b/src/client/components/logged_in/calendar/EventCancelConfirmModal.vue
@@ -14,11 +14,26 @@ import Sheet from '@/client/components/common/Sheet.vue';
  * calls happen here — the consumer wires the `confirm` event to the
  * actual cancellation action.
  *
+ * Props:
+ * @prop {boolean} allowHide - When false, the "Hide from public" toggle is
+ *   suppressed and confirm always emits hideFromPublic:false. Used by the
+ *   single-event cancel control where cancellation is show-as-cancelled only.
+ *   Defaults to true so the recurring-instance flow is unchanged.
+ *
  * Emits:
  * @emits confirm - Fired when the user submits the confirmation
  *   @param {{ hideFromPublic: boolean }} payload
  * @emits close - Fired when the user cancels or dismisses the dialog
  */
+
+const props = withDefaults(
+  defineProps<{
+    allowHide?: boolean;
+  }>(),
+  {
+    allowHide: true,
+  },
+);
 
 const emit = defineEmits<{
   (e: 'confirm', payload: { hideFromPublic: boolean }): void;
@@ -34,7 +49,9 @@ const hideToggleId = useId();
 const hideDescriptionId = useId();
 
 function onSubmit() {
-  emit('confirm', { hideFromPublic: hideFromPublic.value });
+  emit('confirm', {
+    hideFromPublic: props.allowHide ? hideFromPublic.value : false,
+  });
 }
 
 function onCancel() {
@@ -54,7 +71,7 @@ function onSheetClose() {
     <div class="cancel-confirm-body">
       <p class="confirm-message">{{ t('confirm_message') }}</p>
 
-      <label :for="hideToggleId" class="hide-toggle">
+      <label v-if="allowHide" :for="hideToggleId" class="hide-toggle">
         <input
           :id="hideToggleId"
           v-model="hideFromPublic"

--- a/src/client/components/logged_in/calendar/SingleEventCancelControl.vue
+++ b/src/client/components/logged_in/calendar/SingleEventCancelControl.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+/**
+ * SingleEventCancelControl
+ *
+ * Cancel/Restore action for a single (non-recurring) event — i.e. an event
+ * whose only positive schedule materializes exactly one occurrence. Cancelling
+ * is show-as-cancelled ONLY: the EventCancelConfirmModal is reused with
+ * allowHide=false so the "hide from public" toggle is suppressed and the
+ * cancellation always emits hideFromPublic:false.
+ *
+ * State is flipped in place after cancel/restore — no refetch — mirroring
+ * EventCancellationsPanel.
+ *
+ * Props:
+ * @prop {CalendarEvent} event - The single-occurrence event being managed.
+ */
+
+import { computed, nextTick, onMounted, ref } from 'vue';
+import { DateTime } from 'luxon';
+import { useTranslation } from 'i18next-vue';
+
+import PillButton from '@/client/components/common/pill-button.vue';
+import EventCancelConfirmModal from '@/client/components/logged_in/calendar/EventCancelConfirmModal.vue';
+import EventService, {
+  type UpcomingOccurrence,
+} from '@/client/service/event';
+import type { CalendarEvent } from '@/common/model/events';
+
+const props = defineProps<{
+  event: CalendarEvent;
+}>();
+
+const { t } = useTranslation('event_editor', {
+  keyPrefix: 'cancellations',
+});
+
+const eventService = new EventService();
+
+const state = ref<UpcomingOccurrence['state'] | null>(null);
+const showConfirm = ref(false);
+
+// Refs on a PillButton resolve to its component instance, not the native
+// <button>; the element is reached via `$el`. Used to return focus after the
+// trigger that was activated is removed from the DOM on a state flip
+// (WCAG 2.4.3). Mirrors the $el fallback in places-tab.vue.
+const cancelButtonRef = ref(null);
+const restoreButtonRef = ref(null);
+
+function focusPillButton(buttonRef: typeof cancelButtonRef) {
+  const el = (buttonRef.value as { $el?: HTMLElement } | null)?.$el;
+  el?.focus();
+}
+
+/**
+ * The lone positive (non-exclusion) schedule's start. A single event has
+ * exactly one positive schedule with frequency:null that materializes one
+ * occurrence; that occurrence's start is the cancellation key.
+ */
+const occurrenceStart = computed<DateTime | null>(() => {
+  const positive = props.event.schedules.filter(s => !s.isExclusion);
+  return positive.length === 1 ? positive[0].startDate : null;
+});
+
+async function loadState() {
+  const start = occurrenceStart.value;
+  if (!start) return;
+  try {
+    // Single-occurrence state read: we anchor one millisecond before the
+    // occurrence and read the returned occurrence's `state` field (active /
+    // cancelled-shown / hidden), past or future — NOT its absence. The editor
+    // schedule rows are not the source of truth for cancellation: reconcileSchedules
+    // rejects exclusion rows in its update payload, so a cancellation never
+    // round-trips through the editor model.
+    const result = await eventService.listUpcomingOccurrences(
+      props.event.id,
+      start.minus({ milliseconds: 1 }).toISO()!,
+      1,
+    );
+    state.value = result.occurrences[0]?.state ?? 'active';
+  }
+  catch (error) {
+    console.error('SingleEventCancelControl: listUpcomingOccurrences failed', error);
+  }
+}
+
+function onCancelClick() {
+  showConfirm.value = true;
+}
+
+async function onConfirmCancel() {
+  showConfirm.value = false;
+  const start = occurrenceStart.value;
+  if (!start) return;
+  try {
+    // Show-as-cancelled only: hideFromPublic is always false here.
+    await eventService.cancelOccurrence(props.event.id, start.toISO()!, false);
+    state.value = 'cancelled-shown';
+    // The cancel trigger has just been unmounted; return focus to the Restore
+    // button that replaced it so focus doesn't drop to <body> (WCAG 2.4.3).
+    await nextTick();
+    focusPillButton(restoreButtonRef);
+  }
+  catch (error) {
+    console.error('SingleEventCancelControl: cancelOccurrence failed', error);
+  }
+}
+
+function onCloseConfirm() {
+  showConfirm.value = false;
+}
+
+async function onRestoreClick() {
+  const start = occurrenceStart.value;
+  if (!start) return;
+  try {
+    await eventService.restoreOccurrence(props.event.id, start.toISO()!);
+    state.value = 'active';
+    // The Restore button has just been unmounted; return focus to the cancel
+    // trigger that replaced it so focus doesn't drop to <body> (WCAG 2.4.3).
+    await nextTick();
+    focusPillButton(cancelButtonRef);
+  }
+  catch (error) {
+    console.error('SingleEventCancelControl: restoreOccurrence failed', error);
+  }
+}
+
+onMounted(() => {
+  loadState();
+});
+</script>
+
+<template>
+  <div class="single-cancel-control" data-testid="single-event-cancel-control">
+    <!--
+      The live region is rendered unconditionally so its content change is
+      announced when the event is cancelled (WCAG 4.1.3). Toggling the element
+      in/out with v-if means it enters the DOM already-populated, which some
+      screen readers do not announce. The text is empty while active (or still
+      loading) and carries the cancelled-status copy once cancelled.
+    -->
+    <span
+      class="single-cancel-control__status"
+      role="status"
+      data-testid="single-event-cancelled-status"
+    >
+      {{ state && state !== 'active' ? t('single_cancelled_status') : '' }}
+    </span>
+
+    <PillButton
+      v-if="state === 'active'"
+      ref="cancelButtonRef"
+      size="sm"
+      variant="secondary"
+      data-testid="single-event-cancel"
+      @click="onCancelClick"
+    >
+      {{ t('single_cancel_button') }}
+    </PillButton>
+
+    <PillButton
+      v-else-if="state"
+      ref="restoreButtonRef"
+      size="sm"
+      variant="ghost"
+      data-testid="single-event-restore"
+      @click="onRestoreClick"
+    >
+      {{ t('single_restore_button') }}
+    </PillButton>
+
+    <EventCancelConfirmModal
+      v-if="showConfirm"
+      :allow-hide="false"
+      @confirm="onConfirmCancel"
+      @close="onCloseConfirm"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.single-cancel-control {
+  display: flex;
+  align-items: center;
+  gap: var(--pav-space-sm);
+
+  &__status {
+    font-weight: var(--pav-font-weight-semibold);
+    color: var(--pav-text-secondary);
+  }
+}
+</style>

--- a/src/client/components/logged_in/calendar/edit_event.vue
+++ b/src/client/components/logged_in/calendar/edit_event.vue
@@ -994,9 +994,16 @@ form {
                 </p>
               </div>
 
-              <!-- Cancellations Panel Trigger (only for recurring events) -->
+              <!-- Single (non-recurring) event: inline cancel/restore control -->
+              <SingleEventCancelControl
+                v-if="isSingleOccurrenceEvent"
+                :event="editorState.event"
+              />
+
+              <!-- Multi-occurrence event (recurring or multiple one-offs):
+                   cancellations panel trigger -->
               <div
-                v-if="hasRecurringSchedule"
+                v-else-if="hasMultipleOccurrences"
                 class="cancellations-trigger-wrapper"
               >
                 <button
@@ -1113,6 +1120,7 @@ import { useTranslation } from 'i18next-vue';
 import { ArrowLeft, Plus } from 'lucide-vue-next';
 import EventRecurrenceView from './event_recurrence.vue';
 import EventCancellationsPanel from './EventCancellationsPanel.vue';
+import SingleEventCancelControl from './SingleEventCancelControl.vue';
 import languagePicker from '@/client/components/common/language-picker.vue';
 import ImageUpload from '@/client/components/common/media/image-upload.vue';
 import ImageWorkspace from '@/client/components/common/media/image-workspace.vue';
@@ -1254,14 +1262,46 @@ const urlPromptProxy = computed({
 });
 
 /**
- * Whether the event has at least one recurring schedule. A schedule is
- * recurring when its frequency is set. Used to gate the cancellations panel
- * trigger, which is only meaningful for recurring events.
+ * Positive (non-exclusion) schedules. Exclusion rows are cancellation/EXDATE
+ * markers, not occurrence-producing schedules, so the cancel-UI gating reasons
+ * only over positive schedules.
  */
-const hasRecurringSchedule = computed(() => {
-  if (!editorState.event?.schedules) return false;
-  return editorState.event.schedules.some(
-    (schedule) => schedule.frequency !== null && schedule.frequency !== undefined,
+const positiveSchedules = computed(() => {
+  return (editorState.event?.schedules ?? []).filter((schedule) => !schedule.isExclusion);
+});
+
+/**
+ * Whether the event has been persisted (has a server-assigned id). The cancel
+ * and cancellations UI both read occurrence state from the backend by event id,
+ * so they are only meaningful for a saved event. In create mode the event has
+ * no id and neither control should render.
+ */
+const isPersistedEvent = computed(() => Boolean(editorState.event?.id));
+
+/**
+ * A single (non-recurring) event: exactly one positive schedule with no
+ * frequency, which materializes exactly one occurrence. These get the inline
+ * SingleEventCancelControl rather than the multi-occurrence panel.
+ */
+const isSingleOccurrenceEvent = computed(() => {
+  if (!isPersistedEvent.value) return false;
+  const positive = positiveSchedules.value;
+  if (positive.length !== 1) return false;
+  return positive[0].frequency === null || positive[0].frequency === undefined;
+});
+
+/**
+ * A multi-occurrence event: a recurring schedule OR multiple positive
+ * (one-off) schedules. These keep the existing cancellations panel, which
+ * already expands rdates across all occurrences.
+ */
+const hasMultipleOccurrences = computed(() => {
+  if (!isPersistedEvent.value) return false;
+  const positive = positiveSchedules.value;
+  if (positive.length === 0) return false;
+  return (
+    positive.length > 1 ||
+    positive.some((schedule) => schedule.frequency !== null && schedule.frequency !== undefined)
   );
 });
 

--- a/src/client/locales/en/event_editor.json
+++ b/src/client/locales/en/event_editor.json
@@ -177,6 +177,9 @@
     "no_further_occurrences": "No further occurrences",
     "no_occurrences_after": "No occurrences after {{month}}",
     "start_from_today_button": "Start from today",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "single_cancel_button": "Cancel this event",
+    "single_cancelled_status": "This event is cancelled",
+    "single_restore_button": "Restore"
   }
 }

--- a/src/client/locales/es/event_editor.json
+++ b/src/client/locales/es/event_editor.json
@@ -177,6 +177,9 @@
     "no_further_occurrences": "No hay más ocurrencias",
     "no_occurrences_after": "No hay ocurrencias después de {{month}}",
     "start_from_today_button": "Empezar desde hoy",
-    "loading": "Cargando…"
+    "loading": "Cargando…",
+    "single_cancel_button": "Cancelar este evento",
+    "single_cancelled_status": "Este evento está cancelado",
+    "single_restore_button": "Restaurar"
   }
 }

--- a/src/client/locales/fr/event_editor.json
+++ b/src/client/locales/fr/event_editor.json
@@ -177,6 +177,9 @@
     "no_further_occurrences": "Aucune autre occurrence",
     "no_occurrences_after": "Aucune occurrence après {{month}}",
     "start_from_today_button": "Commencer à partir d'aujourd'hui",
-    "loading": "Chargement…"
+    "loading": "Chargement…",
+    "single_cancel_button": "Annuler cet événement",
+    "single_cancelled_status": "Cet événement est annulé",
+    "single_restore_button": "Restaurer"
   }
 }

--- a/src/client/test/components/calendar/SingleEventCancelControl.test.ts
+++ b/src/client/test/components/calendar/SingleEventCancelControl.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { createMemoryHistory, createRouter, Router, RouteRecordRaw } from 'vue-router';
+import { DateTime } from 'luxon';
+
+import { CalendarEvent, CalendarEventSchedule } from '@/common/model/events';
+import SingleEventCancelControl from '@/client/components/logged_in/calendar/SingleEventCancelControl.vue';
+import EventCancelConfirmModal from '@/client/components/logged_in/calendar/EventCancelConfirmModal.vue';
+import { mountComponent } from '@/client/test/lib/vue';
+
+const { listUpcomingOccurrencesMock, cancelOccurrenceMock, restoreOccurrenceMock } = vi.hoisted(() => ({
+  listUpcomingOccurrencesMock: vi.fn(),
+  cancelOccurrenceMock: vi.fn(),
+  restoreOccurrenceMock: vi.fn(),
+}));
+
+vi.mock('@/client/service/event', () => {
+  class MockEventService {
+    listUpcomingOccurrences = (...args: unknown[]) => listUpcomingOccurrencesMock(...args);
+    cancelOccurrence = (...args: unknown[]) => cancelOccurrenceMock(...args);
+    restoreOccurrence = (...args: unknown[]) => restoreOccurrenceMock(...args);
+  }
+  return { default: MockEventService };
+});
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', component: {}, name: 'home' },
+];
+
+const SheetStub = {
+  template: '<div class="sheet-stub"><header><h2>{{ title }}</h2></header><slot /></div>',
+  props: ['title'],
+  emits: ['close'],
+};
+
+const EVENT_ID = 'event-1';
+const START_ISO = '2030-01-01T12:00:00.000Z';
+
+// One instant shared by the fixture and the assertions so the ISO strings the
+// component derives via luxon match exactly regardless of the host timezone.
+const startDate = DateTime.fromISO(START_ISO);
+const expectedAfter = startDate.minus({ milliseconds: 1 }).toISO();
+const expectedStart = startDate.toISO();
+
+/**
+ * A single (non-recurring) event: exactly one positive schedule that
+ * materializes one occurrence. `extraExclusion` adds an exclusion (EXDATE)
+ * row to prove the occurrenceStart computation filters it out.
+ */
+function makeSingleEvent(extraExclusion = false): CalendarEvent {
+  const event = new CalendarEvent();
+  event.id = EVENT_ID;
+  event.calendarId = 'cal-1';
+  const positive = new CalendarEventSchedule('sched-1', startDate);
+  const schedules = [positive];
+  if (extraExclusion) {
+    const exclusion = new CalendarEventSchedule('sched-exdate', startDate);
+    exclusion.isExclusion = true;
+    schedules.push(exclusion);
+  }
+  event.schedules = schedules;
+  return event;
+}
+
+function makeOccurrence(state: 'active' | 'cancelled-shown' | 'hidden') {
+  return { start: expectedStart, state, scheduleId: state === 'active' ? null : 'sch-1' };
+}
+
+async function mountControl(event: CalendarEvent) {
+  const router: Router = createRouter({ history: createMemoryHistory(), routes });
+  await router.push('/');
+  await router.isReady();
+
+  return mountComponent(SingleEventCancelControl, router, {
+    stubs: { Sheet: SheetStub },
+    props: { event },
+  });
+}
+
+describe('SingleEventCancelControl', () => {
+  let currentWrapper: any = null;
+
+  beforeEach(() => {
+    listUpcomingOccurrencesMock.mockReset();
+    cancelOccurrenceMock.mockReset();
+    restoreOccurrenceMock.mockReset();
+    cancelOccurrenceMock.mockResolvedValue(undefined);
+    restoreOccurrenceMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    if (currentWrapper) {
+      currentWrapper.unmount();
+      currentWrapper = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('renders the Cancel trigger for an active single event', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('active')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(false);
+  });
+
+  it('anchors the state read one millisecond before the lone positive schedule start, ignoring exclusion rows', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('active')], hasMore: false });
+
+    // An exclusion (EXDATE) row is present; occurrenceStart must still resolve
+    // to the single POSITIVE schedule's start (!isExclusion filter).
+    const wrapper = await mountControl(makeSingleEvent(true));
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(listUpcomingOccurrencesMock).toHaveBeenCalledTimes(1);
+    const [eventId, after, limit] = listUpcomingOccurrencesMock.mock.calls[0];
+    expect(eventId).toBe(EVENT_ID);
+    expect(after).toBe(expectedAfter);
+    expect(limit).toBe(1);
+    // Active state still renders, proving the exclusion row did not derail gating.
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(true);
+  });
+
+  it('opens EventCancelConfirmModal without the hide-from-public toggle (allowHide=false)', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('active')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(wrapper.findComponent(EventCancelConfirmModal).exists()).toBe(false);
+
+    await wrapper.find('[data-testid="single-event-cancel"]').trigger('click');
+    await flushPromises();
+
+    const modal = wrapper.findComponent(EventCancelConfirmModal);
+    expect(modal.exists()).toBe(true);
+    expect(modal.props('allowHide')).toBe(false);
+  });
+
+  it('cancels via cancelOccurrence(id, start, false) and flips to cancelled-shown in place', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('active')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    await wrapper.find('[data-testid="single-event-cancel"]').trigger('click');
+    await flushPromises();
+
+    const modal = wrapper.findComponent(EventCancelConfirmModal);
+    modal.vm.$emit('confirm', { hideFromPublic: false });
+    await flushPromises();
+
+    // Show-as-cancelled only: hideFromPublic is always false.
+    expect(cancelOccurrenceMock).toHaveBeenCalledWith(EVENT_ID, expectedStart, false);
+
+    // State flips in place to cancelled — Restore replaces Cancel, status shows.
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="single-event-cancelled-status"]').text()).not.toBe('');
+
+    // The flip must NOT re-fetch — the read happened once on mount.
+    expect(listUpcomingOccurrencesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores via restoreOccurrence and flips back to active in place', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('cancelled-shown')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(true);
+
+    await wrapper.find('[data-testid="single-event-restore"]').trigger('click');
+    await flushPromises();
+
+    expect(restoreOccurrenceMock).toHaveBeenCalledWith(EVENT_ID, expectedStart);
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(false);
+
+    expect(listUpcomingOccurrencesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a legacy hidden occurrence as cancelled (Restore + status, no Cancel)', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('hidden')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="single-event-cancelled-status"]').text()).not.toBe('');
+  });
+
+  it('renders no action controls while the state read is pending (loading)', async () => {
+    // Never resolves: the component stays in its null/loading state.
+    listUpcomingOccurrencesMock.mockReturnValue(new Promise(() => {}));
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="single-event-cancel"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="single-event-restore"]').exists()).toBe(false);
+    // The live region is present but empty while loading.
+    expect(wrapper.find('[data-testid="single-event-cancelled-status"]').text()).toBe('');
+  });
+
+  it('always renders the role="status" live region, with text reflecting state', async () => {
+    listUpcomingOccurrencesMock.mockResolvedValue({ occurrences: [makeOccurrence('active')], hasMore: false });
+
+    const wrapper = await mountControl(makeSingleEvent());
+    currentWrapper = wrapper;
+    await flushPromises();
+
+    // Present and empty while active so the change is announced on cancel.
+    const liveRegion = wrapper.find('[role="status"]');
+    expect(liveRegion.exists()).toBe(true);
+    expect(liveRegion.text()).toBe('');
+
+    await wrapper.find('[data-testid="single-event-cancel"]').trigger('click');
+    await flushPromises();
+    wrapper.findComponent(EventCancelConfirmModal).vm.$emit('confirm', { hideFromPublic: false });
+    await flushPromises();
+
+    // Same element instance, now populated — never toggled in/out of the DOM.
+    const after = wrapper.find('[role="status"]');
+    expect(after.exists()).toBe(true);
+    expect(after.text()).not.toBe('');
+  });
+});

--- a/src/client/test/components/calendar/edit-event-cancellations-trigger.test.ts
+++ b/src/client/test/components/calendar/edit-event-cancellations-trigger.test.ts
@@ -4,6 +4,7 @@ import { createRouter, createWebHistory, Router } from 'vue-router';
 import { createPinia, setActivePinia, Pinia } from 'pinia';
 import { nextTick } from 'vue';
 import EditEventView from '@/client/components/logged_in/calendar/edit_event.vue';
+import SingleEventCancelControl from '@/client/components/logged_in/calendar/SingleEventCancelControl.vue';
 import { CalendarEvent } from '@/common/model/events';
 import { Calendar } from '@/common/model/calendar';
 import { EventLocation } from '@/common/model/location';
@@ -21,22 +22,42 @@ const createMockCalendar = (id: string, urlName: string) => {
   return calendar;
 };
 
+type EventKind = 'single' | 'recurring' | 'multiple';
+
 const createEventModelObject = (
   id: string,
-  opts: { recurring: boolean } = { recurring: false },
+  opts: { kind: EventKind } = { kind: 'single' },
 ) => {
   // Build a raw object in the shape `ModelService.getModel` returns to
   // `CalendarEvent.fromObject`. We skip going through the live model to keep
   // the test simple and avoid calling toObject() on plain contents.
+  //
+  // Gating reasons over POSITIVE (non-exclusion) schedules:
+  //   single   -> one positive schedule, no frequency  -> SingleEventCancelControl
+  //   recurring -> one positive schedule with frequency -> EventCancellationsPanel
+  //   multiple  -> 2+ positive one-off schedules        -> EventCancellationsPanel
+  let schedules: Array<Record<string, unknown>>;
+  switch (opts.kind) {
+    case 'recurring':
+      schedules = [{ id: 'sched-1', start: '2030-01-01T12:00:00.000Z', frequency: 'weekly' }];
+      break;
+    case 'multiple':
+      schedules = [
+        { id: 'sched-1', start: '2030-01-01T12:00:00.000Z' },
+        { id: 'sched-2', start: '2030-02-01T12:00:00.000Z' },
+      ];
+      break;
+    default:
+      schedules = [{ id: 'sched-1', start: '2030-01-01T12:00:00.000Z' }];
+  }
+
   return {
     id,
     calendarId: 'calendar-123',
     content: {
-      en: { language: 'en', name: opts.recurring ? 'Recurring Event' : 'One-off Event' },
+      en: { language: 'en', name: `${opts.kind} Event` },
     },
-    schedules: opts.recurring
-      ? [{ id: 'sched-1', frequency: 'weekly' }]
-      : [{ id: 'sched-1' }],
+    schedules,
     location: {},
     categories: [],
   };
@@ -168,6 +189,7 @@ describe('EditEventView - Cancellations Panel Trigger', () => {
         LocationPickerModal: true,
         CreateLocationForm: true,
         EventCancellationsPanel: true,
+        SingleEventCancelControl: true,
       },
     });
 
@@ -188,34 +210,53 @@ describe('EditEventView - Cancellations Panel Trigger', () => {
     vi.clearAllMocks();
   });
 
-  it('hides the trigger when the event has no recurring schedule (create mode)', async () => {
+  it('renders neither cancel control in create mode (unsaved event has no id)', async () => {
+    // Create mode: route /event with no eventId and no model fetch. The
+    // event service's initEvent builds a brand-new event with one default
+    // non-recurring schedule but no id, so neither the single-occurrence
+    // control nor the multi-occurrence trigger should render.
     const wrapper = await mountEditEventView('/event');
 
-    const trigger = wrapper.find('[data-testid="cancellations-trigger"]');
-    expect(trigger.exists()).toBe(false);
+    expect(wrapper.findComponent(SingleEventCancelControl).exists()).toBe(false);
+    expect(wrapper.find('[data-testid="cancellations-trigger"]').exists()).toBe(false);
   });
 
-  it('hides the trigger when the event schedule has no frequency set', async () => {
+  it('renders SingleEventCancelControl (not the panel trigger) for a single non-recurring event', async () => {
     const testId = '00000000-0000-0000-0000-000000000001';
-    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { recurring: false }));
+    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { kind: 'single' }));
 
     const wrapper = await mountEditEventView(`/event/${testId}`, { eventId: testId });
-    const trigger = wrapper.find('[data-testid="cancellations-trigger"]');
-    expect(trigger.exists()).toBe(false);
+
+    // One positive schedule with no frequency -> single-occurrence branch.
+    expect(wrapper.findComponent(SingleEventCancelControl).exists()).toBe(true);
+    // The multi-occurrence cancellations-panel trigger must NOT render.
+    expect(wrapper.find('[data-testid="cancellations-trigger"]').exists()).toBe(false);
   });
 
-  it('shows the trigger when the event has a recurring schedule', async () => {
+  it('renders the panel trigger (not SingleEventCancelControl) for an event with multiple one-off occurrences', async () => {
+    const testId = '00000000-0000-0000-0000-000000000004';
+    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { kind: 'multiple' }));
+
+    const wrapper = await mountEditEventView(`/event/${testId}`, { eventId: testId });
+
+    // 2+ positive schedules -> multi-occurrence branch.
+    expect(wrapper.find('[data-testid="cancellations-trigger"]').exists()).toBe(true);
+    expect(wrapper.findComponent(SingleEventCancelControl).exists()).toBe(false);
+  });
+
+  it('shows the trigger (not SingleEventCancelControl) when the event has a recurring schedule', async () => {
     const testId = '00000000-0000-0000-0000-000000000002';
-    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { recurring: true }));
+    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { kind: 'recurring' }));
 
     const wrapper = await mountEditEventView(`/event/${testId}`, { eventId: testId });
     const trigger = wrapper.find('[data-testid="cancellations-trigger"]');
     expect(trigger.exists()).toBe(true);
+    expect(wrapper.findComponent(SingleEventCancelControl).exists()).toBe(false);
   });
 
   it('renders the EventCancellationsPanel when the trigger is clicked', async () => {
     const testId = '00000000-0000-0000-0000-000000000003';
-    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { recurring: true }));
+    mockGetModel.mockResolvedValueOnce(createEventModelObject(testId, { kind: 'recurring' }));
 
     const wrapper = await mountEditEventView(`/event/${testId}`, { eventId: testId });
     const trigger = wrapper.find('[data-testid="cancellations-trigger"]');

--- a/src/client/test/components/calendar/event-cancel-confirm-modal.test.ts
+++ b/src/client/test/components/calendar/event-cancel-confirm-modal.test.ts
@@ -15,7 +15,7 @@ const SheetStub = {
   emits: ['close'],
 };
 
-const mountModal = async () => {
+const mountModal = async (props: Record<string, any> = {}) => {
   const router: Router = createRouter({
     history: createMemoryHistory(),
     routes,
@@ -26,6 +26,7 @@ const mountModal = async () => {
 
   return mountComponent(EventCancelConfirmModal, router, {
     stubs: { Sheet: SheetStub },
+    props,
   });
 };
 
@@ -122,6 +123,37 @@ describe('EventCancelConfirmModal', () => {
 
       expect(wrapper.emitted('confirm')).toBeTruthy();
       expect(wrapper.emitted('confirm')?.[0]).toEqual([{ hideFromPublic: true }]);
+    });
+  });
+
+  describe('allowHide=false', () => {
+    it('hides the hide-from-public toggle when allowHide is false', async () => {
+      const wrapper = await mountModal({ allowHide: false });
+      currentWrapper = wrapper;
+      await flushPromises();
+
+      expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('Hide from public');
+    });
+
+    it('emits confirm with hideFromPublic=false when allowHide is false', async () => {
+      const wrapper = await mountModal({ allowHide: false });
+      currentWrapper = wrapper;
+      await flushPromises();
+
+      const submitButton = wrapper.find('[data-testid="confirm-submit"]');
+      await submitButton.trigger('click');
+
+      expect(wrapper.emitted('confirm')).toBeTruthy();
+      expect(wrapper.emitted('confirm')?.[0]).toEqual([{ hideFromPublic: false }]);
+    });
+
+    it('shows the hide-from-public toggle by default (allowHide defaults to true)', async () => {
+      const wrapper = await mountModal();
+      currentWrapper = wrapper;
+      await flushPromises();
+
+      expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
     });
   });
 

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1302,17 +1302,64 @@ class EventService {
         // helper is positive-only, and payload rejection above guarantees
         // we never see isException=true here.
         const toStorage = EventScheduleEntity.toStorageDate;
+        // Capture the pre-edit occurrence instant and frequency so a single
+        // (non-recurring) event's exclusion row can follow a date edit below.
+        // The instant is taken from the entity's model projection (not the raw
+        // start_date column) because positive schedules and exclusion rows do
+        // NOT share a storage convention: positive rows store wall-clock digits
+        // reinterpreted in their `timezone` column (keepLocalTime), while the
+        // cancel path writes exclusion rows as true UTC instants with
+        // timezone='UTC'. Comparing raw `start_date` columns therefore only
+        // matched on a UTC server; comparing the resolved UTC instant matches
+        // on any server.
+        const oldStartInstantMs = scheduleEntity.toModel().startDate?.toUTC().toMillis() ?? null;
+        const oldStartDate = scheduleEntity.start_date;
+        const oldFrequency = scheduleEntity.frequency;
+        const newStartDate = toStorage(parsed.startDate) ?? scheduleEntity.start_date;
+        const newFrequency = 'frequency' in schedule ? ((parsed.frequency as string) ?? null) : scheduleEntity.frequency;
         await scheduleEntity.update({
           timezone: parsed.startDate?.zoneName ?? scheduleEntity.timezone,
-          start_date: toStorage(parsed.startDate) ?? scheduleEntity.start_date,
+          start_date: newStartDate,
           end_date: 'end' in schedule ? (toStorage(parsed.endDate) ?? null) : scheduleEntity.end_date,
           event_end_time: 'eventEndTime' in schedule ? (toStorage(parsed.eventEndTime) ?? null) : scheduleEntity.event_end_time,
-          frequency: 'frequency' in schedule ? ((parsed.frequency as string) ?? null) : scheduleEntity.frequency,
+          frequency: newFrequency,
           interval: 'interval' in schedule ? (parsed.interval ?? 0) : scheduleEntity.interval,
           count: 'count' in schedule ? (parsed.count ?? 0) : scheduleEntity.count,
           by_day: byDayValue,
         }, { transaction: tx });
         event.addSchedule(scheduleEntity.toModel());
+
+        // Cancellation-follows-event (single events): when an owner edits the
+        // date/time of a single, non-recurring event that carries a
+        // cancellation, the exclusion row — keyed by start_date — must move
+        // with the event so it stays cancelled. Re-key any matching exclusion
+        // from the old start_date to the new one. Multi-schedule and recurring
+        // events are deliberately excluded: their exclusions are keyed to
+        // individual occurrence dates, not the lone schedule's start_date.
+        const isSingleNonRecurringEdit =
+          existingPositives.length === 1 &&
+          incomingPositiveSchedules.length === 1 &&
+          !oldFrequency && !newFrequency;
+        if (
+          isSingleNonRecurringEdit &&
+          oldStartInstantMs !== null &&
+          parsed.startDate &&
+          oldStartDate && newStartDate &&
+          newStartDate.getTime() !== oldStartDate.getTime()
+        ) {
+          for (const exclusion of existingExclusions) {
+            // Match and re-key by resolved UTC instant (via the model
+            // projection) so the comparison is independent of each row's
+            // storage convention. The new value is written back in the
+            // exclusion's OWN timezone convention via toStorageDate so it
+            // round-trips through toModel() to the new occurrence instant.
+            const exclusionInstantMs = exclusion.toModel().startDate?.toUTC().toMillis() ?? null;
+            if (exclusionInstantMs !== null && exclusionInstantMs === oldStartInstantMs) {
+              const rekeyedStart = toStorage(parsed.startDate.setZone(exclusion.timezone || 'UTC'));
+              await exclusion.update({ start_date: rekeyedStart }, { transaction: tx });
+            }
+          }
+        }
       }
       else {
         event.addSchedule(await this.createEventSchedule(eventId, schedule, tx));

--- a/src/server/calendar/test/EventService/update.test.ts
+++ b/src/server/calendar/test/EventService/update.test.ts
@@ -934,6 +934,132 @@ describe('updateEvent exclusion preservation (reconcileSchedules)', () => {
     expect(findSchedulesStub.called).toBe(false);
   });
 
+  it('should re-key the exclusion row to the new start_date when a single event date is edited', async () => {
+    // A single (non-recurring) event with one positive schedule and a
+    // cancellation exclusion row keyed to the same occurrence. Editing the
+    // event's date must move the exclusion to the new date so it stays
+    // cancelled (cancellation-follows-event).
+    //
+    // The positive schedule uses a NON-UTC timezone so its resolved instant
+    // diverges from its raw start_date column digits. Positive rows store
+    // wall-clock digits reinterpreted via their `timezone` column
+    // (keepLocalTime): raw 10:00 on 2026-01-01 in America/New_York (EST,
+    // UTC-5) resolves to the instant 2026-01-01T15:00:00Z. The exclusion row
+    // (no timezone → UTC convention) is keyed to that RESOLVED instant
+    // (15:00Z), NOT the positive's raw 10:00 digits, because reconcileSchedules
+    // matches the exclusion to the positive by resolved UTC instant — never by
+    // raw column bytes.
+    //
+    // This divergence is the regression guard. The original bug matched/copied
+    // raw start_date column bytes: here that compares 10:00Z (positive) against
+    // 15:00Z (exclusion), which do NOT match, so a buggy implementation never
+    // re-keys the exclusion at all. The correct implementation matches resolved
+    // instants (15:00Z == 15:00Z) and re-keys. Because the divergence is built
+    // into the fixture (not the runner's timezone), the guard discriminates on
+    // any server timezone, including a UTC runner where the old fixture was
+    // vacuous.
+    const positiveRawStart = new Date('2026-01-01T10:00:00Z');
+    const oldOccurrenceInstantMs = DateTime.fromISO('2026-01-01T15:00:00Z', { zone: 'UTC' }).toMillis();
+    const positiveEntity = EventScheduleEntity.build({
+      id: 'positiveScheduleId',
+      event_id: eventId,
+      start_date: positiveRawStart,
+      timezone: 'America/New_York',
+      is_exclusion: false,
+    });
+    const exclusionEntity = EventScheduleEntity.build({
+      id: 'exclusionScheduleId',
+      event_id: eventId,
+      start_date: new Date('2026-01-01T15:00:00Z'),
+      is_exclusion: true,
+      hide_from_public: false,
+    });
+
+    sandbox.stub(EventEntity, 'findByPk').resolves(
+      EventEntity.build({ account_id: 'testAccountId', id: eventId, calendar_id: 'testCalendarId' }),
+    );
+    sandbox.stub(EventEntity.prototype, 'save');
+    sandbox.stub(EventScheduleEntity, 'findAll').resolves([positiveEntity, exclusionEntity]);
+    const updateScheduleStub = sandbox.stub(EventScheduleEntity.prototype, 'update');
+    updateScheduleStub.callsFake(async function(this: typeof positiveEntity, params: Record<string, unknown>) {
+      for (const key in params) {
+        this.set(key, params[key]);
+      }
+      return this;
+    });
+
+    await service.updateEvent(acct, eventId, {
+      schedules: [
+        { id: 'positiveScheduleId', start: '2026-06-15T14:00:00', end: '2026-06-15T16:00:00' },
+      ],
+    });
+
+    // The positive schedule moved to a new date.
+    const positiveUpdate = updateScheduleStub.getCalls().find(c => c.thisValue === positiveEntity);
+    expect(positiveUpdate).toBeDefined();
+    const newStart = positiveUpdate?.args[0].start_date as Date;
+    expect(newStart.getTime()).not.toBe(positiveRawStart.getTime());
+
+    // The exclusion row was re-keyed onto the new occurrence. Positive
+    // schedules and exclusion rows do NOT share a storage convention — positive
+    // rows store wall-clock digits reinterpreted in their `timezone` column
+    // (keepLocalTime), while exclusion rows are written as true UTC instants.
+    // So the re-key is asserted by the resolved occurrence INSTANT via
+    // toModel(), not by raw start_date column equality (which would only hold
+    // on a UTC server).
+    const exclusionUpdate = updateScheduleStub.getCalls().find(c => c.thisValue === exclusionEntity);
+    expect(exclusionUpdate).toBeDefined();
+    const reKeyedInstantMs = exclusionEntity.toModel().startDate?.toUTC().toMillis();
+    expect(reKeyedInstantMs).toBe(positiveEntity.toModel().startDate?.toUTC().toMillis());
+    // And it is genuinely the NEW occurrence, not the old one (15:00Z).
+    expect(reKeyedInstantMs).not.toBe(oldOccurrenceInstantMs);
+  });
+
+  it('should not re-key exclusions for a recurring single event date edit', async () => {
+    // A recurring event's exclusions are keyed to individual occurrence dates,
+    // not the lone schedule's start_date, so editing the schedule must NOT
+    // re-key them.
+    const oldStart = new Date('2026-01-01T10:00:00Z');
+    const positiveEntity = EventScheduleEntity.build({
+      id: 'positiveScheduleId',
+      event_id: eventId,
+      start_date: oldStart,
+      frequency: EventFrequency.WEEKLY as string,
+      timezone: 'UTC',
+      is_exclusion: false,
+    });
+    const exclusionEntity = EventScheduleEntity.build({
+      id: 'exclusionScheduleId',
+      event_id: eventId,
+      start_date: oldStart,
+      is_exclusion: true,
+      hide_from_public: false,
+    });
+
+    sandbox.stub(EventEntity, 'findByPk').resolves(
+      EventEntity.build({ account_id: 'testAccountId', id: eventId, calendar_id: 'testCalendarId' }),
+    );
+    sandbox.stub(EventEntity.prototype, 'save');
+    sandbox.stub(EventScheduleEntity, 'findAll').resolves([positiveEntity, exclusionEntity]);
+    const updateScheduleStub = sandbox.stub(EventScheduleEntity.prototype, 'update');
+    updateScheduleStub.callsFake(async function(this: typeof positiveEntity, params: Record<string, unknown>) {
+      for (const key in params) {
+        this.set(key, params[key]);
+      }
+      return this;
+    });
+
+    await service.updateEvent(acct, eventId, {
+      schedules: [
+        { id: 'positiveScheduleId', start: '2026-06-15T14:00:00' },
+      ],
+    });
+
+    // The exclusion row's update must not have been invoked.
+    const exclusionUpdate = updateScheduleStub.getCalls().find(c => c.thisValue === exclusionEntity);
+    expect(exclusionUpdate).toBeUndefined();
+  });
+
   it('should leave exclusions deleted after a restore (edit unrelated field post-restore)', async () => {
     // Scenario: a cancellation was restored elsewhere (the exclusion row was
     // deleted). Editing an unrelated field (e.g. content) must not recreate

--- a/src/server/calendar/test/integration/single_event_cancellation.test.ts
+++ b/src/server/calendar/test/integration/single_event_cancellation.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+import { DateTime } from 'luxon';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { CalendarEvent } from '@/common/model/events';
+import CalendarInterface from '@/server/calendar/interface';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+import { InvalidOccurrenceDateError } from '@/common/exceptions/calendar';
+
+/**
+ * Service-level integration tests for cancellation of SINGLE (non-recurring)
+ * events, exercised against a real (in-memory) database through
+ * CalendarInterface — not stubbed persistence.
+ *
+ * The occurrence-cancellation machinery (cancelOccurrenceByDate,
+ * assertDateMatchesOccurrence, the exclusion-row model) was built for recurring
+ * events but must work identically for a one-off event, whose lone rdate is the
+ * only occurrence. These tests prove that, plus the Wave-1 "cancellation
+ * follows the event" re-key: when an owner edits the date of a cancelled single
+ * event via updateEvent, the exclusion row is re-keyed onto the new start so
+ * the event stays cancelled at its new date and carries no cancellation at the
+ * old one.
+ *
+ * The chain is driven end-to-end through the persistence layer:
+ *   createEvent -> buildEventInstances -> cancelOccurrenceByDate ->
+ *   updateEvent (date edit) -> buildEventInstances -> listEventInstances.
+ * CalendarInterface does not install the eventBus -> buildEventInstances
+ * handler, so instance materialization is invoked explicitly for determinism.
+ */
+describe('Single-event cancellation (service integration, real DB)', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let account: Account;
+  let calendar: Calendar;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    const eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    // Minimal AP interface stub: these tests stay on local-only code paths,
+    // but listing helpers and lookups expect the interface to be present.
+    calendarInterface.setActivityPubInterface({
+      getSharedEventIds: async () => [],
+      getSharedEventStatusMap: async () => new Map(),
+      findCalendarActorByCalendarId: async () => null,
+      getEventSourceActorUris: async () => new Map(),
+    } as never);
+
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const info = await accountService._setupAccount('single-cancel@pavillion.dev', 'testpassword');
+    account = info.account;
+    calendar = await calendarInterface.createCalendar(account, 'singlecancel');
+  });
+
+  afterAll(async () => {
+    await env.cleanup();
+  });
+
+  /**
+   * Create a single, non-recurring event whose lone schedule starts at `start`.
+   * Returns the created event (with its schedule populated) so callers can read
+   * the schedule id / startDate for subsequent cancel and re-key operations.
+   */
+  async function createSingleEvent(start: DateTime, name: string): Promise<CalendarEvent> {
+    return calendarInterface.createEvent(account, {
+      calendarId: calendar.id,
+      content: { en: { name, description: 'single non-recurring event' } },
+      schedules: [{
+        start: start.toISO(),
+        eventEndTime: start.plus({ hours: 1 }).toISO(),
+      }],
+    });
+  }
+
+  it('cancels a non-recurring single occurrence in shown mode (hideFromPublic=false)', async () => {
+    const start = DateTime.fromISO('2026-08-15T10:00:00.000Z', { zone: 'utc' });
+    const event = await createSingleEvent(start, 'Shown Cancel Single');
+    expect(event.schedules.length).toBe(1);
+
+    // Materialize the lone instance, then confirm it starts active.
+    await calendarInterface.buildEventInstances(event);
+    const before = await calendarInterface.listEventInstances(event);
+    expect(before.length).toBe(1);
+    expect(before[0].isCancelled).toBe(false);
+
+    // Cancel the single occurrence in shown mode. The exclusion row is keyed to
+    // the schedule's start; the rdate still produces the occurrence, so the
+    // listing layer marks it isCancelled rather than dropping it.
+    await calendarInterface.cancelOccurrenceByDate(account, event.id, event.schedules[0].startDate!, false);
+
+    const after = await calendarInterface.listEventInstances(event);
+    expect(after.length).toBe(1);
+    expect(after[0].isCancelled).toBe(true);
+    expect(after[0].start.toUTC().toMillis()).toBe(start.toMillis());
+  });
+
+  it('accepts a past-dated single occurrence (assertDateMatchesOccurrence)', async () => {
+    // A one-off event well in the past. Its rdate is still a valid occurrence,
+    // so cancelOccurrenceByDate must NOT raise InvalidOccurrenceDateError.
+    const start = DateTime.fromISO('2020-03-09T18:30:00.000Z', { zone: 'utc' });
+    const event = await createSingleEvent(start, 'Past Single');
+    await calendarInterface.buildEventInstances(event);
+
+    // The cancel call validates the date against the RRuleSet via
+    // assertDateMatchesOccurrence; a past single occurrence must validate.
+    await expect(
+      calendarInterface.cancelOccurrenceByDate(account, event.id, event.schedules[0].startDate!, false),
+    ).resolves.toBeUndefined();
+
+    const after = await calendarInterface.listEventInstances(event);
+    expect(after.length).toBe(1);
+    expect(after[0].isCancelled).toBe(true);
+
+    // A date that does NOT coincide with the lone rdate must be rejected,
+    // proving the validation is real and not vacuously passing past dates.
+    await expect(
+      calendarInterface.cancelOccurrenceByDate(account, event.id, start.plus({ hours: 1 }), false),
+    ).rejects.toBeInstanceOf(InvalidOccurrenceDateError);
+  });
+
+  it('restores a cancelled single occurrence (cancel -> restore round-trip)', async () => {
+    const start = DateTime.fromISO('2026-10-01T09:00:00.000Z', { zone: 'utc' });
+    const event = await createSingleEvent(start, 'Restore Single');
+    await calendarInterface.buildEventInstances(event);
+
+    await calendarInterface.cancelOccurrenceByDate(account, event.id, event.schedules[0].startDate!, false);
+    const cancelled = await calendarInterface.listEventInstances(event);
+    expect(cancelled.length).toBe(1);
+    expect(cancelled[0].isCancelled).toBe(true);
+
+    // Restore deletes the exclusion row; the occurrence returns to active.
+    await calendarInterface.restoreOccurrenceByDate(account, event.id, event.schedules[0].startDate!);
+    const restored = await calendarInterface.listEventInstances(event);
+    expect(restored.length).toBe(1);
+    expect(restored[0].isCancelled).toBe(false);
+  });
+
+  it('cancellation follows the event when its date is edited (exclusion re-keyed)', async () => {
+    const oldStart = DateTime.fromISO('2026-11-05T14:00:00.000Z', { zone: 'utc' });
+    const newStart = DateTime.fromISO('2026-12-20T14:00:00.000Z', { zone: 'utc' });
+
+    const event = await createSingleEvent(oldStart, 'Re-key Single');
+    const scheduleId = event.schedules[0].id!;
+    await calendarInterface.buildEventInstances(event);
+
+    // Cancel at the original date (shown mode).
+    await calendarInterface.cancelOccurrenceByDate(account, event.id, event.schedules[0].startDate!, false);
+    const atOld = await calendarInterface.listEventInstances(event);
+    expect(atOld.length).toBe(1);
+    expect(atOld[0].start.toUTC().toMillis()).toBe(oldStart.toMillis());
+    expect(atOld[0].isCancelled).toBe(true);
+
+    // Edit the single event's date through updateEvent. reconcileSchedules must
+    // re-key the exclusion row from oldStart to newStart so the cancellation
+    // travels with the event.
+    const updated = await calendarInterface.updateEvent(account, event.id, {
+      schedules: [{ id: scheduleId, start: newStart.toISO() }],
+    });
+
+    // Rebuild instances from the updated schedules: the old instance is removed
+    // and a single instance is materialized at the new date.
+    await calendarInterface.buildEventInstances(updated);
+    const atNew = await calendarInterface.listEventInstances(updated);
+
+    // Exactly one instance, now at the NEW date, still cancelled.
+    expect(atNew.length).toBe(1);
+    expect(atNew[0].start.toUTC().toMillis()).toBe(newStart.toMillis());
+    expect(atNew[0].isCancelled).toBe(true);
+
+    // The old date carries nothing — no lingering instance and no lingering
+    // cancellation keyed to oldStart.
+    const lingeringOld = atNew.find(
+      i => i.start.toUTC().toMillis() === oldStart.toMillis(),
+    );
+    expect(lingeringOld).toBeUndefined();
+  });
+});

--- a/src/server/public/test/integration/event_instance_api.test.ts
+++ b/src/server/public/test/integration/event_instance_api.test.ts
@@ -329,6 +329,89 @@ describe('GET /api/public/v1/events/:eventId/instances/:startTime', () => {
     expect(response.body.event.space.originUri).toBeUndefined();
   });
 
+  /**
+   * Single-event cancellation (epic pv-ibke): cancelling a non-recurring
+   * event's lone occurrence (show-as-cancelled, hideFromPublic=false) must
+   * surface isCancelled:true on every public surface that carries instance
+   * state. Cancellation is instance-scoped — markShownCancellations() flips
+   * the materialized instance row; the event entity itself has no cancelled
+   * state (epic decision: "do NOT add an event-level cancelled state").
+   *
+   * Uses the existing recurring-occurrence cancel path verbatim — a single
+   * event already materializes exactly one rdate occurrence, so the path is
+   * recurrence-agnostic and needs no code change.
+   */
+  describe('cancelled single event reports isCancelled across public surfaces', () => {
+    /**
+     * Cancel a single event's lone occurrence via the authenticated owner
+     * endpoint with hideFromPublic=false (show-as-cancelled). Returns once the
+     * exclusion schedule row is written (204).
+     */
+    async function cancelSingleOccurrence(eventId: string, startIso: string): Promise<void> {
+      const res = await request(env.app)
+        .post(`/api/v1/events/${eventId}/occurrences/cancel`)
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .send({ start: startIso, hideFromPublic: false });
+      if (res.status !== 204) {
+        throw new Error(`Failed to cancel occurrence: ${res.status} ${JSON.stringify(res.body)}`);
+      }
+    }
+
+    it('lists the cancelled single event with isCancelled:true', async () => {
+      // Past-dated single event: its lone rdate is materialized 1:1 at creation
+      // (generateInstances always persists past rdates, regardless of the
+      // [now, now+horizon] window), so it appears in the calendar list without
+      // a prior detail hit. Cancelling a past-dated single event is an
+      // explicitly supported epic-pv-ibke scenario. A fixed past date keeps the
+      // test independent of wall-clock drift.
+      const startIso = '2020-03-15T18:00:00Z';
+      const eventId = await createOneShotEvent(startIso, '2020-03-15T19:00:00Z', 'Cancelled Single (List)');
+      await cancelSingleOccurrence(eventId, startIso);
+
+      const response = await request(env.app)
+        .get('/api/public/v1/calendar/instancecal/events');
+
+      expect(response.status).toBe(200);
+      // The list spans the whole calendar; find this event's lone instance and
+      // assert it is flagged cancelled (shown, not hidden).
+      const row = response.body.find((i: any) => i.event?.id === eventId);
+      expect(row).toBeDefined();
+      expect(row.isCancelled).toBe(true);
+    });
+
+    it('reports isCancelled:true on the instance detail endpoint', async () => {
+      const startIso = '2032-06-20T18:00:00Z';
+      const eventId = await createOneShotEvent(startIso, '2032-06-20T19:00:00Z', 'Cancelled Single (Instance)');
+      await cancelSingleOccurrence(eventId, startIso);
+
+      const response = await request(env.app)
+        .get(`/api/public/v1/events/${eventId}/instances/20320620-1800`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.isCancelled).toBe(true);
+      expect(response.body.event.id).toBe(eventId);
+    });
+
+    it('does not surface an event-level isCancelled on the /events/:id detail endpoint', async () => {
+      // Cancellation is instance-scoped: the badge on the public detail page is
+      // driven by the instance endpoint above, not by /events/:id. The event
+      // entity has no cancelled state (epic pv-ibke: "do NOT add an event-level
+      // cancelled state"; serialization needs no change). This test pins that
+      // contract so a future change can't silently start leaking a cancelled
+      // flag onto the event projection.
+      const startIso = '2032-07-20T18:00:00Z';
+      const eventId = await createOneShotEvent(startIso, '2032-07-20T19:00:00Z', 'Cancelled Single (Event)');
+      await cancelSingleOccurrence(eventId, startIso);
+
+      const response = await request(env.app)
+        .get(`/api/public/v1/events/${eventId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.id).toBe(eventId);
+      expect(response.body.isCancelled).toBeUndefined();
+    });
+  });
+
   it('returns space with content for a Space-scoped event (cache-miss / materialize path)', async () => {
     // Weekly recurring event; probe a far-future occurrence that has no
     // pre-materialized row — exercises the findByPk (cache-miss) branch.

--- a/src/site/components/event-card.vue
+++ b/src/site/components/event-card.vue
@@ -196,6 +196,7 @@ const detailPath = computed(() => {
       <span
         v-if="isCancelled"
         class="cancelled-badge"
+        data-testid="cancelled-badge"
         role="status"
       >
         <CalendarX

--- a/tests/e2e/single-event-cancel-badge.spec.ts
+++ b/tests/e2e/single-event-cancel-badge.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect, Page } from '@playwright/test';
+import { loginAsAdmin } from './helpers/auth';
+import { startTestServer, TestEnvironment } from './helpers/test-server';
+
+/**
+ * E2E Test: Single (non-recurring) event cancel/restore + public Cancelled badge
+ *
+ * Exercises the single-event cancel flow end-to-end (single-instance, no Docker):
+ *
+ *   1. Log in as admin and create a single (non-recurring) event.
+ *   2. Re-open the event in the editor and use the inline SingleEventCancelControl
+ *      to cancel it (show-as-cancelled; the EventCancelConfirmModal is reused with
+ *      its hide-from-public toggle suppressed).
+ *   3. Assert the Cancelled badge appears on the event's card in the public view
+ *      (/view/<calendar>, rendered by src/site/components/event-card.vue).
+ *   4. Restore the event from the editor.
+ *   5. Assert the Cancelled badge is gone from the public card.
+ *
+ * Uses the shared isolated test-server harness (in-memory SQLite, fresh seeded
+ * admin@pavillion.dev / test_calendar). Runs serially.
+ *
+ * Selectors of record:
+ *   - Cancel control container: [data-testid="single-event-cancel-control"]
+ *   - Cancel trigger:           [data-testid="single-event-cancel"]
+ *   - Modal confirm:            [data-testid="confirm-submit"]
+ *   - Cancelled status text:    [data-testid="single-event-cancelled-status"]
+ *   - Restore trigger:          [data-testid="single-event-restore"]
+ *   - Public badge:             article.event-card [data-testid="cancelled-badge"]
+ */
+
+let env: TestEnvironment;
+
+test.describe.configure({ mode: 'serial' });
+
+const ADMIN_CALENDAR = 'test_calendar';
+const EVENT_TITLE = `Single Cancel Badge E2E ${Date.now()}`;
+// A near-future date keeps the event inside the public upcoming-events window
+// while remaining a single (non-recurring) occurrence.
+const EVENT_DATE = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .slice(0, 10);
+
+/**
+ * Create a single (non-recurring) event on the admin's calendar and return to
+ * the events tab. Leaves exactly one positive schedule so the editor renders
+ * SingleEventCancelControl (not the multi-occurrence panel).
+ */
+async function createSingleEvent(page: Page, title: string): Promise<void> {
+  await page.goto(`${env.baseURL}/calendar/${ADMIN_CALENDAR}`);
+  await page.waitForSelector('.event-list, [class*="empty"]', { timeout: 15000 });
+
+  await page.getByRole('button', { name: /create an event/i }).click();
+  await page.waitForSelector('#event-form', { timeout: 10000 });
+
+  await page.locator('#event-name-en').fill(title);
+  await page.locator('.schedule-grid input[type="date"]').first().fill(EVENT_DATE);
+  await page.locator('.schedule-grid input[type="time"]').first().fill('14:00');
+
+  await page.locator('button.btn-save').click();
+
+  await page.waitForURL(`**/calendar/${ADMIN_CALENDAR}`, { timeout: 15000 });
+  await page.waitForSelector('.event-list', { timeout: 10000 });
+
+  const item = page.locator('.event-item').filter({ hasText: title }).first();
+  await expect(item).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Open the named event in the editor via the events-tab pencil button and wait
+ * for the SingleEventCancelControl to finish loading its occurrence state.
+ */
+async function openEditor(page: Page, title: string): Promise<void> {
+  await page.goto(`${env.baseURL}/calendar/${ADMIN_CALENDAR}`);
+  await page.waitForSelector('.event-list', { timeout: 15000 });
+
+  const item = page.locator('.event-item').filter({ hasText: title }).first();
+  await expect(item).toBeVisible({ timeout: 10000 });
+  await item.locator('.edit-btn').click();
+
+  await page.waitForSelector('#event-form', { timeout: 10000 });
+  await expect(
+    page.locator('[data-testid="single-event-cancel-control"]'),
+  ).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Locate the public event card for the named event. Uses the public search box
+ * to narrow the list to the single matching event regardless of how many
+ * seeded events the calendar contains.
+ */
+async function publicEventCard(page: Page, title: string) {
+  await page.goto(`${env.baseURL}/view/${ADMIN_CALENDAR}`);
+
+  const search = page.locator('#public-event-search');
+  await search.waitFor({ state: 'visible', timeout: 15000 });
+  await search.fill(title);
+
+  // Search is debounced (~300ms) before it updates the rendered list. Wait
+  // deterministically for the filtered card rather than sleeping a fixed time;
+  // the title filter is unique so exactly one card matches regardless of
+  // seeded-event volume.
+  const card = page.locator('article.event-card').filter({ hasText: title }).first();
+  await expect(card).toBeVisible({ timeout: 5000 });
+  return card;
+}
+
+test.describe('Single-event cancel/restore + public Cancelled badge', () => {
+  test.beforeAll(async () => {
+    env = await startTestServer();
+  });
+
+  test.afterAll(async () => {
+    if (env?.cleanup) {
+      await env.cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page, env.baseURL);
+  });
+
+  test('cancel shows the badge on the public card; restore removes it', async ({ page }) => {
+    // 1. Create a single (non-recurring) event.
+    await createSingleEvent(page, EVENT_TITLE);
+
+    // Baseline: the public card exists and is NOT cancelled.
+    const baselineCard = await publicEventCard(page, EVENT_TITLE);
+    await expect(baselineCard).toBeVisible({ timeout: 15000 });
+    await expect(baselineCard.locator('[data-testid="cancelled-badge"]')).toHaveCount(0);
+
+    // 2. Cancel the event from the editor (show-as-cancelled).
+    await openEditor(page, EVENT_TITLE);
+    await page.locator('[data-testid="single-event-cancel"]').click();
+
+    const confirm = page.locator('[data-testid="confirm-submit"]');
+    await expect(confirm).toBeVisible({ timeout: 5000 });
+    await confirm.click();
+
+    // The control flips to the cancelled status + Restore button in place.
+    await expect(
+      page.locator('[data-testid="single-event-cancelled-status"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // 3. Cancelled badge appears on the public card.
+    const cancelledCard = await publicEventCard(page, EVENT_TITLE);
+    await expect(cancelledCard).toBeVisible({ timeout: 15000 });
+    await expect(cancelledCard.locator('[data-testid="cancelled-badge"]')).toBeVisible({ timeout: 10000 });
+
+    // 4. Restore the event from the editor.
+    await openEditor(page, EVENT_TITLE);
+    await expect(
+      page.locator('[data-testid="single-event-cancelled-status"]'),
+    ).toBeVisible({ timeout: 10000 });
+    await page.locator('[data-testid="single-event-restore"]').click();
+
+    // The control flips back to the Cancel trigger.
+    await expect(
+      page.locator('[data-testid="single-event-cancel"]'),
+    ).toBeVisible({ timeout: 10000 });
+
+    // 5. Cancelled badge is gone from the public card.
+    const restoredCard = await publicEventCard(page, EVENT_TITLE);
+    await expect(restoredCard).toBeVisible({ timeout: 15000 });
+    await expect(restoredCard.locator('[data-testid="cancelled-badge"]')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Motivation

Only occurrences of recurring events could be cancelled. Owners of single (non-recurring) events were told to hand-edit the title (`Cancelled — …`) or delete the event — neither of which yields a proper Cancelled badge or a clean federated cancellation. This gives single events a first-class Cancel/Restore action with the same Cancelled status and federation propagation that recurring-occurrence cancellation already provides.

## Approach

Cancellation is already recurrence-agnostic — it is an exclusion schedule row keyed to the occurrence instant — so this reuses that path rather than adding any event-level cancelled state:

- **Editor gating** (`edit_event.vue`): a new predicate over *positive* (non-exclusion) schedules. A single, saved, non-recurring event renders the new `SingleEventCancelControl`; events with two or more occurrences (recurring or multiple one-offs) keep the existing cancellations panel. The control only shows for a persisted event, so create-mode shows no cancel UI.
- **`SingleEventCancelControl`**: reuses the existing event service (`cancelOccurrence`/`restoreOccurrence`/`listUpcomingOccurrences`) and the confirmation modal, flipping state in place. Cancellation is **show-as-cancelled only** — the modal gains an `allowHide` prop to suppress the hide-from-public toggle and always sends `hideFromPublic:false`.
- **Cancellation follows the event** (`reconcileSchedules`): editing a cancelled single event's date re-keys its exclusion row. The match/write is done by **resolved UTC instant** (not raw `start_date` columns), because positive rows store wall-clock digits in their timezone column while exclusion rows are true UTC — comparing raw columns silently failed on any non-UTC server.
- **Public surface**: unchanged serialization — the Cancelled badge on the event card is driven by the instance projection. A contract test pins that the event-metadata endpoint does **not** carry an event-level `isCancelled`.
- The calendar-owner guide is updated to drop the title-edit workaround.

No changes to the federation path; cancellation propagates via the existing `Update(Event)` flow.

## Validation

- **build-guardian green** on the final tree: lint (0 errors), unit (8355 passed), integration (676 passed), production build, and single-instance e2e. The new `single-event-cancel-badge` Playwright spec passes. (Pre-existing e2e failures requiring a running dev server / Docker federation certs are unaffected.)
- **Tests added**: backend unit + integration (cancel/restore/past-date/cancellation-follows-event, plus a timezone-discriminating re-key regression guard verified to fail under the original buggy comparison), public-API `isCancelled` contract tests, frontend component + gating tests, and the e2e badge flow.
- **Manual verification** in the running app via Playwright: created a single event, confirmed the Cancel control (and absence of the old panel), show-as-cancelled-only modal, the public Cancelled badge appearing on cancel and disappearing on restore, a past-dated event cancelling successfully, recurring events still using the old panel, and zero console errors.
