### PR TITLE
chore(client): unify repost-removal button label across locales

### DIFF
--- a/src/client/locales/en/calendars.json
+++ b/src/client/locales/en/calendars.json
@@ -66,7 +66,7 @@
       "edit_title": "Edit this event",
       "select_label": "Select event: {{name}}",
       "duplicate_label": "Duplicate event: {{name}}",
-      "unpost_button_label": "Unpost",
+      "unpost_button_label": "Remove repost",
       "unpost_aria_label": "Remove repost of event: {{name}}",
       "unpost_confirm_title": "Remove reposted event?",
       "unpost_confirm_body": "Remove this reposted event from your calendar? It will not be automatically reposted again if the original calendar re-broadcasts it.",

--- a/src/client/locales/es/calendars.json
+++ b/src/client/locales/es/calendars.json
@@ -62,7 +62,7 @@
       "edit_title": "Editar este evento",
       "select_label": "Seleccionar evento: {{name}}",
       "duplicate_label": "Duplicar evento: {{name}}",
-      "unpost_button_label": "Despublicar",
+      "unpost_button_label": "Eliminar reenvío",
       "unpost_aria_label": "Eliminar reenvío del evento: {{name}}",
       "unpost_confirm_title": "¿Eliminar evento reenviado?",
       "unpost_confirm_body": "¿Eliminar este evento reenviado de tu calendario? No se reenviará automáticamente de nuevo si el calendario original lo vuelve a publicar.",

--- a/src/client/locales/fr/calendars.json
+++ b/src/client/locales/fr/calendars.json
@@ -62,7 +62,7 @@
       "edit_title": "Modifier cet événement",
       "select_label": "Sélectionner l'événement : {{name}}",
       "duplicate_label": "Dupliquer l'événement : {{name}}",
-      "unpost_button_label": "Dépublier",
+      "unpost_button_label": "Supprimer la republication",
       "unpost_aria_label": "Supprimer la republication de l'événement : {{name}}",
       "unpost_confirm_title": "Supprimer l'événement republié ?",
       "unpost_confirm_body": "Supprimer cet événement republié de votre calendrier ? Il ne sera pas republié automatiquement si le calendrier d'origine le rediffuse.",


### PR DESCRIPTION
## Motivation

The event-list control for removing a reposted event presented
inconsistent terminology to users. The visible button label read
"Unpost" (es "Despublicar", fr "Dépublier"), while the button's own
aria-label, the confirmation modal title and action, and the success
toast all used the "remove repost" / "reposted event" wording. A
screen-reader user would tab to a button announced as "Remove repost",
activate it, land in a modal titled "Remove reposted event?" with a
"Remove repost" action — yet a sighted user saw a button labelled
"Unpost". The two audiences formed different mental models of the same
action.

## Approach

Standardize on the "remove repost" terminology family, which was already
the dominant convention: it is used by the unpost aria-label, confirm
title/body/action, and success/error toasts, and by the entire `feed`
namespace (`Repost`, `Reposted`, `Remove repost for…`, auto-repost
settings). The only outlier was the visible button label.

Changed the visible button label value only (key names unchanged, so no
call-site updates were required):

- en `calendars.json`: `Unpost` → `Remove repost`
- es `calendars.json`: `Despublicar` → `Eliminar reenvío`
- fr `calendars.json`: `Dépublier` → `Supprimer la republication`

The es/fr replacements reuse each locale's existing confirm-action
translation, so the button now reads identically to its modal action in
every language. The `feed` namespace was reviewed and already coherent,
so it needed no change.

This PR also covered a separate review of the Spanish/French instance
policy strings (admin policy card, view-policy navigation, and the
public /policy page). Those keys were found to already hold natural
translations on main, so no further changes were needed there.

## Validation

- `npm run lint` — passes clean (ESLint + Stylelint).
- All three `calendars.json` files validated as parseable JSON.
- Targeted locale unit tests: `src/client/test/service/locale.test.ts`
  and `src/common/test/i18n/locale-url.test.ts` — 52 passed.
- Confirmed no component or test asserts the literal visible string;
  remaining "Unpost" references are internal identifiers (handler names,
  modal state, comments, e2e descriptions).