### PR TITLE
refactor(federation): consolidate URI/SSRF validators in server/common

### DIFF
--- a/src/server/activitypub/helper/actor-uri.ts
+++ b/src/server/activitypub/helper/actor-uri.ts
@@ -8,8 +8,6 @@
 
 import { validateActorUriProtocol } from '@/server/common/helper/uri-validation';
 
-export { validateActorUriProtocol };
-
 export type ActorType = 'person' | 'calendar';
 
 export interface ParsedActorUri {

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from "events";
 import { logError } from '@/server/common/helper/error-logger';
 import { logActivityRejection } from '../helper/rejection-logger';
-import { validateActorUriProtocol } from '../helper/actor-uri';
+import { validateActorUriProtocol } from '@/server/common/helper/uri-validation';
 import { createLogger } from '@/server/common/helper/logger';
 
 const logger = createLogger('activitypub');


### PR DESCRIPTION
## Motivation

The URI and SSRF validation helpers used across domains were originally
defined inside the `activitypub` domain, which forced calendar and
moderation to reach across a domain boundary to use them (a DEC-003
violation). A prior refactor moved the implementations into
`src/server/common`:

- `validateActorUriProtocol` → `@/server/common/helper/uri-validation`
- `validateUrlNotPrivate` (and `isPrivateIP`, etc.) → `@/server/common/helper/ip-validation`
- `FEDERATION_HTTP_TIMEOUT_MS` → `@/server/common/constants`

One inconsistency remained: `activitypub/helper/actor-uri.ts` still
re-exported `validateActorUriProtocol` as a backward-compat shim, and the
activitypub inbox service imported the validator through that shim rather
than from `server/common` like every other consumer. The `ip-validation`
helper already had no such shim, so this closed the gap and gave each
validator a single canonical home.

## Approach

- `src/server/activitypub/service/inbox.ts` — import
  `validateActorUriProtocol` from `@/server/common/helper/uri-validation`
  directly instead of through the local `../helper/actor-uri` re-export.
- `src/server/activitypub/helper/actor-uri.ts` — remove the
  `export { validateActorUriProtocol }` re-export shim. The file keeps its
  own internal import of the helper for `parseActorUri`; only the
  re-export surface was dropped.

Importers already pointing at `server/common` and left unchanged:
calendar (`calendar.ts`, `import/*`), moderation (`moderation.ts`), and
the remaining activitypub services/helpers (`outbox.ts`, `members.ts`,
`backfill.ts`, `remote-fetch.ts`, `http_signature.ts`).

These are security-critical URL/SSRF validators: **no validator logic was
changed** — only an import path and the removal of a re-export.

## Validation

- `npm run lint` — passes clean (eslint + stylelint).
- Targeted vitest runs, all green:
  - `common/test/helper/uri-validation.test.ts` (12)
  - `common/test/helper/ip-validation.test.ts` (67)
  - `activitypub/test/helper/actor-uri.test.ts` (54)
  - `activitypub/test/service/inbox.test.ts` (73)
  - `moderation/test/service/moderation.test.ts` (134)
  - `moderation/test/service/moderation-acknowledge-forward.test.ts` (16)