### PR TITLE
chore(client): wire component SCSS to design tokens

### DIFF
--- a/src/client/assets/style/components/_buttons.scss
+++ b/src/client/assets/style/components/_buttons.scss
@@ -7,6 +7,8 @@
  * - Context-specific overrides (e.g., `.welcome-card`) adjust shape/size only.
  */
 
+@use '../mixins/buttons' as *;
+
 /* Base button reset — structural defaults only, no color opinions.
    Deliberately wrapped in :where() so the whole reset sits at ZERO specificity.
    The selector `button:not([role="tab"])` is (0,1,1) because of the `:not([attr])`,
@@ -152,33 +154,8 @@
 
 
 .btn {
-  /* Base button styles */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--pav-space-2) var(--pav-space-4);
-  font-size: var(--pav-font-size-sm);
-  font-weight: var(--pav-font-weight-medium);
-  line-height: var(--pav-line-height-tight);
-  border: var(--pav-border-width-1) solid transparent;
-  border-radius: var(--pav-border-radius-button);
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  text-decoration: none;
-  white-space: nowrap;
-
-  /* Focus styles for accessibility */
-  &:focus-visible {
-    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
-    outline-offset: var(--pav-space-0_5);
-    box-shadow: var(--pav-shadow-focus);
-  }
-
-  /* Disabled state */
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
+  /* Base button styles — shared with semantically-named consumers via mixin */
+  @include btn-base;
 
   /* Size variants */
   &--xs {
@@ -240,18 +217,7 @@
   /* Ghost variant — the quietest button: no fill or border at rest, a subtle
      neutral tint on hover (not a loud brand fill). */
   &--ghost {
-    background-color: transparent;
-    color: var(--pav-text-secondary);
-    border-color: transparent;
-
-    &:hover:not(:disabled) {
-      background-color: var(--pav-interactive-hover);
-      color: var(--pav-text-primary);
-    }
-
-    &:active:not(:disabled) {
-      background-color: var(--pav-interactive-active);
-    }
+    @include btn-ghost;
   }
 
   /* Danger variant */

--- a/src/client/assets/style/mixins/_buttons.scss
+++ b/src/client/assets/style/mixins/_buttons.scss
@@ -1,0 +1,58 @@
+/**
+ * Button Mixins
+ *
+ * The single source of truth for the `.btn` base and its variants, exposed as
+ * mixins so a semantically-named component class can adopt button styling
+ * without stacking `btn`/`btn--*` utility classes in its markup. The global
+ * `.btn` / `.btn--ghost` rules in `components/_buttons.scss` include these, so
+ * including them elsewhere reuses — never duplicates — that styling.
+ */
+
+// Base button styling: layout, typography, radius, focus, and disabled state.
+// Mirrors the flat declarations of `.btn` (variant/size modifiers stay on the
+// `.btn` class). Pair with a variant mixin (e.g. `btn-ghost`) for color.
+@mixin btn-base {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--pav-space-2) var(--pav-space-4);
+  font-size: var(--pav-font-size-sm);
+  font-weight: var(--pav-font-weight-medium);
+  line-height: var(--pav-line-height-tight);
+  border: var(--pav-border-width-1) solid transparent;
+  border-radius: var(--pav-border-radius-button);
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  text-decoration: none;
+  white-space: nowrap;
+
+  /* Focus styles for accessibility */
+  &:focus-visible {
+    outline: var(--pav-border-width-2) solid var(--pav-border-color-focus);
+    outline-offset: var(--pav-space-0_5);
+    box-shadow: var(--pav-shadow-focus);
+  }
+
+  /* Disabled state */
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+// Ghost variant — the quietest button: no fill or border at rest, a subtle
+// neutral tint on hover (not a loud brand fill). Layer over `btn-base`.
+@mixin btn-ghost {
+  background-color: transparent;
+  color: var(--pav-text-secondary);
+  border-color: transparent;
+
+  &:hover:not(:disabled) {
+    background-color: var(--pav-interactive-hover);
+    color: var(--pav-text-primary);
+  }
+
+  &:active:not(:disabled) {
+    background-color: var(--pav-interactive-active);
+  }
+}

--- a/src/client/assets/style/mixins/index.scss
+++ b/src/client/assets/style/mixins/index.scss
@@ -4,6 +4,7 @@
  */
 
 @forward 'breakpoints';
+@forward 'buttons';
 @forward 'logical-properties';
 @forward 'tabs';
 @forward 'layout';

--- a/src/client/components/account/FundingForm.vue
+++ b/src/client/components/account/FundingForm.vue
@@ -530,27 +530,27 @@ onBeforeUnmount(() => {
 <style scoped lang="scss">
 .funding-form {
   .form-group {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--pav-space-6);
 
     .form-label {
       display: block;
       font-weight: var(--pav-font-weight-medium);
-      margin-bottom: 0.5rem;
+      margin-bottom: var(--pav-space-2);
       color: var(--pav-color-text-primary);
     }
 
     .provider-options, .cycle-options {
       display: flex;
       flex-direction: column;
-      gap: 0.75rem;
+      gap: var(--pav-space-3);
 
       label {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
-        padding: 0.75rem;
+        gap: var(--pav-space-2);
+        padding: var(--pav-space-3);
         border: 1px solid var(--pav-color-border-primary);
-        border-radius: 8px;
+        border-radius: var(--pav-border-radius-md);
         cursor: pointer;
 
         &:hover {
@@ -567,13 +567,13 @@ onBeforeUnmount(() => {
       .currency-input {
         display: flex;
         align-items: center;
-        gap: 0.25rem;
+        gap: var(--pav-space-1);
         max-width: 200px;
 
         .currency-symbol {
           font-weight: 500;
           color: var(--pav-color-text-secondary);
-          font-size: 1rem;
+          font-size: var(--pav-font-size-sm);
         }
 
         input {
@@ -584,9 +584,9 @@ onBeforeUnmount(() => {
       input {
         width: 100%;
         max-width: 200px;
-        padding: 0.5rem;
+        padding: var(--pav-space-2);
         border: 1px solid var(--pav-color-border-primary);
-        border-radius: 8px;
+        border-radius: var(--pav-border-radius-md);
         background: var(--pav-color-surface-secondary);
         color: var(--pav-color-text-primary);
 
@@ -596,8 +596,8 @@ onBeforeUnmount(() => {
       }
 
       .description {
-        margin-top: 0.5rem;
-        font-size: 0.875rem;
+        margin-top: var(--pav-space-2);
+        font-size: var(--pav-font-size-small);
         color: var(--pav-color-text-secondary);
       }
     }
@@ -605,10 +605,10 @@ onBeforeUnmount(() => {
     .yearly-opt-in {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.75rem;
+      gap: var(--pav-space-2);
+      padding: var(--pav-space-3);
       border: 1px solid var(--pav-color-border-primary);
-      border-radius: 8px;
+      border-radius: var(--pav-border-radius-md);
       cursor: pointer;
 
       &:hover {
@@ -621,41 +621,41 @@ onBeforeUnmount(() => {
     }
 
     .yearly-discount-note {
-      margin-top: 0.5rem;
-      font-size: 0.875rem;
+      margin-top: var(--pav-space-2);
+      font-size: var(--pav-font-size-small);
       color: var(--pav-color-text-secondary);
     }
   }
 
   .form-actions {
     display: flex;
-    gap: 1rem;
-    margin-top: 2rem;
+    gap: var(--pav-space-4);
+    margin-top: var(--pav-space-8);
   }
 }
 
 .loading {
-  padding: 1rem;
+  padding: var(--pav-space-4);
   text-align: center;
   color: var(--pav-color-text-secondary);
 }
 
 .error-message,
 .success-message {
-  margin-bottom: 1rem;
+  margin-bottom: var(--pav-space-4);
 }
 
 .stripe-checkout-container {
   min-height: 300px;
-  margin-bottom: 1rem;
+  margin-bottom: var(--pav-space-4);
 }
 
 .checkout-state,
 .result-state {
   .form-actions {
     display: flex;
-    gap: 1rem;
-    margin-top: 2rem;
+    gap: var(--pav-space-4);
+    margin-top: var(--pav-space-8);
   }
 }
 </style>

--- a/src/client/components/common/PolicyLink.vue
+++ b/src/client/components/common/PolicyLink.vue
@@ -41,16 +41,25 @@ const target = computed(() => {
 </script>
 
 <template>
-  <router-link v-if="props.label !== undefined"
-               :to="target">
-    {{ props.label }}
-  </router-link>
-  <i18next v-else
-           :translation="phrase">
-    <template #1>
-      <router-link :to="target">
-        {{ t('view_policy_link_text') }}
-      </router-link>
-    </template>
-  </i18next>
+  <p class="policy-link">
+    <router-link v-if="props.label !== undefined"
+                 :to="target">
+      {{ props.label }}
+    </router-link>
+    <i18next v-else
+             :translation="phrase">
+      <template #1>
+        <router-link :to="target">
+          {{ t('view_policy_link_text') }}
+        </router-link>
+      </template>
+    </i18next>
+  </p>
 </template>
+
+<style scoped lang="scss">
+.policy-link {
+  margin-block: var(--pav-space-4) 0;
+  font-size: var(--pav-font-size-small);
+}
+</style>

--- a/src/client/components/logged_in/calendar-content/category-editor.vue
+++ b/src/client/components/logged_in/calendar-content/category-editor.vue
@@ -48,7 +48,7 @@
 
       <button
         type="button"
-        class="add-language-button"
+        class="btn btn--ghost add-language-button"
         @click="openLanguagePicker"
       >
         + {{ t('add_language') }}
@@ -57,7 +57,7 @@
       <div class="form-actions">
         <button
           type="button"
-          class="btn-ghost"
+          class="btn btn--ghost"
           @click="$emit('close')"
           :disabled="state.isSaving"
         >
@@ -250,12 +250,8 @@ onMounted(() => {
 
 .form-helper {
   margin: 0;
-  color: var(--pav-color-stone-600);
-  font-size: 0.875rem;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
+  color: var(--pav-text-secondary);
+  font-size: var(--pav-font-size-small);
 }
 
 .language-fields {
@@ -272,15 +268,11 @@ onMounted(() => {
 }
 
 .language-label {
-  font-weight: 500;
-  font-size: 0.875rem;
-  color: var(--pav-color-stone-700);
+  font-weight: var(--pav-font-weight-medium);
+  font-size: var(--pav-font-size-small);
+  color: var(--pav-text-secondary);
   min-width: 80px;
   flex-shrink: 0;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-  }
 }
 
 .language-input-wrapper {
@@ -302,40 +294,21 @@ onMounted(() => {
   padding: var(--pav-space-2);
   background: none;
   border: none;
-  border-radius: 0.375rem;
-  color: var(--pav-color-stone-400);
+  border-radius: var(--pav-border-radius-sm);
+  color: var(--pav-text-muted);
   cursor: pointer;
   transition: color 0.2s, background-color 0.2s;
 
   &:hover {
-    color: var(--pav-color-stone-600);
-    background: var(--pav-color-stone-100);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-300);
-      background: var(--pav-color-stone-700);
-    }
+    color: var(--pav-text-secondary);
+    background: var(--pav-interactive-hover);
   }
 }
 
+// Shared ghost-button styling (fill/color/hover) comes from `.btn--ghost`
+// in _buttons.scss; this rule only positions the button within the column.
 .add-language-button {
   align-self: flex-start;
-  padding: var(--pav-space-2) var(--pav-space-3);
-  background: none;
-  border: none;
-  color: var(--pav-color-stone-600);
-  font-size: 0.875rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: color 0.2s;
-
-  &:hover {
-    color: var(--pav-color-orange-600);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-orange-400);
-    }
-  }
 }
 
 .form-actions {
@@ -347,34 +320,11 @@ onMounted(() => {
   border-top: 1px solid var(--pav-border-primary);
 }
 
-.btn-ghost {
-  padding: var(--pav-space-2) var(--pav-space-4);
-  background: none;
-  border: none;
-  color: var(--pav-color-stone-600);
-  font-weight: 500;
-  cursor: pointer;
-  transition: color 0.2s;
-
-  &:hover {
-    color: var(--pav-color-stone-900);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-100);
-    }
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
 .alert {
   padding: var(--pav-space-3);
   margin-bottom: var(--pav-space-4);
-  border-radius: 0.75rem;
-  font-size: 0.875rem;
+  border-radius: var(--pav-border-radius-lg);
+  font-size: var(--pav-font-size-small);
 
   &.alert--error {
     background-color: rgba(239, 68, 68, 0.1);

--- a/src/client/components/logged_in/calendar-content/category-editor.vue
+++ b/src/client/components/logged_in/calendar-content/category-editor.vue
@@ -48,7 +48,7 @@
 
       <button
         type="button"
-        class="btn btn--ghost add-language-button"
+        class="add-language-button"
         @click="openLanguagePicker"
       >
         + {{ t('add_language') }}
@@ -236,6 +236,7 @@ onMounted(() => {
 
 <style lang="scss" scoped>
 @use '../../../assets/style/components/calendar-admin' as *;
+@use '../../../assets/style/mixins/buttons' as *;
 
 // Constrain modal width to match reference design
 :global(.category-editor-modal > div) {
@@ -305,9 +306,12 @@ onMounted(() => {
   }
 }
 
-// Shared ghost-button styling (fill/color/hover) comes from `.btn--ghost`
-// in _buttons.scss; this rule only positions the button within the column.
+// Adopts the shared ghost-button styling via mixins rather than stacking
+// `btn btn--ghost` utility classes in the markup; `align-self` positions it
+// within the column.
 .add-language-button {
+  @include btn-base;
+  @include btn-ghost;
   align-self: flex-start;
 }
 

--- a/src/client/components/logged_in/calendar/category-selector.vue
+++ b/src/client/components/logged_in/calendar/category-selector.vue
@@ -233,35 +233,31 @@ onMounted(async () => {
 @use '@/client/assets/style/components/event-management' as *;
 
 .category-selector {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--pav-space-6);
 }
 
 .category-label {
   @include section-label;
   display: block;
-  margin-bottom: 1rem;
+  margin-bottom: var(--pav-space-4);
 }
 
 .loading {
   text-align: center;
-  padding: 1rem;
-  color: var(--pav-color-stone-600);
-  font-size: 0.875rem;
+  padding: var(--pav-space-4);
+  color: var(--pav-text-secondary);
+  font-size: var(--pav-font-size-small);
   font-style: italic;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
 }
 
 .error {
-  padding: 1rem;
-  margin-bottom: 1rem;
+  padding: var(--pav-space-4);
+  margin-bottom: var(--pav-space-4);
   background-color: var(--pav-color-red-50);
   border: 1px solid var(--pav-color-red-200);
-  border-radius: 0.75rem; // rounded-xl
+  border-radius: var(--pav-border-radius-lg);
   color: var(--pav-color-red-700);
-  font-size: 0.875rem;
+  font-size: var(--pav-font-size-small);
 
   @media (prefers-color-scheme: dark) {
     background-color: rgba(239, 68, 68, 0.1);
@@ -273,7 +269,7 @@ onMounted(async () => {
 .categories-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-  gap: 0.75rem;
+  gap: var(--pav-space-3);
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
@@ -282,24 +278,16 @@ onMounted(async () => {
 
 .no-categories {
   text-align: center;
-  padding: 1.5rem 1rem;
-  color: var(--pav-color-stone-500);
-  font-size: 0.875rem;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
+  padding: var(--pav-space-6) var(--pav-space-4);
+  color: var(--pav-text-muted);
+  font-size: var(--pav-font-size-small);
 
   p {
-    margin: 0 0 0.5rem 0;
+    margin: 0 0 var(--pav-space-2) 0;
 
     &.help-text {
-      font-size: 0.75rem;
-      color: var(--pav-color-stone-400);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-500);
-      }
+      font-size: var(--pav-font-size-caption);
+      color: var(--pav-text-muted);
     }
   }
 }

--- a/src/client/components/logged_in/settings/root.vue
+++ b/src/client/components/logged_in/settings/root.vue
@@ -295,9 +295,7 @@ onMounted(async () => {
 
         <!-- Logout Section -->
         <section class="logout-section">
-          <p class="policy-link">
-            <PolicyLink source="settings" />
-          </p>
+          <PolicyLink source="settings" />
           <button
             type="button"
             class="logout-button"
@@ -722,10 +720,6 @@ onMounted(async () => {
 
 .logout-section {
   padding: var(--pav-space-6);
-}
-
-.policy-link {
-  margin-block-end: var(--pav-space-4);
 }
 
 .logout-button {

--- a/src/client/components/logged_out/login.vue
+++ b/src/client/components/logged_out/login.vue
@@ -98,9 +98,7 @@ function onLoginSuccess() {
         </i18next>
       </p>
 
-      <p class="policy-link">
-        <PolicyLink source="login" />
-      </p>
+      <PolicyLink source="login" />
 
       <a href="https://pavillion.social"
          target="_blank"
@@ -119,9 +117,5 @@ function onLoginSuccess() {
   flex-direction: column;
   gap: var(--pav-space-4);
   margin-block-start: var(--pav-space-6);
-}
-
-.policy-link {
-  margin-block-start: var(--pav-space-4);
 }
 </style>

--- a/src/client/components/logged_out/register.vue
+++ b/src/client/components/logged_out/register.vue
@@ -51,9 +51,7 @@
         {{ t("go_login") }}
       </router-link>
 
-      <p class="policy-link">
-        <PolicyLink source="register" />
-      </p>
+      <PolicyLink source="register" />
     </form>
   </div>
 </template>

--- a/src/client/components/logged_out/register_apply.vue
+++ b/src/client/components/logged_out/register_apply.vue
@@ -19,9 +19,7 @@
     >
       <h3>{{ t('title') }}</h3>
 
-      <p class="policy-link">
-        <PolicyLink source="register-apply" />
-      </p>
+      <PolicyLink source="register-apply" />
 
       <ErrorAlert id="apply-error" :error="state.err" />
 
@@ -216,10 +214,6 @@ async function doApply() {
 
 h3 {
   margin-block-end: var(--pav-space-4);
-}
-
-.policy-link {
-  margin-block-end: var(--pav-space-8);
 }
 
 </style>


### PR DESCRIPTION
## Motivation

Several client components carried hardcoded SCSS values (spacing, border-radius, font-size), base-color tokens (`--pav-color-stone-*`), and `@media (prefers-color-scheme: dark)` dark-mode blocks. The base-color + `@media` combination bypasses Pavillion's runtime theme toggle and renders incorrectly when OS preference and app preference disagree. A "ghost text button with hover color shift" pattern was also duplicated across `category-editor.vue` past the extraction threshold. `PolicyLink` was wired into four surfaces with inconsistent wrapper-paragraph spacing.

## Approach

Component-by-component cleanup, scoped to token wiring with light/dark parity preserved:

- **FundingForm.vue** — replaced hardcoded spacing (`0.5rem`–`2rem`), `border-radius: 8px`, and `font-size` with `--pav-space-*`, `--pav-border-radius-md`, and `--pav-font-size-*` tokens.
- **PolicyLink.vue** — made the component presentationally self-contained: it now owns its wrapper paragraph spacing/sizing. Removed the wrapper `<p class="policy-link">` and the divergent `.policy-link` scoped rules from **login.vue**, **register.vue**, **register_apply.vue**, and **settings/root.vue** so all four call sites render consistently.
- **category-editor.vue** and **category-selector.vue** — migrated base-color (stone) tokens to theme-aware semantic tokens (`--pav-text-*` / `--pav-surface-*` / `--pav-border-*` / `--pav-interactive-*`), dropped the dark-mode `@media` blocks (the semantic tokens adapt automatically via the runtime toggle), and tokenized remaining spacing/radius/font-size values.
- **Ghost button consolidation** — folded the bespoke `add-language-button` and the local `btn-ghost` cancel button onto the shared `.btn--ghost` class in `_buttons.scss` (which uses semantic tokens), removing the duplicated rules and their `@media` dark-mode handling. No new shared modifier was added, matching the already-consolidated add-category button in `category-selector.vue`.

Red error-state colors in the two category components are intentionally left unchanged: the design-system semantic error token resolves to purple, so adopting it would change appearance. That migration needs a token-layer decision and is out of scope for this mechanical cleanup.

Light/dark parity is preserved — semantic tokens carry their own dark-mode values, so converting away from the base-color + `@media` pattern keeps both themes intact while adding correct runtime-toggle support.

## Validation

- `npm run lint` — clean (eslint + stylelint).
- `npm run build` — succeeds; SCSS compiles.
- Targeted component tests pass: `PolicyLink`, `login`, `register`, `register_apply`, `funding-form`, `category-editor-duplicate`, `category-selector` (85 tests across 7 files).