### PR TITLE
test(admin): tighten funding wizard async waits and price assertion

### DIFF
--- a/src/client/test/components/admin/funding_wizard_integration.test.ts
+++ b/src/client/test/components/admin/funding_wizard_integration.test.ts
@@ -386,8 +386,7 @@ describe('Funding Page Wizard Integration', () => {
       },
     });
 
-    await wrapper.vm.$nextTick();
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await flushPromises();
 
     // Initial load calls getProviders once
     expect(mockService.getProviders).toHaveBeenCalledTimes(1);
@@ -399,8 +398,7 @@ describe('Funding Page Wizard Integration', () => {
     // Close wizard via close event (not provider-connected)
     const wizardComponent = wrapper.findComponent(AddProviderWizard);
     wizardComponent.vm.$emit('close');
-    await wrapper.vm.$nextTick();
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await flushPromises();
 
     // Verify getProviders was called again to refresh the list
     expect(mockService.getProviders).toHaveBeenCalledTimes(2);
@@ -472,9 +470,11 @@ describe('Funding Page Wizard Integration', () => {
 
       expect((wrapper.vm as any).fieldErrors.monthlyPrice).toBeFalsy();
       expect((wrapper.vm as any).fieldErrors.currency).toBeFalsy();
+      // monthlyPrice round-trips: 10000000 millicents -> millicentsToDisplay (÷100000) = 100
+      // -> displayToMillicents (×100000) = 10000000 millicents.
       expect(mockInstance.updateSettings).toHaveBeenCalledWith(expect.objectContaining({
         currency: 'USD',
-        monthlyPrice: expect.any(Number),
+        monthlyPrice: 10000000,
       }));
     });
 


### PR DESCRIPTION
## Motivation

The funding wizard integration tests carried two test-quality issues flagged by the testing auditor:

1. The settings happy-path test asserted `monthlyPrice: expect.any(Number)`, which would pass regardless of the actual converted value. The millicents conversion divisor has regressed before (corrected from 1_000_000 to 100_000), so a loose assertion gives no protection against that class of bug.
2. The provider-refresh test used `await new Promise(resolve => setTimeout(resolve, 100))` to synchronize async data loading — a timing-dependent pattern that can flake.

## Approach

- Replaced both `setTimeout(resolve, 100)` waits with `flushPromises()` (already imported from `@vue/test-utils`) so async draining is deterministic.
- Replaced `expect.any(Number)` with the exact expected value `10000000`. This is the precise integer the wizard produces: the mocked settings provide `monthlyPrice: 10000000` millicents, which round-trips through `millicentsToDisplay` (÷100000 = 100) on load and `displayToMillicents` (×100000 = 10000000) on save. An inline comment documents the derivation.

Test-only changes; no production code touched.

## Validation

- `npm run lint` — clean.
- `npx vitest run src/client/test/components/admin/funding_wizard_integration.test.ts` — 11/11 passing.