### PR TITLE
fix: thread transaction into content lookup and align dismissal cascade

### DIFF
--- a/src/server/activitypub/entity/activitypub.ts
+++ b/src/server/activitypub/entity/activitypub.ts
@@ -239,8 +239,13 @@ class SharedEventEntity extends Model {
  * the calendar owner supersedes the dismissal.
  *
  * The unique index on (event_id, calendar_id) enforces the one-row-per-pair
- * invariant. The event_id FK cascades on delete so dismissals are cleaned
- * up automatically when the underlying local event row is deleted.
+ * invariant. Both the event_id and calendar_id FKs cascade on delete so
+ * dismissals are cleaned up automatically when the underlying local event
+ * or calendar row is deleted.
+ *
+ * Internal lookup table: like the adjacent SharedEventEntity and
+ * EventActivityEntity, it has no domain-model counterpart in
+ * src/common/model/ and therefore intentionally omits toModel()/fromModel().
  */
 @Table({ tableName: 'ap_repost_dismissal' })
 class RepostDismissalEntity extends Model {
@@ -273,7 +278,7 @@ class RepostDismissalEntity extends Model {
   @BelongsTo(() => EventEntity, { foreignKey: 'event_id', onDelete: 'CASCADE' })
   declare event: EventEntity;
 
-  @BelongsTo(() => CalendarEntity, { foreignKey: 'calendar_id' })
+  @BelongsTo(() => CalendarEntity, { foreignKey: 'calendar_id', onDelete: 'CASCADE' })
   declare calendar: CalendarEntity;
 }
 

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1017,6 +1017,7 @@ class EventService {
       for( let [language,content] of Object.entries(eventParams.content) ) {
         let contentEntity = await EventContentEntity.findOne({
           where: { event_id: eventId, language: language },
+          transaction: tx,
         });
 
         if ( contentEntity ) {

--- a/src/server/calendar/test/EventService/transaction_propagation.test.ts
+++ b/src/server/calendar/test/EventService/transaction_propagation.test.ts
@@ -156,6 +156,11 @@ describe('EventService transaction propagation', () => {
         fakeTx,
       );
 
+      // The content lookup that decides update-vs-destroy must read inside the
+      // caller's transaction snapshot (pv-i7n3).
+      expect(contentFindStub.calledOnce).toBe(true);
+      expect(contentFindStub.firstCall.args[0]).toMatchObject({ transaction: fakeTx });
+
       expect(contentUpdateStub.calledOnce).toBe(true);
       // .update(values, options) — options is the 2nd positional arg.
       expect(contentUpdateStub.firstCall.args[1]).toEqual({ transaction: fakeTx });


### PR DESCRIPTION
## Motivation

Two small backend correctness/consistency cleanups flagged by auditors:

1. **Missing transaction on a content read.** `EventService.updateEvent`
   threads `{ transaction: tx }` through every content write (save /
   update / destroy) but the `EventContentEntity.findOne` that decides
   whether to update or destroy the existing content row still read
   outside the caller's transaction. Under PostgreSQL's default READ
   COMMITTED the practical risk is low, but under REPEATABLE READ /
   SERIALIZABLE that read would run on a separate snapshot and could see
   inconsistent state. The sibling `reconcileSchedules` already threads
   tx to its `findAll`; this read should match.

2. **Entity/migration drift on RepostDismissalEntity.** The
   `@BelongsTo(CalendarEntity)` association did not declare
   `onDelete: 'CASCADE'`, even though migration 0018 created the
   `calendar_id` FK with `ON DELETE CASCADE`. Tests build schema from
   entity decorators via `db.sync({ force: true })`, so the decorator
   omission let the test-time schema drift from the migrated schema.

## Approach

- Added `transaction: tx` to the `EventContentEntity.findOne` options in
  `updateEvent` so the lookup participates in the surrounding
  transaction.
- Added `onDelete: 'CASCADE'` to the `RepostDismissalEntity`
  `@BelongsTo(CalendarEntity)` association to match the existing FK
  constraint. **No migration was needed** — migration 0018 already
  creates the constraint; this only aligns the decorator-built schema.
- Documented that `RepostDismissalEntity` is an internal lookup table
  (like `SharedEventEntity` / `EventActivityEntity`) with no domain-model
  counterpart, so it intentionally omits `toModel()`/`fromModel()`.

A deferred, optional cleanup (dropping the `EventEntity` decorator
association in favor of a plain UUID column to match `SharedEventEntity`,
rewriting the cascade test against migration-based schema) was left out
of scope — it is broader rework tied to a separate roadmap item.

## Validation

- `npm run lint` — clean.
- Targeted tests pass (50 tests):
  `transaction_propagation.test.ts` (extended with an assertion that the
  content `findOne` carries `{ transaction: tx }`), `update.test.ts`, and
  the ActivityPub `entity.test.ts` (dismissal cascade coverage).