### PR TITLE
test(activitypub): drop test-of-the-mock federation tracking block

### DIFF
--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -41,9 +41,6 @@ import {
   createMockDeleteActivity,
   createMockFollowActivity,
   createMockUpdateActivity,
-  createMockFederation,
-  getSentActivities,
-  type MockFederationContext,
 } from '@/server/activitypub/test/helpers/fedify-mock';
 
 // Mock the ip-validation module so tests can control SSRF validation behaviour
@@ -1433,65 +1430,6 @@ describe('processOutboxMessage — local/remote dispatcher split', () => {
       'HTTP fallback must not run for null-calendar case',
     ).toBe(false);
     expect(updateStub.calledOnce).toBe(true);
-  });
-});
-
-
-/**
- * Additional tests demonstrating Fedify mock federation usage.
- *
- * These tests show how the MockFederationContext can be used to track
- * activities that would be sent, without making actual HTTP requests.
- * This pattern is useful for testing federation logic in isolation.
- */
-describe('MockFederation Activity Tracking', () => {
-  let mockFed: MockFederationContext;
-
-  beforeEach(() => {
-    mockFed = createMockFederation({ domain: 'local.federation.test' });
-  });
-
-  it('should track Create activities sent through mock federation', async () => {
-    const createActivity = createMockCreateActivity(LOCAL_ACTOR_URL, {
-      type: 'Event',
-      id: `${LOCAL_ACTOR_URL}/events/123`,
-      name: 'Community Meetup',
-      startTime: '2025-01-15T18:00:00Z',
-    });
-
-    await mockFed.sendActivity(createActivity, [
-      REMOTE_INBOX_URL,
-      'https://observerdomain.test/inbox',
-    ]);
-
-    const sent = getSentActivities(mockFed);
-    expect(sent).toHaveLength(1);
-    expect(sent[0].type).toBe('Create');
-    expect(sent[0].recipients).toHaveLength(2);
-  });
-
-  it('should track Follow activities sent through mock federation', async () => {
-    const followActivity = createMockFollowActivity(LOCAL_ACTOR_URL, REMOTE_PROFILE_URL);
-
-    await mockFed.sendActivity(followActivity, [REMOTE_INBOX_URL]);
-
-    const sent = getSentActivities(mockFed);
-    expect(sent).toHaveLength(1);
-    expect(sent[0].type).toBe('Follow');
-    expect(sent[0].recipients).toEqual([REMOTE_INBOX_URL]);
-  });
-
-  it('should allow tracking multiple activities in sequence', async () => {
-    const createActivity = createMockCreateActivity(LOCAL_ACTOR_URL, { type: 'Event' });
-    const followActivity = createMockFollowActivity(LOCAL_ACTOR_URL, REMOTE_PROFILE_URL);
-
-    await mockFed.sendActivity(createActivity, [REMOTE_INBOX_URL]);
-    await mockFed.sendActivity(followActivity, [REMOTE_INBOX_URL]);
-
-    const sent = getSentActivities(mockFed);
-    expect(sent).toHaveLength(2);
-    expect(sent[0].type).toBe('Create');
-    expect(sent[1].type).toBe('Follow');
   });
 });
 


### PR DESCRIPTION
## Motivation

Two test-quality cleanup items in the ActivityPub service tests. This PR addresses one and documents why the other cannot land as a test-only change.

**Resolved:** The "MockFederation Activity Tracking" describe block in `src/server/activitypub/test/service/outbox.test.ts` contained three tests that called `mockFed.sendActivity(...)` and asserted on `getSentActivities(mockFed)`. These exercise only the test helper itself — `createMockFederation`, the mock's `sendActivity` tracking, and `getSentActivities` — and never invoke any production outbox code path. That is the "testing the framework" anti-pattern.

**Not landed (out of scope):** A second item asked to add `actorAccountId`/`actorName` assertions to the `eventUnreposted` emit test in `members.test.ts`. Investigation showed the production emit at `src/server/activitypub/service/members.ts:547` emits only `{ eventId, calendarId }` — there is no `Account` resolution in `unshareEvent` and zero occurrences of `actorAccountId`/`actorName` in `members.ts`. The premise (that those fields are emitted) is not true in current `main`. Asserting them would require modifying production code, which is outside the scope of this test-only change. That work is reported back to its tracker for the production emit to be (re)introduced first.

## Approach

Delete vs relocate decision for the mock-tracking block: **delete**. A dedicated helper test file already exists — `src/server/activitypub/test/helpers/fedify-mock.test.ts` — with `createMockFederation` and `getSentActivities` describe blocks that assert Create/Follow tracking, recipient lists, multi-activity sequencing, copy semantics, and timestamps. That coverage is broader than the three deleted cases, so relocating would only duplicate it. The block is removed and the now-orphaned imports (`createMockFederation`, `getSentActivities`, `MockFederationContext`) are dropped; helpers still used elsewhere in the file are retained.

## Validation

- `npm run lint` — clean (eslint + stylelint).
- `npx vitest run src/server/activitypub/test/service/outbox.test.ts src/server/activitypub/test/service/members.test.ts` — 2 files, 73 tests passing (outbox: 47 after removing the 3 redundant cases; members: 26 unchanged).