### PR TITLE
refactor(client): route policy empty-fallback through sanitized render

### DIFF
--- a/src/client/components/logged_out/instance-policy.vue
+++ b/src/client/components/logged_out/instance-policy.vue
@@ -41,7 +41,7 @@ const settings = computed(() => site_config.settings());
 const policyHtml = computed<string>(() => {
   const policy = settings.value.instancePolicy;
   if (!policy || typeof policy !== 'object') {
-    return `<p>${t('empty_fallback')}</p>`;
+    return renderPolicyMarkdown(t('empty_fallback'));
   }
 
   const currentLang = i18next.language;
@@ -54,7 +54,7 @@ const policyHtml = computed<string>(() => {
     return renderPolicyMarkdown(policy[defaultLang]);
   }
 
-  return `<p>${t('empty_fallback')}</p>`;
+  return renderPolicyMarkdown(t('empty_fallback'));
 });
 
 const backLink = computed<{ name: string; label: string }>(() => {

--- a/src/client/test/components/logged_out/instance-policy.test.ts
+++ b/src/client/test/components/logged_out/instance-policy.test.ts
@@ -120,7 +120,13 @@ describe('InstancePolicy fallback chain', () => {
     const article = wrapper.find('.policy-page__body');
     expect(article.exists()).toBe(true);
     const emptyFallback = i18next.t('policy:empty_fallback');
-    expect(article.text()).toContain(emptyFallback);
+
+    // The fallback is rendered through the same renderPolicyMarkdown /
+    // DOMPurify pipeline as real policy content, so it arrives wrapped in a
+    // sanitized <p> rather than via string-concatenated v-html.
+    const paragraph = article.find('p');
+    expect(paragraph.exists()).toBe(true);
+    expect(paragraph.text()).toContain(emptyFallback);
   });
 
   it('strips dangerous payloads at render time (DOMPurify defense-in-depth)', async () => {


### PR DESCRIPTION
## Motivation

The public `/policy` page (`instance-policy.vue`) built its empty-policy
fallback HTML by string concatenation (`<p>${t('empty_fallback')}</p>`)
and bound it via `v-html`. This was the only `v-html` path in the
component that bypassed the `renderPolicyMarkdown` / DOMPurify pipeline
used for all real policy content. Translator-controlled strings are
project-trusted today, so it was functionally safe, but it left the
component's security model non-uniform: not every `v-html` source went
through sanitization. A future translator introducing `<`/`>` in the
fallback message, or a maintainer reusing the string for a non-trusted
source, could be surprised.

## Approach

Route the empty-fallback message through `renderPolicyMarkdown` in both
return branches of the `policyHtml` computed, so every `v-html` path in
the component is uniformly sanitized through marked + DOMPurify. The
rendered output is equivalent for the normal case: a plain-text message
becomes a single sanitized `<p>`.

## Validation

- `npm run lint` — 0 errors (one pre-existing unrelated warning).
- `npx vitest run src/client/test/components/logged_out/instance-policy.test.ts` — 10/10 pass. The empty-fallback test now asserts the message arrives inside a sanitized `<p>` element produced by the render pipeline rather than a concatenated string.