### PR TITLE
test: expand repost-status coverage and fix outbox spy

### DIFF
--- a/src/common/test/model/calendar_event.test.ts
+++ b/src/common/test/model/calendar_event.test.ts
@@ -125,6 +125,22 @@ describe('CalendarEvent.repostStatus', () => {
     expect(event.isRepost).toBe(true);
   });
 
+  it('should let an explicit repostStatus="none" win over a conflicting legacy isRepost=true in fromObject()', () => {
+    // Distinct branch: when both an explicit repostStatus and a legacy
+    // isRepost flag are present, the explicit tri-state value takes
+    // precedence over the legacy boolean even when they disagree.
+    const obj = {
+      id: 'evt-1',
+      calendarId: 'cal-1',
+      repostStatus: 'none',
+      isRepost: true,
+    };
+
+    const event = CalendarEvent.fromObject(obj);
+    expect(event.repostStatus).toBe('none');
+    expect(event.isRepost).toBe(false);
+  });
+
   it('should default repostStatus to "none" when neither field is present in fromObject()', () => {
     const obj = {
       id: 'evt-1',

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -898,9 +898,13 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
       calendar_id: testCalendar.id,
     });
 
-    // Stubs for downstream calls that should NOT be reached
+    // Stubs for downstream calls that should NOT be reached. addToOutbox
+    // persists via ActivityPubOutboxMessageEntity.build(...).save(), NOT
+    // .create(), so the outbox guard must spy on prototype.save — a spy on
+    // .create would pass vacuously even if the early return regressed and
+    // addToOutbox actually ran.
     const sharedCreateSpy = sandbox.spy(SharedEventEntity, 'create');
-    const outboxCreateSpy = sandbox.spy(ActivityPubOutboxMessageEntity, 'create');
+    const outboxSaveSpy = sandbox.spy(ActivityPubOutboxMessageEntity.prototype, 'save');
     const categorySpy = sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
     const getEventByIdSpy = sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(eventId, null));
 
@@ -914,7 +918,7 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
 
     // Assert
     expect(sharedCreateSpy.called).toBe(false);
-    expect(outboxCreateSpy.called).toBe(false);
+    expect(outboxSaveSpy.called).toBe(false);
     expect(categorySpy.called).toBe(false);
     expect(getEventByIdSpy.called).toBe(false);
     expect(emittedEvents).toHaveLength(0);
@@ -941,6 +945,11 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
     sandbox.stub(calendarInterface.categoryMappingService, 'assignAutoRepostCategories').resolves();
     sandbox.stub(calendarInterface, 'getEventById').resolves(new CalendarEvent(eventId, null));
 
+    // Counterpart to the skip-path guard: positively assert the outbox WAS
+    // written on the non-dismissed happy path, spying on the same
+    // prototype.save the real addToOutbox uses.
+    const outboxSaveSpy = sandbox.spy(ActivityPubOutboxMessageEntity.prototype, 'save');
+
     const emittedEvents: any[] = [];
     eventBus.on('eventReposted', (payload) => emittedEvents.push(payload));
 
@@ -956,6 +965,9 @@ describe('ProcessInboxService - checkAndPerformAutoRepost dismissal gating', () 
     expect(shares).toBe(1);
 
     expect(emittedEvents).toHaveLength(1);
+
+    // The auto-repost cascade must have enqueued at least one outbox message.
+    expect(outboxSaveSpy.called).toBe(true);
   });
 
   it('isolates dismissals per calendar: a dismissal on calendar A does not affect calendar B', async () => {

--- a/src/server/calendar/test/EventService/event_service.test.ts
+++ b/src/server/calendar/test/EventService/event_service.test.ts
@@ -172,6 +172,41 @@ describe('listEvents', () => {
 
       const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
       expect(events[0].repostStatus).toBe('auto');
+      // Pin down the derived getter as well: an auto repost is still a repost.
+      expect(events[0].isRepost).toBe(true);
+    });
+
+    it('should resolve owned, manual, and auto repostStatus values in a single listEvents call', async () => {
+      // Mixes all three tri-state values in one result set: an owned event
+      // (no repost), a manually-shared event, and an auto-reposted event.
+      const ownedId = 'owned-mixed-id';
+      const manualId = '550e8400-e29b-41d4-a716-446655440020';
+      const autoId = '550e8400-e29b-41d4-a716-446655440021';
+
+      service.setActivityPubInterface(
+        buildMockApInterface(
+          [manualId, autoId],
+          { [manualId]: 'manual', [autoId]: 'auto' },
+        ),
+      );
+
+      const ownedEntity = EventEntity.build({ id: ownedId, calendar_id: 'cal-id' });
+      const manualEntity = EventEntity.build({ id: manualId });
+      const autoEntity = EventEntity.build({ id: autoId });
+      sandbox.stub(EventEntity, 'findAll').resolves([ownedEntity, manualEntity, autoEntity]);
+
+      const events = await service.listEvents(new Calendar('cal-id', 'testcal'));
+
+      const owned = events.find(e => e.id === ownedId);
+      const manual = events.find(e => e.id === manualId);
+      const auto = events.find(e => e.id === autoId);
+
+      expect(owned?.repostStatus).toBe('none');
+      expect(owned?.isRepost).toBe(false);
+      expect(manual?.repostStatus).toBe('manual');
+      expect(manual?.isRepost).toBe(true);
+      expect(auto?.repostStatus).toBe('auto');
+      expect(auto?.isRepost).toBe(true);
     });
 
     it('should default legacy EventRepostEntity-only events to "manual"', async () => {


### PR DESCRIPTION
## Motivation

The testing auditor flagged several small, low-effort coverage gaps in the
repost-status test additions. None were blockers, but each weakened the
guarantees the suite was meant to provide — including one false-green risk
where a dismissal-gating assertion could pass even if the guarded code ran.

## Approach

Test-only changes, no production code touched:

- `event_service.test.ts`: the SharedEventEntity-precedence test now also
  asserts `isRepost === true` (pinning the derived getter), and a new test
  exercises all three `repostStatus` values (owned + manual + auto) in a
  single `listEvents` call.
- `calendar_event.test.ts`: new `fromObject` case where an explicit
  `repostStatus: 'none'` conflicts with a legacy `isRepost: true` in the same
  payload, confirming the explicit tri-state value wins.
- `inbox.test.ts` (dismissal gating): `addToOutbox` persists via
  `ActivityPubOutboxMessageEntity.build(...).save()`, not `.create()`, so the
  skip-path guard now spies on `prototype.save` — the old `.create` spy would
  have passed vacuously even if the early return regressed below
  `addToOutbox`. The non-dismissed baseline test now positively asserts the
  outbox was written using the same spy.

## Validation

- `npm run lint` — passes (0 errors; one pre-existing unrelated warning).
- `npx vitest run` on the three touched files — 98 tests pass. The new
  prototype.save spy is confirmed wired to the real write path (the baseline
  test asserts `save` was called; the skip-path test asserts it was not).