### PR TITLE
chore: enable @/ path alias for files under tests/

### DIFF
--- a/tests/e2e/helpers/screen-reader.ts
+++ b/tests/e2e/helpers/screen-reader.ts
@@ -10,4 +10,4 @@
  *   `docs/superpowers/specs/2026-05-13-screen-reader-testing-design.md`
  *   § Phase 2 (helpers/screen-reader.ts).
  */
-export { pageScreenReader, type ScreenReaderHandle } from '../../../src/common/test-utils/screen-reader';
+export { pageScreenReader, type ScreenReaderHandle } from '@/common/test-utils/screen-reader';

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Motivation

The root `tsconfig.json` defines `@/*` -> `src/*`, but its `include` is scoped to `src/**`. Files under `tests/` therefore could not use the `@/` alias and fell back to deep relative paths (e.g. `tests/e2e/helpers/screen-reader.ts` used `../../../src/common/test-utils/screen-reader`). As more e2e helpers land, that fragility compounds; a single `@/` pattern everywhere reduces cognitive load and makes refactors safer.

## Approach

- Add `tests/tsconfig.json` that extends the root config, re-declares the `@/*` -> `src/*` paths against a repo-root `baseUrl` (`..`), and scopes its own `include` to `tests/**/*.ts`. This makes the alias resolve at typecheck time for test files.
- No runner config change was needed: Vitest already exposes `@` via a global `resolve.alias`, and Playwright already resolves `@/*` from the root tsconfig `paths` (the `include` field does not gate Playwright's path resolution).
- Migrate exactly one example file, `tests/e2e/helpers/screen-reader.ts`, to `@/common/test-utils/screen-reader` to prove the wiring. Bulk migration of remaining relative imports is intentionally out of scope.

## Validation

- `npm run lint` — passes (0 errors).
- Playwright: `npx playwright test --list tests/e2e/a11y/screen-reader.smoke.spec.ts` collected the spec, which transitively imports the migrated helper — the `@/` import resolved during collection.
- Vitest: a temporary proof test placed under `tests/` importing `@/common/test-utils/screen-reader` ran green (removed before commit), confirming runtime resolution from a `tests/` file.
- `tsc --noEmit -p tests/tsconfig.json` — no `Cannot find module '@/...'` errors; the migrated file is type-clean.