### PR TITLE
refactor(funding): expose discrete provider-connection methods on interface

### DIFF
--- a/src/server/funding/api/v1.ts
+++ b/src/server/funding/api/v1.ts
@@ -22,11 +22,11 @@ export default class FundingApiV1 {
     app.use('/api/funding/v1', express.json());
 
     // Install admin routes
-    const adminRoutes = new AdminRoutes(internalAPI, internalAPI.providerConnectionService);
+    const adminRoutes = new AdminRoutes(internalAPI);
     adminRoutes.installHandlers(app, '/api/funding/v1');
 
     // Install provider connection routes
-    const providerRoutes = new ProviderConnectionRoutes(internalAPI.providerConnectionService);
+    const providerRoutes = new ProviderConnectionRoutes(internalAPI);
     providerRoutes.installHandlers(app, '/api/funding/v1');
 
     // Install user funding plan routes

--- a/src/server/funding/api/v1/admin.ts
+++ b/src/server/funding/api/v1/admin.ts
@@ -1,7 +1,6 @@
 import express, { Request, Response } from 'express';
 import ExpressHelper from '@/server/common/helper/express';
 import FundingInterface from '@/server/funding/interface';
-import { ProviderConnectionService } from '@/server/funding/service/provider_connection';
 import { WebhookManager } from '@/server/funding/service/provider/webhook_manager';
 import { FundingSettings } from '@/common/model/funding-plan';
 import { ValidationError } from '@/common/exceptions/base';
@@ -20,14 +19,9 @@ import { logError } from '@/server/common/helper/error-logger';
  */
 export default class AdminRoutes {
   private service: FundingInterface;
-  private providerConnectionService: ProviderConnectionService;
 
-  constructor(
-    fundingInterface: FundingInterface,
-    providerConnectionService: ProviderConnectionService,
-  ) {
+  constructor(fundingInterface: FundingInterface) {
     this.service = fundingInterface;
-    this.providerConnectionService = providerConnectionService;
   }
 
   /**
@@ -164,7 +158,7 @@ export default class AdminRoutes {
       // Enhance provider data with configured status from ProviderConnectionService
       const sanitizedProviders = await Promise.all(
         providers.map(async (provider) => {
-          const status = await this.providerConnectionService.getProviderStatus(
+          const status = await this.service.getProviderStatus(
             provider.providerType,
           );
 

--- a/src/server/funding/api/v1/provider_connection.ts
+++ b/src/server/funding/api/v1/provider_connection.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import ExpressHelper from '@/server/common/helper/express';
-import { ProviderConnectionService } from '@/server/funding/service/provider_connection';
+import FundingInterface from '@/server/funding/interface';
 import { ProviderType } from '@/common/model/funding-plan';
 import { ValidationError } from '@/common/exceptions/base';
 import { logError } from '@/server/common/helper/error-logger';
@@ -12,9 +12,9 @@ import { logError } from '@/server/common/helper/error-logger';
  * All routes require admin authentication via ExpressHelper.adminOnly.
  */
 export default class ProviderConnectionRoutes {
-  private service: ProviderConnectionService;
+  private service: FundingInterface;
 
-  constructor(service: ProviderConnectionService) {
+  constructor(service: FundingInterface) {
     this.service = service;
   }
 
@@ -147,7 +147,7 @@ export default class ProviderConnectionRoutes {
 
       const confirmed = confirm === 'true';
 
-      const result = await this.service.disconnectProvider(
+      const result = await this.service.disconnectProviderConnection(
         providerType as ProviderType,
         confirmed,
       );

--- a/src/server/funding/interface/index.ts
+++ b/src/server/funding/interface/index.ts
@@ -1,8 +1,16 @@
 import { EventEmitter } from 'events';
 import FundingService from '@/server/funding/service/funding';
-import { ProviderConnectionService } from '@/server/funding/service/provider_connection';
-import { FundingPlan, FundingSettings, ProviderConfig, FundingStatus, BillingCycle } from '@/common/model/funding-plan';
+import {
+  ProviderConnectionService,
+  type AdminUser,
+  type StripeCredentialInputs,
+  type StripeConfigureResult,
+  type ProviderStatus,
+  type DisconnectionResult,
+} from '@/server/funding/service/provider_connection';
+import { FundingPlan, FundingSettings, ProviderConfig, FundingStatus, BillingCycle, ProviderType } from '@/common/model/funding-plan';
 import type { ProviderInfo } from '@/server/funding/service/funding';
+import type { ProviderCredentials } from '@/server/funding/service/provider/adapter';
 import { ComplimentaryGrant } from '@/common/model/complimentary_grant';
 import { CheckoutSessionResult } from '@/server/funding/service/provider/adapter';
 import type CalendarInterface from '@/server/calendar/interface';
@@ -15,7 +23,7 @@ import type CalendarInterface from '@/server/calendar/interface';
  */
 export default class FundingInterface {
   private fundingService: FundingService;
-  readonly providerConnectionService: ProviderConnectionService;
+  private providerConnectionService: ProviderConnectionService;
 
   constructor(eventBus: EventEmitter) {
     this.fundingService = new FundingService(eventBus);
@@ -95,6 +103,55 @@ export default class FundingInterface {
 
   async disconnectProvider(providerType: 'stripe' | 'paypal'): Promise<void> {
     return this.fundingService.disconnectProvider(providerType);
+  }
+
+  // Provider connection (credential) management
+
+  /**
+   * Get the connection status for a payment provider
+   *
+   * @param providerType - Provider to inspect ('stripe' or 'paypal')
+   * @returns Whether the provider has credentials configured, plus metadata
+   */
+  async getProviderStatus(providerType: ProviderType): Promise<ProviderStatus> {
+    return this.providerConnectionService.getProviderStatus(providerType);
+  }
+
+  /**
+   * Configure Stripe credentials via direct API key entry
+   *
+   * @param credentials - Stripe credentials (publishable_key, secret_key, webhook_secret)
+   * @param adminUser - Admin user performing the configuration
+   * @returns Object with connectionVerified indicating if the Stripe API call succeeded
+   */
+  async configureStripe(credentials: StripeCredentialInputs, adminUser: AdminUser): Promise<StripeConfigureResult> {
+    return this.providerConnectionService.configureStripe(credentials, adminUser);
+  }
+
+  /**
+   * Configure PayPal credentials manually
+   *
+   * @param credentials - PayPal credentials (client_id, client_secret, environment)
+   * @param adminUser - Admin user performing the configuration
+   * @returns True if configuration succeeded
+   */
+  async configurePayPal(credentials: ProviderCredentials, adminUser: AdminUser): Promise<boolean> {
+    return this.providerConnectionService.configurePayPal(credentials, adminUser);
+  }
+
+  /**
+   * Disconnect a payment provider's connection (credentials)
+   *
+   * Named distinctly from {@link disconnectProvider} because this routes to the
+   * provider-connection lifecycle, which supports the confirmation flow and
+   * returns a {@link DisconnectionResult}.
+   *
+   * @param providerType - Provider to disconnect ('stripe' or 'paypal')
+   * @param confirmed - Whether the admin has confirmed disconnection of active plans
+   * @returns Disconnection result, including a confirmation requirement when needed
+   */
+  async disconnectProviderConnection(providerType: ProviderType, confirmed: boolean = false): Promise<DisconnectionResult> {
+    return this.providerConnectionService.disconnectProvider(providerType, confirmed);
   }
 
   // User funding plan operations

--- a/src/server/funding/service/provider_connection.ts
+++ b/src/server/funding/service/provider_connection.ts
@@ -21,7 +21,7 @@ const logger = createLogger('funding');
 /**
  * User object for admin operations
  */
-interface AdminUser {
+export interface AdminUser {
   id: string;
   email: string;
 }
@@ -29,7 +29,7 @@ interface AdminUser {
 /**
  * Stripe credential inputs for configuration
  */
-interface StripeCredentialInputs {
+export interface StripeCredentialInputs {
   publishable_key: string;
   secret_key: string;
   webhook_secret: string;
@@ -38,14 +38,14 @@ interface StripeCredentialInputs {
 /**
  * Result of Stripe configuration including connection verification status
  */
-interface StripeConfigureResult {
+export interface StripeConfigureResult {
   connectionVerified: boolean;
 }
 
 /**
  * Provider status information
  */
-interface ProviderStatus {
+export interface ProviderStatus {
   configured: boolean;
   providerType?: ProviderType;
   enabled?: boolean;
@@ -55,7 +55,7 @@ interface ProviderStatus {
 /**
  * Disconnection result
  */
-interface DisconnectionResult {
+export interface DisconnectionResult {
   requiresConfirmation?: boolean;
   activeFundingPlanCount?: number;
   message?: string;

--- a/src/server/funding/test/admin_api.test.ts
+++ b/src/server/funding/test/admin_api.test.ts
@@ -2,16 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import sinon from 'sinon';
-import FundingService from '@/server/funding/service/funding';
+import FundingInterface from '@/server/funding/interface';
 import AdminRoutes from '@/server/funding/api/v1/admin';
-import { ProviderConnectionService } from '@/server/funding/service/provider_connection';
 import { FundingSettings, ProviderConfig } from '@/common/model/funding-plan';
 import { testApp } from '@/server/common/test/lib/express';
 
 describe('Admin Funding API', () => {
   let router: express.Router;
-  let service: FundingService;
-  let providerConnectionService: ProviderConnectionService;
+  let service: FundingInterface;
   let adminHandlers: AdminRoutes;
   let sandbox: sinon.SinonSandbox;
 
@@ -19,13 +17,12 @@ describe('Admin Funding API', () => {
     sandbox = sinon.createSandbox();
     router = express.Router();
 
-    // Create service with mocked dependencies
+    // Create the funding interface with a mocked event bus
     const eventBus = { emit: sandbox.stub() } as any;
-    service = new FundingService(eventBus);
-    providerConnectionService = new ProviderConnectionService(eventBus);
+    service = new FundingInterface(eventBus);
 
     // Create handlers
-    adminHandlers = new AdminRoutes(service, providerConnectionService);
+    adminHandlers = new AdminRoutes(service);
   });
 
   afterEach(() => {
@@ -209,7 +206,7 @@ describe('Admin Funding API', () => {
       ];
 
       sandbox.stub(service, 'getProviders').resolves(mockProviders);
-      sandbox.stub(providerConnectionService, 'getProviderStatus')
+      sandbox.stub(service, 'getProviderStatus')
         .withArgs('stripe').resolves({ configured: true })
         .withArgs('paypal').resolves({ configured: false });
 
@@ -231,7 +228,7 @@ describe('Admin Funding API', () => {
 
   describe('PUT /admin/providers/:providerType', () => {
     it('should update provider display name and enabled status', async () => {
-      const updateStub = sandbox.stub(service, 'updateProvider').resolves(true);
+      const updateStub = sandbox.stub(service, 'updateProvider').resolves();
 
       router.put('/handler/:providerType', adminHandlers.updateProvider.bind(adminHandlers));
 

--- a/src/server/funding/test/provider_connection_api.test.ts
+++ b/src/server/funding/test/provider_connection_api.test.ts
@@ -3,7 +3,7 @@ import express from 'express';
 import request from 'supertest';
 import sinon from 'sinon';
 import { testApp, addRequestUser } from '@/server/common/test/lib/express';
-import { ProviderConnectionService } from '@/server/funding/service/provider_connection';
+import FundingInterface from '@/server/funding/interface';
 import ProviderConnectionRoutes from '@/server/funding/api/v1/provider_connection';
 import { InvalidCredentialsError, MissingRequiredFieldError } from '@/common/exceptions/funding';
 
@@ -15,7 +15,7 @@ import { InvalidCredentialsError, MissingRequiredFieldError } from '@/common/exc
  */
 describe('Provider Connection API Routes', () => {
   let router: express.Router;
-  let service: ProviderConnectionService;
+  let service: FundingInterface;
   let routes: ProviderConnectionRoutes;
   let sandbox: sinon.SinonSandbox;
 
@@ -23,9 +23,9 @@ describe('Provider Connection API Routes', () => {
     sandbox = sinon.createSandbox();
     router = express.Router();
 
-    // Create service with mocked event bus
+    // Create the funding interface with a mocked event bus
     const eventBus = { emit: sandbox.stub() } as any;
-    service = new ProviderConnectionService(eventBus);
+    service = new FundingInterface(eventBus);
 
     // Create route handlers
     routes = new ProviderConnectionRoutes(service);
@@ -264,7 +264,7 @@ describe('Provider Connection API Routes', () => {
 
   describe('DELETE /admin/providers/:providerType', () => {
     it('should return confirmation requirement when active subscriptions exist', async () => {
-      sandbox.stub(service, 'disconnectProvider').resolves({
+      sandbox.stub(service, 'disconnectProviderConnection').resolves({
         requiresConfirmation: true,
         activeFundingPlanCount: 5,
         message: 'This provider has 5 active subscription(s). Disconnecting will cancel all active subscriptions.',
@@ -282,7 +282,7 @@ describe('Provider Connection API Routes', () => {
     });
 
     it('should disconnect provider when confirmation is provided', async () => {
-      sandbox.stub(service, 'disconnectProvider').resolves({});
+      sandbox.stub(service, 'disconnectProviderConnection').resolves({});
 
       router.delete('/:providerType', routes.disconnectProvider.bind(routes));
 

--- a/src/server/funding/test/webhooks.test.ts
+++ b/src/server/funding/test/webhooks.test.ts
@@ -176,7 +176,6 @@ describe('Webhook Handling', () => {
       handleStripeWebhook = sandbox.stub().resolves();
       const mockInterface = {
         handleStripeWebhook,
-        providerConnectionService: {},
       };
 
       app = express();
@@ -219,7 +218,6 @@ describe('Webhook Handling', () => {
       AccountApiV1.install(bootApp, {} as any);
       FundingApiV1.install(bootApp, {
         handleStripeWebhook,
-        providerConnectionService: {},
       } as any);
 
       const webhookPayload = JSON.stringify({ id: 'evt_boot_order', type: 'invoice.paid' });


### PR DESCRIPTION
## Motivation

`FundingInterface` exposed `providerConnectionService` as a public `readonly` property, leaking a service implementation detail across the domain boundary. Other code (the funding API routes) reached through the interface to call methods directly on the underlying service, violating the thin-delegation interface pattern that the rest of the domain follows.

## Approach

Replaced the public property with discrete delegating methods on `FundingInterface`, one per operation the API layer actually uses:

- `getProviderStatus(providerType)` — used by the admin `GET /admin/providers` handler
- `configureStripe(credentials, adminUser)` — used by `POST /admin/providers/stripe/configure`
- `configurePayPal(credentials, adminUser)` — used by `POST /admin/providers/paypal/configure`
- `disconnectProviderConnection(providerType, confirmed)` — used by `DELETE /admin/providers/:providerType`

The disconnect method is named distinctly because `FundingInterface` already has a `disconnectProvider` (backed by `FundingService`) with a different signature and contract; reusing the name would collide.

`providerConnectionService` is now `private`. The aggregator (`api/v1.ts`) passes only the interface to `AdminRoutes` and `ProviderConnectionRoutes`; both handler classes now depend on `FundingInterface` rather than the service. The supporting types (`ProviderStatus`, `StripeCredentialInputs`, `StripeConfigureResult`, `AdminUser`, `DisconnectionResult`) are exported from the service so the interface can reference them.

## Validation

- `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- Targeted funding tests pass: `admin_api.test.ts`, `provider_connection_api.test.ts`, `webhooks.test.ts`, `provider_connection.test.ts` (68 tests). The two API tests were migrated to construct a real `FundingInterface` and stub the new methods.
- `tsc --noEmit` introduces no new type errors in the funding domain (baseline 73 → 72).