### PR TITLE
refactor(accounts): decouple invitation entity from calendar domain

### DIFF
--- a/src/server/accounts/entity/account_invitation.ts
+++ b/src/server/accounts/entity/account_invitation.ts
@@ -2,7 +2,6 @@ import { Model, Column, Table, BelongsTo, ForeignKey, DataType, PrimaryKey, Befo
 
 import AccountInvitation from '@/common/model/invitation';
 import { AccountEntity } from '@/server/common/entity/account';
-import { CalendarEntity } from '@/server/calendar/entity/calendar';
 import db from '@/server/common/entity/db';
 
 
@@ -31,7 +30,14 @@ export default class AccountInvitationEntity extends Model {
   @Column({ type: DataType.DATE })
   declare expiration_time: Date;
 
-  @ForeignKey(() => CalendarEntity)
+  /**
+   * Calendar this invitation grants editor access to, when set.
+   *
+   * Stored as a plain UUID rather than a typed @ForeignKey to CalendarEntity
+   * to keep this accounts-domain entity decoupled from the calendar domain at
+   * the data layer (see DEC-003). Null for admin invitations that grant no
+   * calendar-scoped access.
+   */
   @Index
   @Column({ type: DataType.UUID, allowNull: true })
   declare calendar_id: string;


### PR DESCRIPTION
## Motivation

`src/server/accounts/entity/account_invitation.ts` imported `CalendarEntity` from `@/server/calendar/entity/calendar` purely to decorate the `calendar_id` column with `@ForeignKey(() => CalendarEntity)`. This is an entity-layer cross-domain import that couples the accounts data layer to the calendar domain, violating the strict domain-boundary rule (DEC-003).

## Approach

The `@ForeignKey` decoration had no paired `@BelongsTo` association, so it was inert for queries — it only marked the column. Removed the import and store `calendar_id` as a plain `DataType.UUID` column, matching the established domain-local pattern already used by `moderation/entity/report.ts` (which references a calendar by id without importing `CalendarEntity`). Added a doc comment explaining the decoupling and the null-for-admin-invitations semantics.

The table schema is created via Sequelize `sync` (no migration defines it) and there was no FK constraint backed by a `@BelongsTo`, so there is nothing to drop at the database layer and behavior is preserved.

## Validation

- `npm run lint` — 0 errors (1 pre-existing warning in an unrelated test file).
- `npx vitest run src/server/accounts/test/account_invitation_entity.test.ts src/server/accounts/test/account_service.test.ts` — 70 tests pass, including the entity tests asserting `calendar_id` can be null, set, read, and round-tripped through `toModel()`.