### PR TITLE
refactor(cli): route backup commands through housekeeping interface

### DIFF
--- a/src/server/cli/index.ts
+++ b/src/server/cli/index.ts
@@ -5,13 +5,13 @@
  */
 
 import { Command } from 'commander';
-import { Sequelize } from 'sequelize-typescript';
 import config from 'config';
 import chalk from 'chalk';
 import { EventEmitter } from 'events';
-import { BackupEntity } from '../housekeeping/entity/backup.js';
-import JobQueueService from '../housekeeping/service/job-queue.js';
-import StorageService from '../housekeeping/service/storage.js';
+import db from '../common/entity/db.js';
+import HousekeepingInterface from '../housekeeping/interface/index.js';
+import EmailInterface from '../email/interface/index.js';
+import AccountsInterface from '../accounts/interface/index.js';
 import * as readline from 'readline';
 import Table from 'cli-table3';
 import { DateTime } from 'luxon';
@@ -21,41 +21,36 @@ import * as path from 'path';
 
 const execAsync = promisify(exec);
 
-// Global resources for cleanup
-let sequelize: Sequelize | null = null;
-let jobQueue: JobQueueService | null = null;
+/**
+ * Lazily-constructed housekeeping interface — the boundary the CLI uses for all
+ * backup and job-queue operations (DEC-003). The CLI does not reach into
+ * housekeeping services or entities directly.
+ */
+let housekeeping: HousekeepingInterface | null = null;
+
+function getHousekeeping(): HousekeepingInterface {
+  if (!housekeeping) {
+    housekeeping = new HousekeepingInterface(new EmailInterface(), new AccountsInterface());
+  }
+  return housekeeping;
+}
 
 /**
- * Initializes database connection for CLI commands.
+ * Initializes the database connection for CLI commands.
+ *
+ * Uses the shared `db` singleton (as the worker and the import:sync command do)
+ * so every entity's `addModels()` self-registration is picked up. SQL logging
+ * is already disabled via the `database.logging` config.
  */
-async function initDatabase(): Promise<Sequelize> {
+async function initDatabase(): Promise<void> {
   try {
-    const dbConfig: any = config.get('database');
-
-    const sequelizeInstance = new Sequelize({
-      ...dbConfig,
-      logging: false, // Disable SQL logging in CLI
-    });
-
-    sequelizeInstance.addModels([BackupEntity]);
-    await sequelizeInstance.authenticate();
+    await db.authenticate();
     console.log(chalk.green('[CLI] Database connected'));
-
-    return sequelizeInstance;
   }
   catch (error) {
     console.error(chalk.red('[CLI] Failed to connect to database:'), error);
     throw error;
   }
-}
-
-/**
- * Initializes job queue service for CLI commands.
- */
-async function initJobQueue(): Promise<JobQueueService> {
-  const jobQueueService = new JobQueueService();
-  await jobQueueService.start();
-  return jobQueueService;
 }
 
 /**
@@ -96,9 +91,8 @@ async function handleBackupCreate() {
     console.log(chalk.blue('[Backup] Queueing manual backup job...'));
 
     await initDatabase();
-    const queue = await initJobQueue();
 
-    const jobId = await queue.publish('backup:create', { type: 'manual' });
+    const jobId = await getHousekeeping().queueManualBackup();
 
     console.log(chalk.green('[Backup] ✓ Backup job queued successfully'));
     console.log(`Job ID: ${jobId}`);
@@ -118,8 +112,7 @@ async function handleBackupList() {
   try {
     await initDatabase();
 
-    const storageService = new StorageService();
-    const backups = await storageService.listBackups();
+    const backups = await getHousekeeping().listBackups();
 
     if (backups.length === 0) {
       console.log(chalk.yellow('No backups found.'));
@@ -139,8 +132,8 @@ async function handleBackupList() {
     });
 
     for (const backup of backups) {
-      const date = DateTime.fromJSDate(backup.created_at).toFormat('yyyy-MM-dd HH:mm:ss');
-      const size = formatBytes(backup.size_bytes);
+      const date = DateTime.fromJSDate(backup.createdAt).toFormat('yyyy-MM-dd HH:mm:ss');
+      const size = formatBytes(backup.sizeBytes);
       const verified = backup.verified ? chalk.green('✓') : chalk.red('✗');
 
       table.push([
@@ -169,14 +162,11 @@ async function handleBackupStatus() {
   try {
     await initDatabase();
 
-    const storageService = new StorageService();
-    const stats = await storageService.getStorageStats();
+    const housekeepingInterface = getHousekeeping();
+    const stats = await housekeepingInterface.getStorageStats();
 
     // Get last successful backup
-    const lastBackup = await BackupEntity.findOne({
-      where: { verified: true },
-      order: [['created_at', 'DESC']],
-    });
+    const lastBackup = await housekeepingInterface.getLastVerifiedBackup();
 
     console.log(chalk.bold('\n📊 Backup System Status\n'));
 
@@ -197,9 +187,9 @@ async function handleBackupStatus() {
     // Last backup
     console.log('\n' + chalk.cyan('Last Backup:'));
     if (lastBackup) {
-      const date = DateTime.fromJSDate(lastBackup.created_at).toFormat('yyyy-MM-dd HH:mm:ss');
+      const date = DateTime.fromJSDate(lastBackup.createdAt).toFormat('yyyy-MM-dd HH:mm:ss');
       console.log(`  Date: ${date}`);
-      console.log(`  Size: ${formatBytes(lastBackup.size_bytes)}`);
+      console.log(`  Size: ${formatBytes(lastBackup.sizeBytes)}`);
       console.log(`  Type: ${lastBackup.type}`);
       console.log(`  Category: ${lastBackup.category}`);
       console.log(`  Verified: ${lastBackup.verified ? chalk.green('✓') : chalk.red('✗')}`);
@@ -236,8 +226,7 @@ async function handleBackupRestore(backupId: string) {
   try {
     await initDatabase();
 
-    const storageService = new StorageService();
-    const backup = await storageService.getBackup(backupId);
+    const backup = await getHousekeeping().getBackup(backupId);
 
     if (!backup) {
       console.error(chalk.red(`[Backup] Backup not found: ${backupId}`));
@@ -249,11 +238,11 @@ async function handleBackupRestore(backupId: string) {
     console.log('This operation will replace the current database with the selected backup.');
     console.log(chalk.red('ALL CURRENT DATA WILL BE LOST!\n'));
 
-    const date = DateTime.fromJSDate(backup.created_at).toFormat('yyyy-MM-dd HH:mm:ss');
+    const date = DateTime.fromJSDate(backup.createdAt).toFormat('yyyy-MM-dd HH:mm:ss');
     console.log(chalk.cyan('Backup Details:'));
     console.log(`  ID: ${backup.id}`);
     console.log(`  Date: ${date}`);
-    console.log(`  Size: ${formatBytes(backup.size_bytes)}`);
+    console.log(`  Size: ${formatBytes(backup.sizeBytes)}`);
     console.log(`  Type: ${backup.type}`);
     console.log(`  Verified: ${backup.verified ? chalk.green('✓') : chalk.red('✗')}\n`);
 
@@ -272,7 +261,7 @@ async function handleBackupRestore(backupId: string) {
     // Perform restore
     console.log(chalk.blue('\n[Restore] Starting database restore...'));
 
-    const backupPath = path.join(backup.storage_location, backup.filename);
+    const backupPath = path.join(backup.storageLocation, backup.filename);
     const dbConfig: any = config.get('database');
 
     // Build pg_restore command
@@ -353,8 +342,9 @@ async function handleHousekeepingStatus() {
 async function handleImportSync(options: { sourceId?: string; calendarId?: string }): Promise<void> {
   try {
     // Use the shared db singleton so every entity's addModels() self-registration
-    // is picked up. The local `sequelize` var tracked here is only used by the
-    // other CLI subcommands; the import:sync path never touches it.
+    // is picked up. Imported dynamically here (rather than reusing the top-level
+    // `db` import) alongside the calendar entity modules below, so the import:sync
+    // path pulls in only what it needs.
     const dbModule = await import('../common/entity/db.js');
     await dbModule.default.authenticate();
     // Touch the import_source / import_run / calendar / event modules so their
@@ -460,13 +450,11 @@ async function main() {
     }
   }
   finally {
-    // Cleanup resources
-    if (jobQueue) {
-      await jobQueue.stop();
-    }
-    if (sequelize) {
-      await sequelize.close();
-    }
+    // Cleanup resources. close() is a no-op if the connection was never
+    // opened (e.g. for --help / --version), so it is safe to call
+    // unconditionally. The job queue used by `backup create` owns its own
+    // lifecycle inside HousekeepingInterface.queueManualBackup.
+    await db.close();
   }
 }
 

--- a/src/server/housekeeping/interface/index.ts
+++ b/src/server/housekeeping/interface/index.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 import EmailInterface from '@/server/email/interface';
 import AccountsInterface from '@/server/accounts/interface';
 import BackupService from '@/server/housekeeping/service/backup';
-import StorageService from '@/server/housekeeping/service/storage';
+import StorageService, { StorageStats } from '@/server/housekeeping/service/storage';
 import DiskMonitorService from '@/server/housekeeping/service/disk-monitor';
 import JobQueueService, { JobPublishOptions } from '@/server/housekeeping/service/job-queue';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';
@@ -13,7 +13,47 @@ import { createLogger } from '@/server/common/helper/logger';
 // housekeeping boundary without reaching into the pg-boss adapter directly.
 export type { JobPublishOptions } from '@/server/housekeeping/service/job-queue';
 
+// Re-exported so callers (e.g. the management CLI) can type backup storage
+// stats without importing the StorageService internal.
+export type { StorageStats } from '@/server/housekeeping/service/storage';
+
 const logger = createLogger('housekeeping');
+
+/**
+ * Backup metadata exposed across the housekeeping domain boundary.
+ *
+ * A plain DTO projection of {@link BackupEntity} so callers (e.g. the
+ * management CLI) can read backup records without importing the Sequelize
+ * entity directly (DEC-003 domain boundary).
+ */
+export interface BackupRecord {
+  id: string;
+  filename: string;
+  sizeBytes: number;
+  createdAt: Date;
+  type: 'manual' | 'scheduled';
+  category: 'daily' | 'weekly' | 'monthly';
+  verified: boolean;
+  storageLocation: string;
+}
+
+/**
+ * Projects a BackupEntity onto the boundary-safe {@link BackupRecord} DTO.
+ * BIGINT `size_bytes` arrives as a string from some drivers, so it is coerced
+ * to a number here once rather than at every call site.
+ */
+function toBackupRecord(entity: BackupEntity): BackupRecord {
+  return {
+    id: entity.id,
+    filename: entity.filename,
+    sizeBytes: Number(entity.size_bytes),
+    createdAt: entity.created_at,
+    type: entity.type,
+    category: entity.category,
+    verified: entity.verified,
+    storageLocation: entity.storage_location,
+  };
+}
 
 /**
  * Status information returned by getStatus method
@@ -275,5 +315,82 @@ export default class HousekeepingInterface {
    */
   getAccountsInterface(): AccountsInterface {
     return this.accountsInterface;
+  }
+
+  /**
+   * Lists all recorded backups, newest first.
+   *
+   * Used by the management CLI's `backup list` command so it can render the
+   * backup inventory without importing the StorageService internal.
+   *
+   * @returns Backup records ordered by creation date descending
+   */
+  async listBackups(): Promise<BackupRecord[]> {
+    const backups = await this.storageService.listBackups();
+    return backups.map(toBackupRecord);
+  }
+
+  /**
+   * Gets a single backup by id.
+   *
+   * Used by the management CLI's `backup restore` command to look up the
+   * backup to restore.
+   *
+   * @param id - Backup id
+   * @returns The backup record, or null if no backup has that id
+   */
+  async getBackup(id: string): Promise<BackupRecord | null> {
+    const backup = await this.storageService.getBackup(id);
+    return backup ? toBackupRecord(backup) : null;
+  }
+
+  /**
+   * Gets the most recent verified backup.
+   *
+   * Used by the management CLI's `backup status` command. Distinct from the
+   * private `getLastBackupInfo` (which returns the trimmed shape the admin
+   * dashboard needs) — the CLI needs the full record.
+   *
+   * @returns The latest verified backup record, or null if none exist
+   */
+  async getLastVerifiedBackup(): Promise<BackupRecord | null> {
+    const lastBackup = await BackupEntity.findOne({
+      where: { verified: true },
+      order: [['created_at', 'DESC']],
+    });
+    return lastBackup ? toBackupRecord(lastBackup) : null;
+  }
+
+  /**
+   * Gets storage statistics for the backup volume.
+   *
+   * Used by the management CLI's `backup status` command.
+   *
+   * @returns Storage statistics including total size, count, and free space
+   */
+  async getStorageStats(): Promise<StorageStats> {
+    return this.storageService.getStorageStats();
+  }
+
+  /**
+   * Queues a one-off manual backup job and returns its id.
+   *
+   * Used by the management CLI's `backup create` command. Self-contained: it
+   * owns a short-lived JobQueueService for the publish rather than the
+   * long-lived queue wired in by `setJobQueueService`, because CLI invocations
+   * are separate processes that don't go through `HousekeepingDomain.initialize`.
+   * The queue is always stopped afterwards so the CLI process can exit cleanly.
+   *
+   * @returns The published job's id, or null if pg-boss returns none
+   */
+  async queueManualBackup(): Promise<string | null> {
+    const queue = new JobQueueService();
+    await queue.start();
+    try {
+      return await queue.publish('backup:create', { type: 'manual' });
+    }
+    finally {
+      await queue.stop();
+    }
   }
 }

--- a/src/server/housekeeping/test/cli-commands.test.ts
+++ b/src/server/housekeeping/test/cli-commands.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
+import HousekeepingInterface from '@/server/housekeeping/interface';
+import EmailInterface from '@/server/email/interface';
+import AccountsInterface from '@/server/accounts/interface';
 import JobQueueService from '@/server/housekeeping/service/job-queue';
 import StorageService from '@/server/housekeeping/service/storage';
 import { BackupEntity } from '@/server/housekeeping/entity/backup';
-import { DateTime } from 'luxon';
 
 /**
  * CLI Commands Test Suite
  *
- * Tests the core logic of CLI commands without spawning actual CLI processes.
- * Tests interact directly with service layer to ensure business logic is correct.
+ * Exercises the HousekeepingInterface methods the management CLI relies on.
+ * The CLI (src/server/cli/index.ts) routes every backup / job-queue operation
+ * through this interface rather than reaching into housekeeping services or
+ * entities directly (DEC-003 domain boundary), so these tests stand in for the
+ * CLI command logic without spawning a process.
  */
-describe('CLI Commands', () => {
+describe('CLI Commands (HousekeepingInterface)', () => {
   let sandbox: sinon.SinonSandbox;
+  let housekeeping: HousekeepingInterface;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    const emailInterface = { sendMail: sandbox.stub() } as unknown as EmailInterface;
+    const accountsInterface = new AccountsInterface();
+    housekeeping = new HousekeepingInterface(emailInterface, accountsInterface);
   });
 
   afterEach(() => {
@@ -23,31 +32,34 @@ describe('CLI Commands', () => {
   });
 
   describe('backup create command', () => {
-    it('should queue backup:create job to pg-boss', async () => {
-      const jobQueueService = new JobQueueService();
-      const publishStub = sandbox.stub(jobQueueService, 'publish').resolves('job-123');
+    it('should queue backup:create job through a self-managed queue', async () => {
+      const startStub = sandbox.stub(JobQueueService.prototype, 'start').resolves();
+      const stopStub = sandbox.stub(JobQueueService.prototype, 'stop').resolves();
+      const publishStub = sandbox.stub(JobQueueService.prototype, 'publish').resolves('job-123');
 
-      // Simulate CLI command logic
-      await jobQueueService.publish('backup:create', { type: 'manual' });
+      const jobId = await housekeeping.queueManualBackup();
 
+      expect(jobId).toBe('job-123');
       expect(publishStub.calledOnce).toBe(true);
       expect(publishStub.firstCall.args[0]).toBe('backup:create');
       expect(publishStub.firstCall.args[1]).toEqual({ type: 'manual' });
+      // Queue lifecycle is owned by the interface, not the CLI.
+      expect(startStub.calledOnce).toBe(true);
+      expect(stopStub.calledOnce).toBe(true);
     });
 
-    it('should return job ID from pg-boss', async () => {
-      const jobQueueService = new JobQueueService();
-      sandbox.stub(jobQueueService, 'publish').resolves('job-abc-123');
+    it('should stop the queue even when publishing fails', async () => {
+      sandbox.stub(JobQueueService.prototype, 'start').resolves();
+      const stopStub = sandbox.stub(JobQueueService.prototype, 'stop').resolves();
+      sandbox.stub(JobQueueService.prototype, 'publish').rejects(new Error('boom'));
 
-      const jobId = await jobQueueService.publish('backup:create', { type: 'manual' });
-
-      expect(jobId).toBe('job-abc-123');
+      await expect(housekeeping.queueManualBackup()).rejects.toThrow('boom');
+      expect(stopStub.calledOnce).toBe(true);
     });
   });
 
   describe('backup list command', () => {
-    it('should output backup metadata table', async () => {
-      const storageService = new StorageService();
+    it('should project backup entities onto boundary-safe records', async () => {
       const mockBackups = [
         {
           id: '123e4567-e89b-12d3-a456-426614174000',
@@ -71,48 +83,53 @@ describe('CLI Commands', () => {
         },
       ] as BackupEntity[];
 
-      sandbox.stub(storageService, 'listBackups').resolves(mockBackups);
+      sandbox.stub(StorageService.prototype, 'listBackups').resolves(mockBackups);
 
-      const backups = await storageService.listBackups();
+      const backups = await housekeeping.listBackups();
 
       expect(backups).toHaveLength(2);
-      expect(backups[0].id).toBe('123e4567-e89b-12d3-a456-426614174000');
-      expect(backups[0].type).toBe('manual');
+      expect(backups[0]).toEqual({
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        filename: 'pavillion_20260112_140530_manual.dump',
+        sizeBytes: 1024000,
+        createdAt: new Date('2026-01-12T14:05:30Z'),
+        type: 'manual',
+        category: 'daily',
+        verified: true,
+        storageLocation: '/backups',
+      });
       expect(backups[1].category).toBe('weekly');
     });
 
-    it('should return empty array when no backups exist', async () => {
-      const storageService = new StorageService();
-      sandbox.stub(storageService, 'listBackups').resolves([]);
+    it('should return an empty array when no backups exist', async () => {
+      sandbox.stub(StorageService.prototype, 'listBackups').resolves([]);
 
-      const backups = await storageService.listBackups();
+      const backups = await housekeeping.listBackups();
 
       expect(backups).toHaveLength(0);
     });
   });
 
   describe('backup status command', () => {
-    it('should show system health summary', async () => {
-      const storageService = new StorageService();
-
+    it('should expose storage statistics', async () => {
       const mockStats = {
-        totalSize: 10485760, // 10MB
+        totalSize: 10485760,
         count: 5,
-        freeSpace: 50000000000, // 50GB
-        totalSpace: 100000000000, // 100GB
+        freeSpace: 50000000000,
+        totalSpace: 100000000000,
         freeSpacePercent: 50,
       };
 
-      sandbox.stub(storageService, 'getStorageStats').resolves(mockStats);
+      sandbox.stub(StorageService.prototype, 'getStorageStats').resolves(mockStats);
 
-      const stats = await storageService.getStorageStats();
+      const stats = await housekeeping.getStorageStats();
 
       expect(stats.count).toBe(5);
       expect(stats.freeSpacePercent).toBe(50);
       expect(stats.totalSize).toBe(10485760);
     });
 
-    it('should retrieve last successful backup', async () => {
+    it('should retrieve the last verified backup as a record', async () => {
       const mockBackup = {
         id: '123e4567-e89b-12d3-a456-426614174000',
         filename: 'pavillion_20260112_140530_manual.dump',
@@ -124,29 +141,31 @@ describe('CLI Commands', () => {
         storage_location: '/backups',
       } as BackupEntity;
 
-      sandbox.stub(BackupEntity, 'findOne').resolves(mockBackup);
+      const findOneStub = sandbox.stub(BackupEntity, 'findOne').resolves(mockBackup);
 
-      const lastBackup = await BackupEntity.findOne({
-        where: { verified: true },
-        order: [['created_at', 'DESC']],
-      });
+      const lastBackup = await housekeeping.getLastVerifiedBackup();
 
       expect(lastBackup).not.toBeNull();
       expect(lastBackup!.verified).toBe(true);
-      expect(lastBackup!.size_bytes).toBe(1024000);
+      expect(lastBackup!.sizeBytes).toBe(1024000);
+      // Only verified backups are considered, newest first.
+      expect(findOneStub.firstCall.args[0]).toEqual({
+        where: { verified: true },
+        order: [['created_at', 'DESC']],
+      });
+    });
+
+    it('should return null when no verified backup exists', async () => {
+      sandbox.stub(BackupEntity, 'findOne').resolves(null);
+
+      const lastBackup = await housekeeping.getLastVerifiedBackup();
+
+      expect(lastBackup).toBeNull();
     });
   });
 
   describe('backup restore command', () => {
-    it('should require backup ID as argument', () => {
-      // This test validates that restore logic checks for backup ID
-      const backupId = '123e4567-e89b-12d3-a456-426614174000';
-
-      expect(backupId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-
-    it('should retrieve backup details before restore', async () => {
-      const storageService = new StorageService();
+    it('should retrieve a single backup record by id', async () => {
       const mockBackup = {
         id: '123e4567-e89b-12d3-a456-426614174000',
         filename: 'pavillion_20260112_140530_manual.dump',
@@ -158,36 +177,22 @@ describe('CLI Commands', () => {
         storage_location: '/backups',
       } as BackupEntity;
 
-      sandbox.stub(storageService, 'getBackup').resolves(mockBackup);
+      sandbox.stub(StorageService.prototype, 'getBackup').resolves(mockBackup);
 
-      const backup = await storageService.getBackup('123e4567-e89b-12d3-a456-426614174000');
+      const backup = await housekeeping.getBackup('123e4567-e89b-12d3-a456-426614174000');
 
       expect(backup).not.toBeNull();
       expect(backup!.id).toBe('123e4567-e89b-12d3-a456-426614174000');
       expect(backup!.verified).toBe(true);
+      expect(backup!.storageLocation).toBe('/backups');
     });
-  });
 
-  describe('housekeeping status command', () => {
-    it('should show registered scheduled jobs', async () => {
-      // This would query pg-boss for scheduled jobs
-      // For now, test data structure for job schedule
-      const jobSchedule = [
-        {
-          name: 'backup:daily',
-          cron: '0 2 * * *',
-          nextRun: DateTime.now().plus({ days: 1 }).set({ hour: 2, minute: 0 }).toJSDate(),
-        },
-        {
-          name: 'disk:check',
-          cron: '0 * * * *',
-          nextRun: DateTime.now().plus({ hours: 1 }).startOf('hour').toJSDate(),
-        },
-      ];
+    it('should return null when the backup id is unknown', async () => {
+      sandbox.stub(StorageService.prototype, 'getBackup').resolves(null);
 
-      expect(jobSchedule).toHaveLength(2);
-      expect(jobSchedule[0].name).toBe('backup:daily');
-      expect(jobSchedule[1].name).toBe('disk:check');
+      const backup = await housekeeping.getBackup('missing-id');
+
+      expect(backup).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Motivation

The management CLI (`src/server/cli/index.ts`) imported `BackupEntity`,
`StorageService`, and `JobQueueService` directly from housekeeping internals,
reaching across the domain boundary instead of going through
`HousekeepingInterface`. This violates the strict domain-boundary rule
(DEC-003): callers should depend only on a domain's public interface.

## Approach

- Added explicit, CLI-scoped methods to `HousekeepingInterface` covering
  exactly what the CLI does: `listBackups`, `getBackup`,
  `getLastVerifiedBackup`, `getStorageStats`, and `queueManualBackup`.
- `queueManualBackup` owns its own short-lived `JobQueueService` (start →
  publish `backup:create` → stop), so the CLI no longer wires pg-boss itself.
  The queue is always stopped, even on failure, so the CLI process exits
  cleanly.
- Backup metadata now crosses the boundary as a plain `BackupRecord` DTO
  rather than the Sequelize entity, so the CLI no longer needs to import
  `BackupEntity`. `StorageStats` is re-exported from the interface for typing.
- The CLI now authenticates the shared `db` singleton (as the worker and
  `import:sync` paths already do) instead of constructing a redundant
  `Sequelize` instance with `addModels([BackupEntity])`. This also let me
  drop two dead global cleanup vars (`sequelize`, `jobQueue`) that were never
  assigned.

Note: the original issue also listed `BackupService`, but it was not actually
imported by the CLI — the live imports were `BackupEntity`, `StorageService`,
and `JobQueueService`.

## Validation

- `npm run lint` — 0 errors (one pre-existing unrelated warning).
- `npx tsc --noEmit` — no type errors in the changed files.
- `npx vitest run` on the housekeeping CLI, dashboard-status, storage-service,
  and job-queue suites — 43 tests pass. The CLI command test suite was
  rewritten to exercise the new interface methods (DTO projection, queue
  lifecycle, verified-backup lookup) rather than the services directly.