### PR TITLE
refactor(calendar): dedupe repostStatus resolution in EventService

### DIFF
--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -426,6 +426,50 @@ class EventService {
   }
 
   /**
+   * Resolve the repostStatus lookup for a calendar's reposted/shared events.
+   *
+   * Consults both repost sources for the calendar and builds a unified map
+   * keyed by event id, with this precedence:
+   *   - SharedEventEntity (via the AP interface) is authoritative and carries
+   *     the auto/manual distinction (derived from auto_posted). Non-UUID keys
+   *     (legacy AP-URL rows) are filtered out — see module-level UUID_REGEX.
+   *   - EventRepostEntity is a legacy direct-repost link with no auto/manual
+   *     distinction; entries present only there default to 'manual'.
+   * Events absent from the returned map are owned by the calendar; call sites
+   * report them as 'none' via `map.get(id) ?? 'none'`.
+   *
+   * A single pair of queries is issued per call regardless of event count.
+   *
+   * @param calendarId - the acting calendar whose repost status to resolve
+   * @returns map of event id -> 'auto' | 'manual' for reposted/shared events
+   */
+  private async resolveRepostStatusForCalendar(
+    calendarId: string,
+  ): Promise<Map<string, 'auto' | 'manual'>> {
+    const [reposts, sharedStatusMap] = await Promise.all([
+      EventRepostEntity.findAll({
+        where: { calendar_id: calendarId },
+        attributes: ['event_id'],
+      }),
+      this.activityPubInterface!.getSharedEventStatusMap(calendarId),
+    ]);
+
+    const repostStatusByEventId = new Map<string, 'auto' | 'manual'>();
+    for (const [eventId, status] of sharedStatusMap.entries()) {
+      if (UUID_REGEX.test(eventId)) {
+        repostStatusByEventId.set(eventId, status);
+      }
+    }
+    for (const r of reposts) {
+      if (!repostStatusByEventId.has(r.event_id)) {
+        repostStatusByEventId.set(r.event_id, 'manual');
+      }
+    }
+
+    return repostStatusByEventId;
+  }
+
+  /**
    * Retrieves events for the provided calendar.
    * Returns events that are either:
    * - Owned by the calendar (calendar_id matches)
@@ -441,37 +485,10 @@ class EventService {
     categories?: string[];
   }): Promise<CalendarEvent[]> {
 
-    // Get event IDs that are reposted or shared by this calendar.
-    //
-    // repostStatus resolution:
-    //   - SharedEventEntity (via AP interface) is the authoritative source and
-    //     carries auto_posted to distinguish 'auto' vs 'manual' shares.
-    //   - EventRepostEntity is a legacy direct-repost link with no auto/manual
-    //     distinction; when an event appears only there it is treated as 'manual'.
-    //   - Events not in either collection (owned by the calendar) report 'none'.
-    const reposts = await EventRepostEntity.findAll({
-      where: { calendar_id: calendar.id },
-      attributes: ['event_id'],
-    });
-    // Get shared event id -> status map via AP interface (derived from auto_posted).
-    // Filter to valid UUIDs for safety since old records may have AP URLs —
-    // see module-level UUID_REGEX.
-    const sharedStatusMap = await this.activityPubInterface!.getSharedEventStatusMap(calendar.id);
-
-    // Build a unified repostStatus map for O(1) lookup during mapping below.
-    // SharedEventEntity takes precedence (auto|manual); EventRepostEntity-only
-    // entries default to 'manual'.
-    const repostStatusByEventId = new Map<string, 'auto' | 'manual'>();
-    for (const [eventId, status] of sharedStatusMap.entries()) {
-      if (UUID_REGEX.test(eventId)) {
-        repostStatusByEventId.set(eventId, status);
-      }
-    }
-    for (const r of reposts) {
-      if (!repostStatusByEventId.has(r.event_id)) {
-        repostStatusByEventId.set(r.event_id, 'manual');
-      }
-    }
+    // Get the repostStatus lookup for events reposted or shared by this
+    // calendar (SharedEventEntity auto/manual, EventRepostEntity-only as
+    // 'manual', owned events as 'none'). See resolveRepostStatusForCalendar.
+    const repostStatusByEventId = await this.resolveRepostStatusForCalendar(calendar.id);
 
     // Query events owned by calendar OR reposted/shared by calendar.
     // Source set is the union of own events, event_repost links, and
@@ -1996,29 +2013,9 @@ class EventService {
     }
 
     // 8. Build authoritative repostStatus map for the acting calendar.
-    // Mirrors the resolution pattern in listEvents (~lines 285-307): consult
-    // SharedEventEntity (via AP interface) for auto/manual distinction, fall
-    // back to EventRepostEntity-only entries as 'manual'. A single pair of
-    // queries is issued per call regardless of event count.
-    const [reposts, sharedStatusMap] = await Promise.all([
-      EventRepostEntity.findAll({
-        where: { calendar_id: actingCalendarId },
-        attributes: ['event_id'],
-      }),
-      this.activityPubInterface!.getSharedEventStatusMap(actingCalendarId),
-    ]);
-
-    const repostStatusByEventId = new Map<string, 'auto' | 'manual'>();
-    for (const [eventId, status] of sharedStatusMap.entries()) {
-      if (UUID_REGEX.test(eventId)) {
-        repostStatusByEventId.set(eventId, status);
-      }
-    }
-    for (const r of reposts) {
-      if (!repostStatusByEventId.has(r.event_id)) {
-        repostStatusByEventId.set(r.event_id, 'manual');
-      }
-    }
+    // See resolveRepostStatusForCalendar for the SharedEventEntity-first,
+    // EventRepostEntity-fallback precedence.
+    const repostStatusByEventId = await this.resolveRepostStatusForCalendar(actingCalendarId);
 
     // 9. Return updated events with their categories (after successful commit).
     // repostStatus is populated authoritatively from the SharedEventEntity +
@@ -2159,32 +2156,16 @@ class EventService {
       throw error;
     }
 
-    // 7. Build authoritative repostStatus map for the acting calendar.
-    // Mirrors the resolution pattern in listEvents (~lines 285-307): consult
-    // SharedEventEntity (via AP interface) for auto/manual distinction, fall
-    // back to EventRepostEntity-only entries as 'manual'. Owned events default
-    // to 'none'.
-    const [reposts, sharedStatusMap] = await Promise.all([
-      EventRepostEntity.findAll({
-        where: { calendar_id: actingCalendarId },
-        attributes: ['event_id'],
-      }),
-      this.activityPubInterface!.getSharedEventStatusMap(actingCalendarId),
-    ]);
-
-    let resolvedStatus: 'none' | 'manual' | 'auto' = 'none';
-    const sharedEntry = sharedStatusMap.get(eventId);
-    if (sharedEntry && UUID_REGEX.test(eventId)) {
-      resolvedStatus = sharedEntry;
-    }
-    else if (reposts.some(r => r.event_id === eventId)) {
-      resolvedStatus = 'manual';
-    }
+    // 7. Build authoritative repostStatus map for the acting calendar and
+    // resolve this event's status from it. See resolveRepostStatusForCalendar
+    // for the SharedEventEntity-first, EventRepostEntity-fallback precedence;
+    // an event absent from the map is owned by the calendar and reports 'none'.
+    const repostStatusByEventId = await this.resolveRepostStatusForCalendar(actingCalendarId);
 
     // Return updated event (after successful commit) with authoritative
     // repostStatus populated.
     const updatedEvent = await this.getEventById(eventId);
-    updatedEvent.repostStatus = resolvedStatus;
+    updatedEvent.repostStatus = repostStatusByEventId.get(eventId) ?? 'none';
 
     return updatedEvent;
   }

--- a/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
+++ b/src/server/calendar/test/EventService/bulk_assign_categories.test.ts
@@ -14,32 +14,7 @@ import CalendarService from '@/server/calendar/service/calendar';
 import { BulkEventsNotFoundError, MixedCalendarEventsError, CategoriesNotFoundError } from '@/common/exceptions/calendar';
 import db from '@/server/common/entity/db';
 import type { Transaction } from 'sequelize';
-
-/**
- * Builds a stub ActivityPubInterface that returns the supplied SharedEventEntity
- * status map from getSharedEventStatusMap. Mirrors the helper used in
- * event_service.test.ts so authoritative repostStatus resolution can be driven
- * from the test inputs.
- */
-function buildMockApInterface(
-  sharedEventIds: string[] = [],
-  statusOverrides: Record<string, 'auto' | 'manual'> = {},
-  calendarIdsForEvent: Record<string, string[]> = {},
-) {
-  const statusMap = new Map<string, 'auto' | 'manual'>();
-  for (const id of sharedEventIds) {
-    statusMap.set(id, statusOverrides[id] ?? 'manual');
-  }
-  const getCalendarIdsForSharedEvent = sinon.stub();
-  // Default behavior: return [] for any event id not explicitly mapped.
-  getCalendarIdsForSharedEvent.callsFake(async (eventId: string) => {
-    return calendarIdsForEvent[eventId] ?? [];
-  });
-  return {
-    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
-    getCalendarIdsForSharedEvent,
-  } as any;
-}
+import { buildMockApInterface } from './helpers/ap-interface';
 
 describe('EventService.bulkAssignCategories', () => {
   let service: EventService;

--- a/src/server/calendar/test/EventService/event_service.test.ts
+++ b/src/server/calendar/test/EventService/event_service.test.ts
@@ -7,27 +7,7 @@ import { EventEntity, EventContentEntity } from '@/server/calendar/entity/event'
 import { EventCategoryAssignmentEntity } from '@/server/calendar/entity/event_category_assignment';
 import { EventRepostEntity } from '@/server/calendar/entity/event_repost';
 import EventService from '@/server/calendar/service/events';
-
-/**
- * Creates a mock ActivityPubInterface with getSharedEventStatusMap stubbed.
- *
- * @param sharedEventIds - Array of event IDs reposted to the calendar.
- * @param statusOverrides - Optional map of eventId -> 'auto'|'manual' to
- *   control the repostStatus resolution. Any id in sharedEventIds not in
- *   statusOverrides defaults to 'manual'.
- */
-function buildMockApInterface(
-  sharedEventIds: string[] = [],
-  statusOverrides: Record<string, 'auto' | 'manual'> = {},
-) {
-  const statusMap = new Map<string, 'auto' | 'manual'>();
-  for (const id of sharedEventIds) {
-    statusMap.set(id, statusOverrides[id] ?? 'manual');
-  }
-  return {
-    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
-  } as any;
-}
+import { buildMockApInterface } from './helpers/ap-interface';
 
 describe('listEvents', () => {
   let service: EventService;

--- a/src/server/calendar/test/EventService/helpers/ap-interface.ts
+++ b/src/server/calendar/test/EventService/helpers/ap-interface.ts
@@ -1,0 +1,38 @@
+import sinon from 'sinon';
+
+/**
+ * Builds a stub ActivityPubInterface for driving EventService repostStatus
+ * resolution from test inputs.
+ *
+ * getSharedEventStatusMap returns a SharedEventEntity status map assembled from
+ * the supplied event ids; getCalendarIdsForSharedEvent answers per-event
+ * calendar lookups. Both are the surfaces EventService consults when resolving
+ * authoritative repostStatus, so stubbing them lets a test fully control the
+ * SharedEventEntity-first / EventRepostEntity-fallback derivation.
+ *
+ * @param sharedEventIds - event ids reposted/shared to the calendar.
+ * @param statusOverrides - optional eventId -> 'auto'|'manual' map controlling
+ *   the resolved status. Any id in sharedEventIds absent here defaults to
+ *   'manual'.
+ * @param calendarIdsForEvent - optional eventId -> calendarId[] map returned by
+ *   getCalendarIdsForSharedEvent; unmapped ids resolve to [].
+ */
+export function buildMockApInterface(
+  sharedEventIds: string[] = [],
+  statusOverrides: Record<string, 'auto' | 'manual'> = {},
+  calendarIdsForEvent: Record<string, string[]> = {},
+) {
+  const statusMap = new Map<string, 'auto' | 'manual'>();
+  for (const id of sharedEventIds) {
+    statusMap.set(id, statusOverrides[id] ?? 'manual');
+  }
+  const getCalendarIdsForSharedEvent = sinon.stub();
+  // Default behavior: return [] for any event id not explicitly mapped.
+  getCalendarIdsForSharedEvent.callsFake(async (eventId: string) => {
+    return calendarIdsForEvent[eventId] ?? [];
+  });
+  return {
+    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
+    getCalendarIdsForSharedEvent,
+  } as any;
+}

--- a/src/server/calendar/test/EventService/replace_event_categories.test.ts
+++ b/src/server/calendar/test/EventService/replace_event_categories.test.ts
@@ -15,30 +15,7 @@ import { EventNotFoundError, InsufficientCalendarPermissionsError, CategoriesNot
 import { ValidationError } from '@/common/exceptions/base';
 import db from '@/server/common/entity/db';
 import type { Transaction } from 'sequelize';
-
-/**
- * Builds a stub ActivityPubInterface mirroring the helper in
- * event_service.test.ts. getSharedEventStatusMap drives authoritative
- * repostStatus resolution post-commit.
- */
-function buildMockApInterface(
-  sharedEventIds: string[] = [],
-  statusOverrides: Record<string, 'auto' | 'manual'> = {},
-  calendarIdsForEvent: Record<string, string[]> = {},
-) {
-  const statusMap = new Map<string, 'auto' | 'manual'>();
-  for (const id of sharedEventIds) {
-    statusMap.set(id, statusOverrides[id] ?? 'manual');
-  }
-  const getCalendarIdsForSharedEvent = sinon.stub();
-  getCalendarIdsForSharedEvent.callsFake(async (eventId: string) => {
-    return calendarIdsForEvent[eventId] ?? [];
-  });
-  return {
-    getSharedEventStatusMap: sinon.stub().resolves(statusMap),
-    getCalendarIdsForSharedEvent,
-  } as any;
-}
+import { buildMockApInterface } from './helpers/ap-interface';
 
 describe('EventService.replaceEventCategories', () => {
   let service: EventService;


### PR DESCRIPTION
## Motivation

`EventService` carried three copies of the same repostStatus resolution
loop — the SharedEventEntity-first / EventRepostEntity-fallback pattern —
in `listEvents`, `bulkAssignCategories`, and `replaceEventCategories`.
Testing, consistency, and complexity auditors all flagged the duplication
(both the production loop and the parallel `buildMockApInterface` test stub).

## Approach

Extracted the shared derivation into a private
`resolveRepostStatusForCalendar(calendarId)` helper returning
`Map<eventId, 'auto' | 'manual'>`. Each call site applies the `'none'`
default via `map.get(id) ?? 'none'`, preserving identical precedence and
resulting `repostStatus`/`isRepost` values. The three loops were behaviorally
identical in intent; `replaceEventCategories` previously resolved a single
event inline but reduces exactly to a `map.get(eventId) ?? 'none'` lookup, so
the map-based helper reproduces it. The only incidental change is `listEvents`
now fetches the two sources via `Promise.all` (like the other sites) instead
of sequentially — same result.

On the test side, consolidated the duplicated `buildMockApInterface` stub into
a shared helper at `test/EventService/helpers/ap-interface.ts` (full 3-arg
signature) and imported it from the three EventService test files that each
carried their own copy. The differently-shaped local stubs in
`ssrf_protection` and `list_event_ids_for_calendar` were left untouched.

## Validation

`npm run lint` (0 errors). Targeted EventService suites pass: `event_service`,
`bulk_assign_categories`, `replace_event_categories`,
`list_event_ids_for_calendar`, `ssrf_protection` — 60 tests passing.
No public behavior or response shapes changed.