### PR TITLE
refactor(calendar): extract emitAfterTx helper for tx-deferred emits

### DIFF
--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -237,6 +237,31 @@ class EventService {
   }
 
   /**
+   * Emits a domain event, deferring the emit until after the supplied
+   * transaction commits when one is present.
+   *
+   * When the caller supplies a transaction, the emit is deferred until after
+   * commit. The setImmediate hop is required to escape Sequelize's CLS
+   * context — without it the listener's async body inherits a CLS scope
+   * that still binds the just-committed transaction, and Sequelize's
+   * implicit transaction lookup picks it up, causing
+   * "commit has been called on this transaction" errors.
+   *
+   * Without a transaction, the emit fires synchronously.
+   *
+   * @private
+   */
+  private emitAfterTx<T>(event: string, payload: T, tx?: Transaction): void {
+    const emit = () => this.eventBus.emit(event, payload);
+    if (tx) {
+      tx.afterCommit(() => setImmediate(emit));
+    }
+    else {
+      emit();
+    }
+  }
+
+  /**
    * Cross-entity invariant: when an event references both a Place (locationId)
    * and a Space (spaceId), the Space must belong to that Place.
    *
@@ -834,24 +859,9 @@ class EventService {
     await eventEntity.save({ transaction: tx });
 
     // Notify media domain that media has been attached to an event.
-    // When the caller supplies a transaction, defer the emit until after
-    // commit. The setImmediate hop is required to escape Sequelize's CLS
-    // context — without it the listener's async body inherits a CLS scope
-    // that still binds the just-committed transaction, and Sequelize's
-    // implicit transaction lookup picks it up, causing
-    // "commit has been called on this transaction" errors.
     if (eventEntity.media_id) {
       const mediaId = eventEntity.media_id;
-      const emitMediaAttached = () => this.eventBus.emit('mediaAttachedToEvent', {
-        mediaId,
-        eventId: event.id,
-      });
-      if (tx) {
-        tx.afterCommit(() => setImmediate(emitMediaAttached));
-      }
-      else {
-        emitMediaAttached();
-      }
+      this.emitAfterTx('mediaAttachedToEvent', { mediaId, eventId: event.id }, tx);
     }
 
     if ( eventParams.content ) {
@@ -867,13 +877,7 @@ class EventService {
       }
     }
 
-    const emitEventCreated = () => this.eventBus.emit('eventCreated', { calendar, event });
-    if (tx) {
-      tx.afterCommit(() => setImmediate(emitEventCreated));
-    }
-    else {
-      emitEventCreated();
-    }
+    this.emitAfterTx('eventCreated', { calendar, event }, tx);
     return event;
   }
 
@@ -1222,33 +1226,12 @@ class EventService {
     await eventEntity.save({ transaction: tx });
 
     // Notify media domain that media has been attached to an event.
-    // When the caller supplies a transaction, defer the emit until after
-    // commit. The setImmediate hop is required to escape Sequelize's CLS
-    // context — without it the listener's async body inherits a CLS scope
-    // that still binds the just-committed transaction, and Sequelize's
-    // implicit transaction lookup picks it up, causing
-    // "commit has been called on this transaction" errors.
     if (newMediaAttached && eventEntity.media_id) {
       const mediaId = eventEntity.media_id;
-      const emitMediaAttached = () => this.eventBus.emit('mediaAttachedToEvent', {
-        mediaId,
-        eventId: event.id,
-      });
-      if (tx) {
-        tx.afterCommit(() => setImmediate(emitMediaAttached));
-      }
-      else {
-        emitMediaAttached();
-      }
+      this.emitAfterTx('mediaAttachedToEvent', { mediaId, eventId: event.id }, tx);
     }
 
-    const emitEventUpdated = () => this.eventBus.emit('eventUpdated', { calendar, event });
-    if (tx) {
-      tx.afterCommit(() => setImmediate(emitEventUpdated));
-    }
-    else {
-      emitEventUpdated();
-    }
+    this.emitAfterTx('eventUpdated', { calendar, event }, tx);
     return event;
   }
 
@@ -2292,7 +2275,10 @@ class EventService {
       throw error;
     }
 
-    // Emit event for ActivityPub federation (after successful commit)
+    // Emit event for ActivityPub federation. Safe to emit directly here
+    // because the internally-managed transaction is already committed above;
+    // if deleteEvent ever takes a caller-supplied tx, route this through
+    // emitAfterTx instead to defer past commit (see its CLS rationale).
     this.eventBus.emit('eventDeleted', {
       calendar,
       event,


### PR DESCRIPTION
## Motivation

EventService open-coded the same transaction-aware emit pattern at four
sites in `createEvent` and `updateEvent`:

```ts
if (tx) { tx.afterCommit(() => setImmediate(emit)); } else { emit(); }
```

Each site was preceded by an identical six-line comment explaining the
Sequelize CLS escape rationale. The duplicated comment was the real
maintenance liability — if the rationale ever changes (Sequelize upgrade,
AsyncLocalStorage replacement), it had to be updated in multiple places.

## Approach

Extracted a private `emitAfterTx<T>(event, payload, tx?)` helper on
EventService that encapsulates the pattern and holds the CLS rationale in
its JSDoc exactly once. The four open-coded sites collapse to single-line
calls. Timing semantics are preserved byte-for-byte: emits defer via
`afterCommit` + `setImmediate` when a transaction is present, and fire
synchronously otherwise.

Also added a marker comment at the `eventDeleted` emit in `deleteEvent`
documenting that the path emits directly because its internally-managed
transaction is already committed, and that the helper applies should that
path ever take a caller-supplied transaction.

Scoped to `events.ts` only — no generic event-bus abstraction, no change
to `deleteEvent`'s signature.

## Validation

- `npm run lint` — clean (0 errors; one pre-existing unrelated warning).
- `npx vitest run` on the tx-deferred-emit coverage:
  - `src/server/calendar/test/integration/create_event_transaction.test.ts` (2 passed)
  - `src/server/calendar/test/EventService/transaction_propagation.test.ts` (7 passed)
  - `src/server/calendar/test/EventService/originator_context.test.ts` (11 passed)