### PR TITLE
refactor(calendar): extract shared BYDAY entry parser

### DIFF
--- a/src/common/test/utils/recurrence-by-day.test.ts
+++ b/src/common/test/utils/recurrence-by-day.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { parseByDayEntry } from '@/common/utils/recurrence-by-day';
+
+describe('parseByDayEntry', () => {
+  describe('plain weekday codes (no ordinal)', () => {
+    it('parses a plain code with a null ordinal', () => {
+      expect(parseByDayEntry('MO')).toEqual({ ordinal: null, dayCode: 'MO' });
+    });
+
+    it('accepts every valid ISO weekday code', () => {
+      for (const code of ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']) {
+        expect(parseByDayEntry(code)).toEqual({ ordinal: null, dayCode: code });
+      }
+    });
+  });
+
+  describe('ordinal-prefixed codes', () => {
+    it('parses a positive ordinal', () => {
+      expect(parseByDayEntry('1MO')).toEqual({ ordinal: 1, dayCode: 'MO' });
+    });
+
+    it('parses a multi-digit positive ordinal', () => {
+      expect(parseByDayEntry('10TU')).toEqual({ ordinal: 10, dayCode: 'TU' });
+    });
+
+    it('parses a negative ordinal', () => {
+      expect(parseByDayEntry('-1FR')).toEqual({ ordinal: -1, dayCode: 'FR' });
+    });
+
+    it('parses a zero ordinal as 0 rather than null', () => {
+      expect(parseByDayEntry('0SA')).toEqual({ ordinal: 0, dayCode: 'SA' });
+    });
+  });
+
+  describe('invalid input', () => {
+    it('rejects an unknown two-letter day code', () => {
+      expect(parseByDayEntry('XX')).toBeNull();
+      expect(parseByDayEntry('1XX')).toBeNull();
+    });
+
+    it('rejects lowercase codes', () => {
+      expect(parseByDayEntry('mo')).toBeNull();
+      expect(parseByDayEntry('1mo')).toBeNull();
+    });
+
+    it('rejects an empty string', () => {
+      expect(parseByDayEntry('')).toBeNull();
+    });
+
+    it('rejects malformed tokens', () => {
+      expect(parseByDayEntry('MON')).toBeNull();
+      expect(parseByDayEntry('M')).toBeNull();
+      expect(parseByDayEntry('1')).toBeNull();
+      expect(parseByDayEntry('MO1')).toBeNull();
+      expect(parseByDayEntry('1 MO')).toBeNull();
+      expect(parseByDayEntry('1.5MO')).toBeNull();
+    });
+  });
+});

--- a/src/common/utils/recurrence-by-day.ts
+++ b/src/common/utils/recurrence-by-day.ts
@@ -1,0 +1,68 @@
+/**
+ * Single source of truth for parsing a stored BYDAY entry (RFC 5545 BYDAY,
+ * e.g. `MO`, `1MO`, `-1FR`).
+ *
+ * The stored format is an OPTIONAL signed ordinal followed by a two-letter ISO
+ * weekday code. An ordinal, when present, encodes "the Nth occurrence of that
+ * weekday in the period" (used with MONTHLY/YEARLY rules to express e.g.
+ * "first Monday of the month").
+ *
+ * This parser is intentionally permissive about the ordinal: it returns a
+ * structured `{ ordinal, dayCode }` and leaves the present-vs-absent policy to
+ * each call site. The presentation helper (recurrence-text) only renders the
+ * nth-weekday case and so rejects entries with no ordinal; the rrule builder
+ * (event_instance) accepts both plain and ordinal forms. Encoding the domain
+ * format once here keeps those two consumers from drifting apart.
+ */
+
+/**
+ * The seven valid ISO weekday codes (RFC 5545 BYDAY values). Matches rrule's
+ * `ALL_WEEKDAYS` exactly.
+ */
+export type ByDayCode = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
+
+const VALID_DAY_CODES = new Set<string>(['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']);
+
+/**
+ * Pattern for a stored BYDAY entry: an optional signed integer ordinal
+ * followed by a two-letter weekday code. The ordinal group is optional so a
+ * plain `MO` and an ordinal `1MO` / `-1FR` both match.
+ */
+const BY_DAY_PATTERN = /^(-?\d+)?([A-Z]{2})$/;
+
+/**
+ * Structured result of parsing a BYDAY entry.
+ */
+export interface ParsedByDay {
+  /** The signed ordinal when present (e.g. 1, -1), or `null` for a plain code. */
+  ordinal: number | null;
+  /** The validated two-letter ISO weekday code. */
+  dayCode: ByDayCode;
+}
+
+/**
+ * Parses a single stored BYDAY entry into structured form.
+ *
+ * @param entry - A BYDAY token such as `MO`, `1MO`, or `-1FR`
+ * @returns `{ ordinal, dayCode }` on success, or `null` when the token does
+ *   not match the BYDAY format or carries an unknown weekday code. Callers
+ *   apply their own handling of the ordinal-present vs. ordinal-absent case.
+ */
+export function parseByDayEntry(entry: string): ParsedByDay | null {
+  const match = entry.match(BY_DAY_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, ordinalStr, dayCode] = match;
+  if (!VALID_DAY_CODES.has(dayCode)) {
+    return null;
+  }
+  let ordinal: number | null = null;
+  if (ordinalStr !== undefined) {
+    ordinal = parseInt(ordinalStr, 10);
+    if (Number.isNaN(ordinal)) {
+      return null;
+    }
+  }
+  return { ordinal, dayCode: dayCode as ByDayCode };
+}

--- a/src/common/utils/recurrence-text.ts
+++ b/src/common/utils/recurrence-text.ts
@@ -1,4 +1,5 @@
 import { CalendarEventSchedule, EventFrequency } from '@/common/model/events';
+import { parseByDayEntry } from '@/common/utils/recurrence-by-day';
 
 /**
  * Structured, locale-agnostic recurrence intent suitable for i18n rendering
@@ -16,27 +17,23 @@ export interface RecurrenceSummary {
 const VALID_DAY_CODES = new Set(['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']);
 
 /**
- * Pattern matching nth-weekday BYDAY codes such as `1MO`, `3FR`, `-1SA`.
- */
-const NTH_WEEKDAY_PATTERN = /^(-?\d+)([A-Z]{2})$/;
-
-/**
  * Parses a BYDAY entry expected to encode an nth-weekday pattern.
  *
+ * Wraps the shared {@link parseByDayEntry} and applies this helper's policy:
+ * an ordinal is REQUIRED. Plain weekday codes (no ordinal) are rejected here
+ * so they fall through to the generic 'Monthly' rendering, preserving the
+ * original behavior of this display path.
+ *
  * @param entry - A BYDAY token such as `1MO` or `-1SA`
- * @returns `{ ordinal, day }` on success, or `null` if the token does not match
+ * @returns `{ ordinal, day }` on success, or `null` if the token does not
+ *   match or carries no ordinal
  */
 function parseNthWeekday(entry: string): { ordinal: number; day: string } | null {
-  const match = entry.match(NTH_WEEKDAY_PATTERN);
-  if (!match) {
+  const parsed = parseByDayEntry(entry);
+  if (!parsed || parsed.ordinal === null) {
     return null;
   }
-  const ordinal = parseInt(match[1], 10);
-  const day = match[2];
-  if (!VALID_DAY_CODES.has(day) || Number.isNaN(ordinal)) {
-    return null;
-  }
-  return { ordinal, day };
+  return { ordinal: parsed.ordinal, day: parsed.dayCode };
 }
 
 /**

--- a/src/server/calendar/service/event_instance.ts
+++ b/src/server/calendar/service/event_instance.ts
@@ -28,10 +28,11 @@ import {
   InvalidOccurrenceDateError,
 } from '@/common/exceptions/calendar';
 import { createLogger } from '@/server/common/helper/logger';
+import { parseByDayEntry } from '@/common/utils/recurrence-by-day';
 
 const logger = createLogger('calendar');
 
-const { RRule, RRuleSet, Weekday, ALL_WEEKDAYS } = rrule;
+const { RRule, RRuleSet, Weekday } = rrule;
 
 /**
  * Forward generation window for recurring event expansion, in months from
@@ -95,21 +96,18 @@ export interface UpcomingOccurrencesResult {
  * express e.g. "first Monday of the month").
  *
  * Returns null for unparseable input so callers can skip malformed entries
- * rather than silently coerce them into the wrong weekday. Note: rrule's
- * Weekday.fromStr silently yields Weekday(-1) for unknown codes rather than
- * throwing, so we explicitly validate the day code against ALL_WEEKDAYS.
+ * rather than silently coerce them into the wrong weekday. The shared
+ * {@link parseByDayEntry} validates the day code against the canonical weekday
+ * set; rrule's Weekday.fromStr would otherwise silently yield Weekday(-1) for
+ * unknown codes rather than throwing.
  */
 function parseByDay(entry: string): InstanceType<typeof Weekday> | null {
-  const match = entry.match(/^(-?\d+)?([A-Z]{2})$/);
-  if (!match) {
+  const parsed = parseByDayEntry(entry);
+  if (!parsed) {
     return null;
   }
-  const [, ordinal, dayCode] = match;
-  if (!ALL_WEEKDAYS.includes(dayCode as any)) {
-    return null;
-  }
-  const weekday = Weekday.fromStr(dayCode as any);
-  return ordinal ? weekday.nth(parseInt(ordinal, 10)) : weekday;
+  const weekday = Weekday.fromStr(parsed.dayCode as any);
+  return parsed.ordinal !== null ? weekday.nth(parsed.ordinal) : weekday;
 }
 
 export default class EventInstanceService {


### PR DESCRIPTION
## Motivation

The stored BYDAY format (`MO`, `1MO`, `-1FR`) was parsed in two places with near-identical but subtly different regexes:

- `src/common/utils/recurrence-text.ts` used `^(-?\d+)([A-Z]{2})$` — ordinal **required** (display helper only renders the nth-weekday case; plain codes fall through to a generic 'Monthly' string).
- `src/server/calendar/service/event_instance.ts` `parseByDay()` used `^(-?\d+)?([A-Z]{2})$` — ordinal **optional** (rrule builder must accept both plain and ordinal forms).

Encoding the same domain format in two regexes invites silent drift if one site later gains tolerance the other lacks.

## Approach

Added `parseByDayEntry()` in `src/common/utils/recurrence-by-day.ts`, a single permissive parser returning structured `{ ordinal: number | null, dayCode }` (ordinal `null` when absent, `null` return when unparseable or unknown day code). The ordinal-present-vs-absent policy stays at each call site, so existing behavior is preserved exactly:

- `recurrence-text.ts` `parseNthWeekday()` now wraps the shared parser and rejects entries with a null ordinal — plain codes still fall through to 'Monthly'.
- `event_instance.ts` `parseByDay()` now wraps the shared parser and applies `.nth()` only when an ordinal is present — both plain and ordinal forms still build the correct rrule Weekday.

The shared parser validates the day code against the canonical weekday set (identical to rrule's `ALL_WEEKDAYS`), which lets the now-unused `ALL_WEEKDAYS` import drop from the service.

## Validation

- `npm run lint`: 0 errors (1 pre-existing unrelated warning).
- `npx vitest run` on the new parser test, the existing `recurrence-text` tests, and the `event_instance` service tests: 104 passed. New test covers plain codes, positive/multi-digit/negative/zero ordinals, unknown codes, lowercase (rejected), empty, and malformed tokens.