### PR TITLE
refactor(calendar): dedupe UrlValidatorFn into shared import types module

### DIFF
--- a/src/server/calendar/service/import/dns-verifier.ts
+++ b/src/server/calendar/service/import/dns-verifier.ts
@@ -11,6 +11,7 @@ import {
 } from '@/common/exceptions/import';
 import { formatVerificationRecord } from '@/server/calendar/service/import/hmac';
 import { hostnameFromUrl, passesPslCheck } from '@/server/calendar/service/import/hostname';
+import type { UrlValidatorFn } from '@/server/calendar/service/import/types';
 import { createLogger } from '@/server/common/helper/logger';
 import { validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
 import { createIcsUrlValidator } from '@/server/common/helper/test-ssrf-gate';
@@ -68,9 +69,6 @@ export type DohFetch = (
   url: string,
   init?: { method?: string; headers?: Record<string, string> },
 ) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
-
-/** URL SSRF validator (scheme + IP-literal private check). */
-export type UrlValidatorFn = (url: string) => Promise<boolean>;
 
 export interface DnsVerifierDependencies {
   fetchImpl?: DohFetch;

--- a/src/server/calendar/service/import/fetcher.ts
+++ b/src/server/calendar/service/import/fetcher.ts
@@ -49,6 +49,7 @@ import {
   createIcsUrlValidator,
   isLocalhostIcsImportAllowed,
 } from '@/server/common/helper/test-ssrf-gate';
+import type { UrlValidatorFn } from '@/server/calendar/service/import/types';
 
 const logger = createLogger('calendar.import.fetcher');
 
@@ -166,9 +167,6 @@ export type AgentFactory = (pinnedIp: string) => Agent;
 
 /** DNS lookup returning the list of resolved IPs. */
 export type DnsLookupFn = (hostname: string) => Promise<string[]>;
-
-/** URL SSRF validator (scheme + IP-literal private check). */
-export type UrlValidatorFn = (url: string) => Promise<boolean>;
 
 /** IP literal SSRF check (true => private / unsafe). */
 export type IpValidatorFn = (ip: string) => boolean;

--- a/src/server/calendar/service/import/types.ts
+++ b/src/server/calendar/service/import/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared dependency-injection types for the ICS import service cluster
+ * (Fetcher, DnsVerifier, ...). Keeping these in one place avoids duplicate
+ * declarations drifting apart across the import modules.
+ */
+
+/** URL SSRF validator (scheme + IP-literal private check). */
+export type UrlValidatorFn = (url: string) => Promise<boolean>;

--- a/src/server/calendar/test/service/import/fetcher.test.ts
+++ b/src/server/calendar/test/service/import/fetcher.test.ts
@@ -11,9 +11,9 @@ import {
   type RequestResponse,
   type AgentFactory,
   type DnsLookupFn,
-  type UrlValidatorFn,
   type IpValidatorFn,
 } from '@/server/calendar/service/import/fetcher';
+import type { UrlValidatorFn } from '@/server/calendar/service/import/types';
 import {
   ImportSourceFetchError,
   ImportSourceSsrfBlockedError,


### PR DESCRIPTION
## Motivation

The ICS import service cluster (`src/server/calendar/service/import/`) declared an identical `UrlValidatorFn` type — `(url: string) => Promise<boolean>` — in two modules, `fetcher.ts` and `dns-verifier.ts`. Two copies of the same SSRF-validator signature can drift apart over time. This was the remaining consistency cleanup tracked as a follow-up to the DnsVerifier deps-object work.

## Approach

Extracted `UrlValidatorFn` into a new shared `service/import/types.ts` and pointed both `fetcher.ts` and `dns-verifier.ts` at the single canonical declaration. Updated the one test importing the type (`fetcher.test.ts`) to source it from the shared module.

The `DnsVerifier` constructor already takes a single `DnsVerifierDependencies` object with no positional/union dispatch, matching the `Fetcher` / `SyncService` cluster norm, so no caller migration was required. No runtime behavior changes — type-only refactor.

## Validation

- `npm run lint` — 0 errors (one pre-existing unrelated warning).
- Targeted tests: `dns-verifier.test.ts`, `fetcher.test.ts`, `import_source_service.test.ts` — 116 passed.