### PR TITLE
refactor(client): use semantic theme tokens in settings, drop media queries

### DIFF
--- a/src/client/components/logged_in/settings/calendar-category-mappings.vue
+++ b/src/client/components/logged_in/settings/calendar-category-mappings.vue
@@ -189,7 +189,7 @@ async function save() {
   gap: var(--pav-space-2);
   background: none;
   border: none;
-  color: var(--pav-color-stone-600);
+  color: var(--pav-text-secondary);
   font-weight: var(--pav-font-weight-medium);
   font-size: var(--pav-font-size-small);
   cursor: pointer;
@@ -198,21 +198,13 @@ async function save() {
   transition: color 0.2s;
 
   &:hover {
-    color: var(--pav-color-orange-600);
+    color: var(--pav-color-interactive-active);
   }
 
   &:focus-visible {
     outline: 2px solid var(--pav-color-orange-500);
     outline-offset: 2px;
     border-radius: 0.25rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-
-    &:hover {
-      color: var(--pav-color-orange-400);
-    }
   }
 }
 
@@ -228,63 +220,41 @@ async function save() {
   h1 {
     font-size: 1.5rem;
     font-weight: var(--pav-font-weight-bold);
-    color: var(--pav-color-stone-900);
+    color: var(--pav-text-primary);
     margin: 0;
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-100);
-    }
   }
 
   .subtitle {
     margin-top: var(--pav-space-1);
     font-size: 0.875rem;
-    color: var(--pav-color-stone-500);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-400);
-    }
+    color: var(--pav-text-muted);
   }
 }
 
 .loading-state {
   padding: var(--pav-space-8);
   text-align: center;
-  color: var(--pav-color-stone-500);
+  color: var(--pav-text-muted);
   font-style: italic;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
 }
 
 .error-state {
   padding: var(--pav-space-4);
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: var(--pav-color-alert-error-bg);
+  border: 1px solid var(--pav-color-error);
   border-radius: 0.75rem;
-  color: var(--pav-color-red-700);
+  color: var(--pav-color-alert-error-text);
   font-size: 0.875rem;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-red-400);
-    background: rgba(239, 68, 68, 0.05);
-  }
 }
 
 .mappings-content {
   display: flex;
   flex-direction: column;
   gap: var(--pav-space-6);
-  background: var(--pav-color-surface-primary);
+  background: var(--pav-surface-primary);
   border-radius: 1rem;
-  border: 1px solid var(--pav-color-stone-200);
+  border: 1px solid var(--pav-border-secondary);
   padding: var(--pav-space-6);
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-900);
-    border-color: var(--pav-color-stone-800);
-  }
 }
 
 .save-row {
@@ -292,11 +262,7 @@ async function save() {
   align-items: center;
   gap: var(--pav-space-4);
   padding-top: var(--pav-space-4);
-  border-top: 1px solid var(--pav-color-stone-100);
-
-  @media (prefers-color-scheme: dark) {
-    border-top-color: var(--pav-color-stone-800);
-  }
+  border-top: 1px solid var(--pav-border-subtle);
 }
 
 .save-button {
@@ -331,19 +297,11 @@ async function save() {
   font-weight: var(--pav-font-weight-medium);
 
   &.success {
-    color: var(--pav-color-green-600);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-green-400);
-    }
+    color: var(--pav-color-success);
   }
 
   &.error {
-    color: var(--pav-color-red-600);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-red-400);
-    }
+    color: var(--pav-color-error);
   }
 }
 </style>

--- a/src/client/components/logged_in/settings/email_modal.vue
+++ b/src/client/components/logged_in/settings/email_modal.vue
@@ -157,43 +157,27 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
 .current-email-text {
   margin: 0;
   font-size: 0.875rem;
-  color: var(--pav-color-stone-500);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
+  color: var(--pav-text-muted);
 
   .current-email-value {
     font-weight: 500;
-    color: var(--pav-color-stone-700);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-300);
-    }
+    color: var(--pav-text-secondary);
   }
 }
 
 .confirm-sent-text {
   margin: 0;
   font-size: 0.875rem;
-  color: var(--pav-color-stone-700);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-  }
+  color: var(--pav-text-secondary);
 }
 
 .error-message {
   padding: var(--pav-space-3);
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: var(--pav-color-alert-error-bg);
+  border: 1px solid var(--pav-color-error);
   border-radius: 0.5rem;
-  color: var(--pav-color-red-700);
+  color: var(--pav-color-alert-error-text);
   font-size: 0.875rem;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-red-400);
-  }
 }
 
 .form-group {
@@ -206,25 +190,21 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--pav-color-stone-700);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-  }
+  color: var(--pav-text-secondary);
 }
 
 .form-input {
   width: 100%;
   padding: 0.75rem 1rem;
-  background: var(--pav-color-stone-50);
-  border: 1px solid var(--pav-color-stone-200);
+  background: var(--pav-surface-secondary);
+  border: 1px solid var(--pav-border-subtle);
   border-radius: 9999px;
-  color: var(--pav-color-stone-900);
+  color: var(--pav-text-primary);
   font-size: 1rem;
   transition: box-shadow 0.2s, border-color 0.2s;
 
   &::placeholder {
-    color: var(--pav-color-stone-400);
+    color: var(--pav-text-muted);
   }
 
   &:focus {
@@ -232,22 +212,12 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
     box-shadow: 0 0 0 2px var(--pav-color-orange-500);
     border-color: transparent;
   }
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-800);
-    border-color: var(--pav-color-stone-700);
-    color: var(--pav-color-stone-100);
-  }
 }
 
 .help-text {
   margin: 0;
   font-size: 0.75rem;
-  color: var(--pav-color-stone-500);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-400);
-  }
+  color: var(--pav-text-muted);
 }
 
 .modal-footer {
@@ -285,12 +255,8 @@ const isValid = computed(() => state.email.length > 0 && state.email.includes('@
   }
 
   &:disabled {
-    background: var(--pav-color-stone-300);
+    background: var(--pav-interactive-disabled);
     cursor: not-allowed;
-
-    @media (prefers-color-scheme: dark) {
-      background: var(--pav-color-stone-700);
-    }
   }
 }
 </style>

--- a/src/client/components/logged_in/settings/password_modal.vue
+++ b/src/client/components/logged_in/settings/password_modal.vue
@@ -117,15 +117,11 @@ const sendPasswordReset = async () => {
 
 .error-message {
   padding: var(--pav-space-3);
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.2);
+  background: var(--pav-color-alert-error-bg);
+  border: 1px solid var(--pav-color-error);
   border-radius: 0.5rem;
-  color: var(--pav-color-red-700);
+  color: var(--pav-color-alert-error-text);
   font-size: 0.875rem;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-red-400);
-  }
 }
 
 .info-box {
@@ -133,14 +129,9 @@ const sendPasswordReset = async () => {
   align-items: flex-start;
   gap: var(--pav-space-4);
   padding: var(--pav-space-4);
-  background: rgba(14, 165, 233, 0.1);
-  border: 1px solid rgba(14, 165, 233, 0.2);
+  background: var(--pav-color-alert-info-bg);
+  border: 1px solid var(--pav-color-info);
   border-radius: 0.75rem;
-
-  @media (prefers-color-scheme: dark) {
-    background: rgba(7, 89, 133, 0.3);
-    border-color: rgba(7, 89, 133, 0.8);
-  }
 }
 
 .info-icon {
@@ -149,21 +140,13 @@ const sendPasswordReset = async () => {
   align-items: center;
   justify-content: center;
   padding: 0.5rem;
-  background: rgba(14, 165, 233, 0.1);
+  background: var(--pav-color-alert-info-bg);
   border-radius: 0.5rem;
-
-  @media (prefers-color-scheme: dark) {
-    background: rgba(3, 105, 161, 0.9);
-  }
 
   .icon-mail {
     width: 1.25rem;
     height: 1.25rem;
-    color: rgb(14, 116, 144);
-
-    @media (prefers-color-scheme: dark) {
-      color: rgb(125, 211, 252);
-    }
+    color: var(--pav-color-info);
   }
 }
 
@@ -175,21 +158,13 @@ const sendPasswordReset = async () => {
   margin: 0;
   font-size: 0.875rem;
   font-weight: 500;
-  color: rgb(12, 74, 110);
-
-  @media (prefers-color-scheme: dark) {
-    color: rgb(224, 242, 254);
-  }
+  color: var(--pav-color-alert-info-text);
 }
 
 .info-description {
   margin: var(--pav-space-1) 0 0 0;
   font-size: 0.875rem;
-  color: rgb(14, 116, 144);
-
-  @media (prefers-color-scheme: dark) {
-    color: rgb(186, 230, 253);
-  }
+  color: var(--pav-color-alert-info-text);
 }
 
 .modal-footer {

--- a/src/client/components/logged_in/settings/root.vue
+++ b/src/client/components/logged_in/settings/root.vue
@@ -393,11 +393,7 @@ onMounted(async () => {
 <style scoped lang="scss">
 .settings-page {
   min-height: 100vh;
-  background: var(--pav-color-stone-50);
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-950);
-  }
+  background: var(--pav-surface-secondary);
 }
 
 .settings-container {
@@ -426,62 +422,41 @@ onMounted(async () => {
   h1 {
     font-size: 1.5rem;
     font-weight: 700;
-    color: var(--pav-color-stone-900);
+    color: var(--pav-text-primary);
     margin: 0;
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-100);
-    }
   }
 
   .subtitle {
     margin-top: var(--pav-space-1);
     font-size: 0.875rem;
-    color: var(--pav-color-stone-500);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-400);
-    }
+    color: var(--pav-text-muted);
   }
 }
 
 .settings-card {
-  background: white;
+  background: var(--pav-surface-primary);
   border-radius: 1rem;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  border: 1px solid var(--pav-color-stone-200);
+  border: 1px solid var(--pav-border-secondary);
   overflow: hidden;
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-900);
-    border-color: var(--pav-color-stone-800);
-  }
 }
 
 .settings-section {
   padding: var(--pav-space-6);
-  border-bottom: 1px solid var(--pav-color-stone-100);
+  border-bottom: 1px solid var(--pav-border-subtle);
 
   &:last-child {
     border-bottom: none;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    border-bottom-color: var(--pav-color-stone-800);
   }
 }
 
 .section-title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--pav-color-stone-400);
+  color: var(--pav-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 var(--pav-space-4) 0;
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-500);
-  }
 }
 
 .settings-fields {
@@ -500,11 +475,7 @@ onMounted(async () => {
   display: block;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--pav-color-stone-700);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-  }
+  color: var(--pav-text-secondary);
 }
 
 .input-with-feedback {
@@ -516,10 +487,10 @@ onMounted(async () => {
 .text-input {
   width: 100%;
   padding: 0.625rem 1rem;
-  background: var(--pav-color-stone-50);
-  border: 1px solid var(--pav-color-stone-200);
+  background: var(--pav-surface-secondary);
+  border: 1px solid var(--pav-border-subtle);
   border-radius: 0.75rem;
-  color: var(--pav-color-stone-900);
+  color: var(--pav-text-primary);
   font-size: 1rem;
   transition: box-shadow 0.2s, border-color 0.2s;
 
@@ -533,17 +504,11 @@ onMounted(async () => {
     opacity: 0.5;
     cursor: not-allowed;
   }
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-800);
-    border-color: var(--pav-color-stone-700);
-    color: var(--pav-color-stone-100);
-  }
 }
 
 .save-feedback {
   font-size: 0.875rem;
-  color: var(--pav-color-green-600);
+  color: var(--pav-color-success);
   font-weight: 500;
 
   &:not(.is-visible) {
@@ -551,15 +516,7 @@ onMounted(async () => {
   }
 
   &.is-error {
-    color: var(--pav-color-red-600);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-green-400);
-
-    &.is-error {
-      color: var(--pav-color-red-400);
-    }
+    color: var(--pav-color-error);
   }
 }
 
@@ -568,57 +525,39 @@ onMounted(async () => {
   align-items: center;
   gap: 0.5rem;
   padding: 0.625rem 1rem;
-  background: var(--pav-color-stone-100);
-  border: 1px solid var(--pav-color-stone-200);
+  background: var(--pav-surface-tertiary);
+  border: 1px solid var(--pav-border-subtle);
   border-radius: 0.75rem;
 
-  @media (prefers-color-scheme: dark) {
-    background: rgba(41, 37, 36, 0.5);
-    border-color: var(--pav-color-stone-700);
-  }
-
   .at-symbol {
-    color: var(--pav-color-stone-400);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-500);
-    }
+    color: var(--pav-text-muted);
   }
 
   .username-text {
-    color: var(--pav-color-stone-600);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-400);
-    }
+    color: var(--pav-text-secondary);
   }
 
   .readonly-badge {
     margin-left: auto;
     font-size: 0.75rem;
-    color: var(--pav-color-stone-400);
-    background: var(--pav-color-stone-200);
+    color: var(--pav-text-muted);
+    background: var(--pav-interactive-disabled);
     padding: 0.125rem 0.5rem;
     border-radius: 9999px;
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-500);
-      background: var(--pav-color-stone-700);
-    }
   }
 }
 
 .select-input {
   width: 100%;
   padding: 0.625rem 2.5rem 0.625rem 1rem;
-  background-color: var(--pav-color-stone-50);
+  background-color: var(--pav-surface-secondary);
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   background-position: right 0.75rem center;
   background-repeat: no-repeat;
   background-size: 1.5em 1.5em;
-  border: 1px solid var(--pav-color-stone-200);
+  border: 1px solid var(--pav-border-subtle);
   border-radius: 0.75rem;
-  color: var(--pav-color-stone-900);
+  color: var(--pav-text-primary);
   font-size: 1rem;
   cursor: pointer;
   appearance: none;
@@ -634,12 +573,6 @@ onMounted(async () => {
     opacity: 0.5;
     cursor: not-allowed;
   }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: var(--pav-color-stone-800);
-    border-color: var(--pav-color-stone-700);
-    color: var(--pav-color-stone-100);
-  }
 }
 
 .security-fields {
@@ -653,12 +586,8 @@ onMounted(async () => {
   padding-top: var(--pav-space-2);
 
   &:not(:first-child) {
-    border-top: 1px solid var(--pav-color-stone-100);
+    border-top: 1px solid var(--pav-border-subtle);
     padding-top: var(--pav-space-4);
-
-    @media (prefers-color-scheme: dark) {
-      border-top-color: var(--pav-color-stone-800);
-    }
   }
 }
 
@@ -669,21 +598,13 @@ onMounted(async () => {
     margin: 0;
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--pav-color-stone-700);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-300);
-    }
+    color: var(--pav-text-secondary);
   }
 
   .security-value {
     margin: var(--pav-space-1) 0 0 0;
     font-size: 0.875rem;
-    color: var(--pav-color-stone-500);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-stone-400);
-    }
+    color: var(--pav-text-muted);
   }
 }
 
@@ -691,7 +612,7 @@ onMounted(async () => {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--pav-color-orange-600);
+  color: var(--pav-color-interactive-active);
   background: transparent;
   border: none;
   border-radius: 0.5rem;
@@ -699,22 +620,13 @@ onMounted(async () => {
   transition: color 0.2s, background-color 0.2s;
 
   &:hover {
-    color: var(--pav-color-orange-700);
-    background: rgba(249, 115, 22, 0.1);
-
-    @media (prefers-color-scheme: dark) {
-      color: var(--pav-color-orange-300);
-      background: rgba(249, 115, 22, 0.1);
-    }
+    color: var(--pav-color-interactive-active-text);
+    background: var(--pav-color-interactive-active-bg);
   }
 
   &:focus-visible {
     outline: 2px solid var(--pav-color-orange-600);
     outline-offset: 2px;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-orange-400);
   }
 }
 
@@ -738,10 +650,6 @@ onMounted(async () => {
 
   &:hover {
     background: rgba(239, 68, 68, 0.1);
-
-    @media (prefers-color-scheme: dark) {
-      background: rgba(127, 29, 29, 0.3);
-    }
   }
 
   .logout-icon {
@@ -752,18 +660,10 @@ onMounted(async () => {
     background: rgba(239, 68, 68, 0.1);
     border-radius: 0.5rem;
 
-    @media (prefers-color-scheme: dark) {
-      background: rgba(127, 29, 29, 0.5);
-    }
-
     .icon {
       width: 1.25rem;
       height: 1.25rem;
       color: var(--pav-color-red-600);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-red-400);
-      }
     }
   }
 
@@ -775,20 +675,12 @@ onMounted(async () => {
       font-size: 0.875rem;
       font-weight: 500;
       color: var(--pav-color-red-600);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-red-400);
-      }
     }
 
     .logout-subtitle {
       margin: var(--pav-space-1) 0 0 0;
       font-size: 0.75rem;
-      color: var(--pav-color-stone-500);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-400);
-      }
+      color: var(--pav-text-muted);
     }
   }
 
@@ -800,33 +692,20 @@ onMounted(async () => {
 
 .admin-card {
   margin-top: var(--pav-space-8);
-  background: white;
+  background: var(--pav-surface-primary);
   border-radius: 0.75rem;
-  border: 1px solid var(--pav-color-stone-200);
+  border: 1px solid var(--pav-border-secondary);
   overflow: hidden;
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-900);
-    border-color: var(--pav-color-stone-800);
-  }
 
   .admin-header {
     padding: var(--pav-space-6) var(--pav-space-6) var(--pav-space-4);
-    border-bottom: 1px solid var(--pav-color-stone-200);
-
-    @media (prefers-color-scheme: dark) {
-      border-bottom-color: var(--pav-color-stone-800);
-    }
+    border-bottom: 1px solid var(--pav-border-secondary);
 
     h2 {
       margin: 0;
       font-size: 1.125rem;
       font-weight: 500;
-      color: var(--pav-color-stone-900);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-100);
-      }
+      color: var(--pav-text-primary);
     }
   }
 
@@ -836,11 +715,7 @@ onMounted(async () => {
     .admin-description {
       margin: 0 0 var(--pav-space-4) 0;
       font-size: 0.875rem;
-      color: var(--pav-color-stone-500);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-400);
-      }
+      color: var(--pav-text-muted);
     }
   }
 }
@@ -877,26 +752,17 @@ onMounted(async () => {
 
 .funding-card {
   margin-top: var(--pav-space-8);
-  background: white;
+  background: var(--pav-surface-primary);
   border-radius: 0.75rem;
-  border: 1px solid var(--pav-color-stone-200);
+  border: 1px solid var(--pav-border-secondary);
   overflow: hidden;
-
-  @media (prefers-color-scheme: dark) {
-    background: var(--pav-color-stone-900);
-    border-color: var(--pav-color-stone-800);
-  }
 
   .funding-card-header {
     display: flex;
     align-items: center;
     gap: var(--pav-space-3);
     padding: var(--pav-space-6) var(--pav-space-6) var(--pav-space-4);
-    border-bottom: 1px solid var(--pav-color-stone-200);
-
-    @media (prefers-color-scheme: dark) {
-      border-bottom-color: var(--pav-color-stone-800);
-    }
+    border-bottom: 1px solid var(--pav-border-secondary);
   }
 
   .funding-card-icon {
@@ -904,21 +770,13 @@ onMounted(async () => {
     align-items: center;
     justify-content: center;
     padding: 0.5rem;
-    background: rgba(249, 115, 22, 0.1);
+    background: var(--pav-color-interactive-active-bg);
     border-radius: 0.5rem;
-
-    @media (prefers-color-scheme: dark) {
-      background: rgba(249, 115, 22, 0.15);
-    }
 
     .icon {
       width: 1.25rem;
       height: 1.25rem;
-      color: var(--pav-color-orange-600);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-orange-400);
-      }
+      color: var(--pav-color-interactive-active);
     }
   }
 
@@ -929,21 +787,13 @@ onMounted(async () => {
       margin: 0;
       font-size: 1.125rem;
       font-weight: 500;
-      color: var(--pav-color-stone-900);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-100);
-      }
+      color: var(--pav-text-primary);
     }
 
     .funding-card-status {
       margin: var(--pav-space-1) 0 0 0;
       font-size: 0.875rem;
-      color: var(--pav-color-stone-500);
-
-      @media (prefers-color-scheme: dark) {
-        color: var(--pav-color-stone-400);
-      }
+      color: var(--pav-text-muted);
     }
   }
 


### PR DESCRIPTION
## Motivation

The settings components (`root.vue`, `email_modal.vue`, `password_modal.vue`, `calendar-category-mappings.vue`) handled dark mode with component-scoped `@media (prefers-color-scheme: dark)` overrides. Those blocks only react to the OS color-scheme preference, so the in-app manual `[data-theme="dark"]` toggle was ignored. The most visible symptom: the settings, admin, and funding cards stayed white when a user explicitly enabled dark mode in the app. This violates the project's dark-mode convention (dark mode belongs in the token-definition layer, never in component `@media` blocks).

## Approach

Replaced the per-component base color tokens (`--pav-color-stone-*`) with the theme-layer semantic tokens (`--pav-surface-*`, `--pav-text-*`, `--pav-border-*`, `--pav-interactive-*`) — the only token tier that carries *both* a manual-toggle `[data-theme="dark"]` variant and an OS-preference variant. Once each component used only theme-aware tokens, all 57 now-redundant `@media (prefers-color-scheme: dark)` blocks were deleted (root 34, email 8, password 6, category-mappings 9). The manual dark-mode toggle now correctly inverts these surfaces.

Status colors moved to the existing design-system semantic tokens rather than the hand-rolled `rgba()` literals: error/success feedback to `--pav-color-error` / `--pav-color-success`, and the password-modal info box to the `--pav-color-alert-info-*` family — aligning them with the colorblind-accessible palette already used by the shared `.alert` component. This shifts a few hues toward the design system (error red->purple, success green->blue, info sky->teal). Destructive (logout) affordances keep the `--pav-color-red-*` base tokens, since no semantic destructive token exists.

Two latent dead overrides that referenced undefined tokens (`--pav-color-stone-950`, `--pav-color-green-*`) were retired in the process.

No new tokens were added; this consumes only existing tokens.

## Validation

- `npm run lint` (eslint + stylelint): passes, 0 errors.
- `npx vitest run` on the two covering test files (`calendar-category-mappings.test.ts`, `settings-language-switcher.test.ts`): 26 passed.
- Grep confirms zero `prefers-color-scheme`, `background: white`, and undefined-token references remain under `src/client/components/logged_in/settings/`.
- Worth an eyeball in the browser: the settings/admin/funding pages in both light and dark (manual toggle), and the status-color hue shifts noted above.