### PR TITLE
fix(client): adapt help/doc link text color for dark mode

### DIFF
--- a/src/client/components/common/doc-link.vue
+++ b/src/client/components/common/doc-link.vue
@@ -57,7 +57,7 @@ onMounted(() => {
   cursor: pointer;
   font-family: inherit;
   font-size: var(--pav-font-size-sm);
-  color: var(--pav-color-brand-primary);
+  color: var(--pav-color-interactive-active-text);
 
   &:hover {
     text-decoration: underline;

--- a/src/client/components/common/help-panel.vue
+++ b/src/client/components/common/help-panel.vue
@@ -105,7 +105,7 @@ const emit = defineEmits<{
   align-items: center;
   gap: var(--pav-space-1);
   font-size: var(--pav-font-size-xs);
-  color: var(--pav-color-brand-primary);
+  color: var(--pav-color-interactive-active-text);
   margin-block-start: var(--pav-space-1);
 }
 
@@ -120,7 +120,7 @@ const emit = defineEmits<{
   align-items: center;
   gap: var(--pav-space-1);
   font-size: var(--pav-font-size-sm);
-  color: var(--pav-color-brand-primary);
+  color: var(--pav-color-interactive-active-text);
   text-decoration: none;
 
   &:hover {


### PR DESCRIPTION
## Motivation

Link-style text in the help/doc surfaces used `--pav-color-brand-primary` — a non-adaptive base color token (orange #F97316) with no dark-mode override. On dark surfaces this risked a WCAG AA contrast shortfall. The issue was systemic across the link surfaces (doc-link trigger, help-panel "read more" and "browse all"), so fixing one in isolation would have created drift.

## Approach

Migrated all three link-text surfaces off the non-adaptive base token onto `--pav-color-interactive-active-text`, an existing theme-aware semantic token that resolves to orange-700 on light surfaces and orange-300 on dark surfaces (defined in `tokens/_colors.scss`). This is the same adaptation mechanism every other semantic color in the app uses, so the link text now adapts to the active theme and keeps adequate contrast on dark surfaces. No token-layer changes were needed — a suitable adaptive token already existed.

- `doc-link.vue` — `.doc-link`
- `help-panel.vue` — `.help-panel__read-more`, `.help-panel__browse-all`

## Validation

- `npm run lint` — 0 errors (stylelint clean; the single warning is a pre-existing, unrelated backend test).
- `npx vitest run src/client/test/components/common/doc-link.test.ts` — 6/6 pass. (No help-panel component test exists.)
- A visual AA-contrast check on dark surfaces is still worth an eyeball.