### PR TITLE
docs: clarify non-authoritative repostStatus on single-event paths

### DIFF
--- a/src/common/model/events.ts
+++ b/src/common/model/events.ts
@@ -92,9 +92,11 @@ class CalendarEvent extends TranslatedModel<CalendarEventContent> {
    * acting (resolved) calendar and assigns the resolved status to each
    * returned event, mirroring the listEvents resolution.
    *
-   * NOT populated by: EventService.getEventById() or EventService.updateEvent().
-   * Events returned by those methods will always have repostStatus='none'
-   * regardless of actual repost state.
+   * NOT populated by: EventService.getEventById(), EventService.updateEvent(),
+   * or EventService.createEvent(). Events returned by those methods will always
+   * have repostStatus='none' regardless of actual repost state. For createEvent
+   * this is the true value (a freshly created event is owned, never a repost),
+   * not a gap; it is named here only so it isn't mistaken for an unflagged one.
    *
    * Default: 'none'. Must be explicitly set after retrieval if needed.
    */

--- a/src/server/public/api/v1/calendar.ts
+++ b/src/server/public/api/v1/calendar.ts
@@ -607,6 +607,11 @@ export default class CalendarRoutes {
       const displayCalendarId = await this.resolveDisplayCalendarId(req.query.calendar);
 
       // getEventById throws EventNotFoundError for unknown ids — catch below.
+      // Caveat: on this single-event path repostStatus / isRepost are
+      // non-authoritative (always 'none' / false) — getEventById does not
+      // consult SharedEventEntity. Authoritative repost status comes only from
+      // the feed / list paths. A future feature needing repost provenance here
+      // must wire SharedEventEntity into getEventById or resolve it here.
       const event = await this.service.getEventById(eventId, displayCalendarId);
       res.json(toPublicEventObject(event.toObject()));
     }


### PR DESCRIPTION
## Motivation

Single-event fetch paths (`getEventById`, `updateEvent`, `createEvent`) return `CalendarEvent.repostStatus = 'none'` without consulting `SharedEventEntity`, while list/feed paths resolve it authoritatively. A consumer audit confirmed no reader relies on `repostStatus` / `isRepost` off the single-event response shapes today, so the chosen resolution is to keep the honest `'none'` default and document it rather than add a query to every single-event fetch. This change documents that intentional non-authoritative behavior so future readers don't mistake it for an unflagged bug.

## Approach

Documentation only — no runtime logic, types, or response shapes change.

- `src/common/model/events.ts`: the `CalendarEvent.repostStatus` "NOT populated by" note now also names `createEvent`, clarifying that `'none'` is the true value for a freshly created (owned) event and is listed only so it isn't mistaken for an unflagged third gap.
- `src/server/public/api/v1/calendar.ts`: the public `getEvent` handler gains a one-line caveat that `repostStatus` / `isRepost` are non-authoritative (always `'none'` / `false`) on the single-event path, since `getEventById` does not consult `SharedEventEntity`; authoritative status comes from the feed / list paths. This is the only place the unpopulated field crosses an API boundary.

## Validation

`npm run lint` passes (0 errors; the one remaining warning is pre-existing in an unrelated test file). No tests apply to a comment-only change. Verified against current code that `getEventById`/`updateEvent`/`createEvent` do not assign `repostStatus`, so the added comments are truthful.