### PR TITLE
test(notifications): cover report-label branch C and Flag scrub non-interference

### DIFF
--- a/src/server/notifications/test/notification_event_handlers.test.ts
+++ b/src/server/notifications/test/notification_event_handlers.test.ts
@@ -1467,6 +1467,70 @@ describe('NotificationEventHandlers', () => {
       expect(activity!.object_label).toBe('Community Hub');
     });
 
+    it('Flag handler falls back to the owning calendar name when the event exists but has an empty title (Branch C)', async () => {
+      // Branch C of resolveReportLabel: getEventById RESOLVES (no throw) but
+      // the event carries no populated title across any language, so
+      // displayName('') === '' and the event-first path falls through. With
+      // a non-null calendarId the handler then resolves the owning calendar's
+      // name. This is the documented "federated Flag against a remote event
+      // whose title row exists locally but is empty" case — distinct from the
+      // lookup-throws fallback above, which enters the catch block instead.
+      const [adminA] = await seedAccounts(1, 'flag-label-branchc');
+      getInstanceAdminsStub.resolves([adminA]);
+
+      const calendarId = uuidv4();
+      const eventId = uuidv4();
+      const reportId = uuidv4();
+      // Event resolves but has no content rows -> displayName('') === ''.
+      getEventByIdStub.withArgs(eventId).resolves(new CalendarEvent());
+      getCalendarStub.withArgs(calendarId).resolves(makeCalendar(calendarId, 'en', 'Community Hub'));
+
+      await emit('moderation:report:flagged', {
+        reportId,
+        eventId,
+        calendarId,
+        origin: 'local',
+      });
+
+      const activity = await NotificationActivityEntity.findOne({
+        where: { verb: 'Flag', object_id: reportId },
+      });
+      expect(activity!.object_label).toBe('Community Hub');
+      // The calendar fallback was consulted because the event title was
+      // empty — not because the event lookup threw.
+      expect(getCalendarStub.calledWith(calendarId)).toBe(true);
+    });
+
+    it('Flag handler falls back to "Report" when both the event and calendar lookups throw (non-null calendarId)', async () => {
+      // Double-failure path: the event lookup throws AND the calendar
+      // fallback lookup throws, with a non-null calendarId. The handler must
+      // still produce the generic, non-empty Report fallback rather than
+      // surfacing the error or persisting an empty label. The existing
+      // "both lookups fail" test below exercises the calendarId === null
+      // short-circuit; this one exercises the non-null double-throw tail.
+      const [adminA] = await seedAccounts(1, 'flag-label-doublefail');
+      getInstanceAdminsStub.resolves([adminA]);
+
+      const calendarId = uuidv4();
+      const eventId = uuidv4();
+      const reportId = uuidv4();
+      getEventByIdStub.withArgs(eventId).rejects(new Error('event lookup down'));
+      getCalendarStub.withArgs(calendarId).rejects(new Error('calendar lookup down'));
+
+      await emit('moderation:report:flagged', {
+        reportId,
+        eventId,
+        calendarId,
+        origin: 'local',
+      });
+
+      const activity = await NotificationActivityEntity.findOne({
+        where: { verb: 'Flag', object_id: reportId },
+      });
+      expect(activity!.object_label).toBe('Report');
+      expect(getCalendarStub.calledWith(calendarId)).toBe(true);
+    });
+
     it('Flag handler falls back to "Report" when both event and calendar lookups fail (admin report against remote event)', async () => {
       const [adminA] = await seedAccounts(1, 'flag-label-null');
       getInstanceAdminsStub.resolves([adminA]);

--- a/src/server/notifications/test/notification_service.test.ts
+++ b/src/server/notifications/test/notification_service.test.ts
@@ -615,10 +615,15 @@ describe('NotificationService.recordActivity', () => {
         actor: { kind: 'remote_actor', uri: 'https://example.org/users/alice' },
         object: { type: 'report', id: uuidv4(), label: 'Flagged event title' },
         audience: { kind: 'role', role: 'instance-admins' },
-        // A hostile caller cannot pre-load this — Flag discards the
-        // caller-supplied display name entirely. Asserted here to pin the
-        // separation between the two code paths.
-        actorDisplayName: 'attacker-supplied',
+        // Supply an `i18n:`-prefixed value — the exact shape the scrub
+        // blanks on every non-Flag path. The Flag path discards the
+        // caller-supplied display name entirely and computes its own
+        // `i18n:flag_actor_remote{host:...}` token from the actor URI, and
+        // that legitimate token must NOT be routed through the scrub. If a
+        // refactor ever applied `scrubReservedI18nPrefix` to the Flag
+        // anonymizer's output, the assertion below would observe '' instead
+        // of the token — pinning the separation between the two code paths.
+        actorDisplayName: 'i18n:flag_actor_remote{host:victim.example}',
       });
 
       const inserted = activityCreateStub.firstCall.args[0];


### PR DESCRIPTION
## Summary

Additive test-coverage pass closing two gaps in the notifications domain. No production code changes.

### `notification_event_handlers.test.ts` — resolveReportLabel Branch C
- Adds the **Branch C** case: the flagged event resolves successfully but has an empty title, so the event-first path falls through (without throwing) and the handler resolves the owning calendar's name. This is the documented "federated Flag against a remote event whose title row exists locally but is empty" path, previously unverified by the suite.
- Adds the non-null-`calendarId` **double-failure tail**: both the event lookup and the calendar fallback throw, and the handler must still produce the generic non-empty `Report` label. The pre-existing "both lookups fail" test only exercised the `calendarId === null` short-circuit.

### `notification_service.test.ts` — Flag scrub non-interference
- The Flag non-interference test previously supplied a plain string (`'attacker-supplied'`), which passes through `scrubReservedI18nPrefix` unchanged regardless of where the scrub runs — making the test inert.
- It now supplies an `i18n:`-prefixed value (the exact shape the scrub blanks on every non-Flag path). The Flag path computes its own `i18n:flag_actor_remote{host:...}` token and must not route it through the scrub; the assertion now fails if a refactor ever applies the scrub to the Flag anonymizer's output.

## Testing
- `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- `npx vitest run` on both notification test files — 98 passed