### PR TITLE
test: cover language-removal wiring in category editor and calendar settings

### DIFF
--- a/src/client/test/components/calendar/calendar-settings-language-removal.test.ts
+++ b/src/client/test/components/calendar/calendar-settings-language-removal.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import I18NextVue from 'i18next-vue';
+import i18next from 'i18next';
+import CalendarSettings from '@/client/components/logged_in/calendar-management/settings.vue';
+import CalendarService from '@/client/service/calendar';
+import FundingService from '@/client/service/funding';
+import Config from '@/client/service/config';
+import { Calendar, CalendarContent } from '@/common/model/calendar';
+
+// Minimal translations required by the settings component
+const SETTINGS_TRANSLATIONS = {
+  'settings.title': 'Calendar Settings',
+  'settings.loading': 'Loading settings...',
+  'settings.calendar_content_section': 'Calendar Title & Description',
+  'settings.calendar_title_help': 'The display name for your calendar.',
+  'settings.calendar_title_label': 'Calendar Title',
+  'settings.calendar_title_placeholder': 'My Community Calendar',
+  'settings.calendar_description_label': 'Calendar Description',
+  'settings.calendar_description_help': 'A brief description of your calendar.',
+  'settings.calendar_description_placeholder': 'A calendar of community events...',
+  'settings.default_date_range_label': 'Default Date Filter',
+  'settings.default_date_range_help': 'Default date filter help.',
+  'settings.date_range_1week': '1 week',
+  'settings.date_range_2weeks': '2 weeks',
+  'settings.date_range_1month': '1 month',
+  'settings.default_event_image_label': 'Default Event Image',
+  'settings.default_event_image_help': 'Default image help.',
+  'settings.remove_language': 'Remove {{language}} translation',
+};
+
+/**
+ * Create a test Calendar with two languages (English + Spanish)
+ */
+function createBilingualCalendar(): Calendar {
+  const calendar = new Calendar('calendar-123', 'test-calendar');
+  calendar.addContent(new CalendarContent('en', 'My Calendar', 'A calendar'));
+  calendar.addContent(new CalendarContent('es', 'Mi Calendario', 'Un calendario'));
+  return calendar;
+}
+
+/**
+ * Mount CalendarSettings with stubs to bypass child-component and modal
+ * concerns that are not under test here.
+ */
+const mountSettings = () => {
+  return mount(CalendarSettings, {
+    global: {
+      plugins: [
+        [I18NextVue, { i18next }],
+        createPinia(),
+      ],
+      stubs: {
+        LoadingMessage: { template: '<div />' },
+        ImageUpload: { template: '<div />' },
+        EventImage: { template: '<div />' },
+        LanguagePicker: { template: '<div />' },
+        FundingSheet: { template: '<div />' },
+        // Stub the tab selector — the remove path under test is the inline
+        // remove-translation-link button on the settings component itself.
+        // Expose panelId/tabId because the parent template calls them on the
+        // component ref to wire up tabpanel aria attributes.
+        LanguageTabSelector: {
+          template: '<div />',
+          methods: {
+            panelId: (lang: string) => `panel-${lang}`,
+            tabId: (lang: string) => `tab-${lang}`,
+          },
+        },
+      },
+    },
+    props: { calendarId: 'calendar-123' },
+  });
+};
+
+describe('CalendarSettings — language removal wiring', () => {
+  beforeAll(async () => {
+    await i18next.init({
+      lng: 'en',
+      resources: {
+        en: {
+          calendars: SETTINGS_TRANSLATIONS,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops the removed language from the calendar when the remove-translation link is clicked', async () => {
+    const calendar = createBilingualCalendar();
+
+    vi.spyOn(CalendarService.prototype, 'getCalendarById').mockResolvedValue(calendar);
+    // Funding disabled so the extended-features card (and its async status
+    // load) stays out of this test.
+    vi.spyOn(FundingService.prototype, 'getOptions').mockResolvedValue({
+      enabled: false,
+      providers: [],
+    } as never);
+    vi.spyOn(Config, 'init').mockResolvedValue({
+      settings: () => ({ siteTitle: 'Test Instance' }),
+    } as never);
+
+    // The component edits a clone of the loaded calendar; capture it so we
+    // can assert the onLanguageRemoved hook dropped the content from the
+    // working copy via entity.dropContent.
+    const cloneSpy = vi.spyOn(Calendar.prototype, 'clone');
+    const dropContentSpy = vi.spyOn(Calendar.prototype, 'dropContent');
+
+    const wrapper = mountSettings();
+    await flushPromises();
+
+    const removeLink = wrapper.find('.remove-translation-link');
+    expect(removeLink.exists()).toBe(true);
+    await removeLink.trigger('click');
+    await flushPromises();
+
+    // currentLanguage is seeded to the calendar's first language ('en'); the
+    // link removes that language and the hook drops it from the clone.
+    expect(dropContentSpy).toHaveBeenCalledWith('en');
+
+    const workingCopy = cloneSpy.mock.results[0].value as Calendar;
+    expect(workingCopy.getLanguages()).toEqual(['es']);
+    expect(workingCopy.getLanguages()).not.toContain('en');
+
+    wrapper.unmount();
+  });
+});

--- a/src/client/test/components/category-editor-duplicate.test.ts
+++ b/src/client/test/components/category-editor-duplicate.test.ts
@@ -25,6 +25,7 @@ const CATEGORY_TRANSLATIONS = {
   'management.error_update_category': 'Error updating category',
   'management.error_duplicate_name': 'A category with this name already exists',
   'management.add_language': 'Add Language',
+  'management.remove_language': 'Remove language',
 };
 
 /**
@@ -33,6 +34,16 @@ const CATEGORY_TRANSLATIONS = {
 function createNewCategory(name = ''): EventCategory {
   const category = new EventCategory('', 'calendar-123');
   category.addContent(new EventCategoryContent('en', name));
+  return category;
+}
+
+/**
+ * Create a test EventCategory with two languages (English + Spanish)
+ */
+function createBilingualCategory(): EventCategory {
+  const category = new EventCategory('cat-1', 'calendar-123');
+  category.addContent(new EventCategoryContent('en', 'Technology'));
+  category.addContent(new EventCategoryContent('es', 'Tecnología'));
   return category;
 }
 
@@ -149,6 +160,45 @@ describe('CategoryEditor — duplicate name validation', () => {
 
     expect(wrapper.emitted('saved')).toBeTruthy();
     expect(wrapper.emitted('close')).toBeTruthy();
+
+    wrapper.unmount();
+  });
+});
+
+describe('CategoryEditor — language removal wiring', () => {
+  beforeAll(async () => {
+    await i18next.init({
+      lng: 'en',
+      resources: {
+        en: {
+          categories: CATEGORY_TRANSLATIONS,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops the removed language from the category when its remove button is clicked', async () => {
+    const category = createBilingualCategory();
+
+    const wrapper = mountEditor(category);
+    await flushPromises();
+
+    // One remove-language button per language field (rendered because the
+    // category has more than one language). Order follows getLanguages():
+    // [en, es]; click the second to remove the non-default language.
+    const removeButtons = wrapper.findAll('.remove-language-button');
+    expect(removeButtons).toHaveLength(2);
+    await removeButtons[1].trigger('click');
+    await flushPromises();
+
+    // The onLanguageRemoved hook should have dropped 'es' content from the
+    // category entity via entity.dropContent.
+    expect(category.getLanguages()).toEqual(['en']);
+    expect(category.getLanguages()).not.toContain('es');
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary
Adds additive component-tier tests for the `onLanguageRemoved` wiring path (remove-language control → composable → hook → `entity.dropContent`) in two consumers of `useLanguageManagement` that previously had no coverage for it.

- **category-editor.vue**: new test mounts a category with two languages, clicks the remove button for the non-default language, and asserts the category's `getLanguages()` no longer includes it.
- **calendar-management/settings.vue**: new test file mounts the settings with a two-language calendar, clicks the inline remove-translation link, and asserts `dropContent` was hit on the working copy and the language is gone from its `getLanguages()`.

No production code changes — tests only.

## Testing
- `npx vitest run` on both touched files: 5 passed
- `npm run lint`: 0 errors