### PR TITLE
test(calendar): cover schedule-update tx threading and strengthen rollback leak check

### DIFF
--- a/src/server/calendar/test/EventService/transaction_propagation.test.ts
+++ b/src/server/calendar/test/EventService/transaction_propagation.test.ts
@@ -209,6 +209,50 @@ describe('EventService transaction propagation', () => {
       expect(scheduleSaveStub.firstCall.args[0]).toEqual({ transaction: fakeTx });
     });
 
+    it('threads transaction into reconcileSchedules update of a matching existing schedule', async () => {
+      // reconcileSchedules branch (A): an incoming schedule carrying an id that
+      // matches an existing positive row is updated in place via
+      // scheduleEntity.update(values, { transaction: tx }). The sibling B/C
+      // branches (create new / destroy absent) are covered above; this asserts
+      // the update branch threads the caller's transaction (events.ts:1360).
+      const findStub = sandbox.stub(EventEntity, 'findByPk');
+      sandbox.stub(EventEntity.prototype, 'save').resolves();
+      const entity = EventEntity.build({
+        id: EVENT_ID,
+        calendar_id: CALENDAR_ID,
+      });
+      findStub.resolves(entity);
+
+      // Existing positive schedule whose id is also present in the payload →
+      // update branch (so it is not destroyed and not re-created).
+      const existingSchedule = EventScheduleEntity.build({
+        id: 'existing-schedule-id',
+        event_id: EVENT_ID,
+        is_exclusion: false,
+      });
+      sandbox.stub(EventScheduleEntity, 'findAll').resolves([existingSchedule]);
+      const scheduleUpdateStub = sandbox
+        .stub(existingSchedule, 'update')
+        .resolves(existingSchedule as any);
+
+      await service.updateEvent(
+        account,
+        EVENT_ID,
+        {
+          schedules: [
+            { id: 'existing-schedule-id', start: '2026-05-01T10:00:00Z', end: '2026-05-01T11:00:00Z' },
+          ],
+        },
+        { source: 'user' },
+        fakeTx,
+      );
+
+      // The matched row's in-place update participates in the caller's tx.
+      expect(scheduleUpdateStub.calledOnce).toBe(true);
+      // .update(values, options) — options is the 2nd positional arg.
+      expect(scheduleUpdateStub.firstCall.args[1]).toEqual({ transaction: fakeTx });
+    });
+
     it('omits transaction when no tx is supplied (backwards compatible)', async () => {
       const findStub = sandbox.stub(EventEntity, 'findByPk');
       const eventSaveStub = sandbox.stub(EventEntity.prototype, 'save').resolves();

--- a/src/server/calendar/test/integration/import_sync.test.ts
+++ b/src/server/calendar/test/integration/import_sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import sinon from 'sinon';
 import { EventEmitter } from 'events';
+import { Op } from 'sequelize';
 import type { VEvent, DateWithTimeZone } from 'node-ical';
 
 import { Account } from '@/common/model/account';
@@ -390,6 +391,27 @@ describe('SyncService integration', () => {
         // rejects. No new EventEntity rows should survive on the test calendar.
         const rowsAfter = await EventEntity.count({ where: { calendar_id: testCalendar.id } });
         expect(rowsAfter).toBe(rowsBefore);
+
+        // Snapshot-delta equality alone could be masked by a coincidental
+        // deletion (rollback fails, leaking 2 rows, while an unrelated 2 rows
+        // vanish). Add a UID-scoped leak assertion targeting the exact events
+        // the failed run would have created. Post-pv-picz, the import UID lives
+        // on the EventImportOriginEntity sibling table, so we detect leaks
+        // there and confirm no EventEntity survives for any leaked origin row.
+        const orphanUids = ['orphan-a@example.test', 'orphan-b@example.test'];
+        const leakedOrigins = await EventImportOriginEntity.findAll({
+          where: {
+            import_source_id: source.id,
+            external_uid: { [Op.in]: orphanUids },
+          },
+        });
+        expect(leakedOrigins).toHaveLength(0);
+
+        const leakedEventIds = leakedOrigins.map(o => o.event_id);
+        const leakedEvents = leakedEventIds.length
+          ? await EventEntity.findAll({ where: { id: { [Op.in]: leakedEventIds } } })
+          : [];
+        expect(leakedEvents).toHaveLength(0);
       }
       finally {
         stub.restore();


### PR DESCRIPTION
## Summary

Additive test coverage only — no production code changes. Closes two follow-up coverage gaps flagged by the testing auditor on the EventService transaction-threading work.

### Gap 1 — schedule-update transaction propagation
`reconcileSchedules` has three branches per incoming schedule: update a matching existing row, create a new one, or destroy an absent one. The unit suite covered create and destroy but not the in-place update. Added a test asserting `scheduleEntity.update(values, { transaction: tx })` threads the caller's transaction.

### Gap 2 — stronger rollback leak assertion
The import-sync rollback integration test relied solely on `rowsBefore === rowsAfter`, which a coincidental deletion could mask. Added a UID-scoped leak assertion: after a failed sync run, confirm no `EventImportOriginEntity` rows (and no surviving `EventEntity` rows) exist for the events the run would have created. The import UID lives on the origin sibling table post-pv-picz, so the leak check targets that table.

## Testing
- `npm run lint` — 0 errors
- `transaction_propagation.test.ts` — 8/8 pass
- `import_sync.test.ts` (integration config) — 12/12 pass