### PR TITLE
fix(logged-out): unify confirm pages heading level and status styles

### DIFF
--- a/src/client/assets/style/layout/_logged-out.scss
+++ b/src/client/assets/style/layout/_logged-out.scss
@@ -95,6 +95,18 @@
       text-align: center;
       margin-block-end: var(--pav-space-10);
     }
+
+    /* Status / result message shared by the logged_out confirm pages
+       (email_confirm, apply_confirm). The dedicated `.confirm-message` hook
+       keeps this scoped to those two pages so the typography (notably the
+       bottom margin) never leaks into the other `.welcome-card` success
+       messages, which carry their own treatment. Semantic theme tokens
+       auto-adapt to light/dark — no manual @media toggle. */
+    .confirm-message {
+      font-size: var(--pav-font-size-base);
+      color: var(--pav-text-secondary);
+      margin-block-end: var(--pav-space-6);
+    }
   }
 
   /* Login info panel (aside within two-column login card) */

--- a/src/client/components/logged_out/apply_confirm.vue
+++ b/src/client/components/logged_out/apply_confirm.vue
@@ -52,9 +52,9 @@ onMounted(async () => {
   <div>
     <!-- Confirming state (initial + while POST is in flight) -->
     <div v-if="state.render === 'confirming'" class="welcome-card">
-      <h3>{{ t('title') }}</h3>
+      <h2>{{ t('title') }}</h2>
       <p
-        class="status-message"
+        class="status-message confirm-message"
         role="status"
         aria-live="polite"
       >
@@ -64,9 +64,9 @@ onMounted(async () => {
 
     <!-- Success state -->
     <div v-else-if="state.render === 'success'" class="welcome-card">
-      <h3>{{ t('title') }}</h3>
+      <h2>{{ t('title') }}</h2>
       <p
-        class="success-message"
+        class="success-message confirm-message"
         role="status"
         aria-live="polite"
       >{{ t('success_message') }}</p>
@@ -78,9 +78,9 @@ onMounted(async () => {
 
     <!-- Invalid / expired / failed state -->
     <div v-else class="welcome-card">
-      <h3>{{ t('title') }}</h3>
+      <h2>{{ t('title') }}</h2>
       <p
-        class="invalid-message"
+        class="invalid-message confirm-message"
         role="alert"
       >{{ t('invalid_message') }}</p>
       <router-link
@@ -92,19 +92,7 @@ onMounted(async () => {
 </template>
 
 <style scoped lang="scss">
-h3 {
+h2 {
   margin-block-end: var(--pav-space-4);
-}
-
-.status-message,
-.success-message,
-.invalid-message {
-  font-size: 1.125rem; /* 18px */
-  color: var(--pav-color-stone-600);
-  margin-block-end: var(--pav-space-6);
-
-  @media (prefers-color-scheme: dark) {
-    color: var(--pav-color-stone-300);
-  }
 }
 </style>

--- a/src/client/components/logged_out/email_confirm.vue
+++ b/src/client/components/logged_out/email_confirm.vue
@@ -77,9 +77,9 @@ onMounted(async () => {
   <div>
     <!-- Confirming state (initial + while the consume is in flight) -->
     <div v-if="state.render === 'confirming'" class="welcome-card">
-      <h3>{{ t('title') }}</h3>
+      <h2>{{ t('title') }}</h2>
       <p
-        class="status-message"
+        class="status-message confirm-message"
         role="status"
         aria-live="polite"
       >
@@ -89,12 +89,12 @@ onMounted(async () => {
 
     <!-- Success state -->
     <div v-else-if="state.render === 'success'" class="welcome-card">
-      <h3
+      <h2
         ref="resultHeading"
         tabindex="-1"
-      >{{ t('title') }}</h3>
+      >{{ t('title') }}</h2>
       <p
-        class="success-message"
+        class="success-message confirm-message"
         role="status"
         aria-live="polite"
       >{{ t('success_message') }}</p>
@@ -106,12 +106,12 @@ onMounted(async () => {
 
     <!-- Invalid / expired / failed state -->
     <div v-else class="welcome-card">
-      <h3
+      <h2
         ref="resultHeading"
         tabindex="-1"
-      >{{ t('title') }}</h3>
+      >{{ t('title') }}</h2>
       <p
-        class="invalid-message"
+        class="invalid-message confirm-message"
         role="alert"
       >{{ t('invalid_message') }}</p>
       <router-link
@@ -123,15 +123,7 @@ onMounted(async () => {
 </template>
 
 <style scoped lang="scss">
-h3 {
+h2 {
   margin-block-end: var(--pav-space-4);
-}
-
-.status-message,
-.success-message,
-.invalid-message {
-  font-size: var(--pav-font-size-base);
-  color: var(--pav-text-secondary);
-  margin-block-end: var(--pav-space-6);
 }
 </style>

--- a/src/client/components/logged_out/root.vue
+++ b/src/client/components/logged_out/root.vue
@@ -18,7 +18,7 @@ const { t } = useTranslation('system');
     </section>
     <footer class="logo">
       <a href="https://pavillion.social" target="_blank" rel="noopener noreferrer">
-        <div class="pavillion-logo"/> {{ t('powered_by') }}
+        <div class="pavillion-logo" aria-hidden="true"/> {{ t('powered_by') }}
       </a>
     </footer>
   </main>

--- a/src/client/test/service/authn.test.ts
+++ b/src/client/test/service/authn.test.ts
@@ -246,6 +246,10 @@ describe('Token Refresh', () => {
 
     let authentication = makeAuth();
     sandbox.useFakeTimers();
+    // Seed a jwt so _refresh_login's jwt() guard passes and it actually
+    // fetches + stores a fresh token — without this the success path is
+    // never exercised and the assertion below passes trivially.
+    authentication.localStore.setItem('jwt', fake_jwt);
 
     let stub1 = sandbox.stub(authentication,"_set_token");
     const axios_get = sandbox.stub(axios, "get");
@@ -254,7 +258,7 @@ describe('Token Refresh', () => {
 
     let promise = authentication._refresh_login( Date.now() + 500)
       .then( () => {
-        expect( stub1.notCalled ).toBe(true);
+        expect( stub1.calledOnceWith(fake_jwt) ).toBe(true);
       });
     sandbox.clock.runAll();
 


### PR DESCRIPTION
## Summary
Cleanup/unification of the two logged-out confirm pages (`email_confirm.vue`, `apply_confirm.vue`), which had drifted and shared duplicated styles.

- **a11y (WCAG 1.3.1 / 2.4.6):** both pages rendered the card title as `<h3>` directly under the layout's `<h1>` with no `<h2>`. Promoted both to `<h2>` (the `.welcome-card h2, h3` rule already styles both identically, so the visual title is unchanged).
- **Stylesheet dedup:** the status-message `<style>` block was byte-identical across both pages. Extracted the shared typography into a dedicated `.confirm-message` hook in `_logged-out.scss` using semantic theme tokens.
- **Dark-mode fix (apply_confirm):** `apply_confirm.vue` still used the old hardcoded form (`1.125rem`, `stone-600` + a manual `@media (prefers-color-scheme: dark)` toggle). The `@media` toggle does not track the app's `[data-theme]` switch, producing a low-contrast result in dark mode. Now uses `--pav-text-secondary` / `--pav-font-size-base`, matching the already-fixed `email_confirm.vue`.
- **Minor a11y:** decorative footer logo in `root.vue` marked `aria-hidden`.
- **Test repair:** the `_refresh_login 'valid'` unit test never seeded a jwt, so it never exercised the token-set path its assertion implied (passed trivially). Seeded a jwt and asserted `_set_token` is actually called.

## Scope note (visual QA)
The shared rule uses a confirm-only `.confirm-message` hook class so the bottom margin does not leak into the other `welcome-card` success messages (register, password-forgot, etc.), which keep their own scoped styles. **The apply_confirm dark-mode change is an intentional contrast/behavior shift** — recommend a visual QA pass on both confirm pages in light and dark themes before merge.

## Testing
- `npm run lint` — 0 errors (1 pre-existing warning in an untouched file)
- Targeted: `apply_confirm.test.ts`, `email_confirm.test.ts`, `authn.test.ts` — 48 passed