### PR TITLE
feat(calendar): add ICS file-upload backend foundation

### DIFF
--- a/migrations/0039_add_import_source_file_upload.ts
+++ b/migrations/0039_add_import_source_file_upload.ts
@@ -1,0 +1,96 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import {
+  addColumnIfNotExists,
+  removeColumnIfExists,
+  changeColumnNullability,
+} from '../src/server/common/migrations/helpers.js';
+
+/**
+ * Add file-upload support to import_source.
+ *
+ * The ICS import feature originally modelled every source as a live URL that
+ * the sync pipeline polls. This migration lets the same table also represent a
+ * one-shot uploaded .ics file (organizer migration onboarding — see epic
+ * pv-84da) without introducing a second entity.
+ *
+ * Three schema changes:
+ * - `source_type` ENUM('url','file') NOT NULL DEFAULT 'url' — the
+ *   discriminator that tells the pipeline how the source was intaken. The
+ *   default backfills every existing row to 'url', preserving current
+ *   behaviour for all live sync subscriptions.
+ * - `original_filename` VARCHAR(255) NULL — the uploaded file's display name,
+ *   surfaced in the admin UI for file sources; NULL for url sources.
+ * - `url` becomes nullable — a file source has no live URL to store. URL
+ *   sources continue to carry a non-null url (enforced at the service layer,
+ *   since the column can no longer enforce it for both variants).
+ *
+ * SQLite caveat: relaxing a column's nullability (and removing columns) forces
+ * Sequelize to rebuild the table from `describeTable` metadata, which does not
+ * carry ON DELETE / ON UPDATE actions — silently dropping the calendar_id
+ * CASCADE. After any such rebuild we re-assert that foreign key so calendar
+ * deletion still cascades to its import sources. On PostgreSQL these are
+ * in-place ALTERs that leave the FK untouched, so the fix-up is skipped there.
+ *
+ * Reference: bead pv-84da.1.1 (ICS file upload import — schema foundation).
+ */
+
+/**
+ * Re-assert the calendar_id → calendar ON DELETE/UPDATE CASCADE foreign key.
+ *
+ * Only needed on SQLite, where the nullability/column-removal rebuilds above
+ * drop the cascade actions. Rebuilding the table via a single changeColumn on
+ * calendar_id restores the cascade (from the attributes passed here) while
+ * preserving every other column's current shape (from describeTable).
+ */
+async function restoreCalendarCascadeOnSqlite(sequelize: Sequelize): Promise<void> {
+  if (sequelize.getDialect() !== 'sqlite') {
+    return;
+  }
+  await sequelize.getQueryInterface().changeColumn('import_source', 'calendar_id', {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: { model: 'calendar', key: 'id' },
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  });
+}
+
+export default {
+  async up({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    await addColumnIfNotExists(queryInterface, 'import_source', 'source_type', {
+      type: DataTypes.ENUM('url', 'file'),
+      allowNull: false,
+      defaultValue: 'url',
+    });
+
+    await addColumnIfNotExists(queryInterface, 'import_source', 'original_filename', {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    });
+
+    await changeColumnNullability(queryInterface, 'import_source', 'url', {
+      type: DataTypes.STRING(2048),
+      allowNull: true,
+    });
+
+    await restoreCalendarCascadeOnSqlite(sequelize);
+  },
+
+  async down({ context: sequelize }: { context: Sequelize }) {
+    const queryInterface = sequelize.getQueryInterface();
+
+    // Reverse in the opposite order: restore the url NOT NULL constraint
+    // first, then drop the two new columns.
+    await changeColumnNullability(queryInterface, 'import_source', 'url', {
+      type: DataTypes.STRING(2048),
+      allowNull: false,
+    });
+
+    await removeColumnIfExists(queryInterface, 'import_source', 'original_filename');
+    await removeColumnIfExists(queryInterface, 'import_source', 'source_type');
+
+    await restoreCalendarCascadeOnSqlite(sequelize);
+  },
+};

--- a/src/common/model/import_source.ts
+++ b/src/common/model/import_source.ts
@@ -66,6 +66,20 @@ export const IMPORT_SOURCE_LAST_STATUSES: readonly ImportSourceLastStatus[] = [
 ];
 
 /**
+ * Allowed values for the `source_type` column on import_source.
+ *
+ * A discriminator that records how the source was intaken:
+ * - `'url'`  — a live ICS feed URL the sync pipeline polls (the original,
+ *              and still the default for every pre-existing row).
+ * - `'file'` — a one-shot uploaded .ics file. File sources have no live URL
+ *              (`url` is null) and carry the uploaded name in
+ *              `originalFilename`.
+ */
+export type ImportSourceType = 'url' | 'file';
+
+export const IMPORT_SOURCE_TYPES: readonly ImportSourceType[] = ['url', 'file'];
+
+/**
  * Plain domain model for an ICS import source.
  *
  * Represents a subscribed ICS feed URL that a calendar owner has registered
@@ -79,7 +93,21 @@ export const IMPORT_SOURCE_LAST_STATUSES: readonly ImportSourceLastStatus[] = [
  */
 export class ImportSource extends PrimaryModel {
   calendarId: string;
-  url: string;
+  /**
+   * How this source was intaken. `'url'` for a polled live feed (default),
+   * `'file'` for a one-shot uploaded .ics file.
+   */
+  sourceType: ImportSourceType;
+  /**
+   * The live ICS feed URL for `'url'` sources, or `null` for `'file'` sources
+   * (an uploaded file has no URL to poll).
+   */
+  url: string | null;
+  /**
+   * The display name of the uploaded file for `'file'` sources, or `null` for
+   * `'url'` sources.
+   */
+  originalFilename: string | null;
   enabled: boolean;
   /**
    * The verification mechanism the owner has committed to for this source,
@@ -104,12 +132,14 @@ export class ImportSource extends PrimaryModel {
    *
    * @param id - Unique identifier (UUID)
    * @param calendarId - UUID of the owning calendar
-   * @param url - The ICS feed URL
+   * @param url - The ICS feed URL, or null for file-backed sources
    */
-  constructor(id: string = '', calendarId: string = '', url: string = '') {
+  constructor(id: string = '', calendarId: string = '', url: string | null = '') {
     super(id);
     this.calendarId = calendarId;
+    this.sourceType = 'url';
     this.url = url;
+    this.originalFilename = null;
     this.enabled = true;
     this.verificationType = null;
     this.verificationState = 'unverified';
@@ -135,7 +165,9 @@ export class ImportSource extends PrimaryModel {
     return {
       id: this.id,
       calendarId: this.calendarId,
+      sourceType: this.sourceType,
       url: this.url,
+      originalFilename: this.originalFilename,
       enabled: this.enabled,
       verificationType: this.verificationType,
       verificationState: this.verificationState,
@@ -162,7 +194,9 @@ export class ImportSource extends PrimaryModel {
    * @returns A new ImportSource instance
    */
   static fromObject(obj: Record<string, any>): ImportSource {
-    const model = new ImportSource(obj.id ?? '', obj.calendarId ?? '', obj.url ?? '');
+    const model = new ImportSource(obj.id ?? '', obj.calendarId ?? '', obj.url ?? null);
+    model.sourceType = (obj.sourceType as ImportSourceType) ?? 'url';
+    model.originalFilename = obj.originalFilename ?? null;
     model.enabled = obj.enabled ?? true;
     model.verificationType =
       (obj.verificationType as ImportSourceVerificationType) ?? null;

--- a/src/common/test/import_source.test.ts
+++ b/src/common/test/import_source.test.ts
@@ -5,6 +5,7 @@ import {
   IMPORT_SOURCE_VERIFICATION_STATES,
   IMPORT_SOURCE_VERIFICATION_TYPES,
   IMPORT_SOURCE_LAST_STATUSES,
+  IMPORT_SOURCE_TYPES,
 } from '@/common/model/import_source';
 
 describe('ImportSource', () => {
@@ -14,7 +15,10 @@ describe('ImportSource', () => {
 
       expect(model.id).toBe('');
       expect(model.calendarId).toBe('');
+      // A bare source defaults to a url source with no uploaded filename.
+      expect(model.sourceType).toBe('url');
       expect(model.url).toBe('');
+      expect(model.originalFilename).toBeNull();
       expect(model.enabled).toBe(true);
       // verificationType is null until the owner picks a verification method
       // through the verify-ownership wizard.
@@ -63,6 +67,10 @@ describe('ImportSource', () => {
         'rate_limited',
       ]);
     });
+
+    it('exposes source types (discriminator)', () => {
+      expect(IMPORT_SOURCE_TYPES).toEqual(['url', 'file']);
+    });
   });
 
   describe('toObject()', () => {
@@ -84,7 +92,9 @@ describe('ImportSource', () => {
       expect(obj).toEqual({
         id: 'src-1',
         calendarId: 'cal-1',
+        sourceType: 'url',
         url: 'https://example.com/cal.ics',
+        originalFilename: null,
         enabled: false,
         verificationType: null,
         verificationState: 'verified',
@@ -162,6 +172,9 @@ describe('ImportSource', () => {
       const model = ImportSource.fromObject({});
 
       expect(model.enabled).toBe(true);
+      // Absent source discriminator falls back to the url source shape.
+      expect(model.sourceType).toBe('url');
+      expect(model.originalFilename).toBeNull();
       // null is the "no method chosen yet" sentinel; fromObject preserves
       // that rather than falling back to a concrete method.
       expect(model.verificationType).toBeNull();
@@ -204,6 +217,51 @@ describe('ImportSource', () => {
       const roundTripped = ImportSource.fromObject(original.toObject());
 
       expect(roundTripped.toObject()).toEqual(original.toObject());
+    });
+  });
+
+  describe("'file' source variant", () => {
+    // Every other test constructs a default 'url' source with a null
+    // originalFilename. A file-upload source is the non-default case: it
+    // carries source_type='file', a null url, and a non-null originalFilename.
+    function makeFileModel(): ImportSource {
+      const model = new ImportSource('file-1', 'cal-1', null);
+      model.sourceType = 'file';
+      model.originalFilename = 'exported-events.ics';
+      return model;
+    }
+
+    it('toObject serializes the file discriminator and originalFilename', () => {
+      const obj = makeFileModel().toObject();
+
+      expect(obj.sourceType).toBe('file');
+      expect(obj.originalFilename).toBe('exported-events.ics');
+      expect(obj.url).toBeNull();
+    });
+
+    it('fromObject deserializes the file discriminator and originalFilename', () => {
+      const model = ImportSource.fromObject({
+        id: 'file-1',
+        calendarId: 'cal-1',
+        sourceType: 'file',
+        url: null,
+        originalFilename: 'exported-events.ics',
+      });
+
+      expect(model.sourceType).toBe('file');
+      expect(model.originalFilename).toBe('exported-events.ics');
+      expect(model.url).toBeNull();
+    });
+
+    it('round-trips a file source through toObject/fromObject', () => {
+      const original = makeFileModel();
+
+      const roundTripped = ImportSource.fromObject(original.toObject());
+
+      expect(roundTripped.toObject()).toEqual(original.toObject());
+      expect(roundTripped.sourceType).toBe('file');
+      expect(roundTripped.originalFilename).toBe('exported-events.ics');
+      expect(roundTripped.url).toBeNull();
     });
   });
 });

--- a/src/server/calendar/entity/import_source.ts
+++ b/src/server/calendar/entity/import_source.ts
@@ -15,6 +15,7 @@ import {
 import {
   ImportSource,
   ImportSourceLastStatus,
+  ImportSourceType,
   ImportSourceVerificationState,
   ImportSourceVerificationType,
 } from '@/common/model/import_source';
@@ -50,8 +51,15 @@ class ImportSourceEntity extends Model {
   @Column({ type: DataType.UUID, allowNull: false })
   declare calendar_id: string;
 
-  @Column({ type: DataType.STRING(2048), allowNull: false })
-  declare url: string;
+  @Default('url')
+  @Column({ type: DataType.ENUM('url', 'file'), allowNull: false })
+  declare source_type: ImportSourceType;
+
+  @Column({ type: DataType.STRING(2048), allowNull: true })
+  declare url: string | null;
+
+  @Column({ type: DataType.STRING(255), allowNull: true })
+  declare original_filename: string | null;
 
   @Default(true)
   @Column({ type: DataType.BOOLEAN, allowNull: false })
@@ -120,6 +128,8 @@ class ImportSourceEntity extends Model {
    */
   toModel(): ImportSource {
     const model = new ImportSource(this.id, this.calendar_id, this.url);
+    model.sourceType = this.source_type;
+    model.originalFilename = this.original_filename;
     model.enabled = this.enabled;
     model.verificationType = this.verification_type;
     model.verificationState = this.verification_state;
@@ -146,7 +156,9 @@ class ImportSourceEntity extends Model {
     return ImportSourceEntity.build({
       id: model.id,
       calendar_id: model.calendarId,
+      source_type: model.sourceType,
       url: model.url,
+      original_filename: model.originalFilename,
       enabled: model.enabled,
       verification_type: model.verificationType,
       verification_state: model.verificationState,

--- a/src/server/calendar/service/import/import_source_service.ts
+++ b/src/server/calendar/service/import/import_source_service.ts
@@ -16,9 +16,11 @@ import { ValidationError } from '@/common/exceptions/base';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
 import {
+  ImportSourceDnsVerificationError,
   ImportSourceNotFoundError,
   ImportSourceRelMeVerificationError,
   ImportSourceSsrfBlockedError,
+  IMPORT_DNS_MISMATCH,
   IMPORT_RELME_HOSTNAME_MISMATCH,
   IMPORT_RELME_LINK_NOT_FOUND,
   IMPORT_RELME_PAGE_FETCH_ERROR,
@@ -469,6 +471,19 @@ class ImportSourceService {
    * {@link ImportSourceDnsVerificationError} on any non-success.
    */
   private async verifyDnsTxtSource(entity: ImportSourceEntity): Promise<ImportSource> {
+    if (!entity.url) {
+      // Defensive: DNS-TXT verification derives its challenge target from the
+      // source hostname, so a source with no url has no identity to verify.
+      // File sources never receive a verification_type (guarded in
+      // verifySource), and migration 0039 enforces a non-null url for url
+      // sources at the service layer, so this branch is unreachable in
+      // practice — fail closed rather than pass null into the resolver.
+      logger.warn(
+        { importSourceId: entity.id, reason: IMPORT_DNS_MISMATCH },
+        'DNS verification rejected: source URL is null',
+      );
+      throw new ImportSourceDnsVerificationError(IMPORT_DNS_MISMATCH);
+    }
     const result = await this.dnsVerifier.verify({
       sourceId: entity.id,
       calendarId: entity.calendar_id,
@@ -520,6 +535,19 @@ class ImportSourceService {
     entity: ImportSourceEntity,
     verificationPageUrl: string | undefined,
   ): Promise<ImportSource> {
+    if (!entity.url) {
+      // Defensive: rel-me verification matches against the source hostname, so
+      // a source with no url has no identity to verify. File sources never
+      // receive a verification_type (guarded in verifySource), and migration
+      // 0039 enforces a non-null url for url sources at the service layer, so
+      // this branch is unreachable in practice — fail closed rather than pass
+      // null into hostnameFromUrl.
+      logger.warn(
+        { importSourceId: entity.id, reason: IMPORT_RELME_HOSTNAME_MISMATCH },
+        'rel-me verification rejected: source URL is null',
+      );
+      throw new ImportSourceRelMeVerificationError(IMPORT_RELME_HOSTNAME_MISMATCH);
+    }
     const sourceHostname = hostnameFromUrl(entity.url);
     if (!sourceHostname) {
       // Defensive: entity.url passed createSource validation, so this should

--- a/src/server/calendar/service/import/sync.ts
+++ b/src/server/calendar/service/import/sync.ts
@@ -136,6 +136,39 @@ export interface SyncInput {
   importSourceId: string;
 }
 
+/**
+ * Input to {@link SyncService.processIcsBuffer}.
+ *
+ * Covers pipeline steps 5–12 (parse → map → dedup → create/update dispatch →
+ * source bookkeeping → record ImportRun → purge). The fetch phase (steps 1–4)
+ * and its fetch-outcome bookkeeping stay in {@link SyncService.syncSource}; any
+ * fetch-derived source updates are handed down via {@link fetchBookkeeping} and
+ * applied only inside the successful transaction (step 9) so a parse failure
+ * never clobbers the stored etag/content-hash.
+ */
+export interface ProcessIcsOptions {
+  /**
+   * Dedup strategy. `'source'` dedups by `(import_source_id, external_uid,
+   * external_recurrence_id)` — the URL-sync model implemented here. `'calendar'`
+   * (calendar-wide UID dedup for file uploads) is implemented in pv-84da.1.3;
+   * passing it here throws.
+   */
+  dedupScope: 'source' | 'calendar';
+  /** Requester identity threaded into EventService create/update writes. */
+  account: Account;
+  /** Wall-clock time the enclosing run began (preserved on SyncResult.startedAt). */
+  startedAt: Date;
+  /**
+   * Fetch-derived source bookkeeping applied inside the successful transaction
+   * (step 9). Supplied by the URL-sync fetch path; the file-upload path
+   * (pv-84da.1.4) omits it or supplies its own.
+   */
+  fetchBookkeeping?: {
+    etag?: string | null;
+    contentHash: string | null;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // SyncService
 // ---------------------------------------------------------------------------
@@ -210,6 +243,23 @@ class SyncService {
 
     this.assertVerifiedForSync(sourceEntity);
 
+    // URL-sync invariant. syncSource fetches the feed over the network, so it
+    // is only meaningful for 'url' sources — which the design guarantees carry
+    // a non-null url at the service layer even though migration 0039 relaxed
+    // the column to nullable for the 'file' variant (0039 doc comment: "URL
+    // sources continue to carry a non-null url (enforced at the service layer,
+    // since the column can no longer enforce it for both variants)"). Enforce
+    // that guarantee here so the fetch phase can rely on a non-null url. A
+    // 'file' source — or a 'url' source with a null url, which must never
+    // happen — fails loud rather than silently fetching an undefined URL.
+    if (sourceEntity.source_type !== 'url' || !sourceEntity.url) {
+      throw new Error(
+        `syncSource: import source ${importSourceId} is not a syncable url source `
+        + `(source_type=${sourceEntity.source_type}, hasUrl=${sourceEntity.url != null})`,
+      );
+    }
+    const sourceUrl = sourceEntity.url;
+
     if (!this.rateLimiter.tryAcquire(importSourceId, this.nowFn().getTime())) {
       throw new ImportSourceVerifyRateLimitError();
     }
@@ -220,7 +270,7 @@ class SyncService {
     let fetchResult: FetcherResult;
     try {
       fetchResult = await this.fetcher.fetch({
-        url: sourceEntity.url,
+        url: sourceUrl,
         importSourceId,
         etag: sourceEntity.etag ?? undefined,
       });
@@ -273,13 +323,71 @@ class SyncService {
       });
     }
 
-    // --- Parse phase -----------------------------------------------------
+    // --- Hand off to the shared ICS processing pipeline (steps 5–12) -----
+    // Fetch-outcome bookkeeping above stays in syncSource. The fetch-derived
+    // etag/content-hash are passed down and applied only inside the successful
+    // transaction (step 9), preserving the "don't clobber on parse failure"
+    // contract.
+    return this.processIcsBuffer(
+      fetchResult.body,
+      sourceEntity,
+      {
+        dedupScope: 'source',
+        account: input.account,
+        startedAt,
+        fetchBookkeeping: {
+          etag: fetchResult.etag,
+          contentHash: fetchResult.contentHash,
+        },
+      },
+    );
+  }
+
+  /**
+   * Run pipeline steps 5–12 over an in-memory ICS buffer: parse the VCALENDAR,
+   * map + dedup + dispatch its VEVENTs, apply source bookkeeping, record the
+   * ImportRun, and purge beyond the retention cap.
+   *
+   * Extracted from {@link syncSource} so file uploads (pv-84da.1.4) can enter
+   * the pipeline after their own intake step instead of a network fetch. Pure
+   * extraction — no behavior change on the URL-sync path.
+   *
+   * Never throws for "expected" failure cases (parse errors, individual write
+   * failures) — the outcome is captured in a persisted ImportRun row and
+   * returned. Only catastrophic infrastructure failures propagate.
+   *
+   * @param buffer Raw ICS bytes (utf8-decoded before parsing).
+   * @param source The import source these events belong to.
+   * @param opts Dedup scope, acting account, run start time, and optional
+   *   fetch-derived source bookkeeping.
+   * @param tx Optional transaction to enlist the event writes in. When omitted,
+   *   a dedicated transaction is opened (the URL-sync path). When supplied, the
+   *   caller owns the transaction (the file-upload path, pv-84da.1.4).
+   */
+  async processIcsBuffer(
+    buffer: Buffer,
+    source: ImportSourceEntity,
+    opts: ProcessIcsOptions,
+    tx?: Transaction,
+  ): Promise<SyncResult> {
+    if (opts.dedupScope !== 'source') {
+      // Calendar-wide dedup is implemented in pv-84da.1.3. Until then, refuse
+      // rather than silently falling through to per-source dedup.
+      throw new Error(
+        `processIcsBuffer: dedupScope '${opts.dedupScope}' is not implemented (see pv-84da.1.3)`,
+      );
+    }
+
+    const importSourceId = source.id;
+    const { account, startedAt } = opts;
+
+    // --- Parse phase (step 5) --------------------------------------------
     let parsed: CalendarResponse;
     try {
-      parsed = this.parseICS(fetchResult.body.toString('utf8'));
+      parsed = this.parseICS(buffer.toString('utf8'));
     }
     catch (err) {
-      await this.updateSourceOnFetchFailure(sourceEntity, 'parse_error');
+      await this.updateSourceOnFetchFailure(source, 'parse_error');
       return this.recordRun({
         sourceId: importSourceId,
         startedAt,
@@ -296,7 +404,7 @@ class SyncService {
     // primary language via the event service's already-wired calendarService
     // helper. If unavailable, default to 'en'. This is a best-effort lookup;
     // the mapper only uses it to stamp a language code on content.
-    const primaryLanguage = await this.resolveCalendarPrimaryLanguage(sourceEntity.calendar_id);
+    const primaryLanguage = await this.resolveCalendarPrimaryLanguage(source.calendar_id);
 
     // --- Extract VCALENDAR-level X-WR-TIMEZONE fallback ------------------
     // node-ical surfaces it on `parsed.vcalendar['WR-TIMEZONE']`. The mapper
@@ -312,7 +420,7 @@ class SyncService {
     let firstErrorMessage: string | null = null;
 
     try {
-      await db.transaction(async (tx) => {
+      await this.runTransactional(tx, async (txn) => {
         // Collect existing origin rows (with eager-joined event) keyed on the
         // dedup tuple. The join is resolved via EventImportOriginEntity's
         // @BelongsTo on the child side; EventEntity deliberately has no
@@ -320,7 +428,7 @@ class SyncService {
         const existing = await EventImportOriginEntity.findAll({
           where: { import_source_id: importSourceId },
           include: [{ model: EventEntity, required: false }],
-          transaction: tx,
+          transaction: txn,
         });
         const existingByKey = new Map<string, EventImportOriginEntity>();
         for (const origin of existing) {
@@ -333,7 +441,7 @@ class SyncService {
         // have a caller-requester identity for writes; we build a synthetic
         // account scoped to the calendar owner so EventService permission
         // checks pass. In practice the calling API layer passes its own.
-        const actingAccount = input.account;
+        const actingAccount = account;
 
         for (const vevent of vevents) {
           let mapped: MapperOutput;
@@ -358,19 +466,19 @@ class SyncService {
           const existingOrigin = existingByKey.get(key);
           try {
             if (!existingOrigin) {
-              await this.createEvent(actingAccount, sourceEntity, mapped, tx);
+              await this.createEvent(actingAccount, source, mapped, txn);
               counts.created++;
             }
             else if (existingOrigin.locally_edited) {
-              await this.touchSourceLastSeen(existingOrigin, tx);
+              await this.touchSourceLastSeen(existingOrigin, txn);
               counts.skippedLocallyEdited++;
             }
             else if (this.sourceIsNewer(mapped.source_last_modified, existingOrigin.source_last_modified)) {
-              await this.updateEvent(actingAccount, existingOrigin.event_id, sourceEntity, mapped, tx);
+              await this.updateEvent(actingAccount, existingOrigin.event_id, source, mapped, txn);
               counts.updated++;
             }
             else {
-              await this.touchSourceLastSeen(existingOrigin, tx);
+              await this.touchSourceLastSeen(existingOrigin, txn);
             }
           }
           catch (err) {
@@ -391,13 +499,17 @@ class SyncService {
           }
         }
 
-        // Source bookkeeping inside the same transaction.
+        // Source bookkeeping inside the same transaction (step 9). Fetch-derived
+        // etag/content-hash are applied here — only on this successful path, so
+        // a parse failure never overwrites the stored values.
         const newStatus: ImportSourceEntity['last_status'] = parseErrorCount > 0 ? 'parse_error' : 'ok';
-        sourceEntity.etag = fetchResult.etag ?? sourceEntity.etag;
-        sourceEntity.content_hash = fetchResult.contentHash;
-        sourceEntity.last_fetched_at = this.nowFn();
-        sourceEntity.last_status = newStatus;
-        await sourceEntity.save({ transaction: tx });
+        if (opts.fetchBookkeeping) {
+          source.etag = opts.fetchBookkeeping.etag ?? source.etag;
+          source.content_hash = opts.fetchBookkeeping.contentHash;
+          source.last_fetched_at = this.nowFn();
+        }
+        source.last_status = newStatus;
+        await source.save({ transaction: txn });
       });
     }
     catch (err) {
@@ -413,7 +525,7 @@ class SyncService {
         'ics.sync.transaction_failed',
       );
       const message = firstErrorMessage ?? this.sanitizedErrorMessage(err);
-      await this.updateSourceOnFetchFailure(sourceEntity, 'parse_error');
+      await this.updateSourceOnFetchFailure(source, 'parse_error');
       return this.recordRun({
         sourceId: importSourceId,
         startedAt,
@@ -436,6 +548,22 @@ class SyncService {
     await this.purgeOldRuns(importSourceId);
 
     return result;
+  }
+
+  /**
+   * Run `fn` inside the caller's transaction when one is supplied, otherwise
+   * open a dedicated transaction. Keeps the URL-sync path (no `tx`) behaving
+   * exactly as before while letting the file-upload path (pv-84da.1.4) enlist
+   * the event writes in a transaction it already owns.
+   */
+  private async runTransactional<T>(
+    tx: Transaction | undefined,
+    fn: (tx: Transaction) => Promise<T>,
+  ): Promise<T> {
+    if (tx) {
+      return fn(tx);
+    }
+    return db.transaction(fn);
   }
 
   // -------------------------------------------------------------------------

--- a/src/server/calendar/test/entity/import_source_entity.test.ts
+++ b/src/server/calendar/test/entity/import_source_entity.test.ts
@@ -131,6 +131,32 @@ describe('ImportSourceEntity', () => {
     });
   });
 
+  describe('file-upload fields (sourceType / originalFilename)', () => {
+    it('round-trips sourceType and originalFilename through fromModel -> toModel', () => {
+      const id = uuidv4();
+      const calendarId = uuidv4();
+      const model = new ImportSource(id, calendarId, null);
+      model.sourceType = 'file';
+      model.originalFilename = 'exported-events.ics';
+
+      const entity = ImportSourceEntity.fromModel(model);
+      expect(entity.source_type).toBe('file');
+      expect(entity.original_filename).toBe('exported-events.ics');
+      expect(entity.url ?? null).toBeNull();
+
+      const roundTrip = entity.toModel();
+      expect(roundTrip.sourceType).toBe('file');
+      expect(roundTrip.originalFilename).toBe('exported-events.ics');
+      expect(roundTrip.url ?? null).toBeNull();
+    });
+
+    it('defaults sourceType to url and originalFilename to null on a bare model', () => {
+      const model = new ImportSource();
+      expect(model.sourceType).toBe('url');
+      expect(model.originalFilename).toBeNull();
+    });
+  });
+
   describe('verification_type column defaults', () => {
     it('does not stamp a verification_type when not specified on build', () => {
       // The column is nullable with no DB default. An entity built without

--- a/src/server/calendar/test/integration/import_source_migrations.test.ts
+++ b/src/server/calendar/test/integration/import_source_migrations.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Sequelize } from 'sequelize-typescript';
 import { QueryTypes } from 'sequelize';
 import path from 'path';
+import fs from 'fs';
 import { randomUUID } from 'crypto';
 
-import { runMigrations } from '@/server/common/migrations/runner';
+import { runMigrations, createMigrationRunner } from '@/server/common/migrations/runner';
 
 /**
  * Integration tests for bead pv-1qcp.1.1 (ICS import foundation schema),
@@ -403,6 +404,172 @@ describe('ICS import foundation migrations', () => {
       );
 
       expect(row.verification_type).toBe('rel-me');
+    });
+  });
+
+  describe('file-upload columns (0039)', () => {
+    it('adds source_type and original_filename and drops NOT NULL on url', async () => {
+      const qi = sequelize.getQueryInterface();
+      const desc = await qi.describeTable('import_source') as Record<string, { allowNull: boolean }>;
+
+      expect(desc).toHaveProperty('source_type');
+      expect(desc).toHaveProperty('original_filename');
+      // source_type is required, original_filename is optional.
+      expect(desc.source_type.allowNull).toBe(false);
+      expect(desc.original_filename.allowNull).toBe(true);
+      // url is now nullable so file-backed sources (no live URL) can exist.
+      expect(desc.url.allowNull).toBe(true);
+    });
+
+    it('defaults source_type to url when a new row omits the column', async () => {
+      const calendarId = await seedCalendar();
+      const sourceId = randomUUID();
+      await sequelize.query(
+        `INSERT INTO import_source
+           (id, calendar_id, url, enabled, verification_state, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 'unverified', datetime('now'), datetime('now'))`,
+        { replacements: [sourceId, calendarId, 'https://example.test/default-source-type.ics'] },
+      );
+
+      const [row] = await sequelize.query<{ source_type: string }>(
+        `SELECT source_type FROM import_source WHERE id = ?`,
+        { replacements: [sourceId], type: QueryTypes.SELECT },
+      );
+      expect(row.source_type).toBe('url');
+    });
+
+    it('accepts a file source with a null url and an original_filename', async () => {
+      const calendarId = await seedCalendar();
+      const sourceId = randomUUID();
+      await sequelize.query(
+        `INSERT INTO import_source
+           (id, calendar_id, url, source_type, original_filename, enabled,
+            verification_state, created_at, updated_at)
+         VALUES (?, ?, NULL, 'file', ?, 1, 'verified', datetime('now'), datetime('now'))`,
+        { replacements: [sourceId, calendarId, 'my-events.ics'] },
+      );
+
+      const [row] = await sequelize.query<{
+        url: string | null;
+        source_type: string;
+        original_filename: string | null;
+      }>(
+        `SELECT url, source_type, original_filename FROM import_source WHERE id = ?`,
+        { replacements: [sourceId], type: QueryTypes.SELECT },
+      );
+      expect(row.url).toBeNull();
+      expect(row.source_type).toBe('file');
+      expect(row.original_filename).toBe('my-events.ics');
+    });
+
+    it('preserves the calendar_id ON DELETE CASCADE across the nullability change', async () => {
+      // Relaxing url to nullable rebuilds import_source on SQLite; the
+      // migration must re-assert the calendar cascade so deleting a calendar
+      // still removes its import sources (guards against Sequelize's
+      // describeTable dropping ON DELETE actions during the rebuild).
+      const calendarId = await seedCalendar();
+      const sourceId = await seedImportSource(calendarId);
+
+      await sequelize.query('DELETE FROM calendar WHERE id = ?', { replacements: [calendarId] });
+
+      const [row] = await sequelize.query<{ count: number }>(
+        `SELECT COUNT(*) AS count FROM import_source WHERE id = ?`,
+        { replacements: [sourceId], type: QueryTypes.SELECT },
+      );
+      expect(row.count).toBe(0);
+    });
+  });
+
+  describe('file-upload migration backfill and reversibility (0039)', () => {
+    // A dedicated Sequelize instance that stops one migration short of 0039 so
+    // we can seed a pre-existing url source and observe the backfill/rollback
+    // behaviour of the file-upload migration in isolation.
+    let staged: Sequelize;
+
+    beforeEach(async () => {
+      staged = new Sequelize({ dialect: 'sqlite', storage: ':memory:', logging: false });
+      await staged.query('PRAGMA foreign_keys = ON');
+    });
+
+    afterEach(async () => {
+      await staged.close();
+    });
+
+    async function migrateTo(prefix: string): Promise<void> {
+      // Resolve the umzug migration name by prefix (robust to whether the
+      // runner retains the `.ts` extension in the migration name) and apply
+      // every pending migration up to and including it.
+      const runner = createMigrationRunner(staged, migrationsDir);
+      const pending = await runner.pending();
+      const target = pending.find((m) => m.name.startsWith(prefix));
+      if (!target) {
+        throw new Error(`No pending migration matching prefix ${prefix}`);
+      }
+      await runner.up({ to: target.name });
+    }
+
+    async function migrateAll(): Promise<void> {
+      const runner = createMigrationRunner(staged, migrationsDir);
+      await runner.up();
+    }
+
+    function migrationFile(prefix: string): string {
+      const file = fs
+        .readdirSync(migrationsDir)
+        .find((f) => f.startsWith(prefix) && f.endsWith('.ts'));
+      if (!file) {
+        throw new Error(`No migration file matching prefix ${prefix}`);
+      }
+      return file;
+    }
+
+    it('backfills pre-existing rows with source_type=url', async () => {
+      // Run every migration up to (but not including) the file-upload one.
+      await migrateTo('0038');
+
+      const accountId = randomUUID();
+      const calendarId = randomUUID();
+      const sourceId = randomUUID();
+      await staged.query(
+        `INSERT INTO account (id, username, email, createdAt, updatedAt)
+         VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+        { replacements: [accountId, `user-${accountId.slice(0, 8)}`, `${accountId.slice(0, 8)}@example.test`] },
+      );
+      await staged.query(
+        `INSERT INTO calendar (id, url_name, languages, createdAt, updatedAt)
+         VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
+        { replacements: [calendarId, `cal-${calendarId.slice(0, 8)}`, 'en'] },
+      );
+      await staged.query(
+        `INSERT INTO import_source
+           (id, calendar_id, url, enabled, verification_state, created_at, updated_at)
+         VALUES (?, ?, ?, 1, 'unverified', datetime('now'), datetime('now'))`,
+        { replacements: [sourceId, calendarId, 'https://legacy.example.test/feed.ics'] },
+      );
+
+      // Now apply the file-upload migration on top of the seeded legacy row.
+      await migrateAll();
+
+      const [row] = await staged.query<{ source_type: string; url: string }>(
+        `SELECT source_type, url FROM import_source WHERE id = ?`,
+        { replacements: [sourceId], type: QueryTypes.SELECT },
+      );
+      expect(row.source_type).toBe('url');
+      // The pre-existing url value survives the column changes.
+      expect(row.url).toBe('https://legacy.example.test/feed.ics');
+    });
+
+    it('rolls back cleanly: down removes new columns and restores NOT NULL on url', async () => {
+      await migrateAll();
+
+      const m0039 = (await import(path.join(migrationsDir, migrationFile('0039')))).default;
+      await m0039.down({ context: staged });
+
+      const qi = staged.getQueryInterface();
+      const desc = await qi.describeTable('import_source') as Record<string, { allowNull: boolean }>;
+      expect(desc).not.toHaveProperty('source_type');
+      expect(desc).not.toHaveProperty('original_filename');
+      expect(desc.url.allowNull).toBe(false);
     });
   });
 

--- a/src/server/calendar/test/service/import/sync.test.ts
+++ b/src/server/calendar/test/service/import/sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
+import type { Transaction } from 'sequelize';
 import type { VEvent, DateWithTimeZone } from 'node-ical';
 
 import { Account } from '@/common/model/account';
@@ -70,7 +71,9 @@ function makeSourceEntity(overrides: Partial<ImportSourceEntity> = {}): ImportSo
   return {
     id: 'ssssssss-ssss-ssss-ssss-ssssssssssss',
     calendar_id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    source_type: 'url',
     url: 'https://events.example.test/feed.ics',
+    original_filename: null,
     enabled: true,
     verification_state: 'verified',
     verification_token: null,
@@ -247,6 +250,35 @@ describe('SyncService', () => {
       sandbox.stub(ImportSourceEntity, 'findByPk').resolves(null);
       await expect(service.syncSource({ account, importSourceId: 'missing' }))
         .rejects.toBeInstanceOf(ImportSourceNotFoundError);
+    });
+
+    it('throws for a file source (no syncable url) before any fetch', async () => {
+      // Migration 0039 relaxed import_source.url to nullable for the 'file'
+      // variant. syncSource is a URL-sync path: it must fail loud on a file
+      // source (or a url source with a null url) rather than pass null into
+      // the network fetch.
+      sandbox.stub(ImportSourceEntity, 'findByPk').resolves(
+        makeSourceEntity({
+          source_type: 'file',
+          url: null,
+          original_filename: 'exported-events.ics',
+        }),
+      );
+
+      await expect(service.syncSource({ account, importSourceId: 'src-1' }))
+        .rejects.toThrow(/not a syncable url source/);
+      // The fetch phase must never run for a non-url source.
+      expect(fetcher.fetch.called).toBe(false);
+    });
+
+    it('throws for a url source whose url is unexpectedly null', async () => {
+      sandbox.stub(ImportSourceEntity, 'findByPk').resolves(
+        makeSourceEntity({ source_type: 'url', url: null }),
+      );
+
+      await expect(service.syncSource({ account, importSourceId: 'src-1' }))
+        .rejects.toThrow(/not a syncable url source/);
+      expect(fetcher.fetch.called).toBe(false);
     });
 
     it('refuses sync when verification is unverified', async () => {
@@ -478,8 +510,12 @@ describe('SyncService', () => {
   // --------------------------------------------------------------------------
 
   describe('four-case event dispatch', () => {
-    function setupWith(vevents: VEvent[], existingOrigins: EventImportOriginEntity[] = []) {
-      const src = makeSourceEntity();
+    function setupWith(
+      vevents: VEvent[],
+      existingOrigins: EventImportOriginEntity[] = [],
+      sourceOverrides: Partial<ImportSourceEntity> = {},
+    ) {
+      const src = makeSourceEntity(sourceOverrides);
       sandbox.stub(ImportSourceEntity, 'findByPk').resolves(src);
       fetcher.fetch.resolves({
         outcome: 'ok',
@@ -516,13 +552,14 @@ describe('SyncService', () => {
     it('dedup bulk-load queries EventImportOriginEntity with EventEntity eager-joined', async () => {
       // Use a fresh findAll spy so we can inspect the call args directly.
       const vevent = makeVEvent({ uid: 'new-a@example.test' });
-      const src = setupWith([vevent], []);
+      const src = setupWith([vevent], [], { id: 'src-input-id' });
       void src;
 
       eventService.createEvent.callsFake(async () => ({ id: 'evt-new-a' } as never));
 
-      // The orchestrator's findAll uses the `importSourceId` input it was
-      // given; we pass 'src-input-id' and assert the query carried it.
+      // The pipeline keys the dedup query on the resolved source's id
+      // (findByPk(importSourceId).id === importSourceId in production); we align
+      // the fixture's id with the input and assert the query carried it.
       await service.syncSource({ account, importSourceId: 'src-input-id' });
 
       const findAllStub = EventImportOriginEntity.findAll as sinon.SinonStub;
@@ -914,6 +951,160 @@ describe('SyncService', () => {
 
       const result = await service.syncSource({ account, importSourceId: 'src-1' });
       expect(result.outcome).toBe('no_changes');
+      expect(eventService.createEvent.called).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // processIcsBuffer direct entry (pv-84da.1.2)
+  // --------------------------------------------------------------------------
+
+  describe('processIcsBuffer', () => {
+    // The extraction target: pipeline steps 5–12 driven directly from an
+    // in-memory buffer, bypassing the fetch phase. This is the entry point the
+    // file-upload path (pv-84da.1.4) will reuse.
+
+    function makeProcessService(vevents: VEvent[], existingOrigins: EventImportOriginEntity[] = []): SyncService {
+      sandbox.stub(EventImportOriginEntity, 'findAll').resolves(
+        existingOrigins as unknown as EventImportOriginEntity[],
+      );
+      return new SyncService({
+        eventService: eventService as unknown as EventService,
+        calendarService: calendarService as unknown as CalendarService,
+        fetcher: fetcher as unknown as Fetcher,
+        rateLimiter,
+        parseICS: () => {
+          const out: Record<string, VEvent> = {};
+          vevents.forEach((v, i) => { out[`v-${i}`] = v; });
+          return out as never;
+        },
+      });
+    }
+
+    it('parses the buffer and creates events, recording a success run', async () => {
+      const src = makeSourceEntity();
+      const veventA = makeVEvent({ uid: 'buf-a@example.test' });
+      const veventB = makeVEvent({ uid: 'buf-b@example.test' });
+      const svc = makeProcessService([veventA, veventB]);
+      eventService.createEvent.callsFake(async () => ({ id: 'evt-buf' } as never));
+
+      const startedAt = new Date('2026-04-22T10:00:00Z');
+      const result = await svc.processIcsBuffer(
+        Buffer.from('BEGIN:VCALENDAR\r\nEND:VCALENDAR'),
+        src,
+        { dedupScope: 'source', account, startedAt },
+      );
+
+      expect(result.outcome).toBe('success');
+      expect(result.eventsCreated).toBe(2);
+      expect(result.startedAt.getTime()).toBe(startedAt.getTime());
+      expect(eventService.createEvent.callCount).toBe(2);
+      for (const call of eventService.createEvent.getCalls()) {
+        expect(call.args[2]).toEqual({ source: 'import' });
+      }
+    });
+
+    it('applies fetchBookkeeping onto the source only inside the successful transaction', async () => {
+      const src = makeSourceEntity({ etag: 'W/"old"', content_hash: 'OLD-HASH' });
+      const svc = makeProcessService([makeVEvent({ uid: 'buf-c@example.test' })]);
+      eventService.createEvent.callsFake(async () => ({ id: 'evt-buf-c' } as never));
+
+      const result = await svc.processIcsBuffer(
+        Buffer.from('BEGIN:VCALENDAR'),
+        src,
+        {
+          dedupScope: 'source',
+          account,
+          startedAt: new Date('2026-04-22T10:00:00Z'),
+          fetchBookkeeping: { etag: 'W/"new"', contentHash: 'NEW-HASH' },
+        },
+      );
+
+      expect(result.outcome).toBe('success');
+      expect(src.etag).toBe('W/"new"');
+      expect(src.content_hash).toBe('NEW-HASH');
+      expect(src.last_status).toBe('ok');
+      expect((src.save as sinon.SinonStub).called).toBe(true);
+    });
+
+    it('records parse_error without clobbering etag/content_hash when parsing throws', async () => {
+      const src = makeSourceEntity({ etag: 'W/"keep"', content_hash: 'KEEP-HASH' });
+      const svc = new SyncService({
+        eventService: eventService as unknown as EventService,
+        calendarService: calendarService as unknown as CalendarService,
+        fetcher: fetcher as unknown as Fetcher,
+        rateLimiter,
+        parseICS: () => { throw new Error('malformed calendar'); },
+      });
+
+      const result = await svc.processIcsBuffer(
+        Buffer.from('junk'),
+        src,
+        {
+          dedupScope: 'source',
+          account,
+          startedAt: new Date('2026-04-22T10:00:00Z'),
+          fetchBookkeeping: { etag: 'W/"new"', contentHash: 'NEW-HASH' },
+        },
+      );
+
+      expect(result.outcome).toBe('parse_error');
+      expect(src.last_status).toBe('parse_error');
+      // Parse failed before the transaction — the stored etag/content_hash
+      // survive so the next conditional GET stays valid.
+      expect(src.etag).toBe('W/"keep"');
+      expect(src.content_hash).toBe('KEEP-HASH');
+    });
+
+    it('enlists event writes in a caller-supplied transaction and never opens its own', async () => {
+      // runTransactional has two branches: open a dedicated db.transaction
+      // (URL-sync path, no tx) or reuse the caller's tx (file-upload path,
+      // pv-84da.1.4). This exercises the caller-supplied branch: the tx must
+      // thread through to the event write, the origin upsert, and the source
+      // bookkeeping save, while db.transaction is never called.
+      const src = makeSourceEntity();
+      const svc = makeProcessService([makeVEvent({ uid: 'buf-tx@example.test' })]);
+      eventService.createEvent.callsFake(async () => ({ id: 'evt-buf-tx' } as never));
+
+      const callerTx = { LEVEL: 'caller-tx' } as unknown as Transaction;
+      const dbTxStub = db.transaction as sinon.SinonStub;
+
+      const result = await svc.processIcsBuffer(
+        Buffer.from('BEGIN:VCALENDAR'),
+        src,
+        { dedupScope: 'source', account, startedAt: new Date('2026-04-22T10:00:00Z') },
+        callerTx,
+      );
+
+      // Behavior: the run still succeeds and creates the event.
+      expect(result.outcome).toBe('success');
+      expect(result.eventsCreated).toBe(1);
+
+      // The caller owns the transaction — the orchestrator must NOT open one.
+      expect(dbTxStub.called).toBe(false);
+
+      // The caller's tx flows through to every write in the transactional body.
+      expect(eventService.createEvent.calledOnce).toBe(true);
+      // createEvent(account, params, { source: 'import' }, tx) — tx is arg 3.
+      expect(eventService.createEvent.firstCall.args[3]).toBe(callerTx);
+      const upsertOptions = originUpsertStub.firstCall.args[1] as Record<string, unknown>;
+      expect(upsertOptions.transaction).toBe(callerTx);
+      const saveArgs = (src.save as sinon.SinonStub).firstCall.args[0];
+      expect(saveArgs).toMatchObject({ transaction: callerTx });
+    });
+
+    it("throws when dedupScope is 'calendar' (implemented in pv-84da.1.3)", async () => {
+      const src = makeSourceEntity();
+      const svc = makeProcessService([makeVEvent()]);
+
+      await expect(
+        svc.processIcsBuffer(
+          Buffer.from('BEGIN:VCALENDAR'),
+          src,
+          { dedupScope: 'calendar', account, startedAt: new Date() },
+        ),
+      ).rejects.toThrow(/not implemented/);
+      // Nothing should have been parsed or written.
       expect(eventService.createEvent.called).toBe(false);
     });
   });


### PR DESCRIPTION
## Motivation

First of four stacked PRs adding ICS **file-upload** import as a sibling to the existing URL-sync import path — for organizers migrating from a system they can export from but can't host a live `.ics` endpoint. This PR lays the backend foundation: the schema/model discriminator and the pipeline seam that a non-fetch intake path will reuse. No user-facing behavior yet.

## Approach

Two commits:

1. **`feat(calendar): add file-source columns to import_source`** — Adds `source_type ENUM('url','file')` (default `'url'`) and a nullable `original_filename` to `import_source`, and relaxes `url` to nullable so file-backed sources need no URL. This is a discriminator on the *existing* `ImportSource` entity, not a new entity — a file upload is an import source that simply lacks a refetch verb. Because the column can no longer enforce a non-null url for url sources, that invariant moves to the service layer: the DNS and rel-me verification paths guard `url` before use. A SQLite-only quirk is handled: `changeColumn` rebuilds the table from `describeTable` metadata (which omits `ON DELETE` actions), silently dropping `calendar_id ON DELETE CASCADE`; the migration re-asserts the cascade FK under a dialect guard (as migration 0011 does). PostgreSQL alters in place and is unaffected.

2. **`refactor(calendar): extract processIcsBuffer from syncSource`** — Splits the ICS ingestion pipeline at the fetch/process seam so a fetched buffer can enter it independently of the URL fetch step. `processIcsBuffer` owns parse → map → dedup → dispatch → ImportRun → retention-purge; `syncSource` keeps fetch and fetch-outcome bookkeeping (etag/content-hash/304) and hands the body off. A `dedupScope` option is threaded through with only `'source'` implemented (`'calendar'` throws pending the next PR). The URL-sync path is behavior-identical. `syncSource` now asserts `source_type='url'` + non-null url before fetching, so a file source fails loud rather than passing null downstream.

Reviewed pre-merge by consistency, complexity, testing, cross-bead-integration, and architecture auditors. A type-safety regression from the nullable-`url` widening (three unguarded consumers, caught by `tsc --noEmit`) was found and fixed before this PR was opened; the service-layer guards above are that fix.

Two accepted LOW notes: the invariant guards throw bare `Error` (deliberate fail-loud asserts for unreachable programmer errors, not user-facing surfaces), and the model constructor's `url` default stays `''` (file-source construction, which sets `url` explicitly, lands in PR C/D).

## Validation

- `npm run lint`: pass (0 errors).
- Unit: **8484 pass** (full suite).
- `npm run build` / `tsc`: pass — confirms the type regression is cleared.
- Integration: 702 pass. The single failure (`cancel_event_occurrence.test.ts:269`, a pagination-cursor assertion) is **pre-existing on `main`** — verified failing identically on `main` (30 pass / 1 fail), unrelated to this change.
- E2E failures in this run are environmental to the local worktree (missing Docker-federation TLS cert `alpha.federation.local.crt`, test-server startup flakiness, an event-card timing timeout), not code regressions.
- New coverage: migration schema/backfill/cascade-survival/down-reversal, `'file'`-variant model serialization, entity round-trip (in the dedicated entity unit file), the `processIcsBuffer` branches, and the new url guards.

---

**Stacked PR 1 of 4** — base `main`. Merge first. Subsequent: `feat/ics-upload-backend-import` (dedup + endpoint) → `feat/ics-upload-client-service` → `feat/ics-upload-form-integration`. Each later PR is based on its predecessor; re-target to `main` as each lands.
