### PR TITLE
feat(federation): align Event federation with FEP-8a8e

### DIFF
--- a/src/server/activitypub/api/v1/server.ts
+++ b/src/server/activitypub/api/v1/server.ts
@@ -9,11 +9,13 @@ import FollowActivity from '@/server/activitypub/model/action/follow';
 import AcceptActivity from '@/server/activitypub/model/action/accept';
 import AnnounceActivity from '@/server/activitypub/model/action/announce';
 import UndoActivity from '@/server/activitypub/model/action/undo';
+import JoinActivity from '@/server/activitypub/model/action/join';
 import ActivityPubInterface from '@/server/activitypub/interface';
 import { logError } from '@/server/common/helper/error-logger';
 import CalendarInterface from '@/server/calendar/interface';
 import { EventNotFoundError } from '@/common/exceptions/calendar';
 import { createLogger } from '@/server/common/helper/logger';
+import { AP_CONTEXT } from '@/server/activitypub/model/base';
 
 const logger = createLogger('activitypub');
 import { verifyHttpSignature, extractKeyIdOrigin } from '@/server/activitypub/helper/http_signature';
@@ -31,6 +33,7 @@ import {
   acceptActivitySchema,
   announceActivitySchema,
   undoActivitySchema,
+  joinActivitySchema,
 } from '@/server/activitypub/validation/schemas';
 
 /**
@@ -190,8 +193,12 @@ export default class ActivityPubServerRoutes {
       const EventObject = (await import('@/server/activitypub/model/object/event')).EventObject;
       const eventObject = new EventObject(calendar, event);
 
+      // Standalone object responses (unlike activity-wrapped objects) carry no
+      // enclosing envelope, so they must declare their own JSON-LD @context —
+      // including the pavillion namespace so the pavillion:* extension terms
+      // expand for strict processors rather than being dropped.
       res.setHeader('Content-Type', 'application/activity+json');
-      res.json(eventObject.toActivityPubObject());
+      res.json({ '@context': AP_CONTEXT, ...eventObject.toActivityPubObject() });
     }
     catch (error) {
       logError(error, `Error fetching event ${req.params.eventid}`);
@@ -244,8 +251,11 @@ export default class ActivityPubServerRoutes {
       const { NoteObject } = await import('@/server/activitypub/model/object/note');
       const noteObject = new NoteObject(calendar, event);
 
+      // Standalone object response — declare its own JSON-LD @context. The Note
+      // emits no pavillion:* terms today, but it shares the standalone-object
+      // context so the endpoint is AS2-conformant and uniform with getEvent.
       res.setHeader('Content-Type', 'application/activity+json');
-      res.json(noteObject.toActivityPubObject());
+      res.json({ '@context': AP_CONTEXT, ...noteObject.toActivityPubObject() });
     }
     catch (error) {
       logError(error, `Error fetching note for event ${req.params.eventid}`);
@@ -273,8 +283,11 @@ export default class ActivityPubServerRoutes {
       const { SeriesObject } = await import('@/server/activitypub/model/object/series');
 
       const items = seriesList.map(series => new SeriesObject(calendar, series).toActivityPubObject());
+      // The collection is the top-level JSON-LD document; its @context governs
+      // the pavillion:content term carried by each nested series item, so it
+      // must include the pavillion namespace.
       const collection = {
-        '@context': 'https://www.w3.org/ns/activitystreams',
+        '@context': AP_CONTEXT,
         type: 'OrderedCollection',
         totalItems: items.length,
         orderedItems: items,
@@ -315,8 +328,10 @@ export default class ActivityPubServerRoutes {
       const { SeriesObject } = await import('@/server/activitypub/model/object/series');
       const seriesObject = new SeriesObject(calendar, series);
 
+      // Standalone object response — declare its own JSON-LD @context including
+      // the pavillion namespace so the pavillion:content term expands.
       res.setHeader('Content-Type', 'application/activity+json');
-      res.json(seriesObject.toActivityPubObject());
+      res.json({ '@context': AP_CONTEXT, ...seriesObject.toActivityPubObject() });
     }
     catch (error) {
       logError(error, `Error fetching series ${req.params.seriesid}`);
@@ -379,6 +394,11 @@ export default class ActivityPubServerRoutes {
         break;
       case 'Undo':
         activityValidation = undoActivitySchema.safeParse(req.body);
+        break;
+      case 'Join':
+        // FEP-8a8e: validate the inbound Join so it can be enqueued and
+        // answered with an Ignore. Pavillion never acts on the Join itself.
+        activityValidation = joinActivitySchema.safeParse(req.body);
         break;
       default:
         res.status(400).json({
@@ -465,6 +485,9 @@ export default class ActivityPubServerRoutes {
         break;
       case 'Undo':
         message = UndoActivity.fromObject(req.body);
+        break;
+      case 'Join':
+        message = JoinActivity.fromObject(req.body);
         break;
     }
 

--- a/src/server/activitypub/events/index.ts
+++ b/src/server/activitypub/events/index.ts
@@ -15,7 +15,6 @@ import ActivityPubInterface from '../interface';
 import CreateActivity from '../model/action/create';
 import UpdateActivity from '../model/action/update';
 import DeleteActivity from '../model/action/delete';
-import AnnounceActivity from '../model/action/announce';
 import { EventObject } from '../model/object/event';
 import { NoteObject } from '../model/object/note';
 import { ActivityPubOutboxMessageEntity, ActivityPubInboxMessageEntity } from '@/server/activitypub/entity/activitypub';
@@ -72,11 +71,11 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
   }
 
   /**
-   * Dispatch an outbound Announce for a locally-created event.
+   * Dispatch an outbound Create(Event) for a locally-created event.
    * Returns early when payload.calendar is null/undefined, which indicates
    * the event originated from a remote instance (incoming AP Create routed
    * via EventService.addRemoteEvent). Without this guard, processing a
-   * remote create would trigger an outbound Announce back to federation,
+   * remote create would trigger an outbound Create back to federation,
    * creating a loop. Mirrors the handleEventUpdated guard.
    */
   private async handleEventCreated(payload: ActivityPubEventCreatedPayload): Promise<void> {
@@ -116,9 +115,19 @@ export default class ActivityPubEventHandlers implements DomainEventHandlers {
 
     // The outbox dispatcher fans out to both local and remote followers.
     // Local followers are routed in-process via ProcessInboxService.
+    //
+    // New local events federate as Create with the full embedded Event object
+    // (deterministic id `{eventUrl}/create`), mirroring the Update(Event) shape
+    // emitted by handleEventUpdated. Announce is reserved for reposts (sharing
+    // another calendar's event) — see the auto-repost cascade in inbox.ts. Per
+    // FEP-8a8e, event platforms (Mobilizon, Gancio) ingest events via Create,
+    // so originals must be Create(Event), not a URL-only Announce.
     await this.service.addToOutbox(
       payload.calendar,
-      new AnnounceActivity(actorUrl, eventUrl).addressPublic(`${actorUrl}/followers`),
+      new CreateActivity(
+        actorUrl,
+        new EventObject(payload.calendar, payload.event),
+      ).addressPublic(`${actorUrl}/followers`),
     );
 
     // Paired Create(Note) emission for Mastodon-class peers that ignore

--- a/src/server/activitypub/helper/fep_category_map.ts
+++ b/src/server/activitypub/helper/fep_category_map.ts
@@ -1,0 +1,272 @@
+import type { EventCategory } from '@/common/model/event_category';
+
+/**
+ * FEP-8a8e event category vocabulary and Pavillion mapping helpers.
+ *
+ * FEP-8a8e (https://w3id.org/fep/8a8e) defines a shared, controlled vocabulary
+ * for the bare `category` property on an Event. Pavillion's own categories are
+ * instance-defined, translatable `EventCategory` models (no static enum), so
+ * there is no authoritative mapping onto the FEP vocabulary. This module
+ * implements a keyword heuristic (v1) that matches category NAMES — in every
+ * language the category carries — against the FEP enum values.
+ *
+ * Directionality:
+ *  - Outbound: {@link mapEventCategoriesToFep} turns a Pavillion event's
+ *    categories into the deduped list of confidently-matched FEP enum values,
+ *    emitted as the bare FEP `category` property ALONGSIDE the existing
+ *    `pavillion:categories` URIs (which still carry full Pavillion↔Pavillion
+ *    fidelity). Unmatched categories emit nothing.
+ *  - Inbound: {@link resolveFepCategoriesToLocalIds} maps inbound FEP enum
+ *    values back onto a calendar's EXISTING local categories by running each
+ *    local category name through the same heuristic. It never invents
+ *    categories — federation input is not allowed to create instance taxonomy.
+ *
+ * Admin-overridable mappings are intentionally OUT OF SCOPE for v1; if the
+ * heuristic proves too weak, an override layer is the documented follow-up.
+ */
+
+/**
+ * The FEP-8a8e `category` controlled vocabulary — the exact 36 enum values
+ * from the FEP-8a8e recommended-categories list. Emitted verbatim on the wire.
+ */
+export const FEP_CATEGORY_VALUES = [
+  'ARTS',
+  'AUTO_BOAT_AIR',
+  'BOOK_CLUBS',
+  'BUSINESS',
+  'CAUSES',
+  'CLIMATE_ENVIRONMENT',
+  'COMMUNITY',
+  'COMEDY',
+  'CRAFTS',
+  'CREATIVE_JAM',
+  'DIY_MAKER_SPACES',
+  'FAMILY_EDUCATION',
+  'FASHION_BEAUTY',
+  'FESTIVALS',
+  'FILM_MEDIA',
+  'FOOD_DRINK',
+  'GAMES',
+  'INCLUSIVE_SPACES',
+  'LANGUAGE_CULTURE',
+  'LEARNING',
+  'LGBTQ',
+  'MEETING',
+  'MEDITATION_WELLBEING',
+  'MOVEMENTS_POLITICS',
+  'MUSIC',
+  'NETWORKING',
+  'OUTDOORS_ADVENTURE',
+  'PARTY',
+  'PERFORMING_VISUAL_ARTS',
+  'PETS',
+  'PHOTOGRAPHY',
+  'SCIENCE_TECH',
+  'SPIRITUALITY_RELIGION_BELIEFS',
+  'SPORTS',
+  'THEATRE',
+  'WORKSHOPS_SKILL_SHARING',
+] as const;
+
+export type FepCategory = typeof FEP_CATEGORY_VALUES[number];
+
+const FEP_CATEGORY_SET: ReadonlySet<string> = new Set(FEP_CATEGORY_VALUES);
+
+/**
+ * Ordered keyword heuristic. Each entry maps a FEP enum value to a list of
+ * lowercase keywords; a category name matches an entry when any keyword occurs
+ * as a whole word in the name. The list is evaluated top-to-bottom and the
+ * FIRST matching entry wins.
+ *
+ * Ordering only changes the result when a SINGLE name matches keywords in more
+ * than one entry. Two mechanisms create that situation, and both are resolved
+ * by putting the more-specific entry FIRST:
+ *   - Phrase subsumption — a specific multi-word keyword contains a generic
+ *     one. "Visual Arts" matches PERFORMING_VISUAL_ARTS (`visual arts`) AND
+ *     ARTS (`arts`); PVA is ordered first and wins. Likewise "Family Education"
+ *     matches FAMILY_EDUCATION (`family`) AND LEARNING (`education`), and
+ *     "Art Jam" matches CREATIVE_JAM (`art jam`) AND ARTS (`art`).
+ *   - Shared bare keyword — the SAME keyword string appears under two entries.
+ *     This is deliberately avoided: every bare keyword is owned by exactly one
+ *     entry, so the result never depends on order for a shared keyword. In
+ *     particular `musical` is owned solely by MUSIC (a bare "Musical" reads as
+ *     music); a stage musical named "Musical Theatre" still resolves to THEATRE
+ *     via the unambiguous `theatre` keyword, since THEATRE precedes MUSIC.
+ *
+ * Entries whose keyword sets do not overlap any other entry (e.g. THEATRE vs
+ * ARTS, MEDITATION_WELLBEING vs SPIRITUALITY_RELIGION_BELIEFS) are order-
+ * independent; their relative position is retained only as defensive guidance
+ * for future keyword additions.
+ */
+const CATEGORY_KEYWORDS: ReadonlyArray<readonly [FepCategory, readonly string[]]> = [
+  ['LGBTQ', ['lgbtq', 'lgbtqia', 'lgbt', 'queer', 'pride', 'gay', 'lesbian', 'trans', 'transgender', 'nonbinary', 'non-binary']],
+  ['MOVEMENTS_POLITICS', ['politics', 'political', 'protest', 'rally', 'activism', 'activist', 'campaign', 'election', 'demonstration', 'movement', 'union']],
+  ['CLIMATE_ENVIRONMENT', ['climate', 'environment', 'environmental', 'sustainability', 'sustainable', 'ecology', 'ecological', 'conservation', 'recycling']],
+  ['CAUSES', ['cause', 'causes', 'charity', 'charitable', 'fundraiser', 'fundraising', 'donation', 'nonprofit', 'benefit', 'philanthropy']],
+  ['COMEDY', ['comedy', 'comedic', 'standup', 'stand-up']],
+  ['THEATRE', ['theatre', 'theater', 'drama', 'improv']],
+  ['PERFORMING_VISUAL_ARTS', ['performing arts', 'visual arts', 'dance', 'dancing', 'ballet', 'opera', 'performance']],
+  ['PHOTOGRAPHY', ['photography', 'photo', 'photos', 'photographer']],
+  ['FILM_MEDIA', ['film', 'films', 'movie', 'movies', 'cinema', 'screening', 'documentary', 'media']],
+  ['MUSIC', ['music', 'musical', 'concert', 'concerts', 'gig', 'band', 'bands', 'orchestra', 'choir', 'symphony', 'recital', 'dj']],
+  ['CREATIVE_JAM', ['creative jam', 'art jam', 'jam session']],
+  ['ARTS', ['art', 'arts', 'gallery', 'exhibition', 'exhibit', 'painting', 'sculpture']],
+  ['BOOK_CLUBS', ['book club', 'book clubs', 'books', 'reading', 'literature', 'author', 'poetry']],
+  ['GAMES', ['game', 'games', 'gaming', 'boardgame', 'board game', 'tabletop', 'chess', 'trivia', 'esports', 'video game']],
+  ['SPORTS', ['sport', 'sports', 'football', 'soccer', 'basketball', 'baseball', 'hockey', 'tennis', 'marathon', 'cycling', 'rugby', 'cricket', 'volleyball', 'athletics']],
+  ['OUTDOORS_ADVENTURE', ['outdoor', 'outdoors', 'hiking', 'hike', 'camping', 'adventure', 'trail', 'kayaking', 'climbing']],
+  ['MEDITATION_WELLBEING', ['meditation', 'wellbeing', 'well-being', 'wellness', 'mindfulness', 'yoga', 'self-care']],
+  ['SPIRITUALITY_RELIGION_BELIEFS', ['spiritual', 'spirituality', 'religion', 'religious', 'church', 'worship', 'faith', 'prayer', 'temple', 'mosque', 'synagogue']],
+  ['FOOD_DRINK', ['food', 'drink', 'drinks', 'dinner', 'lunch', 'brunch', 'tasting', 'culinary', 'cooking', 'wine', 'beer', 'coffee', 'restaurant', 'potluck', 'barbecue', 'bbq']],
+  ['CRAFTS', ['craft', 'crafts', 'knitting', 'sewing', 'quilting', 'pottery', 'ceramics', 'crochet']],
+  ['DIY_MAKER_SPACES', ['diy', 'maker', 'makerspace', 'fabrication', 'woodworking']],
+  ['WORKSHOPS_SKILL_SHARING', ['workshop', 'workshops', 'skillshare', 'skill-share', 'skill share', 'seminar', 'tutorial', 'training']],
+  ['SCIENCE_TECH', ['science', 'scientific', 'tech', 'technology', 'coding', 'programming', 'hackathon', 'robotics', 'engineering', 'software', 'developer']],
+  ['FASHION_BEAUTY', ['fashion', 'beauty', 'makeup', 'cosmetics']],
+  ['PETS', ['pet', 'pets', 'dog', 'dogs', 'cat', 'cats', 'animal', 'animals']],
+  ['FAMILY_EDUCATION', ['family', 'kids', 'children', 'parenting', 'school']],
+  ['LEARNING', ['learning', 'lecture', 'class', 'course', 'study', 'education', 'educational']],
+  ['LANGUAGE_CULTURE', ['language', 'culture', 'cultural', 'heritage', 'linguistic']],
+  ['FESTIVALS', ['festival', 'festivals', 'fest', 'carnival', 'fair']],
+  ['PARTY', ['party', 'parties', 'celebration', 'nightlife']],
+  ['NETWORKING', ['networking', 'meetup', 'mixer']],
+  ['BUSINESS', ['business', 'entrepreneur', 'entrepreneurship', 'startup', 'marketing', 'finance']],
+  ['MEETING', ['meeting', 'assembly']],
+  ['COMMUNITY', ['community', 'neighborhood', 'neighbourhood', 'volunteer', 'civic']],
+  ['INCLUSIVE_SPACES', ['inclusive', 'accessibility', 'disability', 'neurodiverse', 'safe space']],
+  ['AUTO_BOAT_AIR', ['automotive', 'motorcycle', 'boat', 'sailing', 'aviation', 'aircraft']],
+];
+
+/**
+ * Precompiled keyword matchers. Each keyword becomes a whole-word regex so that
+ * e.g. `art` matches "Art" and "Art Show" but NOT "party" or "cart".
+ */
+const COMPILED_KEYWORDS: ReadonlyArray<readonly [FepCategory, RegExp]> = CATEGORY_KEYWORDS.map(
+  ([fep, keywords]) => [
+    fep,
+    new RegExp(
+      '(?:^|[^a-z0-9])(?:' + keywords.map(escapeRegExp).join('|') + ')(?:[^a-z0-9]|$)',
+      'i',
+    ),
+  ] as const,
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Maps a single category name onto a FEP-8a8e enum value using the keyword
+ * heuristic. Returns the first (highest-priority) matching enum value, or null
+ * when no keyword matches confidently.
+ */
+export function mapNameToFepCategory(name: string): FepCategory | null {
+  if (typeof name !== 'string') {
+    return null;
+  }
+  const normalized = name.toLowerCase().trim();
+  if (normalized.length === 0) {
+    return null;
+  }
+  for (const [fep, matcher] of COMPILED_KEYWORDS) {
+    if (matcher.test(normalized)) {
+      return fep;
+    }
+  }
+  return null;
+}
+
+/**
+ * Maps a Pavillion EventCategory onto a FEP-8a8e enum value by running every
+ * language name it carries through the heuristic. English is checked first for
+ * determinism, then remaining languages in their existing order. Returns the
+ * first confident match across all names, or null.
+ */
+export function mapCategoryToFepCategory(category: EventCategory): FepCategory | null {
+  if (!category) {
+    return null;
+  }
+  const languages = category.getLanguages();
+  const ordered = languages.includes('en')
+    ? ['en', ...languages.filter(lang => lang !== 'en')]
+    : languages;
+
+  for (const lang of ordered) {
+    const content = category._content[lang];
+    const match = content ? mapNameToFepCategory(content.name) : null;
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+/**
+ * Outbound: maps a Pavillion event's categories onto the deduped, order-preserved
+ * list of FEP-8a8e enum values for the bare `category` property. Categories that
+ * do not map to any enum value contribute nothing. Returns an empty array when
+ * no category maps — callers omit the `category` property entirely in that case.
+ */
+export function mapEventCategoriesToFep(categories: EventCategory[]): FepCategory[] {
+  if (!Array.isArray(categories) || categories.length === 0) {
+    return [];
+  }
+  const seen = new Set<FepCategory>();
+  const result: FepCategory[] = [];
+  for (const category of categories) {
+    const fep = mapCategoryToFepCategory(category);
+    if (fep && !seen.has(fep)) {
+      seen.add(fep);
+      result.push(fep);
+    }
+  }
+  return result;
+}
+
+/**
+ * Normalizes an inbound FEP `category` field (string or @list array of strings)
+ * into the deduped set of recognized FEP enum values. Unknown or malformed
+ * entries are dropped defensively.
+ */
+export function parseInboundFepCategories(raw: unknown): FepCategory[] {
+  const values = Array.isArray(raw) ? raw : [raw];
+  const seen = new Set<FepCategory>();
+  const result: FepCategory[] = [];
+  for (const value of values) {
+    if (typeof value === 'string' && FEP_CATEGORY_SET.has(value)) {
+      const fep = value as FepCategory;
+      if (!seen.has(fep)) {
+        seen.add(fep);
+        result.push(fep);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Inbound: resolves a set of inbound FEP enum values onto a calendar's EXISTING
+ * local categories, by running each local category name through the same
+ * heuristic and keeping those whose mapped enum is in the inbound set. Returns
+ * the deduped list of matching local category ids. Never creates categories —
+ * only local categories that already exist can match.
+ */
+export function resolveFepCategoriesToLocalIds(
+  fepValues: FepCategory[],
+  localCategories: EventCategory[],
+): string[] {
+  if (fepValues.length === 0 || !Array.isArray(localCategories) || localCategories.length === 0) {
+    return [];
+  }
+  const wanted = new Set<FepCategory>(fepValues);
+  const seenIds = new Set<string>();
+  const result: string[] = [];
+  for (const category of localCategories) {
+    const fep = mapCategoryToFepCategory(category);
+    if (fep && wanted.has(fep) && !seenIds.has(category.id)) {
+      seenIds.add(category.id);
+      result.push(category.id);
+    }
+  }
+  return result;
+}

--- a/src/server/activitypub/helper/fep_category_map.ts
+++ b/src/server/activitypub/helper/fep_category_map.ts
@@ -23,6 +23,14 @@ import type { EventCategory } from '@/common/model/event_category';
  *
  * Admin-overridable mappings are intentionally OUT OF SCOPE for v1; if the
  * heuristic proves too weak, an override layer is the documented follow-up.
+ *
+ * MAINTENANCE RULE: the keyword table below is FROZEN. Do not add, remove, or
+ * reorder keywords in response to mis-mapping or missing-mapping reports (the
+ * keywords are English-only, so non-English instances get no matches — that is
+ * a known limitation, not a bug to patch here). Such a report is the trigger to
+ * build the replacement: an explicit optional FEP mapping on EventCategory
+ * (e.g. a nullable enum field with a 36-option select), with this heuristic
+ * demoted to fallback or deleted.
  */
 
 /**

--- a/src/server/activitypub/helper/outbox.ts
+++ b/src/server/activitypub/helper/outbox.ts
@@ -23,12 +23,25 @@ export async function addToOutbox(
   calendar: Calendar,
   message: ActivityPubActivity,
 ): Promise<void> {
+  // Persist the SERIALIZED wire form (`toObject()`), not the live activity
+  // instance. An embedded ActivityPubObject (EventObject / NoteObject) only
+  // renders its full AP/FEP-8a8e representation — startTime, endTime,
+  // pavillion:schedules, etc. — through its `toActivityPubObject()` serializer,
+  // which `ActivityPubActivity.toObject()` invokes while the object is still a
+  // live instance. Storing the raw instance lets Sequelize JSON-serialize only
+  // its incidental enumerable fields (`_event`, `_calendar`, ...), dropping the
+  // schedule terms; both the local in-process dispatch and remote HTTP delivery
+  // then rebuild the activity from that lossy row via `fromObject()`, so the
+  // FEP serializer never runs and followers reconstruct an event with no
+  // schedules (and therefore no event_instance rows). Serializing here is the
+  // single point that guarantees the stored, locally-dispatched, and
+  // HTTP-delivered forms are byte-identical.
   const messageEntity = ActivityPubOutboxMessageEntity.build({
     id: message.id,
     type: message.type,
     calendar_id: calendar.id,
     message_time: DateTime.utc(),
-    message: message,
+    message: message.toObject(),
   });
   await messageEntity.save();
 

--- a/src/server/activitypub/model/action/ignore.ts
+++ b/src/server/activitypub/model/action/ignore.ts
@@ -1,0 +1,54 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityPubActivity } from '@/server/activitypub/model/base';
+
+/**
+ * Represents an Ignore activity in the ActivityPub protocol.
+ *
+ * Pavillion emits Ignore in exactly one situation: to satisfy the FEP-8a8e
+ * requirement that a server respond to a Join activity it does not handle with
+ * an Ignore. Pavillion has no RSVP/attendance model (joinMode: 'none'), so a
+ * Join is never actionable — the Ignore is a courtesy reply telling the sender
+ * their Join was seen and deliberately not acted on.
+ *
+ * Structurally this mirrors AcceptActivity (a direct reply that embeds the
+ * activity being responded to as its `object`), with a deterministic id of
+ * `{actor}/ignores/{uuid}`. Unlike Accept, the reply is addressed directly to
+ * the sender (never as:Public); `to` is preserved through fromObject so the
+ * outbound wire payload round-trips the single-recipient addressing.
+ */
+class IgnoreActivity extends ActivityPubActivity {
+
+  constructor(actorUrl: string, objectActivity: Record<string, any> | any) {
+    super(actorUrl);
+    this.type = 'Ignore';
+    this.object = objectActivity;
+    this.id = actorUrl + '/ignores/' + uuidv4();
+  }
+
+  static fromObject(object: Record<string, any>): IgnoreActivity | null {
+    if (!object || typeof object !== 'object') {
+      return null;
+    }
+
+    if (!object.actor || typeof object.actor !== 'string') {
+      return null;
+    }
+
+    if (!object.object) {
+      return null;
+    }
+
+    const activity = new IgnoreActivity(object.actor, object.object);
+    if (object.id) {
+      activity.id = object.id;
+    }
+    // Preserve direct addressing so the delivered Ignore stays scoped to the
+    // sender (never public).
+    if (object.to && Array.isArray(object.to)) {
+      activity.to = object.to;
+    }
+    return activity;
+  }
+}
+
+export default IgnoreActivity;

--- a/src/server/activitypub/model/action/join.ts
+++ b/src/server/activitypub/model/action/join.ts
@@ -1,0 +1,51 @@
+import { v4 as uuidv4 } from 'uuid';
+import { ActivityPubActivity } from '@/server/activitypub/model/base';
+
+/**
+ * Represents a Join activity in the ActivityPub protocol.
+ *
+ * Pavillion never originates a Join — it only ingests inbound Joins from peers
+ * (e.g. Mobilizon) that model event attendance/RSVP as a Join(Event). Pavillion
+ * has no attendance model (DEC-004: no attendee tracking; the Event is emitted
+ * with joinMode: 'none'), so an inbound Join is never actionable. Per FEP-8a8e,
+ * a server that does not handle a Join MUST respond with an Ignore; the inbox
+ * dispatch does exactly that (see ProcessInboxService.processJoinActivity).
+ *
+ * This model exists so the inbound HTTP path can validate and enqueue a Join
+ * like any other supported activity type. The `object` (the thing being joined)
+ * may be either a URI string or an embedded object, so it is stored as-is.
+ */
+class JoinActivity extends ActivityPubActivity {
+
+  constructor(actorUrl: string, objectIdentifier: string | Record<string, any>) {
+    super(actorUrl);
+    this.type = 'Join';
+    this.object = objectIdentifier as any;
+    this.id = actorUrl + '/joins/' + uuidv4();
+  }
+
+  static fromObject(object: Record<string, any>): JoinActivity | null {
+    if (!object || typeof object !== 'object') {
+      return null;
+    }
+
+    if (!object.actor || typeof object.actor !== 'string') {
+      return null;
+    }
+
+    if (!object.object) {
+      return null;
+    }
+
+    const activity = new JoinActivity(object.actor, object.object);
+    if (object.id) {
+      activity.id = object.id;
+    }
+    if (object.to && Array.isArray(object.to)) {
+      activity.to = object.to;
+    }
+    return activity;
+  }
+}
+
+export default JoinActivity;

--- a/src/server/activitypub/model/base.ts
+++ b/src/server/activitypub/model/base.ts
@@ -3,8 +3,56 @@ import { Calendar } from '@/common/model/calendar';
 
 const AS_PUBLIC = 'https://www.w3.org/ns/activitystreams#Public';
 
+/** The base ActivityStreams 2.0 context IRI. */
+const AS_CONTEXT = 'https://www.w3.org/ns/activitystreams';
+
+/**
+ * Stable, project-level vocabulary IRI for Pavillion's ActivityPub extension
+ * terms (pavillion:content, pavillion:schedules, pavillion:place,
+ * pavillion:space, pavillion:categories, pavillion:series, pavillion:urlPrompt).
+ *
+ * This is deliberately a SINGLE shared IRI across every Pavillion instance —
+ * NOT a per-instance `https://{domain}/ns#` IRI. A per-domain IRI would make
+ * the same term (e.g. `pavillion:content`) expand to a different IRI on each
+ * instance, so cross-instance Pavillion payloads would not be JSON-LD-equivalent
+ * and a strict processor would treat them as different properties. Pinning one
+ * project namespace keeps federated Pavillion↔Pavillion payloads term-stable.
+ */
+const PAVILLION_NAMESPACE_IRI = 'https://pavillion.social/ns/activitypub#';
+
+/**
+ * JSON-LD @context term object mapping the `pavillion` prefix to the Pavillion
+ * vocabulary IRI. Declaring this inside the @context array lets JSON-LD-strict
+ * peers expand the pavillion:* extension terms instead of silently dropping
+ * them.
+ */
+const PAVILLION_CONTEXT_TERM: Record<string, string> = { pavillion: PAVILLION_NAMESPACE_IRI };
+
+/**
+ * FEP-8a8e event-extension context document IRI (https://w3id.org/fep/8a8e).
+ *
+ * FEP-8a8e defines its event terms (displayEndTime, timezone, eventStatus) as
+ * BARE, unprefixed top-level Event properties — unlike Pavillion's prefixed
+ * pavillion:* terms. Per the FEP-8a8e spec examples, the vocabulary is pulled in
+ * by listing its remote context document IRI as a plain string in the @context
+ * array (NOT as a { prefix: IRI } mapping). Declaring it lets JSON-LD-strict
+ * peers expand the bare FEP terms Pavillion emits on federated events instead of
+ * silently dropping them.
+ */
+const FEP_8A8E_CONTEXT = 'https://w3id.org/fep/8a8e';
+
+/**
+ * Full ActivityStreams + FEP-8a8e + Pavillion JSON-LD @context. Used both for
+ * the outbound activity envelope (below) and for standalone object/collection
+ * responses (GET event/series and the series collection) that carry pavillion:*
+ * and FEP-8a8e terms but are not wrapped in an activity envelope.
+ */
+const AP_CONTEXT: (string | Record<string, string>)[] = [AS_CONTEXT, FEP_8A8E_CONTEXT, PAVILLION_CONTEXT_TERM];
+
 class ActivityPubActivity {
-  context: string[] = ['https://www.w3.org/ns/activitystreams'];
+  // Spread AP_CONTEXT (single source of truth) into a fresh per-instance array
+  // so instances never share a mutable reference.
+  context: (string | Record<string, string>)[] = [...AP_CONTEXT];
   id: string = '';
   type: string = '';
   actor: string = '';
@@ -95,4 +143,14 @@ class ActivityPubActor {
   }
 }
 
-export { ActivityPubActivity, ActivityPubActor, ActivityPubObject, AS_PUBLIC };
+export {
+  ActivityPubActivity,
+  ActivityPubActor,
+  ActivityPubObject,
+  AS_PUBLIC,
+  AS_CONTEXT,
+  AP_CONTEXT,
+  FEP_8A8E_CONTEXT,
+  PAVILLION_NAMESPACE_IRI,
+  PAVILLION_CONTEXT_TERM,
+};

--- a/src/server/activitypub/model/object/event.ts
+++ b/src/server/activitypub/model/object/event.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 import he from 'he';
-import { DateTime } from 'luxon';
+import { DateTime, IANAZone } from 'luxon';
 import striptags from 'striptags';
 
 import { Calendar } from '@/common/model/calendar';
@@ -10,6 +10,7 @@ import { ActivityPubObject } from '@/server/activitypub/model/base';
 import { SeriesObject } from '@/server/activitypub/model/object/series';
 import { createLogger } from '@/server/common/helper/logger';
 import { sanitizeExternalUrlHref } from '@/server/activitypub/helper/url-sanitizer';
+import { mapEventCategoriesToFep } from '@/server/activitypub/helper/fep_category_map';
 
 const logger = createLogger('activitypub');
 
@@ -155,8 +156,77 @@ class EventObject extends ActivityPubObject {
       const synthesizedEnd = DateTime.fromISO(startTime, { setZone: true }).plus({ hours: 1 });
       if (synthesizedEnd.isValid) {
         result.endTime = synthesizedEnd.toISO();
+        // FEP-8a8e displayEndTime (bare term, see AP_CONTEXT in base.ts): the
+        // endTime above is fabricated — the real end time is unknown — so signal
+        // FEP-aware peers (Mobilizon, etc.) NOT to present it as fact. Emitted
+        // `false` ONLY on this synthesized branch; when a real eventEndTime
+        // exists we emit no displayEndTime at all (its FEP default is true).
+        result.displayEndTime = false;
       }
     }
+
+    // --- FEP-8a8e event extension terms (https://w3id.org/fep/8a8e) ---
+    // Emitted as BARE (unprefixed) keys per the FEP-8a8e spec, which defines
+    // displayEndTime / timezone / eventStatus as top-level Event properties.
+    // The FEP context document IRI is declared in AP_CONTEXT (base.ts) so
+    // JSON-LD peers expand them. (displayEndTime is emitted above, inline with
+    // the synthesized-endTime branch it qualifies.)
+
+    // timezone: the IANA identifier of the first schedule's start zone, so peers
+    // can reconstruct the intended wall-clock time instead of relying on the ISO
+    // offset alone. Omitted when the zone is a fixed offset (e.g. 'UTC+2') rather
+    // than a named IANA zone — a bare offset carries no more than startTime
+    // already does. 'UTC' is itself a valid IANA zone and IS emitted.
+    const scheduleZone = firstSchedule?.startDate?.zoneName;
+    if (scheduleZone && IANAZone.isValidZone(scheduleZone)) {
+      result.timezone = scheduleZone;
+    }
+
+    // eventStatus: Pavillion has no event-level cancellation state (whole-event
+    // removal federates as a Delete activity; per-occurrence cancellation lives
+    // in pavillion:schedules). Every live serialized event is therefore
+    // Scheduled — emitted unconditionally so non-Pavillion peers see a status.
+    result.eventStatus = 'EventScheduled';
+
+    // --- FEP-8a8e event extension terms (continued) ---
+    // organizers / joinMode are bare (unprefixed) FEP-8a8e keys; the FEP context
+    // IRI is already declared in AP_CONTEXT (base.ts), so no @context change is
+    // needed here.
+
+    // organizers: FEP-8a8e's only MUST beyond name/startTime/endTime. The
+    // property must be present on every Event; a null value would signal
+    // intentional non-disclosure of the organizer. Pavillion always discloses
+    // the owning calendar actor, so we emit the Collection form mirroring
+    // attributedTo (the calendar actor URI) as its single member.
+    result.organizers = {
+      type: 'Collection',
+      totalItems: 1,
+      items: [this.attributedTo],
+    };
+
+    // joinMode: 'none' states explicitly that Pavillion has no RSVP/attendance
+    // model (DEC-004: no attendee tracking). 'none' is FEP-8a8e's blessed signal
+    // for "this event cannot be joined", so FEP-aware peers suppress any RSVP UI
+    // and never send a Join they expect us to honour.
+    result.joinMode = 'none';
+
+    // --- FEP-8a8e category (pv-2p29.4) ---
+    // category: the bare FEP-8a8e `category` property, a shared controlled
+    // vocabulary (MUSIC, SPORTS, ...) that non-Pavillion peers (Mobilizon,
+    // Gancio) can interpret. Pavillion categories are instance-defined
+    // TranslatedModels, so we map each category NAME onto the closest FEP enum
+    // value via a keyword heuristic (fep_category_map). Emitted ALONGSIDE the
+    // pavillion:categories URIs below — those still carry full Pavillion↔
+    // Pavillion fidelity; this bare enum is the interop surface. Emitted as an
+    // array per the FEP-8a8e `xsd:string (@list)` range. Categories that do not
+    // map confidently contribute nothing, and the property is omitted entirely
+    // when no category maps. The FEP context IRI is already declared in
+    // AP_CONTEXT (base.ts), so no @context change is needed here.
+    const fepCategories = mapEventCategoriesToFep(event.categories ?? []);
+    if (fepCategories.length > 0) {
+      result.category = fepCategories;
+    }
+
     // location: emitted as Place with optional PostalAddress; omitted if no location.
     // When a Space is present, the flat `as:Place.name` is concatenated as
     // `Place — Space` in the primary language so non-Pavillion peers (Mobilizon,
@@ -392,12 +462,36 @@ class EventObject extends ActivityPubObject {
       result.schedules = apObject.schedules;
     }
     else if (apObject.startTime) {
-      // Synthesize a schedule from standard AS startTime/endTime
+      // Synthesize a schedule from standard AS startTime/endTime.
+      //
+      // FEP-8a8e timezone: when a non-Pavillion peer supplies the IANA
+      // `timezone` the event's times are given in, reinterpret the AS instants
+      // into that zone so the reconstructed schedule carries the intended
+      // wall-clock time rather than a raw UTC/offset instant (fixing events that
+      // otherwise render at the wrong local time). Only IANA-valid zone names
+      // are honoured; a bare offset (or garbage) is ignored and the instant
+      // passes through unchanged. displayEndTime / eventStatus are non-mapping
+      // FEP terms — they are tolerated (spread through, ignored downstream)
+      // rather than acted on; a remote EventCancelled is intentionally NOT
+      // applied here (would require an origin-gated hide flow — follow-up).
+      const inboundZone = typeof apObject.timezone === 'string' && IANAZone.isValidZone(apObject.timezone)
+        ? apObject.timezone
+        : null;
+      const applyZone = (iso: string): string => {
+        if (!inboundZone) {
+          return iso;
+        }
+        // `{ zone }` interprets an offset-less string as wall-clock in the zone,
+        // and converts an offset-bearing instant into the zone — both preserve
+        // the absolute instant while attaching the intended local zone.
+        const dt = DateTime.fromISO(iso, { zone: inboundZone });
+        return dt.isValid ? dt.toISO()! : iso;
+      };
       const schedule: Record<string, any> = {
-        start: apObject.startTime,
+        start: applyZone(apObject.startTime),
       };
       if (apObject.endTime) {
-        schedule.end = apObject.endTime;
+        schedule.end = applyZone(apObject.endTime);
       }
       result.schedules = [schedule];
     }

--- a/src/server/activitypub/service/inbox.ts
+++ b/src/server/activitypub/service/inbox.ts
@@ -13,6 +13,7 @@ import UpdateActivity from "@/server/activitypub/model/action/update";
 import DeleteActivity from "@/server/activitypub/model/action/delete";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
+import IgnoreActivity from "@/server/activitypub/model/action/ignore";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
 import { ActivityPubInboxMessageEntity, EventActivityEntity, FollowerCalendarEntity, FollowingCalendarEntity, RepostDismissalEntity, SharedEventEntity } from "@/server/activitypub/entity/activitypub";
 import { EventObjectEntity } from "@/server/activitypub/entity/event_object";
@@ -27,6 +28,7 @@ import { ReportCategory } from "@/common/model/report";
 import { Calendar } from "@/common/model/calendar";
 import { addToOutbox } from "@/server/activitypub/helper/outbox";
 import { fetchRemoteObject } from "@/server/activitypub/helper/remote-fetch";
+import { parseInboundFepCategories, resolveFepCategoriesToLocalIds } from "@/server/activitypub/helper/fep_category_map";
 import { Op } from "sequelize";
 import config from "config";
 
@@ -472,6 +474,18 @@ class ProcessInboxService {
           await this.processShareEvent(calendar, activity);
         }
         break;
+      case 'Join':
+        {
+          // FEP-8a8e: Pavillion has no attendance model (events are emitted with
+          // joinMode: 'none'), so an inbound Join is never actionable. The FEP
+          // requires we respond with an Ignore rather than silently drop it.
+          // No state is mutated here. The blocked-instance gate in
+          // processInboxMessage already short-circuits Joins from blocked
+          // instances before dispatch, so this handler only runs for allowed
+          // senders.
+          await this.processJoinActivity(calendar, message.message);
+        }
+        break;
       case 'Flag':
         {
           await this.processFlagActivity(calendar, message.message);
@@ -520,6 +534,42 @@ class ProcessInboxService {
     }
   }
 
+
+  /**
+   * Processes an inbound Join activity by replying with an Ignore.
+   *
+   * FEP-8a8e: Pavillion emits every Event with `joinMode: 'none'` and keeps no
+   * attendance/RSVP state (DEC-004), so a Join is never actionable. Rather than
+   * silently drop it, the FEP requires responding with an Ignore. This handler
+   * therefore performs NO state mutation — it only queues an Ignore addressed
+   * directly to the sender (never as:Public).
+   *
+   * The Ignore embeds the original Join as its `object` (mirroring how Accept
+   * embeds the Follow it answers), so the sender can correlate the reply. The
+   * outbox resolves delivery to `object.actor` — the Join sender — and the
+   * explicit single-recipient `to` keeps the reply off the public timeline.
+   *
+   * @param calendar - The calendar that received the Join
+   * @param message - The raw inbound Join activity payload
+   * @returns {Promise<void>}
+   */
+  async processJoinActivity(calendar: Calendar, message: any): Promise<void> {
+    const senderActor = message?.actor;
+    if (!senderActor || typeof senderActor !== 'string') {
+      logger.warn('[INBOX] Join activity missing actor; cannot reply with Ignore');
+      return;
+    }
+
+    logger.info({ senderActor, calendarUrlName: calendar.urlName }, '[INBOX] Ignoring unhandled Join activity');
+
+    const localActorUrl = ActivityPubActor.actorUrl(calendar);
+    const ignoreActivity = new IgnoreActivity(localActorUrl, message);
+    // Address the reply to the sender only — an Ignore is a private courtesy
+    // response, never a public-timeline activity.
+    ignoreActivity.to = [senderActor];
+
+    await addToOutbox(this.eventBus, calendar, ignoreActivity);
+  }
 
   /**
    * Processes a Flag activity by creating a federated report.
@@ -781,7 +831,20 @@ class ProcessInboxService {
     });
 
     if (existingApObject) {
-      // Event already exists, skip
+      // On the local in-process dispatch path (`trustLocalOrigin`), the
+      // EventObjectEntity for this event is written by handleEventCreated
+      // BEFORE the outbox fans the Create out to same-instance followers, so
+      // an existing row is expected — it is NOT a duplicate delivery. Local
+      // originals now federate as Create(Event) (Announce is reserved for
+      // reposts), so the auto-repost cascade for same-instance followers must
+      // be driven here; this is the Create-path equivalent of the
+      // processShareEvent → checkAndPerformAutoRepost cascade that previously
+      // ran when originals were Announced. isOriginal is true because a Create
+      // is always authored by its actor (matches the trailing call below).
+      if (options.trustLocalOrigin) {
+        await this.checkAndPerformAutoRepost(calendar, actorUri, apObjectId, true);
+      }
+      // Remote re-delivery of an already-known event is a genuine duplicate: skip.
       return null;
     }
 
@@ -900,6 +963,35 @@ class ProcessInboxService {
     // Check for auto-repost (skip if Person actor or no event created)
     if (!isPersonActor && createdEvent) {
       await this.checkAndPerformAutoRepost(calendar, actorUri, apObjectId, true);
+    }
+
+    // FEP-8a8e category fallback (pv-2p29.4): when the payload carries NO
+    // pavillion:categories / bare categories URIs (sourceCategories === null,
+    // i.e. a non-Pavillion peer such as Mobilizon/Gancio), fall back to the bare
+    // FEP-8a8e `category` enum. Resolve those enum values onto this calendar's
+    // EXISTING local categories by name heuristic and assign the matches, so the
+    // federated event lands with usable categories. pavillion:categories always
+    // takes precedence — this path only runs when it is absent. Federation input
+    // NEVER creates categories: only pre-existing local categories can match.
+    // Failure-safe: category assignment must never abort event ingest.
+    if (createdEvent && sourceCategories === null) {
+      try {
+        const inboundFep = parseInboundFepCategories((message.object as any)?.category);
+        if (inboundFep.length > 0) {
+          const localCategories = await this.calendarInterface.getCategories(calendar.id);
+          const localIds = resolveFepCategoriesToLocalIds(inboundFep, localCategories);
+          if (localIds.length > 0) {
+            // assignManualRepostCategories assigns the given local category ids
+            // to the event with no permission check; the ids here are resolved
+            // from this calendar's own categories, so they are trusted by
+            // construction.
+            await this.calendarInterface.assignManualRepostCategories(createdEvent.id, localIds);
+          }
+        }
+      }
+      catch (error) {
+        logger.warn({ err: error }, '[INBOX] FEP category fallback mapping failed, proceeding without categories');
+      }
     }
 
     return createdEvent;

--- a/src/server/activitypub/service/outbox.ts
+++ b/src/server/activitypub/service/outbox.ts
@@ -16,6 +16,7 @@ import AddActivity from "@/server/activitypub/model/action/add";
 import RemoveActivity from "@/server/activitypub/model/action/remove";
 import FollowActivity from "@/server/activitypub/model/action/follow";
 import AcceptActivity from "@/server/activitypub/model/action/accept";
+import IgnoreActivity from "@/server/activitypub/model/action/ignore";
 import AnnounceActivity from "@/server/activitypub/model/action/announce";
 import CreateActivity from "@/server/activitypub/model/action/create";
 import UndoActivity from "@/server/activitypub/model/action/undo";
@@ -315,6 +316,18 @@ class ProcessOutboxService {
           throw new Error('Failed to parse Accept activity');
         }
         // For Accept activities, send to the actor of the original Follow
+        if (activity.object && typeof activity.object === 'object' && activity.object.actor) {
+          recipients = [activity.object.actor];
+        }
+        break;
+      case 'Ignore':
+        activity = IgnoreActivity.fromObject(message.message);
+        if (!activity) {
+          throw new Error('Failed to parse Ignore activity');
+        }
+        // FEP-8a8e Join reply: deliver only to the actor of the embedded Join
+        // (the sender). Mirrors Accept — a direct, single-recipient reply that
+        // is never fanned out to followers or the public timeline.
         if (activity.object && typeof activity.object === 'object' && activity.object.actor) {
           recipients = [activity.object.actor];
         }

--- a/src/server/activitypub/service/server.ts
+++ b/src/server/activitypub/service/server.ts
@@ -350,8 +350,8 @@ export default class ActivityPubService {
 
   /**
    * Retrieve paginated outbox messages for a calendar.
-   * Returns only public activity types (Announce, Update, Delete) that were
-   * successfully processed.
+   * Returns only public activity types (Create, Announce, Update, Delete) that
+   * were successfully processed.
    *
    * @param calendarId - The calendar ID to query
    * @param cursor - Optional ISO 8601 timestamp cursor for paging (exclusive upper bound)
@@ -359,7 +359,13 @@ export default class ActivityPubService {
    * @returns Object with items array and totalItems count
    */
   async readOutbox(calendarId: string, cursor?: Date, limit: number = 20): Promise<{ items: ActivityPubOutboxMessageEntity[], totalItems: number }> {
-    const publicTypes = ['Announce', 'Update', 'Delete'];
+    // 'Create' MUST be served: local originals now federate as Create(Event)
+    // (Announce is reserved for reposts), so a follower's backfill walk of this
+    // outbox — and FEP-8a8e event consumers (Mobilizon/Gancio) — only see
+    // originals if Create is in the collection. Inbound Create(Note) is
+    // short-circuited by the receiver (ProcessInboxService.processCreateEvent),
+    // so serving the paired Note here cannot create a duplicate feed event.
+    const publicTypes = ['Create', 'Announce', 'Update', 'Delete'];
     const where: Record<string, any> = {
       calendar_id: calendarId,
       type: publicTypes,

--- a/src/server/activitypub/test/api/get-endpoints.test.ts
+++ b/src/server/activitypub/test/api/get-endpoints.test.ts
@@ -81,6 +81,14 @@ describe('GET /calendars/:urlname/events/:eventid', () => {
     expect(result.startTime).toBe(startDt.toISO());
     expect(result.attributedTo).toContain('/calendars/mycal');
     expect(result.id).toContain('/calendars/mycal/events/event-uuid');
+    // Standalone object response must declare a full @context including the
+    // pavillion namespace so the pavillion:* extension terms expand for
+    // JSON-LD-strict peers instead of being silently dropped.
+    expect(result['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      'https://w3id.org/fep/8a8e',
+      { pavillion: 'https://pavillion.social/ns/activitypub#' },
+    ]);
     // Verify pavillion extensions are present
     expect(result['pavillion:content']).toBeDefined();
     expect(result['pavillion:schedules']).toBeDefined();
@@ -203,6 +211,12 @@ describe('GET /calendars/:urlname/events/:eventid/note', () => {
     expect(result.id).toMatch(/\/note$/);
     expect(result.id).toContain(`/calendars/mycal/events/${validEventId}/note`);
     expect(result.attributedTo).toContain('/calendars/mycal');
+    // Standalone object response must declare its own JSON-LD @context.
+    expect(result['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      'https://w3id.org/fep/8a8e',
+      { pavillion: 'https://pavillion.social/ns/activitypub#' },
+    ]);
   });
 });
 
@@ -269,6 +283,13 @@ describe('GET /calendars/:urlname/series/:seriesid', () => {
     expect(result.name).toBe('Concert Series');
     expect(result.attributedTo).toContain('/calendars/mycal');
     expect(result.id).toContain('/calendars/mycal/series/series-uuid');
+    // Standalone object response must declare a full @context including the
+    // pavillion namespace for the pavillion:content term.
+    expect(result['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      'https://w3id.org/fep/8a8e',
+      { pavillion: 'https://pavillion.social/ns/activitypub#' },
+    ]);
     expect(result['pavillion:content']).toBeDefined();
   });
 
@@ -342,6 +363,14 @@ describe('GET /calendars/:urlname/series (collection)', () => {
     expect(result.type).toBe('OrderedCollection');
     expect(result.totalItems).toBe(2);
     expect(result.orderedItems).toHaveLength(2);
+    // The collection is the top-level JSON-LD document; its @context must
+    // declare the pavillion namespace so the pavillion:content term carried by
+    // each nested series item expands for strict processors.
+    expect(result['@context']).toEqual([
+      'https://www.w3.org/ns/activitystreams',
+      'https://w3id.org/fep/8a8e',
+      { pavillion: 'https://pavillion.social/ns/activitypub#' },
+    ]);
 
     // Verify items are serialized via toActivityPubObject, not raw instances
     expect(result.orderedItems[0].name).toBe('First Series');

--- a/src/server/activitypub/test/events.test.ts
+++ b/src/server/activitypub/test/events.test.ts
@@ -239,10 +239,11 @@ describe('handleEventCreated', () => {
     await teardownActivityPubSchema();
   });
 
-  it('creates an EventObjectEntity for the local event before dispatching paired Announce(Event) + Create(Note)', async () => {
+  it('creates an EventObjectEntity for the local event before dispatching paired Create(Event) + Create(Note)', async () => {
     const calendar = Calendar.fromObject({ id: uuidv4(), urlName: 'my_calendar' });
     const event = CalendarEvent.fromObject({ id: uuidv4() });
     const actorUrl = ActivityPubActor.actorUrl(calendar);
+    const eventUrl = EventObject.eventUrl(calendar, event);
 
     // Stub the service methods that would otherwise hit the database / network
     sandbox.stub(service, 'actorUrl').resolves(actorUrl);
@@ -255,21 +256,40 @@ describe('handleEventCreated', () => {
     const eventObject = await EventObjectEntity.findOne({ where: { event_id: event.id } });
     expect(eventObject, 'EventObjectEntity must exist for local event').not.toBeNull();
     expect(eventObject!.attributed_to).toBe(actorUrl);
-    // Paired emission: Announce(Event) first, Create(Note) second, both with
-    // public addressing so Mastodon-class peers render the Note while
-    // Pavillion-aware peers consume the Event.
+    // Paired emission: Create(Event) first, Create(Note) second, both with
+    // public addressing. New local originals federate as Create(Event) with the
+    // full embedded Event object (Announce is reserved for reposts); the paired
+    // Create(Note) lets Mastodon-class peers render the event on profile
+    // timelines.
     expect(addToOutboxStub.calledTwice).toBe(true);
 
-    // Announce envelope must be addressed publicly with followers in cc and a
-    // populated published timestamp — without these, Mastodon ignores the
-    // activity in profile timelines and HTTP delivery loses audience info.
-    const announceCall = addToOutboxStub.getCall(0);
-    expect(announceCall.args[0]).toBe(calendar);
-    const announce = announceCall.args[1];
-    expect(announce.type).toBe('Announce');
-    expect(announce.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
-    expect(announce.cc).toEqual([`${actorUrl}/followers`]);
-    expect(announce.published).toBeInstanceOf(Date);
+    // Create(Event) envelope must embed the full Event object, carry the
+    // deterministic `{eventUrl}/create` id, and be addressed publicly with
+    // followers in cc and a populated published timestamp — without these,
+    // Mastodon/Mobilizon/Gancio ignore the activity or lose audience info.
+    const createEventCall = addToOutboxStub.getCall(0);
+    expect(createEventCall.args[0]).toBe(calendar);
+    const createEvent = createEventCall.args[1];
+    expect(createEvent.type).toBe('Create');
+    expect(createEvent.object.type).toBe('Event');
+    expect(createEvent.id).toBe(`${eventUrl}/create`);
+    expect(createEvent.to).toEqual(['https://www.w3.org/ns/activitystreams#Public']);
+    expect(createEvent.cc).toEqual([`${actorUrl}/followers`]);
+    expect(createEvent.published).toBeInstanceOf(Date);
+
+    // PRIVACY: the embedded Event object is now sent to federation (public +
+    // followers), so its serialized wire form must not leak internal
+    // identifiers. Actors are addressed by public URL (attributedTo), never by
+    // the internal calendar/account UUIDs. This guards against a regression
+    // that serializes internal ids onto the public payload.
+    const embeddedEvent = (createEvent.object as EventObject).toActivityPubObject();
+    expect(embeddedEvent).not.toHaveProperty('calendarId');
+    expect(embeddedEvent).not.toHaveProperty('accountId');
+    expect(embeddedEvent.attributedTo).toBe(actorUrl);
+
+    // No Announce is emitted for originals — Announce is repost-only.
+    const emittedTypes = addToOutboxStub.getCalls().map(c => c.args[1].type);
+    expect(emittedTypes).not.toContain('Announce');
 
     // Paired Create(Note) emission with matching public addressing. The Note
     // wraps the same canonical event so Mastodon-class peers render it on
@@ -334,13 +354,13 @@ describe('handleEventCreated', () => {
     ).toBe(true);
   });
 
-  it('returns early without dispatching Announce when payload.calendar is null (remote-origin event)', async () => {
+  it('returns early without dispatching Create when payload.calendar is null (remote-origin event)', async () => {
     // EventService.addRemoteEvent emits eventCreated with calendar:null so the
     // calendar-domain buildEventInstances handler materializes canonical rows
     // for inbound federated events. The AP handler must early-return on the
     // same payload — without this guard, the handler would call
     // EventObject.eventUrl(null, ...) (crash) and addToOutbox(null, ...)
-    // (re-Announce a remote event back to federation, creating a loop).
+    // (re-Create a remote event back to federation, creating a loop).
     const event = CalendarEvent.fromObject({ id: uuidv4() });
 
     const actorUrlStub = sandbox.stub(service, 'actorUrl');

--- a/src/server/activitypub/test/helper/fep_category_map.test.ts
+++ b/src/server/activitypub/test/helper/fep_category_map.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+
+import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
+import {
+  FEP_CATEGORY_VALUES,
+  mapNameToFepCategory,
+  mapCategoryToFepCategory,
+  mapEventCategoriesToFep,
+  parseInboundFepCategories,
+  resolveFepCategoriesToLocalIds,
+} from '@/server/activitypub/helper/fep_category_map';
+
+/**
+ * Builds an EventCategory with one or more language names.
+ */
+function category(id: string, names: Record<string, string>): EventCategory {
+  const cat = new EventCategory(id, 'calendar-id');
+  for (const [lang, name] of Object.entries(names)) {
+    cat.addContent(new EventCategoryContent(lang, name));
+  }
+  return cat;
+}
+
+describe('fep_category_map', () => {
+
+  describe('FEP_CATEGORY_VALUES', () => {
+    it('contains exactly the 36 FEP-8a8e enum values', () => {
+      expect(FEP_CATEGORY_VALUES).toHaveLength(36);
+      expect(FEP_CATEGORY_VALUES).toContain('MUSIC');
+      expect(FEP_CATEGORY_VALUES).toContain('SPORTS');
+      expect(FEP_CATEGORY_VALUES).toContain('MOVEMENTS_POLITICS');
+      expect(FEP_CATEGORY_VALUES).toContain('WORKSHOPS_SKILL_SHARING');
+      expect(FEP_CATEGORY_VALUES).toContain('LGBTQ');
+    });
+
+    it('has no duplicate values', () => {
+      expect(new Set(FEP_CATEGORY_VALUES).size).toBe(FEP_CATEGORY_VALUES.length);
+    });
+  });
+
+  describe('mapNameToFepCategory (name -> enum heuristic)', () => {
+    it('maps obvious names to their enum via whole-word keywords', () => {
+      expect(mapNameToFepCategory('Music')).toBe('MUSIC');
+      expect(mapNameToFepCategory('Live Concert')).toBe('MUSIC');
+      expect(mapNameToFepCategory('Sports')).toBe('SPORTS');
+      expect(mapNameToFepCategory('Local Football League')).toBe('SPORTS');
+      expect(mapNameToFepCategory('Workshop')).toBe('WORKSHOPS_SKILL_SHARING');
+      expect(mapNameToFepCategory('Pride Celebration')).toBe('LGBTQ');
+      expect(mapNameToFepCategory('Political Rally')).toBe('MOVEMENTS_POLITICS');
+    });
+
+    it('is case-insensitive and tolerant of surrounding words', () => {
+      expect(mapNameToFepCategory('WEEKLY yoga class')).toBe('MEDITATION_WELLBEING');
+      expect(mapNameToFepCategory('Community Potluck Dinner')).toBe('FOOD_DRINK');
+    });
+
+    it('returns null when no keyword matches confidently', () => {
+      expect(mapNameToFepCategory('Miscellaneous')).toBeNull();
+      expect(mapNameToFepCategory('Zephyr')).toBeNull();
+      expect(mapNameToFepCategory('')).toBeNull();
+      expect(mapNameToFepCategory('   ')).toBeNull();
+    });
+
+    it('does not match keywords as sub-strings of unrelated words', () => {
+      // "art" must not fire on "party" or "cart"
+      expect(mapNameToFepCategory('Birthday Cart')).toBeNull();
+      // "party" resolves to PARTY, never ARTS
+      expect(mapNameToFepCategory('Block Party')).toBe('PARTY');
+    });
+
+    it('prefers the more specific entry when one name matches multiple entries (phrase subsumption)', () => {
+      // "visual arts" (PERFORMING_VISUAL_ARTS) subsumes "arts" (ARTS); PVA is
+      // ordered first and wins.
+      expect(mapNameToFepCategory('Visual Arts Evening')).toBe('PERFORMING_VISUAL_ARTS');
+      // "family" (FAMILY_EDUCATION) + "education" (LEARNING) both match; the
+      // more specific FAMILY_EDUCATION is ordered first and wins.
+      expect(mapNameToFepCategory('Family Education Night')).toBe('FAMILY_EDUCATION');
+      // "art jam" (CREATIVE_JAM) subsumes "art" (ARTS); CREATIVE_JAM wins.
+      expect(mapNameToFepCategory('Weekend Art Jam')).toBe('CREATIVE_JAM');
+    });
+
+    it('resolves a bare "musical" to MUSIC (single-owner keyword), not THEATRE', () => {
+      // Regression guard for the one real shared-keyword collision: "musical"
+      // is owned solely by MUSIC. A name carrying only "musical" must resolve
+      // to MUSIC deterministically, independent of array order.
+      expect(mapNameToFepCategory('Musical Night')).toBe('MUSIC');
+      expect(mapNameToFepCategory('The Musical Revue')).toBe('MUSIC');
+      // A named stage musical still lands on THEATRE via the unambiguous
+      // "theatre" keyword (THEATRE precedes MUSIC in the array).
+      expect(mapNameToFepCategory('Musical Theatre Showcase')).toBe('THEATRE');
+    });
+  });
+
+  describe('mapCategoryToFepCategory (translated model, all languages)', () => {
+    it('matches on the English name when present', () => {
+      expect(mapCategoryToFepCategory(category('c1', { en: 'Music' }))).toBe('MUSIC');
+    });
+
+    it('falls back to a non-English name when English does not match', () => {
+      // English name is opaque, but the German name maps to MUSIC ("konzert")
+      const cat = category('c1', { en: 'Programm', de: 'Konzert' });
+      // 'konzert' is not an English keyword, so this stays null — heuristic is
+      // English-keyword based in v1. Documents the known limitation.
+      expect(mapCategoryToFepCategory(cat)).toBeNull();
+    });
+
+    it('matches when a non-English language carries an English-recognizable name', () => {
+      const cat = category('c1', { fr: 'Programme', en: 'Photography Walk' });
+      expect(mapCategoryToFepCategory(cat)).toBe('PHOTOGRAPHY');
+    });
+
+    it('returns null for a category with no matching names', () => {
+      expect(mapCategoryToFepCategory(category('c1', { en: 'General' }))).toBeNull();
+    });
+  });
+
+  describe('mapEventCategoriesToFep (outbound)', () => {
+    it('returns deduped enum values preserving first-seen order', () => {
+      const cats = [
+        category('c1', { en: 'Live Music' }),
+        category('c2', { en: 'Concert Series' }), // also MUSIC -> deduped
+        category('c3', { en: 'Food & Drink' }),
+      ];
+      expect(mapEventCategoriesToFep(cats)).toEqual(['MUSIC', 'FOOD_DRINK']);
+    });
+
+    it('omits categories that do not map', () => {
+      const cats = [
+        category('c1', { en: 'General' }),
+        category('c2', { en: 'Sports Night' }),
+      ];
+      expect(mapEventCategoriesToFep(cats)).toEqual(['SPORTS']);
+    });
+
+    it('returns an empty array for no categories', () => {
+      expect(mapEventCategoriesToFep([])).toEqual([]);
+      expect(mapEventCategoriesToFep(undefined as any)).toEqual([]);
+    });
+  });
+
+  describe('parseInboundFepCategories', () => {
+    it('accepts a single string enum value', () => {
+      expect(parseInboundFepCategories('MUSIC')).toEqual(['MUSIC']);
+    });
+
+    it('accepts an array of enum values and dedupes', () => {
+      expect(parseInboundFepCategories(['MUSIC', 'SPORTS', 'MUSIC'])).toEqual(['MUSIC', 'SPORTS']);
+    });
+
+    it('drops unknown or malformed values defensively', () => {
+      expect(parseInboundFepCategories(['MUSIC', 'NOT_A_CATEGORY', 42, null, {}])).toEqual(['MUSIC']);
+      expect(parseInboundFepCategories('nonsense')).toEqual([]);
+      expect(parseInboundFepCategories(undefined)).toEqual([]);
+      expect(parseInboundFepCategories(null)).toEqual([]);
+    });
+  });
+
+  describe('resolveFepCategoriesToLocalIds (inbound)', () => {
+    it('resolves inbound enums to existing local categories by name heuristic', () => {
+      const local = [
+        category('local-music', { en: 'Concerts' }),   // -> MUSIC
+        category('local-sport', { en: 'Sports' }),      // -> SPORTS
+        category('local-misc', { en: 'General' }),      // -> null
+      ];
+      expect(resolveFepCategoriesToLocalIds(['MUSIC'], local)).toEqual(['local-music']);
+      expect(resolveFepCategoriesToLocalIds(['MUSIC', 'SPORTS'], local).sort())
+        .toEqual(['local-music', 'local-sport']);
+    });
+
+    it('returns empty when no local category matches the inbound enum', () => {
+      const local = [category('local-misc', { en: 'General' })];
+      expect(resolveFepCategoriesToLocalIds(['MUSIC'], local)).toEqual([]);
+    });
+
+    it('never invents ids and handles empty inputs', () => {
+      expect(resolveFepCategoriesToLocalIds([], [category('c1', { en: 'Music' })])).toEqual([]);
+      expect(resolveFepCategoriesToLocalIds(['MUSIC'], [])).toEqual([]);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    it('a local category emitted as FEP resolves back to itself', () => {
+      const local = [category('local-music', { en: 'Music Night' })];
+      const emitted = mapEventCategoriesToFep(local);
+      expect(emitted).toEqual(['MUSIC']);
+      const resolved = resolveFepCategoriesToLocalIds(emitted, local);
+      expect(resolved).toEqual(['local-music']);
+    });
+  });
+});

--- a/src/server/activitypub/test/inbox-source-categories.test.ts
+++ b/src/server/activitypub/test/inbox-source-categories.test.ts
@@ -20,6 +20,8 @@ import ProcessInboxService from '@/server/activitypub/service/inbox';
 import { EventObjectEntity } from '@/server/activitypub/entity/event_object';
 import CreateActivity from '@/server/activitypub/model/action/create';
 import { Calendar, CalendarContent } from '@/common/model/calendar';
+import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
 import { EventEmitter } from 'events';
 import CalendarInterface from '@/server/calendar/interface';
 
@@ -230,5 +232,201 @@ describe('ProcessInboxService - source_categories parsing', () => {
 
     expect(capturedDefaults).not.toBeNull();
     expect(capturedDefaults.source_categories).toBeNull();
+  });
+
+  describe('FEP-8a8e category fallback (inbound)', () => {
+
+    function localCategory(id: string, name: string): EventCategory {
+      const cat = new EventCategory(id, testCalendar.id);
+      cat.addContent(new EventCategoryContent('en', name));
+      return cat;
+    }
+
+    it('assigns matching local categories from the FEP category when pavillion:categories absent', async () => {
+      const localEventId = uuidv4();
+      const eventApId = `https://mobilizon.example/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Mobilizon Concert',
+        // No pavillion:categories / bare categories URIs; only the FEP enum
+        category: 'MUSIC',
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: localEventId } as any);
+
+      const getCategoriesStub = sandbox.stub(calendarInterface, 'getCategories').resolves([
+        localCategory('local-music', 'Concerts'),
+        localCategory('local-misc', 'General'),
+      ]);
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories').resolves();
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+      await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      expect(getCategoriesStub.calledOnceWith(testCalendar.id)).toBe(true);
+      expect(assignStub.calledOnce).toBe(true);
+      expect(assignStub.firstCall.args[0]).toBe(localEventId);
+      expect(assignStub.firstCall.args[1]).toEqual(['local-music']);
+    });
+
+    it('does not assign when the FEP category has no matching local category', async () => {
+      const eventApId = `https://mobilizon.example/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Mobilizon Concert',
+        category: 'MUSIC',
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: uuidv4() } as any);
+
+      sandbox.stub(calendarInterface, 'getCategories').resolves([
+        localCategory('local-misc', 'General'),
+      ]);
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories').resolves();
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+      await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      expect(assignStub.called).toBe(false);
+    });
+
+    it('never creates categories: only resolves against existing local categories', async () => {
+      const eventApId = `https://mobilizon.example/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Mobilizon Event',
+        category: ['MUSIC', 'SPORTS'],
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: uuidv4() } as any);
+
+      // Calendar has an empty taxonomy — nothing to match, nothing created.
+      const getCategoriesStub = sandbox.stub(calendarInterface, 'getCategories').resolves([]);
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories').resolves();
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+      await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      expect(getCategoriesStub.calledOnce).toBe(true);
+      expect(assignStub.called).toBe(false);
+    });
+
+    it('pavillion:categories take precedence: FEP fallback is skipped when categories present', async () => {
+      const eventApId = `https://remote.example.com/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Pavillion Event',
+        categories: [
+          `https://remote.example.com/api/public/v1/calendars/remotecal/categories/${categoryId1}`,
+        ],
+        category: 'MUSIC',
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: uuidv4() } as any);
+
+      const getCategoriesStub = sandbox.stub(calendarInterface, 'getCategories').resolves([
+        localCategory('local-music', 'Concerts'),
+      ]);
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories').resolves();
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+      await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      // sourceCategories is non-null (bare categories parsed) -> FEP path skipped
+      expect(getCategoriesStub.called).toBe(false);
+      expect(assignStub.called).toBe(false);
+    });
+
+    it('assigns nothing for an unrecognized/garbage remote category value', async () => {
+      const eventApId = `https://mobilizon.example/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Mobilizon Event',
+        category: 'TOTALLY_NOT_A_CATEGORY',
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: uuidv4() } as any);
+
+      const getCategoriesStub = sandbox.stub(calendarInterface, 'getCategories').resolves([]);
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories').resolves();
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+      const result = await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      // Garbage value parses to no FEP enums: no category lookup, no assignment,
+      // and ingest still completes normally.
+      expect(getCategoriesStub.called).toBe(false);
+      expect(assignStub.called).toBe(false);
+      expect(result).toBeDefined();
+    });
+
+    it('is failure-safe: a thrown category assignment does not abort event ingest', async () => {
+      const localEventId = uuidv4();
+      const eventApId = `https://mobilizon.example/events/${uuidv4()}`;
+      const eventObject = {
+        id: eventApId,
+        type: 'Event',
+        attributedTo: calendarActorUri,
+        name: 'Mobilizon Concert',
+        category: 'MUSIC',
+      };
+
+      sandbox.stub(EventObjectEntity, 'findOrCreate').callsFake(async (options: any) => {
+        return [{ event_id: options.defaults.event_id } as any, true];
+      });
+      sandbox.stub(EventObjectEntity, 'findOne').resolves(null);
+      (calendarInterface.addRemoteEvent as any).restore?.();
+      sandbox.stub(calendarInterface, 'addRemoteEvent').resolves({ id: localEventId } as any);
+
+      sandbox.stub(calendarInterface, 'getCategories').resolves([
+        localCategory('local-music', 'Concerts'),
+      ]);
+      // Assignment throws — ingest must still succeed and return the event.
+      const assignStub = sandbox.stub(calendarInterface, 'assignManualRepostCategories')
+        .rejects(new Error('database unavailable'));
+
+      const createActivity = new CreateActivity(calendarActorUri, eventObject);
+
+      const result = await inboxService['processCreateEvent'](testCalendar, createActivity);
+
+      expect(assignStub.calledOnce).toBe(true);
+      expect(result).toBeDefined();
+      expect((result as any).id).toBe(localEventId);
+    });
   });
 });

--- a/src/server/activitypub/test/inbox.test.ts
+++ b/src/server/activitypub/test/inbox.test.ts
@@ -125,7 +125,14 @@ describe('ProcessInboxService - Follow Activity Processing', () => {
 
       expect(outboxMessage?.message).toBeDefined();
       expect((outboxMessage?.message as any).type).toBe('Accept');
-      expect((outboxMessage?.message as any).object).toEqual(followActivity);
+      // The outbox persists the serialized wire form (activity.toObject()), so
+      // the embedded Follow is its AP representation — not the raw class
+      // instance. Assert the identifying fields survive the round-trip.
+      const acceptObject = (outboxMessage?.message as any).object;
+      expect(acceptObject.type).toBe('Follow');
+      expect(acceptObject.id).toBe(followActivity.id);
+      expect(acceptObject.actor).toBe(remoteActorUrl);
+      expect(acceptObject.object).toBe(testCalendar.id);
     });
 
     it('should not create duplicate follower record if already exists', async () => {

--- a/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
+++ b/src/server/activitypub/test/integration/outbox-local-dispatch.integration.test.ts
@@ -376,13 +376,14 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     ).toBe(true);
   });
 
-  it('emits paired Announce(Event) + Create(Note) rows in A outbox with matching public addressing', async () => {
-    // pv-l35p paired-emission contract: handleEventCreated queues an
-    // Announce(Event) (Pavillion-native consumers) AND a Create(Note)
-    // (Mastodon-class peer rendering). Both must address the public
-    // collection with followers in cc, otherwise Mastodon drops them
-    // from profile timelines. We fetch ALL of A's outbox messages and
-    // filter by activity type + wrapped object type in JS so the
+  it('emits paired Create(Event) + Create(Note) rows in A outbox with matching public addressing', async () => {
+    // Paired-emission contract (pv-2p29.5): handleEventCreated queues a
+    // Create(Event) with the full embedded Event object (Pavillion-native and
+    // FEP-8a8e event-platform consumers — Mobilizon/Gancio) AND a Create(Note)
+    // (Mastodon-class peer rendering). Announce is reserved for reposts. Both
+    // must address the public collection with followers in cc, otherwise
+    // Mastodon drops them from profile timelines. We fetch ALL of A's outbox
+    // messages and filter by activity type + wrapped object type in JS so the
     // assertion stays valid as more paired activity types are added.
     const event = await calendarInterface.createEvent(accountA, {
       calendarId: calendarA.id,
@@ -399,7 +400,7 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     const publicCollection = 'https://www.w3.org/ns/activitystreams#Public';
     const followersCollection = `${actorUrlA}/followers`;
 
-    // Poll until both the Announce(Event) and the Create(Note) are queued.
+    // Poll until both the Create(Event) and the Create(Note) are queued.
     // handleEventCreated awaits the two addToOutbox calls sequentially, so
     // observing the second row guarantees the first is also present. Each
     // filter is scoped to this event's specific Event/Note IRI so prior
@@ -410,35 +411,41 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
         const messages = await ActivityPubOutboxMessageEntity.findAll({
           where: { calendar_id: calendarA.id },
         });
-        const announceEvent = messages.find(
-          m => m.type === 'Announce' && (m.message as any)?.object === eventUrl,
+        const createEvent = messages.find(
+          m => m.type === 'Create' && (m.message as any)?.object?.type === 'Event' && (m.message as any)?.object?.id === eventUrl,
         );
         const createNote = messages.find(
           m => m.type === 'Create' && (m.message as any)?.object?.type === 'Note' && (m.message as any)?.object?.id === noteUrl,
         );
-        return announceEvent && createNote ? { announceEvent, createNote } : null;
+        return createEvent && createNote ? { createEvent, createNote } : null;
       },
-      { maxWaitMs: 2000, label: 'paired Announce(Event) + Create(Note) rows in A outbox' },
+      { maxWaitMs: 2000, label: 'paired Create(Event) + Create(Note) rows in A outbox' },
     );
 
     const aOutboxMessages = await ActivityPubOutboxMessageEntity.findAll({
       where: { calendar_id: calendarA.id },
     });
 
-    // Type-specific filter for the Announce(Event) row. The Announce wraps
-    // an IRI string (not a nested object), so we identify it by the
-    // matching canonical event URL. Filtering in JS (rather than a
-    // SQL `type:` clause) is deliberate: it documents at the call site
-    // that future paired activity additions cannot silently bump this
-    // count, because the assertion is pinned to a single activity type
-    // wrapping a specific object IRI.
+    // Type-specific filter for the Create(Event) row. The Create wraps the
+    // full embedded Event object, so we identify it by the wrapped object's
+    // type AND its canonical Event IRI (event-scoped, so prior tests on A
+    // don't satisfy this assertion).
+    const createEventRows = aOutboxMessages.filter(
+      m => m.type === 'Create' && (m.message as any)?.object?.type === 'Event' && (m.message as any)?.object?.id === eventUrl,
+    );
+    expect(
+      createEventRows.length,
+      'A must queue exactly one Create(Event) for this event',
+    ).toBe(1);
+
+    // No Announce may be queued for an original — Announce is repost-only.
     const announceEventRows = aOutboxMessages.filter(
       m => m.type === 'Announce' && (m.message as any)?.object === eventUrl,
     );
     expect(
       announceEventRows.length,
-      'A must queue exactly one Announce(Event) for this event',
-    ).toBe(1);
+      'A must NOT queue an Announce for an original event (Announce is repost-only)',
+    ).toBe(0);
 
     // Type-specific filter for the Create(Note) row. The Create wraps a
     // full Note object, so we identify it by the wrapped object's type
@@ -449,16 +456,16 @@ describe('Outbox Local Dispatch (cross-hop remote follower regression)', () => {
     );
     expect(
       createNoteRows.length,
-      'A must queue exactly one Create(Note) paired with the Announce(Event)',
+      'A must queue exactly one Create(Note) paired with the Create(Event)',
     ).toBe(1);
 
     // Both rows must be addressed publicly with followers in cc — without
     // this, Mastodon ignores the activities in profile timelines and HTTP
     // delivery loses audience info. This is the addressing invariant the
     // paired-emission contract relies on.
-    const announceMessage = announceEventRows[0].message as any;
-    expect(announceMessage.to).toEqual([publicCollection]);
-    expect(announceMessage.cc).toEqual([followersCollection]);
+    const createEventMessage = createEventRows[0].message as any;
+    expect(createEventMessage.to).toEqual([publicCollection]);
+    expect(createEventMessage.cc).toEqual([followersCollection]);
 
     const createMessage = createNoteRows[0].message as any;
     expect(createMessage.to).toEqual([publicCollection]);

--- a/src/server/activitypub/test/model/action/activities.test.ts
+++ b/src/server/activitypub/test/model/action/activities.test.ts
@@ -5,6 +5,8 @@ import UpdateActivity from '@/server/activitypub/model/action/update';
 import AnnounceActivity from '@/server/activitypub/model/action/announce';
 import FollowActivity from '@/server/activitypub/model/action/follow';
 import AcceptActivity from '@/server/activitypub/model/action/accept';
+import IgnoreActivity from '@/server/activitypub/model/action/ignore';
+import JoinActivity from '@/server/activitypub/model/action/join';
 import UndoActivity from '@/server/activitypub/model/action/undo';
 
 const PUBLIC_URI = 'https://www.w3.org/ns/activitystreams#Public';
@@ -434,13 +436,21 @@ describe('Activity Model fromObject Null Checks', () => {
       // Serialize to object
       const serialized = acceptActivity.toObject();
 
-      // Verify Accept has @context
+      // Verify Accept has @context declaring both AS2 and the pavillion namespace
       expect(serialized).toHaveProperty('@context');
-      expect(serialized['@context']).toEqual(['https://www.w3.org/ns/activitystreams']);
+      expect(serialized['@context']).toEqual([
+        'https://www.w3.org/ns/activitystreams',
+        'https://w3id.org/fep/8a8e',
+        { pavillion: 'https://pavillion.social/ns/activitypub#' },
+      ]);
 
       // Verify the nested Follow object also has @context, not context
       expect(serialized.object).toHaveProperty('@context');
-      expect(serialized.object['@context']).toEqual(['https://www.w3.org/ns/activitystreams']);
+      expect(serialized.object['@context']).toEqual([
+        'https://www.w3.org/ns/activitystreams',
+        'https://w3id.org/fep/8a8e',
+        { pavillion: 'https://pavillion.social/ns/activitypub#' },
+      ]);
 
       // Verify context property does NOT exist on nested object
       expect(serialized.object).not.toHaveProperty('context');
@@ -449,6 +459,90 @@ describe('Activity Model fromObject Null Checks', () => {
       expect(serialized.object.type).toBe('Follow');
       expect(serialized.object.actor).toBe('https://beta.example.com/calendars/bx_6ztiy');
       expect(serialized.object.object).toBe('https://alpha.example.com/calendars/ax_5eggn');
+    });
+  });
+
+  describe('IgnoreActivity', () => {
+    it('should return null for null / undefined / non-object input', () => {
+      expect(IgnoreActivity.fromObject(null as any)).toBeNull();
+      expect(IgnoreActivity.fromObject(undefined as any)).toBeNull();
+      expect(IgnoreActivity.fromObject('string' as any)).toBeNull();
+      expect(IgnoreActivity.fromObject(123 as any)).toBeNull();
+    });
+
+    it('should return null when actor is missing or not a string', () => {
+      expect(IgnoreActivity.fromObject({
+        object: { type: 'Join', actor: 'https://example.com/users/2' },
+      })).toBeNull();
+      expect(IgnoreActivity.fromObject({
+        actor: { id: 'https://example.com/users/1' },
+        object: { type: 'Join', actor: 'https://example.com/users/2' },
+      })).toBeNull();
+    });
+
+    it('should return null when object is missing', () => {
+      expect(IgnoreActivity.fromObject({
+        actor: 'https://example.com/calendars/mycal',
+      })).toBeNull();
+    });
+
+    it('constructs an Ignore embedding the object with a deterministic id and Ignore type', () => {
+      const join = { type: 'Join', actor: 'https://remote.example/users/bob', object: 'https://example.com/calendars/mycal/events/e1' };
+      const ignore = new IgnoreActivity('https://example.com/calendars/mycal', join);
+
+      expect(ignore.type).toBe('Ignore');
+      expect(ignore.actor).toBe('https://example.com/calendars/mycal');
+      expect(ignore.object).toBe(join);
+      expect(ignore.id).toMatch(/^https:\/\/example\.com\/calendars\/mycal\/ignores\/[0-9a-f-]+$/);
+    });
+
+    it('is never public: does not address as:Public and preserves direct `to` through fromObject', () => {
+      const result = IgnoreActivity.fromObject({
+        actor: 'https://example.com/calendars/mycal',
+        object: { type: 'Join', actor: 'https://remote.example/users/bob', object: 'https://example.com/calendars/mycal' },
+        id: 'https://example.com/calendars/mycal/ignores/1',
+        to: ['https://remote.example/users/bob'],
+      });
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('Ignore');
+      expect(result?.id).toBe('https://example.com/calendars/mycal/ignores/1');
+      expect(result?.to).toEqual(['https://remote.example/users/bob']);
+      expect(result?.to).not.toContain(PUBLIC_URI);
+
+      const serialized = result!.toObject();
+      expect(serialized.to).toEqual(['https://remote.example/users/bob']);
+      expect(serialized.cc ?? []).not.toContain(PUBLIC_URI);
+      expect(serialized['@context']).toEqual([
+        'https://www.w3.org/ns/activitystreams',
+        'https://w3id.org/fep/8a8e',
+        { pavillion: 'https://pavillion.social/ns/activitypub#' },
+      ]);
+    });
+  });
+
+  describe('JoinActivity', () => {
+    it('should return null for null / undefined / non-object input', () => {
+      expect(JoinActivity.fromObject(null as any)).toBeNull();
+      expect(JoinActivity.fromObject(undefined as any)).toBeNull();
+      expect(JoinActivity.fromObject('string' as any)).toBeNull();
+    });
+
+    it('should return null when actor is missing or object is missing', () => {
+      expect(JoinActivity.fromObject({ object: 'https://example.com/calendars/mycal' })).toBeNull();
+      expect(JoinActivity.fromObject({ actor: 'https://remote.example/users/bob' })).toBeNull();
+    });
+
+    it('creates a Join with valid input, preserving id and object', () => {
+      const result = JoinActivity.fromObject({
+        actor: 'https://remote.example/users/bob',
+        object: 'https://example.com/calendars/mycal/events/e1',
+        id: 'https://remote.example/activities/join/1',
+      });
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe('Join');
+      expect(result?.actor).toBe('https://remote.example/users/bob');
+      expect(result?.object).toBe('https://example.com/calendars/mycal/events/e1');
+      expect(result?.id).toBe('https://remote.example/activities/join/1');
     });
   });
 

--- a/src/server/activitypub/test/model/object/event.test.ts
+++ b/src/server/activitypub/test/model/object/event.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/server/common/helper/logger', () => ({
 import { Calendar } from '@/common/model/calendar';
 import { CalendarEvent, CalendarEventContent, CalendarEventSchedule, UrlPrompt } from '@/common/model/events';
 import { EventCategory } from '@/common/model/event_category';
+import { EventCategoryContent } from '@/common/model/event_category_content';
 import { EventSeries } from '@/common/model/event_series';
 import { EventSeriesContent } from '@/common/model/event_series_content';
 import { EventLocation, EventLocationContent, EventLocationSpace, EventLocationSpaceContent } from '@/common/model/location';
@@ -77,6 +78,71 @@ describe('EventObject', () => {
       const obj = new EventObject(calendar, event);
 
       expect(obj.categories[0]).toMatch(new RegExp(`^https://${domain.replace(/\./g, '\\.')}/`));
+    });
+
+  });
+
+  describe('FEP-8a8e category emission', () => {
+
+    function categoryWithName(id: string, name: string): EventCategory {
+      const cat = new EventCategory(id, 'calendar-uuid');
+      cat.addContent(new EventCategoryContent('en', name));
+      return cat;
+    }
+
+    it('emits the FEP category enum alongside pavillion:categories', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Concert', 'A show'));
+      event.categories = [categoryWithName('cat-1', 'Live Music')];
+
+      const obj = new EventObject(calendar, event).toActivityPubObject();
+
+      // Bare FEP category (interop surface)
+      expect(obj.category).toEqual(['MUSIC']);
+      // pavillion:categories URIs still emitted unchanged (full fidelity)
+      expect(obj['pavillion:categories']).toEqual([
+        `https://${domain}/api/public/v1/calendar/mycal/categories/cat-1`,
+      ]);
+    });
+
+    it('dedupes mapped enums and omits unmappable categories', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Event', ''));
+      event.categories = [
+        categoryWithName('cat-1', 'Live Music'),
+        categoryWithName('cat-2', 'Concert Series'), // also MUSIC -> deduped
+        categoryWithName('cat-3', 'Sports Night'),
+        categoryWithName('cat-4', 'Miscellaneous'),   // no match -> omitted
+      ];
+
+      const obj = new EventObject(calendar, event).toActivityPubObject();
+
+      expect(obj.category).toEqual(['MUSIC', 'SPORTS']);
+    });
+
+    it('omits the category property entirely when no category maps', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Event', ''));
+      event.categories = [categoryWithName('cat-1', 'Miscellaneous')];
+
+      const obj = new EventObject(calendar, event).toActivityPubObject();
+
+      expect(obj.category).toBeUndefined();
+      // pavillion:categories still present regardless
+      expect(obj['pavillion:categories']).toHaveLength(1);
+    });
+
+    it('omits the category property when the event has no categories', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Event', ''));
+
+      const obj = new EventObject(calendar, event).toActivityPubObject();
+
+      expect(obj.category).toBeUndefined();
     });
 
   });
@@ -164,6 +230,35 @@ describe('EventObject', () => {
       expect(result['pavillion:categories']).toBeDefined();
       expect(result['pavillion:series']).toBeDefined();
       expect(result['pavillion:schedules']).toBeDefined();
+    });
+
+    it('should emit FEP-8a8e organizers collection mirroring attributedTo', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Test Event', ''));
+
+      const obj = new EventObject(calendar, event);
+      const result = obj.toActivityPubObject();
+
+      // organizers is FEP-8a8e's only additional MUST; present on every Event,
+      // disclosing the owning calendar actor (same URI as attributedTo).
+      expect(result.organizers).toEqual({
+        type: 'Collection',
+        totalItems: 1,
+        items: [`https://${domain}/calendars/mycal`],
+      });
+      expect(result.organizers.items[0]).toBe(result.attributedTo);
+    });
+
+    it('should emit joinMode:none on every event (no RSVP model)', () => {
+      const calendar = new Calendar('calendar-uuid', 'mycal');
+      const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+      event.addContent(new CalendarEventContent('en', 'Test Event', ''));
+
+      const obj = new EventObject(calendar, event);
+      const result = obj.toActivityPubObject();
+
+      expect(result.joinMode).toBe('none');
     });
 
     it('should include nameMap and summaryMap for multilingual events', () => {
@@ -295,6 +390,103 @@ describe('EventObject', () => {
       const result = obj.toActivityPubObject();
 
       expect(result).not.toHaveProperty('location');
+    });
+
+    describe('FEP-8a8e extension terms (displayEndTime, timezone, eventStatus)', () => {
+
+      it('should emit displayEndTime:false when endTime is synthesized (no real eventEndTime)', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'No End', ''));
+        // Schedule with a startDate but no eventEndTime → endTime is synthesized.
+        event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00.000Z'))];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result).toHaveProperty('endTime');
+        expect(result.displayEndTime).toBe(false);
+      });
+
+      it('should NOT emit displayEndTime when a real eventEndTime exists', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Real End', ''));
+        const startDt = DateTime.fromISO('2026-04-15T09:00:00.000Z');
+        const schedule = new CalendarEventSchedule('s1', startDt);
+        schedule.eventEndTime = DateTime.fromISO('2026-04-15T11:00:00.000Z');
+        event.schedules = [schedule];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result.endTime).toBe(schedule.eventEndTime.toISO());
+        expect(result).not.toHaveProperty('displayEndTime');
+      });
+
+      it('should emit timezone with the IANA identifier of the first schedule start zone', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Zoned Event', ''));
+        event.schedules = [
+          new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00', { zone: 'America/New_York' })),
+        ];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result.timezone).toBe('America/New_York');
+      });
+
+      it('should emit timezone "UTC" for a UTC-default schedule', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'UTC Event', ''));
+        // EventScheduleEntity.toModel builds UTC schedules with an explicit
+        // { zone: 'UTC' } (the default when no timezone column is stored), so the
+        // startDate's zoneName is 'UTC' rather than the server's local zone.
+        event.schedules = [
+          new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00.000Z', { zone: 'utc' })),
+        ];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result.timezone).toBe('UTC');
+      });
+
+      it('should omit timezone when the schedule zone is a fixed offset (not a named IANA zone)', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Offset Event', ''));
+        // setZone:true preserves the ISO offset as a FixedOffsetZone (zoneName 'UTC-5')
+        event.schedules = [
+          new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00-05:00', { setZone: true })),
+        ];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result).not.toHaveProperty('timezone');
+      });
+
+      it('should omit timezone when the event has no schedule start date', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.date = '2026-04-15';
+        event.addContent(new CalendarEventContent('en', 'No Schedule', ''));
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result).not.toHaveProperty('timezone');
+      });
+
+      it('should always emit eventStatus EventScheduled for a live event', () => {
+        const calendar = new Calendar('calendar-uuid', 'mycal');
+        const event = new CalendarEvent('event-uuid', 'calendar-uuid');
+        event.addContent(new CalendarEventContent('en', 'Live Event', ''));
+        event.schedules = [new CalendarEventSchedule('s1', DateTime.fromISO('2026-04-15T09:00:00.000Z'))];
+
+        const result = new EventObject(calendar, event).toActivityPubObject();
+
+        expect(result.eventStatus).toBe('EventScheduled');
+      });
+
     });
 
     it('should use "Untitled Event" when content is empty', () => {
@@ -1458,6 +1650,90 @@ describe('EventObject', () => {
       const result = EventObject.fromActivityPubObject(apObject);
       expect(result.content.de).toBeDefined();
       expect(result.content.de.description).toBe('Deutsch');
+    });
+
+    describe('FEP-8a8e extension terms parsing', () => {
+
+      it('should parse an object carrying all three FEP terms cleanly', () => {
+        const apObject = {
+          type: 'Event',
+          id: 'https://mobilizon.example/events/9',
+          name: 'FEP Event',
+          summary: 'A description',
+          startTime: '2026-04-15T09:00:00Z',
+          endTime: '2026-04-15T10:00:00Z',
+          displayEndTime: false,
+          timezone: 'Europe/Vienna',
+          eventStatus: 'EventCancelled',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        // Parses without error; core fields still normalize as usual.
+        expect(result.content.en.name).toBe('FEP Event');
+        expect(result.content.en.description).toBe('A description');
+        expect(result.date).toBe('2026-04-15');
+        expect(result.schedules).toHaveLength(1);
+      });
+
+      it('should reinterpret a synthesized schedule into a valid IANA timezone (preserving the instant)', () => {
+        const apObject = {
+          name: 'Zoned',
+          startTime: '2014-12-31T23:00:00Z',
+          endTime: '2015-01-01T01:00:00Z',
+          timezone: 'Europe/Vienna',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        // Absolute instant is preserved...
+        expect(DateTime.fromISO(result.schedules[0].start).toUTC().toISO())
+          .toBe('2014-12-31T23:00:00.000Z');
+        // ...but the schedule now carries Vienna's +01:00 offset, so the
+        // wall-clock reconstructs as 00:00 local rather than 23:00 UTC.
+        expect(result.schedules[0].start).toContain('+01:00');
+        expect(result.schedules[0].end).toContain('+01:00');
+      });
+
+      it('should ignore a fixed-offset (non-IANA) timezone and leave instants unchanged', () => {
+        const apObject = {
+          name: 'Bad Zone',
+          startTime: '2026-04-15T09:00:00Z',
+          timezone: 'UTC+5',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.schedules[0].start).toBe('2026-04-15T09:00:00Z');
+      });
+
+      it('should ignore a non-string / garbage timezone without error', () => {
+        const apObject = {
+          name: 'Garbage Zone',
+          startTime: '2026-04-15T09:00:00Z',
+          timezone: 'Not/AZone',
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        expect(result.schedules[0].start).toBe('2026-04-15T09:00:00Z');
+      });
+
+      it('should not apply inbound timezone when pavillion:schedules are present (Pavillion peer path)', () => {
+        const apObject = {
+          name: 'Pav Event',
+          startTime: '2026-04-15T09:00:00Z',
+          timezone: 'Europe/Vienna',
+          'pavillion:schedules': [{ id: 's1', start: '2026-04-15T09:00:00Z' }],
+        };
+
+        const result = EventObject.fromActivityPubObject(apObject);
+
+        // pavillion:schedules pass through verbatim; the FEP timezone hint is
+        // only used on the synthesize-from-startTime path.
+        expect(result.schedules).toEqual([{ id: 's1', start: '2026-04-15T09:00:00Z' }]);
+      });
+
     });
 
     describe('externalUrl + urlPrompt parsing', () => {

--- a/src/server/activitypub/test/service/inbox.test.ts
+++ b/src/server/activitypub/test/service/inbox.test.ts
@@ -275,6 +275,62 @@ describe('processInboxMessage', () => {
     expect(createStub.calledOnce).toBe(true);
   });
 
+  it('should reply to an inbound Join with an Ignore addressed to the sender only', async () => {
+    // FEP-8a8e: Pavillion does not handle Join (no attendance model), so an
+    // inbound Join must be answered with an Ignore addressed to the sender —
+    // never publicly — and must not mutate any state.
+    const eventBus = new EventEmitter();
+    const testCalendarInterface = new CalendarInterface(eventBus);
+    const testService = new ProcessInboxService(eventBus, testCalendarInterface);
+
+    sandbox.stub(testService.calendarInterface, 'getCalendar')
+      .resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: 'testcalendar' }));
+
+    const outboxSaveStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'save').resolves();
+    // Guard against any accidental state mutation on the Join path.
+    const addRemoteEventStub = sandbox.stub(testService.calendarInterface, 'addRemoteEvent');
+    const followerCreateStub = sandbox.stub(FollowerCalendarEntity, 'create');
+
+    let emittedActivity: any = null;
+    eventBus.on('outboxMessageAdded', (activity) => {
+      emittedActivity = activity;
+    });
+
+    const joinActivity = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: `${REMOTE_ACTOR_URL}/activities/join/1`,
+      type: 'Join',
+      actor: REMOTE_ACTOR_URL,
+      object: `${LOCAL_CALENDAR_URL}/events/123`,
+    };
+
+    const message = ActivityPubInboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Join',
+      message: joinActivity,
+    });
+    sandbox.stub(ActivityPubInboxMessageEntity.prototype, 'update').resolves();
+
+    await testService.processInboxMessage(message);
+
+    // An Ignore was queued to the outbox.
+    expect(outboxSaveStub.calledOnce).toBe(true);
+    expect(emittedActivity).not.toBeNull();
+    expect(emittedActivity.type).toBe('Ignore');
+
+    // Addressed to the sender only, never as:Public.
+    expect(emittedActivity.to).toEqual([REMOTE_ACTOR_URL]);
+    expect(emittedActivity.to).not.toContain('https://www.w3.org/ns/activitystreams#Public');
+    expect(emittedActivity.cc).not.toContain('https://www.w3.org/ns/activitystreams#Public');
+
+    // The Ignore embeds the original Join so the sender can correlate it.
+    expect(emittedActivity.object).toEqual(joinActivity);
+
+    // No state was mutated.
+    expect(addRemoteEventStub.called).toBe(false);
+    expect(followerCreateStub.called).toBe(false);
+  });
+
   it('should process an announce activity', async () => {
     // Use Fedify helper to create a proper Announce (share) activity
     const activityMessage = createMockAnnounceActivity(REMOTE_ACTOR_URL, REMOTE_EVENT_URL);
@@ -501,6 +557,20 @@ describe('processInboxMessage', () => {
 
       // Should return gracefully without throwing
       // No assertions needed - just verify it doesn't throw
+    });
+
+    it('should handle processJoinActivity with missing actor (no Ignore queued, no throw)', async () => {
+      const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: 'testcalendar' });
+
+      // A Join with no actor cannot be replied to — the guard must return early
+      // without queuing an Ignore (which would otherwise be addressed to nobody).
+      const outboxSaveStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'save').resolves();
+
+      // Missing actor (cast to any for defensive edge-case test)
+      await service.processJoinActivity(calendar, { object: `${LOCAL_CALENDAR_URL}/events/123` } as any);
+
+      // No outbox entity created, and it resolves without throwing.
+      expect(outboxSaveStub.called).toBe(false);
     });
   });
 });
@@ -841,6 +911,99 @@ describe('actorOwnsObject', () => {
   });
 });
 
+describe('processCreateEvent existing-object auto-repost trust gate', () => {
+  // Guards the trustLocalOrigin branch added to processCreateEvent's
+  // existingApObject early-return. Local originals now federate as
+  // Create(Event) (Announce is repost-only). handleEventCreated pre-creates the
+  // EventObjectEntity before the outbox fans the Create out to same-instance
+  // followers, so a local-dispatch Create ALWAYS finds an existing row. The
+  // auto-repost cascade for same-instance followers must therefore be driven
+  // from this branch — but ONLY on the trusted local-dispatch path. Remote
+  // re-delivery of a known event must NOT re-trigger auto-repost (the negative
+  // case is the security boundary).
+  //
+  // Both tests stub checkAndPerformAutoRepost itself, so the auto-repost policy
+  // gate (auto_repost_originals) inside it never runs. That makes the
+  // trustLocalOrigin branch guard the ONLY thing that can determine whether the
+  // method is called — the assertions cannot be satisfied incidentally by a
+  // disabled follow policy, which is the discrimination the prior near-miss
+  // coverage lacked.
+  let service: ProcessInboxService;
+  let sandbox: sinon.SinonSandbox = sinon.createSandbox();
+
+  const TEST_CALENDAR_ID = 'trust-gate-calendar-id';
+  const SOURCE_ACTOR_URL = 'https://pavillion.dev/calendars/source';
+  const LOCAL_EVENT_URL = 'https://pavillion.dev/calendars/source/events/evt-1';
+
+  beforeEach(() => {
+    const eventBus = new EventEmitter();
+    const calendarInterface = new CalendarInterface(eventBus);
+    service = new ProcessInboxService(eventBus, calendarInterface);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('does NOT call checkAndPerformAutoRepost for an existing event without trustLocalOrigin (remote re-delivery)', async () => {
+    // An EventObjectEntity already exists for this ap_id — simulates a remote
+    // Create re-delivering an event this instance already knows about.
+    sandbox.stub(EventObjectEntity, 'findOne').resolves(
+      EventObjectEntity.build({
+        event_id: 'existing-event-id',
+        ap_id: LOCAL_EVENT_URL,
+        attributed_to: SOURCE_ACTOR_URL,
+      }),
+    );
+    const autoRepostSpy = sandbox.stub(service as any, 'checkAndPerformAutoRepost').resolves();
+
+    const activityMessage = createMockCreateActivity(SOURCE_ACTOR_URL, {
+      type: 'Event',
+      id: LOCAL_EVENT_URL,
+      name: 'Already-known Event',
+    });
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID });
+
+    // No options: this is the untrusted (remote / HTTP inbox) path.
+    const result = await service.processCreateEvent(calendar, activityMessage);
+
+    expect(result, 'existing event is a genuine duplicate: skip').toBeNull();
+    expect(
+      autoRepostSpy.called,
+      'auto-repost must NOT run for remote re-delivery of a known event',
+    ).toBe(false);
+  });
+
+  it('calls checkAndPerformAutoRepost once with isOriginal=true for an existing event with trustLocalOrigin (local dispatch)', async () => {
+    sandbox.stub(EventObjectEntity, 'findOne').resolves(
+      EventObjectEntity.build({
+        event_id: 'existing-event-id',
+        ap_id: LOCAL_EVENT_URL,
+        attributed_to: SOURCE_ACTOR_URL,
+      }),
+    );
+    const autoRepostSpy = sandbox.stub(service as any, 'checkAndPerformAutoRepost').resolves();
+
+    const activityMessage = createMockCreateActivity(SOURCE_ACTOR_URL, {
+      type: 'Event',
+      id: LOCAL_EVENT_URL,
+      name: 'Local Original',
+    });
+    const calendar = Calendar.fromObject({ id: TEST_CALENDAR_ID });
+
+    // trustLocalOrigin: true is set only by handleLocalActivityDispatch.
+    const result = await service.processCreateEvent(calendar, activityMessage, { trustLocalOrigin: true });
+
+    expect(result, 'local dispatch of a same-instance original still returns null (no second event row)').toBeNull();
+    expect(autoRepostSpy.calledOnce, 'auto-repost cascade must run exactly once on the trusted local-dispatch path').toBe(true);
+    // isOriginal must be true — a Create is always authored by its actor.
+    expect(autoRepostSpy.firstCall.args[0]).toBe(calendar);
+    expect(autoRepostSpy.firstCall.args[1]).toBe(SOURCE_ACTOR_URL);
+    expect(autoRepostSpy.firstCall.args[2]).toBe(LOCAL_EVENT_URL);
+    expect(autoRepostSpy.firstCall.args[3]).toBe(true);
+  });
+});
+
 describe('isAuthorizedRemoteEditor caching', () => {
   let service: ProcessInboxService;
   let calendarInterface: CalendarInterface;
@@ -1133,6 +1296,42 @@ describe('Structured Logging for Activity Rejections', () => {
       const updateArgs = updateStub.firstCall.args[0];
       expect(updateArgs.processed_status).toBe('blocked');
       expect(updateArgs.processed_time).toBeDefined();
+    });
+
+    it('should NOT reply with an Ignore to a Join from a blocked instance, but DOES for a non-blocked sender', async () => {
+      // FEP-8a8e Join reply must sit behind the blocklist gate: a blocked
+      // instance's Join is short-circuited before dispatch (no Ignore queued),
+      // while a non-blocked non-follower's Join still reaches the handler and
+      // gets an Ignore (Join is not gated by the follow-relationship filter).
+      sandbox.stub(service.calendarInterface, 'getCalendar')
+        .resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID, urlName: TEST_CALENDAR_URL_NAME }));
+      sandbox.stub(ActivityPubInboxMessageEntity.prototype, 'update').resolves();
+      const outboxSaveStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'save').resolves();
+
+      const isBlockedStub = sandbox.stub(service.moderationInterface!, 'isInstanceBlocked');
+
+      const buildJoin = (actorUrl: string, id: string) => ActivityPubInboxMessageEntity.build({
+        id,
+        calendar_id: TEST_CALENDAR_ID,
+        type: 'Join',
+        message: {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: `${actorUrl}/activities/${id}`,
+          type: 'Join',
+          actor: actorUrl,
+          object: `https://local.federation.test/calendars/${TEST_CALENDAR_URL_NAME}/events/123`,
+        },
+      });
+
+      // Blocked sender: no Ignore queued.
+      isBlockedStub.resolves(true);
+      await service.processInboxMessage(buildJoin(BLOCKED_ACTOR_URL, 'join-blocked'));
+      expect(outboxSaveStub.called, 'blocked Join must not produce an Ignore').toBe(false);
+
+      // Non-blocked, non-follower sender: Ignore is queued.
+      isBlockedStub.resolves(false);
+      await service.processInboxMessage(buildJoin(REMOTE_ACTOR_URL, 'join-allowed'));
+      expect(outboxSaveStub.calledOnce, 'non-blocked Join must produce exactly one Ignore').toBe(true);
     });
   });
 

--- a/src/server/activitypub/test/service/outbox.test.ts
+++ b/src/server/activitypub/test/service/outbox.test.ts
@@ -1151,6 +1151,127 @@ describe('processOutboxMessage — explicit `to` honoring and per-type local dis
     expect(postStub.called, 'Accept: HTTP POST must not be used for local recipient').toBe(false);
   });
 
+  it('Ignore: resolves the delivery recipient from the embedded Join actor and POSTs to it', async () => {
+    // FEP-8a8e Join reply. The Ignore embeds the original Join; the Join's
+    // `actor` (the sender) is the sole delivery recipient. This exercises the
+    // `case 'Ignore':` recipient-resolution branch end-to-end over HTTP.
+    const joinSenderUri = 'https://remote.federation.test/users/bob';
+    const ignoreMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Ignore',
+      actor: LOCAL_ACTOR_URL,
+      id: `${LOCAL_ACTOR_URL}/ignores/ignore-1`,
+      to: [joinSenderUri],
+      object: {
+        type: 'Join',
+        actor: joinSenderUri,
+        object: `${LOCAL_ACTOR_URL}/events/e1`,
+        id: `${joinSenderUri}/activities/join-1`,
+      },
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Ignore',
+      message: ignoreMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const getRecipientsStub = sandbox.stub(service, 'getRecipients');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+    resolveStub.resolves(REMOTE_INBOX_URL);
+
+    await service.processOutboxMessage(message);
+
+    // Recipient is the Join sender (object.actor) — NOT follower fan-out.
+    expect(getRecipientsStub.called, 'Ignore must not fan out to followers').toBe(false);
+    expect(resolveStub.calledOnceWith(joinSenderUri)).toBe(true);
+    expect(postStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
+  it('Ignore: local recipient routes to handleLocalActivityDispatch instead of HTTP', async () => {
+    const localCalendar = Calendar.fromObject({ id: 'local-cal-ignore' });
+    const joinSenderUri = 'https://local.federation.test/calendars/localcal-ignore';
+    const ignoreMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Ignore',
+      actor: LOCAL_ACTOR_URL,
+      id: `${LOCAL_ACTOR_URL}/ignores/ignore-local-1`,
+      to: [joinSenderUri],
+      object: {
+        type: 'Join',
+        actor: joinSenderUri,
+        object: `${LOCAL_ACTOR_URL}/events/e1`,
+        id: `${joinSenderUri}/activities/join-local-1`,
+      },
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Ignore',
+      message: ignoreMsg,
+    });
+
+    resolveLocalStub.resolves(localCalendar);
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    sandbox.stub(service, 'resolveInboxUrl');
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+
+    await service.processOutboxMessage(message);
+
+    expect(resolveLocalStub.calledOnceWith(joinSenderUri)).toBe(true);
+    expect(
+      (mockInbox.handleLocalActivityDispatch as sinon.SinonStub).calledOnce,
+      'Ignore: local dispatch must fire for local recipient',
+    ).toBe(true);
+    expect(postStub.called, 'Ignore: HTTP POST must not be used for local recipient').toBe(false);
+  });
+
+  it('Ignore: a malformed (non-object) embedded object resolves to no recipient without crashing', async () => {
+    // Guard case: if `object` is a bare string rather than an embedded Join,
+    // the `typeof activity.object === 'object'` guard fails, so no recipient is
+    // resolved. The message must complete cleanly (status ok) rather than
+    // delivering an Ignore addressed to nobody or throwing.
+    const ignoreMsg = {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Ignore',
+      actor: LOCAL_ACTOR_URL,
+      id: `${LOCAL_ACTOR_URL}/ignores/ignore-malformed-1`,
+      object: 'https://remote.federation.test/activities/join-1',
+    };
+
+    const message = ActivityPubOutboxMessageEntity.build({
+      calendar_id: TEST_CALENDAR_ID,
+      type: 'Ignore',
+      message: ignoreMsg,
+    });
+
+    const getCalendarStub = sandbox.stub(service.calendarService, 'getCalendar');
+    const postStub = sandbox.stub(axios, 'post').resolves();
+    const updateStub = sandbox.stub(ActivityPubOutboxMessageEntity.prototype, 'update');
+    const resolveStub = sandbox.stub(service, 'resolveInboxUrl');
+    stubSigning(service, sandbox);
+
+    getCalendarStub.resolves(Calendar.fromObject({ id: TEST_CALENDAR_ID }));
+
+    await service.processOutboxMessage(message);
+
+    expect(resolveStub.called, 'no recipient should be resolved for a malformed object').toBe(false);
+    expect(resolveLocalStub.called, 'no local dispatch for a malformed object').toBe(false);
+    expect(postStub.called, 'no HTTP POST for a malformed object').toBe(false);
+    expect(updateStub.calledOnce).toBe(true);
+    expect(updateStub.getCalls()[0].args[0]['processed_status']).toBe('ok');
+  });
+
   it('Flag: local recipient routes to handleLocalActivityDispatch instead of HTTP', async () => {
     const localCalendar = Calendar.fromObject({ id: 'local-cal-flag' });
     const flagMsg = {

--- a/src/server/activitypub/test/validation/schemas-activities.test.ts
+++ b/src/server/activitypub/test/validation/schemas-activities.test.ts
@@ -17,6 +17,7 @@ import {
   deleteActivitySchema,
   announceActivitySchema,
   undoActivitySchema,
+  joinActivitySchema,
 } from '@/server/activitypub/validation/schemas';
 
 describe('ActivityPub Validation Schemas - Activities', () => {
@@ -1644,6 +1645,62 @@ describe('ActivityPub Validation Schemas - Activities', () => {
 
       const result = undoActivitySchema.safeParse(validUndo);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('joinActivitySchema', () => {
+    it('should accept a valid Join activity with a URI object', () => {
+      const validJoin = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/join/1',
+        type: 'Join',
+        actor: 'https://remote.example/users/bob',
+        object: 'https://example.com/calendars/mycal/events/e1',
+      };
+
+      const result = joinActivitySchema.safeParse(validJoin);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('Join');
+      }
+    });
+
+    it('should accept a Join activity with an embedded object', () => {
+      const validJoin = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/join/2',
+        type: 'Join',
+        actor: 'https://remote.example/users/bob',
+        object: {
+          id: 'https://example.com/calendars/mycal/events/e1',
+          type: 'Event',
+        },
+      };
+
+      const result = joinActivitySchema.safeParse(validJoin);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a Join activity with the wrong type', () => {
+      const invalidJoin = {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        id: 'https://remote.example/activities/join/3',
+        type: 'Follow',
+        actor: 'https://remote.example/users/bob',
+        object: 'https://example.com/calendars/mycal/events/e1',
+      };
+
+      const result = joinActivitySchema.safeParse(invalidJoin);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject a Join activity missing required fields', () => {
+      const result = joinActivitySchema.safeParse({
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'Join',
+        actor: 'https://remote.example/users/bob',
+      });
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/src/server/activitypub/validation/schemas.ts
+++ b/src/server/activitypub/validation/schemas.ts
@@ -164,6 +164,12 @@ export const ACTIVITY_TYPES = [
   'Block',
   'Add',
   'Remove',
+  // FEP-8a8e: peers (e.g. Mobilizon) send Join to RSVP/attend an event.
+  // Pavillion does not handle attendance, so it validates and enqueues the
+  // Join only to reply with an Ignore (FEP-8a8e's blessed unhandled-Join
+  // response). Both must be recognized activity types.
+  'Join',
+  'Ignore',
 ] as const;
 
 /**
@@ -415,3 +421,26 @@ export type AnnounceActivity = z.infer<typeof announceActivitySchema>;
  * Type for a validated Undo activity.
  */
 export type UndoActivity = z.infer<typeof undoActivitySchema>;
+
+/**
+ * Schema for ActivityPub Join activity.
+ *
+ * A Join activity indicates the actor wants to join/attend the object (an event
+ * or group). Pavillion does not implement an attendance model, so it never acts
+ * on a Join — it validates the inbound shape only so the activity can be
+ * enqueued and answered with an Ignore per FEP-8a8e.
+ *
+ * The object being joined can be a URI reference or an embedded object.
+ *
+ * @see https://www.w3.org/TR/activitystreams-vocabulary/#dfn-join
+ * @see https://w3id.org/fep/8a8e
+ */
+export const joinActivitySchema = activityBaseSchema.extend({
+  type: z.literal('Join'),
+  object: objectReferenceSchema,
+});
+
+/**
+ * Type for a validated Join activity.
+ */
+export type JoinActivity = z.infer<typeof joinActivitySchema>;

--- a/src/server/calendar/test/integration/create_event.test.ts
+++ b/src/server/calendar/test/integration/create_event.test.ts
@@ -97,9 +97,11 @@ describe('Event API', () => {
     let entity = await EventEntity.findOne({ where: { id: response.body.id } });
 
     // Poll for the outbox message to be processed (ARM CI runners need more time).
-    // Event creation now emits paired Announce(Event) + Create(Note) so we
-    // filter by activity type instead of ordering — protects against future
-    // activity additions and removes order-dependence.
+    // Locally-created originals now federate as paired Create(Event) +
+    // Create(Note) (Announce is reserved for reposts), so we filter for the
+    // Create wrapping the full embedded Event object. Filtering by activity +
+    // wrapped-object type protects against future activity additions and
+    // removes order-dependence.
     let message: ActivityPubOutboxMessageEntity | null = null;
     for (let i = 0; i < 20; i++) {
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -107,28 +109,36 @@ describe('Event API', () => {
         where: { calendar_id: calendar.id },
         order: [['message_time', 'ASC']],
       });
-      message = messages.find(m => (m.message as any)?.type === 'Announce') ?? null;
+      message = messages.find(
+        m => (m.message as any)?.type === 'Create' && (m.message as any)?.object?.type === 'Event',
+      ) ?? null;
       if (message?.processed_time) break;
     }
 
     expect(response.status,"api call succeeded").toBe(201);
     expect(response.body.id,"got back an object with an id").toBeDefined();
     expect(response.body.error,"no error in the response").toBeUndefined();
-    expect(entity,"found the event in the database").toBeDefined();
-    expect(message,"activity message was sent to outbox").toBeDefined();
+    // Assert non-null directly (not toBeDefined, which passes on null): if the
+    // Create(Event) emission regressed to Announce or broke entirely, the poll
+    // above leaves `message` null, and this test MUST fail rather than skip the
+    // real assertions. Same for `entity`. This is the integration guard for the
+    // epic's core wire-format change, so the failure signal has to be real.
+    expect(entity,"found the event in the database").not.toBeNull();
+    expect(message,"Create(Event) activity message was sent to outbox").not.toBeNull();
 
-    if (message && entity) {
-      // Use type assertion to access properties
-      const messageObj = message.message as any;
-      // Event propagation uses Announce activity, not Create
-      expect(messageObj.type,"proper message type created").toBe('Announce');
-      // The object field is the event URL string, which should contain the event ID
-      expect(messageObj.object, "has an appropriate event URL").toContain(entity.id);
-      expect(message.processed_time,"message in the outbox was processed").not.toBe(null);
-    }
-    // Paired emission: Announce(Event) + Create(Note) both post to follower
+    // Use type assertion to access properties. Asserted unconditionally (no
+    // `if (message && entity)` guard) so a missing Create row fails the test.
+    const messageObj = message!.message as any;
+    // Originals propagate as Create(Event) with the full embedded Event
+    // object, not Announce (Announce is repost-only).
+    expect(messageObj.type,"proper message type created").toBe('Create');
+    expect(messageObj.object?.type,"Create wraps an Event object").toBe('Event');
+    // The embedded object's id is the event URL, which should contain the event ID
+    expect(messageObj.object?.id, "has an appropriate event URL").toContain(entity!.id);
+    expect(message!.processed_time,"message in the outbox was processed").not.toBe(null);
+    // Paired emission: Create(Event) + Create(Note) both post to follower
     // inboxes. The remote-post contract under test is "the event reached
-    // federation" — assert at least one post (the Announce leg) happened.
+    // federation" — assert at least one post happened.
     expect(postStub.called,"post to remote inbox").toBe(true);
   });
 });


### PR DESCRIPTION
## Motivation

Pavillion's ActivityPub Event federation predated FEP-8a8e ("A Common Approach to Using the Event Object Type"), the draft that synthesizes current Mobilizon/Gancio/Friendica/Hubzilla practice for federating `type: Event`. Several gaps meant Pavillion events were either invisible to or mis-rendered by those platforms:

- The `pavillion:*` extension prefix was never declared in any JSON-LD `@context`, so strict processors silently dropped every extension term. The standalone GET event endpoint returned a bare object with no `@context` at all.
- New local events federated as `Announce(url)` rather than `Create(Event)`, so Event-only consumers never ingested them.
- Missing FEP extension properties (`displayEndTime`, `timezone`, `eventStatus`, `organizers`, `joinMode`) and no mapping onto the shared FEP category enum.
- No handling for inbound `Join` activities (FEP requires an `Ignore` response from servers that don't model attendance).

## Approach

**JSON-LD `@context` foundation.** Declared a single shared vocabulary IRI for `pavillion:*` terms (project-level, not per-instance, so cross-instance payloads stay JSON-LD-equivalent) plus the FEP-8a8e namespace, and attached a full `@context` to the standalone GET event/note/series responses.

**Wire format.** New local events now federate as `Create(Event)` with the full embedded object (aligning with the existing `Update(Event)` path); `Announce` is reserved for reposts. The same-instance auto-repost cascade is preserved through a local-dispatch trust gate — remote re-delivery of a known event still skips.

**Event serialization.** Emit `displayEndTime: false` when `endTime` is synthesized, `timezone` (IANA), `eventStatus`, `organizers` (mirroring the calendar actor — no user PII), and `joinMode: 'none'`. Map instance-defined categories onto the FEP category enum via a keyword heuristic, emitted alongside the existing `pavillion:categories` URIs. Inbound parsing tolerates the new terms, reconstructs wall-clock time from a remote `timezone`, and maps remote FEP categories onto **existing** local categories — never auto-creating taxonomy.

**Join handling.** Pavillion has no RSVP model, so inbound `Join` activities receive an `Ignore` addressed to the sender only. The handler is side-effect-free and stores no attendee state, consistent with the no-attendee-tracking privacy posture.

## Validation

- Lint: 0 errors. Unit tests: 8537 passing. Frontend build: clean.
- Each area landed with per-change adversarial review (security, consistency, complexity, privacy, testing) plus cross-change integration and architecture passes. Two review rounds surfaced and fixed **real latent bugs**: a same-instance auto-repost cascade break introduced by the Announce→Create switch, and a category-mapping ordering bug (a bare "Musical" mapped to THEATRE instead of MUSIC).
- Added targeted coverage for the new `Ignore` delivery path, the inbound `Join` missing-actor and blocklist paths, the local-dispatch trust gate (positive + negative), inbound timezone reinterpretation, FEP category resolution (including the failure-safe "never aborts ingest" and "never auto-creates" guarantees), and a privacy regression assertion that the embedded `Create(Event)` object carries no internal identifiers.
- Pre-existing, unrelated failures remain out of scope: two integration tests in `calendar/test/integration/cancel_event_occurrence.test.ts` (occurrence pagination) and environmental E2E failures (no dev server / no Docker federation certs).

**Not yet done — follow-up:** manual interop verification against live Mobilizon/Gancio/Friendica/Hubzilla peers and a real inbound `Join`. The wire-format changes are expected to fix remote rendering, but that is asserted from the spec, not yet observed against running peers.