### PR TITLE
feat(calendar): add ICS file-upload dedup, service, and endpoint

### DIFF
--- a/src/common/exceptions/import.ts
+++ b/src/common/exceptions/import.ts
@@ -27,6 +27,16 @@ export const IMPORT_PARSE_ERROR = 'IMPORT_PARSE_ERROR';
 export const IMPORT_VERIFY_RATE_LIMITED = 'IMPORT_VERIFY_RATE_LIMITED';
 export const IMPORT_SOURCE_NOT_VERIFIED = 'IMPORT_SOURCE_NOT_VERIFIED';
 
+// File-upload intake codes (pv-84da.1.4). These describe failures unique to
+// the multipart file-upload path — an in-memory buffer with no remote URL to
+// fetch. Like every other code here they are opaque, sanitized identifiers
+// safe to surface over the HTTP wire and to key client i18n lookups.
+export const IMPORT_FILE_EMPTY = 'IMPORT_FILE_EMPTY';
+export const IMPORT_FILE_TOO_LARGE = 'IMPORT_FILE_TOO_LARGE';
+export const IMPORT_FILE_BAD_FORMAT = 'IMPORT_FILE_BAD_FORMAT';
+export const IMPORT_FILE_TOO_MANY_EVENTS = 'IMPORT_FILE_TOO_MANY_EVENTS';
+export const IMPORT_SOURCE_CAP_EXCEEDED = 'IMPORT_SOURCE_CAP_EXCEEDED';
+
 // DNS verification reason codes — exactly one of these is used as the
 // user-visible message for ImportSourceDnsVerificationError.
 export const IMPORT_DNS_NOT_FOUND = 'IMPORT_DNS_NOT_FOUND';
@@ -192,5 +202,95 @@ export class ImportSourceNotVerifiedError extends Error {
     this.name = 'ImportSourceNotVerifiedError';
     this.details = details;
     Object.setPrototypeOf(this, ImportSourceNotVerifiedError.prototype);
+  }
+}
+
+/**
+ * Thrown when a file upload carries no bytes (missing multipart field or a
+ * zero-length buffer). Maps to HTTP 400 in the API handler.
+ */
+export class ImportSourceFileEmptyError extends Error {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(details?: Record<string, unknown>) {
+    super(IMPORT_FILE_EMPTY);
+    this.name = 'ImportSourceFileEmptyError';
+    this.details = details;
+    Object.setPrototypeOf(this, ImportSourceFileEmptyError.prototype);
+  }
+}
+
+/**
+ * Thrown when an uploaded file exceeds the 10 MiB intake cap. Maps to HTTP
+ * 400 in the API handler. The raw byte length is kept on `details` only.
+ */
+export class ImportSourceFileTooLargeError extends Error {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(details?: Record<string, unknown>) {
+    super(IMPORT_FILE_TOO_LARGE);
+    this.name = 'ImportSourceFileTooLargeError';
+    this.details = details;
+    Object.setPrototypeOf(this, ImportSourceFileTooLargeError.prototype);
+  }
+}
+
+/**
+ * Thrown when an uploaded file fails the intake format checks before any
+ * events are persisted: a disallowed content type / extension, a payload
+ * that does not begin with `BEGIN:VCALENDAR`, or ICS bytes that the parser
+ * cannot read at all (malformed). Maps to HTTP 400 in the API handler.
+ *
+ * NOTE: a file that parses as a valid VCALENDAR but yields zero usable
+ * VEVENTs is NOT this error — that reuses {@link ImportSourceParseError}
+ * (HTTP 422) to distinguish "the file is broken" from "the file is fine but
+ * empty of events".
+ */
+export class ImportSourceFileBadFormatError extends Error {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(details?: Record<string, unknown>) {
+    super(IMPORT_FILE_BAD_FORMAT);
+    this.name = 'ImportSourceFileBadFormatError';
+    this.details = details;
+    Object.setPrototypeOf(this, ImportSourceFileBadFormatError.prototype);
+  }
+}
+
+/**
+ * Thrown when an uploaded file carries more VEVENTs than the per-file import
+ * ceiling ({@link IMPORT_FILE_TOO_MANY_EVENTS}). The bound is a DoS mitigation:
+ * a 10 MiB file of minimal VEVENTs can hold ~130k+ events, each an INSERT in a
+ * single transaction, and `parseICS` is synchronous/CPU-bound. The check runs
+ * after VEVENT extraction but before the create loop, so no events are written.
+ * Maps to HTTP 422 in the API handler (the file is well-formed but its event
+ * count is not acceptable). The parsed/limit counts are kept on `details` only.
+ */
+export class ImportSourceFileTooManyEventsError extends Error {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(details?: Record<string, unknown>) {
+    super(IMPORT_FILE_TOO_MANY_EVENTS);
+    this.name = 'ImportSourceFileTooManyEventsError';
+    this.details = details;
+    Object.setPrototypeOf(this, ImportSourceFileTooManyEventsError.prototype);
+  }
+}
+
+/**
+ * Thrown when creating another import source would exceed the per-calendar
+ * source cap. Maps to HTTP 409 Conflict in the API handler (the request
+ * conflicts with the current state of the calendar). Distinct from the
+ * URL-create path's generic {@link ValidationError} cap rejection so the
+ * file-upload frontend can key an actionable message off `errorName`.
+ */
+export class ImportSourceCapExceededError extends Error {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(details?: Record<string, unknown>) {
+    super(IMPORT_SOURCE_CAP_EXCEEDED);
+    this.name = 'ImportSourceCapExceededError';
+    this.details = details;
+    Object.setPrototypeOf(this, ImportSourceCapExceededError.prototype);
   }
 }

--- a/src/common/test/import-exceptions.test.ts
+++ b/src/common/test/import-exceptions.test.ts
@@ -6,6 +6,11 @@ import {
   ImportSourceParseError,
   ImportSourceDnsVerificationError,
   ImportSourceVerifyRateLimitError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
   IMPORT_DNS_NOT_FOUND,
   IMPORT_DNS_MISMATCH,
   IMPORT_DNS_RESOLVER_DISAGREEMENT,
@@ -16,6 +21,11 @@ import {
   IMPORT_PARSE_ERROR,
   IMPORT_NOT_FOUND,
   IMPORT_VERIFY_RATE_LIMITED,
+  IMPORT_FILE_EMPTY,
+  IMPORT_FILE_TOO_LARGE,
+  IMPORT_FILE_BAD_FORMAT,
+  IMPORT_FILE_TOO_MANY_EVENTS,
+  IMPORT_SOURCE_CAP_EXCEEDED,
 } from '@/common/exceptions/import';
 
 /**
@@ -36,6 +46,11 @@ const errorMap: Record<string, new (...args: never[]) => Error> = {
   ImportSourceParseError: ImportSourceParseError as unknown as new () => Error,
   ImportSourceDnsVerificationError: ImportSourceDnsVerificationError as unknown as new () => Error,
   ImportSourceVerifyRateLimitError: ImportSourceVerifyRateLimitError as unknown as new () => Error,
+  ImportSourceFileEmptyError: ImportSourceFileEmptyError as unknown as new () => Error,
+  ImportSourceFileTooLargeError: ImportSourceFileTooLargeError as unknown as new () => Error,
+  ImportSourceFileBadFormatError: ImportSourceFileBadFormatError as unknown as new () => Error,
+  ImportSourceFileTooManyEventsError: ImportSourceFileTooManyEventsError as unknown as new () => Error,
+  ImportSourceCapExceededError: ImportSourceCapExceededError as unknown as new () => Error,
 };
 
 describe('ICS import exceptions', () => {
@@ -137,6 +152,74 @@ describe('ICS import exceptions', () => {
     });
   });
 
+  describe('ImportSourceFileEmptyError', () => {
+    it('uses a fixed sanitized message and has errorName set', () => {
+      const err = new ImportSourceFileEmptyError();
+      expect(err.name).toBe('ImportSourceFileEmptyError');
+      expect(err.message).toBe(IMPORT_FILE_EMPTY);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(ImportSourceFileEmptyError);
+    });
+  });
+
+  describe('ImportSourceFileTooLargeError', () => {
+    it('uses a fixed sanitized message', () => {
+      const err = new ImportSourceFileTooLargeError();
+      expect(err.name).toBe('ImportSourceFileTooLargeError');
+      expect(err.message).toBe(IMPORT_FILE_TOO_LARGE);
+    });
+
+    it('keeps the raw byte length in details only, never in the message', () => {
+      const err = new ImportSourceFileTooLargeError({ bytes: 11534336 });
+      expect(err.message).toBe(IMPORT_FILE_TOO_LARGE);
+      expect(err.message).not.toContain('11534336');
+      expect(err.details).toEqual({ bytes: 11534336 });
+    });
+  });
+
+  describe('ImportSourceFileBadFormatError', () => {
+    it('uses a fixed sanitized message', () => {
+      const err = new ImportSourceFileBadFormatError();
+      expect(err.name).toBe('ImportSourceFileBadFormatError');
+      expect(err.message).toBe(IMPORT_FILE_BAD_FORMAT);
+    });
+
+    it('keeps the rejection reason in details only', () => {
+      const err = new ImportSourceFileBadFormatError({ reason: 'missing_vcalendar_signature' });
+      expect(err.message).toBe(IMPORT_FILE_BAD_FORMAT);
+      expect(err.details).toEqual({ reason: 'missing_vcalendar_signature' });
+    });
+  });
+
+  describe('ImportSourceFileTooManyEventsError', () => {
+    it('uses a fixed sanitized message', () => {
+      const err = new ImportSourceFileTooManyEventsError();
+      expect(err.name).toBe('ImportSourceFileTooManyEventsError');
+      expect(err.message).toBe(IMPORT_FILE_TOO_MANY_EVENTS);
+    });
+
+    it('keeps parsed/limit counts in details only, never in the message', () => {
+      const err = new ImportSourceFileTooManyEventsError({ parsedEvents: 20000, maxEvents: 10000 });
+      expect(err.message).toBe(IMPORT_FILE_TOO_MANY_EVENTS);
+      expect(err.message).not.toContain('20000');
+      expect(err.details).toEqual({ parsedEvents: 20000, maxEvents: 10000 });
+    });
+  });
+
+  describe('ImportSourceCapExceededError', () => {
+    it('uses a fixed sanitized message', () => {
+      const err = new ImportSourceCapExceededError();
+      expect(err.name).toBe('ImportSourceCapExceededError');
+      expect(err.message).toBe(IMPORT_SOURCE_CAP_EXCEEDED);
+    });
+
+    it('keeps the cap value in details only', () => {
+      const err = new ImportSourceCapExceededError({ cap: 10 });
+      expect(err.message).toBe(IMPORT_SOURCE_CAP_EXCEEDED);
+      expect(err.details).toEqual({ cap: 10 });
+    });
+  });
+
   describe('cross-HTTP round-trip serialization', () => {
     const cases: Array<{ name: string; err: Error }> = [
       { name: 'ImportSourceNotFoundError', err: new ImportSourceNotFoundError() },
@@ -145,6 +228,11 @@ describe('ICS import exceptions', () => {
       { name: 'ImportSourceParseError', err: new ImportSourceParseError() },
       { name: 'ImportSourceDnsVerificationError', err: new ImportSourceDnsVerificationError(IMPORT_DNS_NOT_FOUND) },
       { name: 'ImportSourceVerifyRateLimitError', err: new ImportSourceVerifyRateLimitError() },
+      { name: 'ImportSourceFileEmptyError', err: new ImportSourceFileEmptyError() },
+      { name: 'ImportSourceFileTooLargeError', err: new ImportSourceFileTooLargeError() },
+      { name: 'ImportSourceFileBadFormatError', err: new ImportSourceFileBadFormatError() },
+      { name: 'ImportSourceFileTooManyEventsError', err: new ImportSourceFileTooManyEventsError() },
+      { name: 'ImportSourceCapExceededError', err: new ImportSourceCapExceededError() },
     ];
 
     for (const { name, err } of cases) {

--- a/src/server/calendar/api/v1/import_source.ts
+++ b/src/server/calendar/api/v1/import_source.ts
@@ -1,4 +1,5 @@
-import express, { Request, Response, Application } from 'express';
+import express, { Request, Response, Application, NextFunction } from 'express';
+import multer from 'multer';
 
 import { Account } from '@/common/model/account';
 import { ImportSourceVerificationType } from '@/common/model/import_source';
@@ -14,6 +15,11 @@ import {
   ImportSourceFetchError,
   ImportSourceSsrfBlockedError,
   ImportSourceParseError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
 } from '@/common/exceptions/import';
 import ExpressHelper from '@/server/common/helper/express';
 import { logError } from '@/server/common/helper/error-logger';
@@ -22,8 +28,39 @@ import {
   limitImportSourceVerifyBySource,
   limitImportSourceSyncBySource,
 } from '@/server/common/middleware/rate-limiters';
+import { MAX_BODY_BYTES, ALLOWED_CONTENT_TYPES } from '../../service/import/fetcher';
 import CalendarInterface from '../../interface';
 import type { SyncResult } from '../../service/import/sync';
+
+/**
+ * Hard byte cap for an uploaded .ics file. Reuses the ICS URL fetcher's
+ * {@link MAX_BODY_BYTES} (10 MiB) so the transport, service, and fetch paths
+ * share one ceiling instead of maintaining independent copies.
+ */
+const FILE_MAX_BYTES = MAX_BODY_BYTES;
+
+/**
+ * Content types an .ics upload may declare. Reuses the fetcher's
+ * {@link ALLOWED_CONTENT_TYPES} allowlist. Many exporters mislabel the file as
+ * `application/octet-stream`, so a `.ics` filename extension is accepted as an
+ * alternative (the service still enforces the `BEGIN:VCALENDAR` signature sniff,
+ * so a lie about the type cannot smuggle a non-ICS payload through).
+ */
+const ALLOWED_ICS_MIME_TYPES = ALLOWED_CONTENT_TYPES;
+
+/**
+ * Multer instance for the file-upload route: in-memory storage (the buffer is
+ * handed straight to the ICS pipeline, never written to disk), a single file,
+ * and the 10 MiB transport cap. Mirrors the media-domain upload pattern
+ * (src/server/media/api/v1/media.ts).
+ */
+const icsUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: FILE_MAX_BYTES,
+    files: 1,
+  },
+});
 
 /**
  * API routes for per-calendar ICS import sources.
@@ -69,6 +106,18 @@ class ImportSourceRoutes {
       ExpressHelper.loggedInOnly,
       limitWidgetConfigByAccount,
       this.createSource.bind(this),
+    );
+    router.post(
+      '/calendars/:calendarId/import-sources/file',
+      ExpressHelper.loggedInOnly,
+      limitWidgetConfigByAccount,
+      // Authorize BEFORE multer buffers up to 10 MiB into memory. A non-editor
+      // (or a bad calendar id) is rejected 400/403/404 here so an unauthorized
+      // caller cannot force a large in-memory buffer for a calendar they do
+      // not own. The service layer re-checks access as defense in depth.
+      this.assertFileUploadAccess.bind(this),
+      this.uploadIcsFile.bind(this),
+      this.createSourceFromFile.bind(this),
     );
     router.get(
       '/calendars/:calendarId/import-sources/:id',
@@ -156,6 +205,149 @@ class ImportSourceRoutes {
     catch (error) {
       this.handleError(res, error, 'Error creating import source');
     }
+  }
+
+  /**
+   * Pre-buffer authorization for the file-upload route. Runs BEFORE the multer
+   * intake middleware so an unauthorized caller (bad UUID, missing calendar, or
+   * non-editor) is rejected without multer buffering the up-to-10-MiB body into
+   * memory. HTTP concerns only: validate the UUID shape, then confirm editor
+   * access via the calendar interface. The service layer repeats these checks
+   * as defense in depth (a non-HTTP caller — e.g. a CLI importer — bypasses this
+   * middleware entirely).
+   */
+  async assertFileUploadAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const account = req.user as Account;
+    const { calendarId } = req.params;
+
+    if (!ExpressHelper.isValidUUID(calendarId)) {
+      res.status(400).json({
+        error: 'invalid calendarId format',
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    try {
+      const calendar = await this.service.getCalendar(calendarId);
+      if (!calendar) {
+        res.status(404).json({
+          error: 'Calendar not found',
+          errorName: 'CalendarNotFoundError',
+        });
+        return;
+      }
+
+      const canModify = await this.service.userCanModifyCalendar(account, calendar);
+      if (!canModify) {
+        res.status(403).json({
+          error: 'Permission denied',
+          errorName: 'CalendarEditorPermissionError',
+        });
+        return;
+      }
+
+      next();
+    }
+    catch (error) {
+      this.handleError(res, error, 'Error authorizing import file upload');
+    }
+  }
+
+  /**
+   * Multipart intake middleware for the file-upload route. Wraps multer's
+   * `single('file')` so its own errors (notably the 10 MiB `LIMIT_FILE_SIZE`
+   * transport cap) are translated to the sanitized `{ error, errorName }`
+   * envelope instead of bubbling to the default Express error handler as a 500.
+   * On success it populates `req.file` and continues to the handler.
+   */
+  uploadIcsFile(req: Request, res: Response, next: NextFunction): void {
+    icsUpload.single('file')(req, res, (err: unknown) => {
+      if (err) {
+        if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+          res.status(400).json({
+            error: 'Uploaded file exceeds the size limit',
+            errorName: 'ImportSourceFileTooLargeError',
+          });
+          return;
+        }
+        res.status(400).json({
+          error: 'Invalid file upload',
+          errorName: 'ValidationError',
+        });
+        return;
+      }
+      next();
+    });
+  }
+
+  /**
+   * POST /api/v1/calendars/:calendarId/import-sources/file
+   *
+   * Create a file-backed import source from a multipart .ics upload and run
+   * its events through the shared ICS pipeline. HTTP concerns only — UUID
+   * shape, file presence, and the content-type / extension allowlist. All
+   * business validation (editor access, size, VCALENDAR sniff, per-calendar
+   * cap, parse) lives in the service. On success returns 201 `{ source, run }`.
+   */
+  async createSourceFromFile(req: Request, res: Response): Promise<void> {
+    const account = req.user as Account;
+    const { calendarId } = req.params;
+    const file = req.file;
+
+    if (!ExpressHelper.isValidUUID(calendarId)) {
+      res.status(400).json({
+        error: 'invalid calendarId format',
+        errorName: 'ValidationError',
+      });
+      return;
+    }
+
+    if (!file || !file.buffer || file.buffer.length === 0) {
+      res.status(400).json({
+        error: 'No file uploaded',
+        errorName: 'ImportSourceFileEmptyError',
+      });
+      return;
+    }
+
+    if (!this.isAllowedIcsUpload(file)) {
+      res.status(400).json({
+        error: 'File is not an ICS calendar',
+        errorName: 'ImportSourceFileBadFormatError',
+      });
+      return;
+    }
+
+    try {
+      const { source, run } = await this.service.createImportSourceFromFile(
+        account,
+        calendarId,
+        file.buffer,
+        file.originalname,
+      );
+      res.status(201).json({
+        source: source.toObject(),
+        run: toImportRunSummary(run, source.id),
+      });
+    }
+    catch (error) {
+      this.handleError(res, error, 'Error creating import source from file');
+    }
+  }
+
+  /**
+   * Accept an upload when its declared content type is in the ICS allowlist,
+   * or (defensively) when the filename ends in `.ics`. The service's
+   * `BEGIN:VCALENDAR` signature sniff is the real content gate; this is a
+   * cheap first filter on the transport-declared type.
+   */
+  private isAllowedIcsUpload(file: Express.Multer.File): boolean {
+    const mime = (file.mimetype ?? '').toLowerCase().split(';')[0].trim();
+    if (ALLOWED_ICS_MIME_TYPES.has(mime)) {
+      return true;
+    }
+    return (file.originalname ?? '').toLowerCase().endsWith('.ics');
   }
 
   /**
@@ -399,8 +591,33 @@ class ImportSourceRoutes {
       });
       return;
     }
-    if (error instanceof ImportSourceParseError) {
+    if (
+      error instanceof ImportSourceParseError
+      || error instanceof ImportSourceFileTooManyEventsError
+    ) {
+      // 422: the payload parsed but its event content is not acceptable — no
+      // usable VEVENTs (ParseError) or too many VEVENTs (TooManyEvents, a DoS
+      // bound). Distinct from the 400 malformed-file bucket below.
       res.status(422).json({
+        error: error.message,
+        errorName: error.name,
+      });
+      return;
+    }
+    // File-upload intake failures (pv-84da.1.4).
+    if (
+      error instanceof ImportSourceFileEmptyError
+      || error instanceof ImportSourceFileTooLargeError
+      || error instanceof ImportSourceFileBadFormatError
+    ) {
+      res.status(400).json({
+        error: error.message,
+        errorName: error.name,
+      });
+      return;
+    }
+    if (error instanceof ImportSourceCapExceededError) {
+      res.status(409).json({
         error: error.message,
         errorName: error.name,
       });

--- a/src/server/calendar/interface/index.ts
+++ b/src/server/calendar/interface/index.ts
@@ -965,6 +965,32 @@ export default class CalendarInterface {
   }
 
   /**
+   * Create a file-backed import source from an uploaded .ics buffer and run
+   * its events through the shared ICS pipeline in a single transaction. Unlike
+   * {@link createImportSource}, the source is created pre-verified (no domain
+   * to prove) and never enters the sync/verify flows.
+   *
+   * @param account - The requesting account (must own or edit the calendar)
+   * @param calendarId - The calendar UUID
+   * @param buffer - The raw uploaded .ics bytes
+   * @param originalFilename - The upload's display name (stored for the list UI)
+   * @returns The persisted file source and the import run summary
+   */
+  async createImportSourceFromFile(
+    account: Account,
+    calendarId: string,
+    buffer: Buffer,
+    originalFilename: string,
+  ): Promise<{ source: ImportSource; run: SyncResult }> {
+    return this.importSourceService.createSourceFromFile(
+      account,
+      calendarId,
+      buffer,
+      originalFilename,
+    );
+  }
+
+  /**
    * Get a single import source by id, scoped to the calendar.
    *
    * @param account - The requesting account (must own or edit the calendar)

--- a/src/server/calendar/service/import/fetcher.ts
+++ b/src/server/calendar/service/import/fetcher.ts
@@ -66,11 +66,19 @@ export const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MiB
 /** First-bytes sniff window for BEGIN:VCALENDAR signature. */
 export const SIGNATURE_SNIFF_BYTES = 256;
 
-/** Required signature at the start of the body. */
-const VCALENDAR_SIGNATURE = 'BEGIN:VCALENDAR';
+/**
+ * Required signature at the start of the body. Exported so the file-upload
+ * intake path (import_source_service.ts) shares one definition rather than
+ * re-declaring its own copy.
+ */
+export const VCALENDAR_SIGNATURE = 'BEGIN:VCALENDAR';
 
-/** Accepted content types (case-insensitive, parameter-stripped). */
-const ALLOWED_CONTENT_TYPES: ReadonlySet<string> = new Set([
+/**
+ * Accepted content types (case-insensitive, parameter-stripped). Exported so
+ * the multipart upload route (import_source.ts) reuses the same allowlist the
+ * URL fetcher enforces instead of maintaining a parallel copy.
+ */
+export const ALLOWED_CONTENT_TYPES: ReadonlySet<string> = new Set([
   'text/calendar',
   'text/x-calendar',
   'application/calendar',
@@ -81,6 +89,20 @@ const REJECTED_CONTENT_TYPES: ReadonlySet<string> = new Set([
   'text/html',
   'application/xhtml+xml',
 ]);
+
+/**
+ * True when the buffer's leading bytes begin with `BEGIN:VCALENDAR`, allowing a
+ * UTF-8 BOM or leading whitespace. Inspects only the first
+ * {@link SIGNATURE_SNIFF_BYTES} bytes. Shared by the URL fetch path (below) and
+ * the file-upload intake path so a payload that fails the sniff on one intake
+ * route fails it identically on the other.
+ */
+export function hasVcalendarSignature(buffer: Buffer): boolean {
+  const window = buffer
+    .subarray(0, Math.min(buffer.length, SIGNATURE_SNIFF_BYTES))
+    .toString('utf8');
+  return window.replace(/^﻿/, '').trimStart().startsWith(VCALENDAR_SIGNATURE);
+}
 
 /**
  * User-Agent string per privacy-advisor — no instance hostname.
@@ -429,12 +451,8 @@ export class Fetcher {
         //    `Content-Length` is not trusted.
         const body = await readBodyCapped(response.body, MAX_BODY_BYTES);
 
-        // 8. Signature sniff.
-        const signatureWindow = body
-          .subarray(0, Math.min(body.length, SIGNATURE_SNIFF_BYTES))
-          .toString('utf8');
-        // Allow a BOM or leading whitespace before BEGIN:VCALENDAR.
-        if (!signatureWindow.replace(/^﻿/, '').trimStart().startsWith(VCALENDAR_SIGNATURE)) {
+        // 8. Signature sniff (BOM / leading whitespace tolerant).
+        if (!hasVcalendarSignature(body)) {
           throw new ImportSourceFetchError({ reason: 'missing_vcalendar_signature' });
         }
 

--- a/src/server/calendar/service/import/import_source_service.ts
+++ b/src/server/calendar/service/import/import_source_service.ts
@@ -20,6 +20,11 @@ import {
   ImportSourceNotFoundError,
   ImportSourceRelMeVerificationError,
   ImportSourceSsrfBlockedError,
+  ImportSourceParseError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceCapExceededError,
   IMPORT_DNS_MISMATCH,
   IMPORT_RELME_HOSTNAME_MISMATCH,
   IMPORT_RELME_LINK_NOT_FOUND,
@@ -28,6 +33,7 @@ import {
   IMPORT_RELME_PSL_VIOLATION,
 } from '@/common/exceptions/import';
 import { ImportSourceEntity } from '@/server/calendar/entity/import_source';
+import db from '@/server/common/entity/db';
 import { isPrivateIP, validateUrlNotPrivate } from '@/server/common/helper/ip-validation';
 import { createIcsUrlValidator, isLocalhostIcsImportAllowed } from '@/server/common/helper/test-ssrf-gate';
 import { createLogger } from '@/server/common/helper/logger';
@@ -35,6 +41,7 @@ import CalendarService from '@/server/calendar/service/calendar';
 import { generateVerificationToken } from '@/server/calendar/service/import/hmac';
 import { hostnameFromUrl, passesPslCheck } from '@/server/calendar/service/import/hostname';
 import { DnsVerifier, VERIFICATION_VALIDITY_DAYS } from '@/server/calendar/service/import/dns-verifier';
+import { MAX_BODY_BYTES, hasVcalendarSignature } from '@/server/calendar/service/import/fetcher';
 import type SyncService from '@/server/calendar/service/import/sync';
 import type { SyncResult } from '@/server/calendar/service/import/sync';
 
@@ -58,6 +65,35 @@ const RELME_HEADERS_TIMEOUT_MS = 15_000;
 const RELME_BODY_TIMEOUT_MS = 30_000;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Hard byte cap for an uploaded .ics file. Reuses the ICS URL fetcher's
+ * {@link MAX_BODY_BYTES} (10 MiB) so the two intake paths share one ceiling
+ * rather than maintaining independent copies. The multer middleware also
+ * enforces this at the transport layer; the service re-checks the decoded
+ * buffer as defense in depth (callers other than the HTTP route — e.g. a
+ * future CLI importer — bypass multer).
+ */
+const FILE_MAX_BYTES = MAX_BODY_BYTES;
+
+/**
+ * Maximum VEVENTs accepted from a single uploaded file (DoS bound). A 10 MiB
+ * file of minimal VEVENTs can carry ~130k+ events; parsing is synchronous and
+ * CPU-bound and each event is an INSERT in one transaction, so an unbounded
+ * count is a denial-of-service lever. This is a product-tunable ceiling — raise
+ * it if a legitimate migration needs more, but never remove the bound. Applies
+ * to the FILE intake path only; URL sync passes no `maxEvents` and is unchanged.
+ */
+const MAX_EVENTS_PER_FILE_IMPORT = 10000;
+
+/**
+ * Maximum stored length of an uploaded file's original name. The
+ * `original_filename` column is VARCHAR(255); an over-length name would raise a
+ * raw DB error surfaced as a generic 500, so we truncate defensively before
+ * insert. Truncation (not rejection) keeps a cosmetic display field from
+ * failing an otherwise-valid import.
+ */
+const ORIGINAL_FILENAME_MAX_LENGTH = 255;
 
 /**
  * Promisified `dns.lookup` returning every resolved address. Used by the
@@ -211,6 +247,159 @@ class ImportSourceService {
     );
 
     return entity.toModel();
+  }
+
+  /**
+   * Create a file-backed import source from an uploaded .ics buffer and run
+   * its events through the shared ICS pipeline in a single transaction.
+   *
+   * Unlike {@link createSource} (which registers a live URL to be polled and
+   * requires a later DNS/rel-me ownership proof), a file source is created
+   * pre-verified: the uploader is importing into a calendar they already own,
+   * so there is no domain to prove. The row is stamped
+   * `verification_state='verified'` with a null `verification_type` and no
+   * expiry — file trust is permanent (spec field table).
+   *
+   * Intake is security-sensitive, so validation runs in a fixed order and
+   * fails closed on the first problem:
+   *   1. editor access on the calendar (403 CalendarEditorPermissionError /
+   *      404 CalendarNotFoundError)
+   *   2. non-empty buffer (400 {@link ImportSourceFileEmptyError})
+   *   3. 10 MiB size cap (400 {@link ImportSourceFileTooLargeError})
+   *   4. `BEGIN:VCALENDAR` signature sniff (400
+   *      {@link ImportSourceFileBadFormatError})
+   *   5. per-calendar source cap (409 {@link ImportSourceCapExceededError})
+   *
+   * Only after every guard passes is anything written. The source row insert
+   * and the {@link SyncService.processIcsBuffer} run share ONE transaction, so
+   * a malformed payload (or a file with zero usable events) rolls the source
+   * row back — a rejected upload never leaves an orphan source. `processIcsBuffer`
+   * captures parse failures as a run outcome rather than throwing, so we
+   * inspect the returned {@link SyncResult} and throw the mapping exception
+   * ourselves to trigger the rollback:
+   *   - `outcome === 'parse_error'`  → {@link ImportSourceFileBadFormatError} (400)
+   *   - parsed but zero usable events → {@link ImportSourceParseError} (422)
+   *
+   * @param account - The requesting account (must own or edit the calendar)
+   * @param calendarId - The calendar UUID
+   * @param buffer - The raw uploaded .ics bytes
+   * @param originalFilename - The upload's display name (stored for the list UI)
+   * @returns The persisted file source and the import run summary
+   * @throws CalendarNotFoundError, CalendarEditorPermissionError,
+   *   ImportSourceFileEmptyError, ImportSourceFileTooLargeError,
+   *   ImportSourceFileBadFormatError, ImportSourceCapExceededError,
+   *   ImportSourceParseError
+   */
+  async createSourceFromFile(
+    account: Account,
+    calendarId: string,
+    buffer: Buffer,
+    originalFilename: string,
+  ): Promise<{ source: ImportSource; run: SyncResult }> {
+    await this.assertEditorAccess(account, calendarId);
+
+    if (!buffer || buffer.length === 0) {
+      throw new ImportSourceFileEmptyError();
+    }
+
+    if (buffer.length > FILE_MAX_BYTES) {
+      throw new ImportSourceFileTooLargeError({ bytes: buffer.length });
+    }
+
+    if (!hasVcalendarSignature(buffer)) {
+      throw new ImportSourceFileBadFormatError({ reason: 'missing_vcalendar_signature' });
+    }
+
+    await this.assertUnderSourceCapForFile(calendarId);
+
+    if (!this.syncService) {
+      throw new Error('ImportSourceService.createSourceFromFile called without SyncService wiring');
+    }
+    const syncService = this.syncService;
+
+    // The original_filename column is VARCHAR(255); an over-length name would
+    // raise a raw DB error surfaced as a generic 500. Truncate defensively —
+    // the field is a cosmetic display label, so trimming it is preferable to
+    // failing an otherwise-valid import.
+    const storedFilename = (originalFilename ?? '').slice(0, ORIGINAL_FILENAME_MAX_LENGTH);
+
+    const startedAt = new Date();
+    const contentHash = crypto.createHash('sha256').update(buffer).digest('hex');
+    const id = uuidv4();
+
+    // Source insert + event pipeline share one transaction. Throwing inside it
+    // (malformed payload / no usable events) rolls the source row back with the
+    // event writes so a rejected upload leaves nothing behind.
+    const result = await db.transaction(async (tx) => {
+      const entity = await ImportSourceEntity.create(
+        {
+          id,
+          calendar_id: calendarId,
+          source_type: 'file',
+          url: null,
+          original_filename: storedFilename,
+          enabled: true,
+          verification_type: null,
+          verification_state: 'verified',
+          verified_at: startedAt,
+          verification_expires_at: null,
+          etag: null,
+          content_hash: contentHash,
+          last_fetched_at: startedAt,
+          last_status: 'ok',
+        },
+        { transaction: tx },
+      );
+
+      const run = await syncService.processIcsBuffer(
+        buffer,
+        entity,
+        {
+          dedupScope: 'calendar',
+          account,
+          startedAt,
+          // DoS bound for the file path only: reject a file whose VEVENT count
+          // exceeds the ceiling BEFORE the create loop, throwing inside this
+          // transaction so the source row rolls back. URL sync omits maxEvents.
+          maxEvents: MAX_EVENTS_PER_FILE_IMPORT,
+        },
+        tx,
+      );
+
+      if (run.outcome === 'parse_error') {
+        // The parser could not read the payload at all — treat as a bad file
+        // (400) and roll the source row back.
+        throw new ImportSourceFileBadFormatError({ reason: 'parse_error' });
+      }
+
+      const usableEvents =
+        run.eventsCreated
+        + run.eventsUpdated
+        + (run.eventsSkippedSyncManaged ?? 0)
+        + (run.eventsPreservedLocalEdits ?? 0)
+        + run.eventsSkippedLocallyEdited;
+      if (usableEvents === 0) {
+        // Valid VCALENDAR but nothing to import (no VEVENTs). Roll back — a
+        // no-op upload should not create a source row. 422 distinguishes this
+        // from a malformed file.
+        throw new ImportSourceParseError({ reason: 'no_usable_vevents' });
+      }
+
+      return { source: entity.toModel(), run };
+    });
+
+    logger.info(
+      {
+        calendarId,
+        importSourceId: id,
+        outcome: result.run.outcome,
+        eventsCreated: result.run.eventsCreated,
+        eventsUpdated: result.run.eventsUpdated,
+      },
+      'Created file import source and ran ICS pipeline',
+    );
+
+    return result;
   }
 
   /**
@@ -822,6 +1011,15 @@ class ImportSourceService {
   /**
    * Enforce the per-calendar source cap. The cap is config-driven
    * (`calendar.import.maxSourcesPerCalendar`, default 10).
+   *
+   * STATUS DIVERGENCE (intentional): the URL-create path throws a generic
+   * {@link ValidationError} → HTTP 400 here, while the file-upload path throws
+   * {@link ImportSourceCapExceededError} → HTTP 409 in
+   * {@link assertUnderSourceCapForFile}. The file frontend keys an actionable
+   * "too many sources" message off the distinct `errorName`; the URL form
+   * surfaces the cap as a field-level validation message. Kept divergent by
+   * design — see the spec's error-surface table (409 cap is spec-mandated for
+   * the file route).
    */
   private async assertUnderSourceCap(calendarId: string): Promise<void> {
     const cap = this.getMaxSourcesPerCalendar();
@@ -834,6 +1032,28 @@ class ImportSourceService {
         `Calendar has reached the maximum of ${cap} import sources`,
         { url: [`Calendar has reached the maximum of ${cap} import sources`] },
       );
+    }
+  }
+
+  /**
+   * File-upload variant of {@link assertUnderSourceCap}. Same count + cap, but
+   * throws {@link ImportSourceCapExceededError} (→ HTTP 409) instead of the
+   * URL path's {@link ValidationError} (→ HTTP 400 via `sendValidationError`).
+   * A cap hit is a conflict with the calendar's current state, and the
+   * file-upload frontend keys its message off this distinct `errorName`.
+   *
+   * STATUS DIVERGENCE (intentional): see {@link assertUnderSourceCap} for the
+   * paired URL-path 400 rationale. The 409 here is spec-mandated for the file
+   * route (spec error-surface table).
+   */
+  private async assertUnderSourceCapForFile(calendarId: string): Promise<void> {
+    const cap = this.getMaxSourcesPerCalendar();
+    const count = await ImportSourceEntity.count({
+      where: { calendar_id: calendarId },
+    });
+
+    if (count >= cap) {
+      throw new ImportSourceCapExceededError({ cap });
     }
   }
 

--- a/src/server/calendar/service/import/import_source_service.ts
+++ b/src/server/calendar/service/import/import_source_service.ts
@@ -1012,6 +1012,12 @@ class ImportSourceService {
    * Enforce the per-calendar source cap. The cap is config-driven
    * (`calendar.import.maxSourcesPerCalendar`, default 10).
    *
+   * SCOPE: the cap counts only `source_type: 'url'` sync sources. File-upload
+   * sources are excluded — they are one-shot, ephemeral import records (see the
+   * spec's "older file source can end with zero origins … stays as run history"
+   * note), so re-uploading a file many times must not consume cap slots and
+   * lock a calendar out of adding sync feeds.
+   *
    * STATUS DIVERGENCE (intentional): the URL-create path throws a generic
    * {@link ValidationError} → HTTP 400 here, while the file-upload path throws
    * {@link ImportSourceCapExceededError} → HTTP 409 in
@@ -1024,7 +1030,7 @@ class ImportSourceService {
   private async assertUnderSourceCap(calendarId: string): Promise<void> {
     const cap = this.getMaxSourcesPerCalendar();
     const count = await ImportSourceEntity.count({
-      where: { calendar_id: calendarId },
+      where: { calendar_id: calendarId, source_type: 'url' },
     });
 
     if (count >= cap) {
@@ -1042,6 +1048,11 @@ class ImportSourceService {
    * A cap hit is a conflict with the calendar's current state, and the
    * file-upload frontend keys its message off this distinct `errorName`.
    *
+   * SCOPE: like {@link assertUnderSourceCap}, this counts only `source_type:
+   * 'url'` sync sources — a file upload does not count itself, so repeated
+   * uploads never trip the cap. It fires only when the calendar's *sync* feeds
+   * already fill the cap, keeping ephemeral file imports out of the limit.
+   *
    * STATUS DIVERGENCE (intentional): see {@link assertUnderSourceCap} for the
    * paired URL-path 400 rationale. The 409 here is spec-mandated for the file
    * route (spec error-surface table).
@@ -1049,7 +1060,7 @@ class ImportSourceService {
   private async assertUnderSourceCapForFile(calendarId: string): Promise<void> {
     const cap = this.getMaxSourcesPerCalendar();
     const count = await ImportSourceEntity.count({
-      where: { calendar_id: calendarId },
+      where: { calendar_id: calendarId, source_type: 'url' },
     });
 
     if (count >= cap) {

--- a/src/server/calendar/service/import/sync.ts
+++ b/src/server/calendar/service/import/sync.ts
@@ -52,6 +52,7 @@ import { CalendarEvent } from '@/common/model/events';
 import {
   ImportSourceFetchError,
   ImportSourceParseError,
+  ImportSourceFileTooManyEventsError,
   ImportSourceNotFoundError,
   ImportSourceNotVerifiedError,
   ImportSourceSsrfBlockedError,
@@ -120,6 +121,30 @@ export interface SyncResult {
    * is left untouched so a later UI can flag them.
    */
   eventsDisappeared: number;
+  /**
+   * Calendar-wide dedup only: uploaded events that matched an origin owned by a
+   * URL-sync source. Skipped untouched — updating a sync-owned event would be
+   * silently reverted at the next sync, and stealing its origin would make the
+   * sync source re-create the event as a duplicate. `recordRun` always populates
+   * this (0 on the per-source path); optional so the field is additive for
+   * existing `SyncResult` literals.
+   */
+  eventsSkippedSyncManaged?: number;
+  /**
+   * Calendar-wide dedup only: uploaded events that matched an origin flagged
+   * `locally_edited`. Skipped to preserve manual edits (mirror sync semantics).
+   * `recordRun` always populates this (0 on the per-source path); optional so
+   * the field is additive for existing `SyncResult` literals.
+   */
+  eventsPreservedLocalEdits?: number;
+  /**
+   * Calendar-wide dedup only: per-event detail for the sync-managed skips,
+   * carrying the owning URL source's `url` so the run summary can name which
+   * sync feed owns each skipped event. `recordRun` always populates this (empty
+   * on the per-source path); optional so the field is additive for existing
+   * `SyncResult` literals.
+   */
+  skippedSyncManagedDetails?: Array<{ externalUid: string; sourceUrl: string | null }>;
   /** Sanitized error message. Only populated on non-success outcomes. */
   errorMessage: string | null;
 }
@@ -149,15 +174,28 @@ export interface SyncInput {
 export interface ProcessIcsOptions {
   /**
    * Dedup strategy. `'source'` dedups by `(import_source_id, external_uid,
-   * external_recurrence_id)` — the URL-sync model implemented here. `'calendar'`
-   * (calendar-wide UID dedup for file uploads) is implemented in pv-84da.1.3;
-   * passing it here throws.
+   * external_recurrence_id)` — the URL-sync model. `'calendar'` dedups
+   * calendar-wide: every `event_import_origin` row on the calendar (joined
+   * through `import_source.calendar_id`), keyed on `(external_uid,
+   * external_recurrence_id)` and tagged with the owning source's `source_type`.
+   * The calendar scope is the file-upload refresh model (pv-84da.1.3): a
+   * re-uploaded export updates matched events in place instead of duplicating.
    */
   dedupScope: 'source' | 'calendar';
   /** Requester identity threaded into EventService create/update writes. */
   account: Account;
   /** Wall-clock time the enclosing run began (preserved on SyncResult.startedAt). */
   startedAt: Date;
+  /**
+   * Optional ceiling on the number of VEVENTs accepted from the parsed file.
+   * When set and the extracted VEVENT count exceeds it, the run throws
+   * {@link ImportSourceFileTooManyEventsError} AFTER extraction but BEFORE the
+   * create loop, so no events are written (and, on the file path, the enclosing
+   * transaction's source row rolls back). A DoS bound for the FILE intake path
+   * only — the URL-sync path omits this so its fetch/parse behavior is
+   * unchanged.
+   */
+  maxEvents?: number;
   /**
    * Fetch-derived source bookkeeping applied inside the successful transaction
    * (step 9). Supplied by the URL-sync fetch path; the file-upload path
@@ -370,14 +408,6 @@ class SyncService {
     opts: ProcessIcsOptions,
     tx?: Transaction,
   ): Promise<SyncResult> {
-    if (opts.dedupScope !== 'source') {
-      // Calendar-wide dedup is implemented in pv-84da.1.3. Until then, refuse
-      // rather than silently falling through to per-source dedup.
-      throw new Error(
-        `processIcsBuffer: dedupScope '${opts.dedupScope}' is not implemented (see pv-84da.1.3)`,
-      );
-    }
-
     const importSourceId = source.id;
     const { account, startedAt } = opts;
 
@@ -387,7 +417,7 @@ class SyncService {
       parsed = this.parseICS(buffer.toString('utf8'));
     }
     catch (err) {
-      await this.updateSourceOnFetchFailure(source, 'parse_error');
+      await this.updateSourceOnFetchFailure(source, 'parse_error', tx);
       return this.recordRun({
         sourceId: importSourceId,
         startedAt,
@@ -398,6 +428,20 @@ class SyncService {
     }
 
     const vevents = this.extractVevents(parsed);
+
+    // --- VEVENT-count DoS bound (file intake path only) ------------------
+    // Enforced after extraction but BEFORE any transaction / event write, so a
+    // file whose event count exceeds the ceiling writes nothing. This throw is
+    // deliberately OUTSIDE the transactional try/catch below (which converts
+    // failures into a recorded run) so it propagates to the caller: on the file
+    // path that unwinds the enclosing db.transaction and rolls the source row
+    // back. The URL-sync path passes no `maxEvents`, so this is a no-op there.
+    if (opts.maxEvents !== undefined && vevents.length > opts.maxEvents) {
+      throw new ImportSourceFileTooManyEventsError({
+        parsedEvents: vevents.length,
+        maxEvents: opts.maxEvents,
+      });
+    }
 
     // --- Derive calendar primary language (for mapper) -------------------
     // We only have calendar_id on the source; load the calendar's configured
@@ -415,7 +459,16 @@ class SyncService {
 
     // --- Transactional body --------------------------------------------------
     // All persistence inside this transaction rolls back together on failure.
-    let counts = { created: 0, updated: 0, skippedLocallyEdited: 0, disappeared: 0 };
+    let counts = {
+      created: 0,
+      updated: 0,
+      skippedLocallyEdited: 0,
+      disappeared: 0,
+      skippedSyncManaged: 0,
+      preservedLocalEdits: 0,
+    };
+    // Calendar-wide dedup only: owning-source detail for each sync-managed skip.
+    const skippedSyncManagedDetails: Array<{ externalUid: string; sourceUrl: string | null }> = [];
     let parseErrorCount = 0;
     let firstErrorMessage: string | null = null;
 
@@ -425,14 +478,56 @@ class SyncService {
         // dedup tuple. The join is resolved via EventImportOriginEntity's
         // @BelongsTo on the child side; EventEntity deliberately has no
         // reciprocal @HasOne (parent stays unaware — see epic DESIGN).
-        const existing = await EventImportOriginEntity.findAll({
-          where: { import_source_id: importSourceId },
-          include: [{ model: EventEntity, required: false }],
-          transaction: txn,
-        });
+        //
+        // Scope selects the breadth of the dedup map:
+        //  - 'source'   → rows owned by this source only (URL-sync model).
+        //  - 'calendar' → every origin row on the calendar, joined through
+        //                 import_source.calendar_id and tagged (via the
+        //                 eager-joined ImportSourceEntity) with the owning
+        //                 source's type + url so the match rules can branch on
+        //                 who owns each event (file upload refresh model).
         const existingByKey = new Map<string, EventImportOriginEntity>();
-        for (const origin of existing) {
-          existingByKey.set(dedupKey(origin.external_uid, origin.external_recurrence_id), origin);
+        if (opts.dedupScope === 'calendar') {
+          const existing = await EventImportOriginEntity.findAll({
+            include: [
+              { model: EventEntity, required: false },
+              {
+                model: ImportSourceEntity,
+                required: true,
+                where: { calendar_id: source.calendar_id },
+              },
+            ],
+            transaction: txn,
+          });
+          for (const origin of existing) {
+            const key = dedupKey(origin.external_uid, origin.external_recurrence_id);
+            const current = existingByKey.get(key);
+            if (!current) {
+              existingByKey.set(key, origin);
+              continue;
+            }
+            // Two origin rows on the calendar share this (uid, recurrence) — the
+            // DB allows it (the unique index is per-source). Prefer the row
+            // already owned by the uploading source. Re-pointing that row to
+            // itself is a no-op, so this sidesteps the
+            // (import_source_id, external_uid, recurrence) unique-index
+            // collision that would fire if we instead re-pointed a foreign
+            // source's row into a slot the uploading source already occupies.
+            if (origin.import_source_id === importSourceId
+              && current.import_source_id !== importSourceId) {
+              existingByKey.set(key, origin);
+            }
+          }
+        }
+        else {
+          const existing = await EventImportOriginEntity.findAll({
+            where: { import_source_id: importSourceId },
+            include: [{ model: EventEntity, required: false }],
+            transaction: txn,
+          });
+          for (const origin of existing) {
+            existingByKey.set(dedupKey(origin.external_uid, origin.external_recurrence_id), origin);
+          }
         }
 
         const seenKeys = new Set<string>();
@@ -465,7 +560,38 @@ class SyncService {
 
           const existingOrigin = existingByKey.get(key);
           try {
-            if (!existingOrigin) {
+            if (opts.dedupScope === 'calendar') {
+              // Calendar-wide match rules (file-upload refresh model):
+              //  - no match          → create event + origin on this source
+              //  - locally_edited    → skip; preserve the manual edit
+              //  - file-owned match  → update event, re-point origin to this
+              //                        source ("most recent importer owns
+              //                        provenance"). stampImportOrigin's
+              //                        upsert on event_id rewrites
+              //                        import_source_id to the uploading source.
+              //  - url-owned match   → skip untouched; a sync would revert any
+              //                        update, and stealing its origin would
+              //                        make the sync re-create a duplicate.
+              if (!existingOrigin) {
+                await this.createEvent(actingAccount, source, mapped, txn);
+                counts.created++;
+              }
+              else if (existingOrigin.locally_edited) {
+                counts.preservedLocalEdits++;
+              }
+              else if (existingOrigin.importSource?.source_type === 'file') {
+                await this.updateEvent(actingAccount, existingOrigin.event_id, source, mapped, txn);
+                counts.updated++;
+              }
+              else {
+                counts.skippedSyncManaged++;
+                skippedSyncManagedDetails.push({
+                  externalUid: mapped.external_uid,
+                  sourceUrl: existingOrigin.importSource?.url ?? null,
+                });
+              }
+            }
+            else if (!existingOrigin) {
               await this.createEvent(actingAccount, source, mapped, txn);
               counts.created++;
             }
@@ -492,10 +618,18 @@ class SyncService {
 
         // Disappeared origin rows: left untouched (keep-on-disappearance).
         // A disappeared origin row indicates a disappeared event.
-        for (const [key, origin] of existingByKey) {
-          if (!seenKeys.has(key)) {
-            counts.disappeared++;
-            void origin; // explicit: no write
+        //
+        // Only meaningful on the per-source path: a URL sync fetches the whole
+        // feed, so an origin absent from this run genuinely disappeared. A file
+        // upload is a one-shot partial snapshot spanning the whole calendar —
+        // every other source's events would count as "disappeared", which is
+        // nonsense — so the calendar scope skips this pass entirely.
+        if (opts.dedupScope !== 'calendar') {
+          for (const [key, origin] of existingByKey) {
+            if (!seenKeys.has(key)) {
+              counts.disappeared++;
+              void origin; // explicit: no write
+            }
           }
         }
 
@@ -525,7 +659,7 @@ class SyncService {
         'ics.sync.transaction_failed',
       );
       const message = firstErrorMessage ?? this.sanitizedErrorMessage(err);
-      await this.updateSourceOnFetchFailure(source, 'parse_error');
+      await this.updateSourceOnFetchFailure(source, 'parse_error', tx);
       return this.recordRun({
         sourceId: importSourceId,
         startedAt,
@@ -542,6 +676,7 @@ class SyncService {
       startedAt,
       outcome: finalOutcome,
       counts,
+      skippedSyncManagedDetails,
       errorMessage: firstErrorMessage,
     });
 
@@ -769,13 +904,28 @@ class SyncService {
    * in a dedicated save, separate from any event writes (which don't exist
    * on this path). We do NOT clobber etag/content_hash on failure — the
    * previous values stay valid for the next conditional GET.
+   *
+   * Transaction handling: the URL-sync path (no `tx`) persists the status with
+   * a standalone `save()`, as before. The file-upload path passes the enclosing
+   * caller-owned transaction; there the source row was `create`d inside that
+   * still-uncommitted transaction, so a standalone `save()` on a fresh
+   * connection would match zero visible rows (and could fail against an
+   * already-aborted transaction). We therefore mutate the in-memory entity for
+   * the returned run's bookkeeping but skip the standalone write — the enclosing
+   * transaction is about to roll the source row back anyway, so persisting a
+   * failure status on a doomed row is both impossible and pointless.
    */
   private async updateSourceOnFetchFailure(
     source: ImportSourceEntity,
     status: ImportSourceEntity['last_status'],
+    tx?: Transaction,
   ): Promise<void> {
     source.last_fetched_at = this.nowFn();
     source.last_status = status;
+    if (tx) {
+      // Caller-owned transaction (file-upload path): skip the standalone write.
+      return;
+    }
     await source.save();
   }
 
@@ -807,7 +957,14 @@ class SyncService {
       updated: number;
       skippedLocallyEdited: number;
       disappeared: number;
+      // Calendar-wide dedup counters. Optional so the URL-sync fetch-failure
+      // call sites keep passing the four-field literal unchanged; they surface
+      // on SyncResult only (no ImportRun columns — persistence is out of scope
+      // for pv-84da.1.3, which touches sync.ts + its test only).
+      skippedSyncManaged?: number;
+      preservedLocalEdits?: number;
     };
+    skippedSyncManagedDetails?: Array<{ externalUid: string; sourceUrl: string | null }>;
     errorMessage: string | null;
   }): Promise<SyncResult> {
     const row = await ImportRunEntity.create({
@@ -840,6 +997,9 @@ class SyncService {
       eventsUpdated: input.counts.updated,
       eventsSkippedLocallyEdited: input.counts.skippedLocallyEdited,
       eventsDisappeared: input.counts.disappeared,
+      eventsSkippedSyncManaged: input.counts.skippedSyncManaged ?? 0,
+      eventsPreservedLocalEdits: input.counts.preservedLocalEdits ?? 0,
+      skippedSyncManagedDetails: input.skippedSyncManagedDetails ?? [],
       errorMessage: input.errorMessage,
     };
   }

--- a/src/server/calendar/test/api/import_source.test.ts
+++ b/src/server/calendar/test/api/import_source.test.ts
@@ -18,9 +18,14 @@ import {
   ImportSourceFetchError,
   ImportSourceSsrfBlockedError,
   ImportSourceParseError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceFileBadFormatError,
+  ImportSourceCapExceededError,
   IMPORT_DNS_NOT_FOUND,
   IMPORT_RELME_LINK_NOT_FOUND,
 } from '@/common/exceptions/import';
+import type { SyncResult } from '@/server/calendar/service/import/sync';
 import { testApp } from '@/server/common/test/lib/express';
 import ImportSourceRoutes from '@/server/calendar/api/v1/import_source';
 import CalendarInterface from '@/server/calendar/interface';
@@ -46,6 +51,7 @@ describe('ImportSourceRoutes', () => {
     mockInterface = {
       listImportSources: sandbox.stub(),
       createImportSource: sandbox.stub(),
+      createImportSourceFromFile: sandbox.stub(),
       getImportSource: sandbox.stub(),
       deleteImportSource: sandbox.stub(),
       issueImportSourceChallenge: sandbox.stub(),
@@ -209,6 +215,395 @@ describe('ImportSourceRoutes', () => {
       // No internal details must leak into the response body.
       const body = JSON.stringify(response.body);
       expect(body).not.toContain('database failure');
+    });
+  });
+
+  describe('POST /calendars/:calendarId/import-sources/file', () => {
+    const VALID_ICS = 'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:a@x\nEND:VEVENT\nEND:VCALENDAR\n';
+
+    function makeFileSource(): ImportSource {
+      const source = new ImportSource(SOURCE_ID, CALENDAR_ID, null);
+      source.sourceType = 'file';
+      source.originalFilename = 'calendar.ics';
+      source.verificationState = 'verified';
+      return source;
+    }
+
+    function makeRun(): SyncResult {
+      return {
+        runId: 'run-file',
+        startedAt: new Date('2026-07-08T10:00:00Z'),
+        outcome: 'success',
+        eventsCreated: 3,
+        eventsUpdated: 1,
+        eventsSkippedLocallyEdited: 0,
+        eventsDisappeared: 0,
+        eventsSkippedSyncManaged: 0,
+        eventsPreservedLocalEdits: 0,
+        skippedSyncManagedDetails: [],
+        errorMessage: null,
+      };
+    }
+
+    /**
+     * Register the real route pipeline (pre-middleware that stamps the account
+     * + calendarId, then the multer intake middleware, then the handler) so the
+     * multipart parsing and content-type gating are exercised end-to-end.
+     */
+    function registerFileRoute(calendarId: string = CALENDAR_ID): void {
+      router.post(
+        '/handler',
+        (req, _res, next) => {
+          attachAccount(req);
+          req.params.calendarId = calendarId;
+          next();
+        },
+        routes.uploadIcsFile.bind(routes),
+        (req, res) => routes.createSourceFromFile(req, res),
+      );
+    }
+
+    it('creates a file source and returns 201 with { source, run }', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.resolves({ source: makeFileSource(), run: makeRun() });
+
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.source.sourceType).toBe('file');
+      expect(response.body.source.url).toBeNull();
+      expect(response.body.source.originalFilename).toBe('calendar.ics');
+      expect(response.body.run.eventsCreated).toBe(3);
+      expect(response.body.run.eventsUpdated).toBe(1);
+      expect(response.body.run.importSourceId).toBe(SOURCE_ID);
+      expect(stub.calledOnce).toBe(true);
+      // Buffer + filename forwarded to the service.
+      expect(Buffer.isBuffer(stub.firstCall.args[2])).toBe(true);
+      expect(stub.firstCall.args[3]).toBe('calendar.ics');
+    });
+
+    it('accepts an octet-stream MIME when the filename ends in .ics', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.resolves({ source: makeFileSource(), run: makeRun() });
+
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'export.ics',
+          contentType: 'application/octet-stream',
+        });
+
+      expect(response.status).toBe(201);
+      expect(stub.calledOnce).toBe(true);
+    });
+
+    it('returns 400 (ImportSourceFileEmptyError) when no file is attached', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .field('note', 'no file here');
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ImportSourceFileEmptyError');
+      expect(stub.called).toBe(false);
+    });
+
+    it('returns 400 (ImportSourceFileBadFormatError) for a disallowed type and non-.ics name', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from('<html></html>'), {
+          filename: 'notacalendar.txt',
+          contentType: 'text/plain',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ImportSourceFileBadFormatError');
+      expect(stub.called).toBe(false);
+    });
+
+    it('returns 400 (ImportSourceFileTooLargeError) when multer rejects an oversized upload', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      registerFileRoute();
+
+      const oversized = Buffer.concat([
+        Buffer.from('BEGIN:VCALENDAR\n'),
+        Buffer.alloc(10 * 1024 * 1024 + 1024),
+      ]);
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', oversized, {
+          filename: 'big.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ImportSourceFileTooLargeError');
+      expect(stub.called).toBe(false);
+    });
+
+    it('returns 400 (ValidationError) when calendarId is not a UUID', async () => {
+      registerFileRoute(INVALID_ID);
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+    });
+
+    it('maps the per-calendar cap to 409 (ImportSourceCapExceededError)', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new ImportSourceCapExceededError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(409);
+      expect(response.body.errorName).toBe('ImportSourceCapExceededError');
+    });
+
+    it('maps a parsed-but-empty file to 422 (ImportSourceParseError)', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new ImportSourceParseError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(422);
+      expect(response.body.errorName).toBe('ImportSourceParseError');
+    });
+
+    it('maps a malformed payload to 400 (ImportSourceFileBadFormatError)', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new ImportSourceFileBadFormatError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ImportSourceFileBadFormatError');
+    });
+
+    it('maps missing editor access to 403', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new CalendarEditorPermissionError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body.errorName).toBe('CalendarEditorPermissionError');
+    });
+
+    it('maps a missing calendar to 404', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new CalendarNotFoundError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('CalendarNotFoundError');
+    });
+
+    it('surfaces a service-layer empty-buffer rejection as 400', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new ImportSourceFileEmptyError());
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ImportSourceFileEmptyError');
+    });
+
+    it('maps a too-many-events rejection to 422 (ImportSourceFileTooManyEventsError)', async () => {
+      const stub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      stub.rejects(new ImportSourceFileTooManyEventsError({ parsedEvents: 20000, maxEvents: 10000 }));
+      registerFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(422);
+      expect(response.body.errorName).toBe('ImportSourceFileTooManyEventsError');
+      // details must never travel over the wire.
+      expect(JSON.stringify(response.body)).not.toContain('parsedEvents');
+    });
+  });
+
+  describe('POST /calendars/:calendarId/import-sources/file — pre-buffer authorization', () => {
+    const VALID_ICS = 'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:a@x\nEND:VEVENT\nEND:VCALENDAR\n';
+
+    /**
+     * Register the REAL route pipeline including the pre-buffer authorization
+     * middleware (assertFileUploadAccess) that runs BEFORE multer. This lets us
+     * assert that an unauthorized caller is rejected without the upload ever
+     * reaching the service.
+     */
+    function registerAuthorizedFileRoute(calendarId: string = CALENDAR_ID): void {
+      router.post(
+        '/handler',
+        (req, _res, next) => {
+          attachAccount(req);
+          req.params.calendarId = calendarId;
+          next();
+        },
+        (req, res, next) => routes.assertFileUploadAccess(req, res, next),
+        routes.uploadIcsFile.bind(routes),
+        (req, res) => routes.createSourceFromFile(req, res),
+      );
+    }
+
+    it('rejects a non-editor with 403 and never processes the upload', async () => {
+      (mockInterface as any).getCalendar = sandbox.stub().resolves({ id: CALENDAR_ID });
+      (mockInterface as any).userCanModifyCalendar = sandbox.stub().resolves(false);
+      const createStub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+
+      registerAuthorizedFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(403);
+      expect(response.body.errorName).toBe('CalendarEditorPermissionError');
+      // The upload was rejected before multer buffered / the service ran.
+      expect(createStub.called).toBe(false);
+    });
+
+    it('returns 404 when the calendar does not exist, without processing the upload', async () => {
+      (mockInterface as any).getCalendar = sandbox.stub().resolves(null);
+      (mockInterface as any).userCanModifyCalendar = sandbox.stub().resolves(true);
+      const createStub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+
+      registerAuthorizedFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(404);
+      expect(response.body.errorName).toBe('CalendarNotFoundError');
+      expect(createStub.called).toBe(false);
+    });
+
+    it('returns 400 for a non-UUID calendarId, without processing the upload', async () => {
+      (mockInterface as any).getCalendar = sandbox.stub().resolves({ id: CALENDAR_ID });
+      (mockInterface as any).userCanModifyCalendar = sandbox.stub().resolves(true);
+      const getStub = (mockInterface as any).getCalendar as sinon.SinonStub;
+      const createStub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+
+      registerAuthorizedFileRoute(INVALID_ID);
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.errorName).toBe('ValidationError');
+      // UUID shape is rejected before any interface lookup.
+      expect(getStub.called).toBe(false);
+      expect(createStub.called).toBe(false);
+    });
+
+    it('proceeds to the handler when the caller is an editor', async () => {
+      (mockInterface as any).getCalendar = sandbox.stub().resolves({ id: CALENDAR_ID });
+      (mockInterface as any).userCanModifyCalendar = sandbox.stub().resolves(true);
+      const createStub = mockInterface.createImportSourceFromFile as sinon.SinonStub;
+      const source = new ImportSource(SOURCE_ID, CALENDAR_ID, null);
+      source.sourceType = 'file';
+      source.originalFilename = 'calendar.ics';
+      createStub.resolves({
+        source,
+        run: {
+          runId: 'run-file',
+          startedAt: new Date('2026-07-08T10:00:00Z'),
+          outcome: 'success',
+          eventsCreated: 1,
+          eventsUpdated: 0,
+          eventsSkippedLocallyEdited: 0,
+          eventsDisappeared: 0,
+          eventsSkippedSyncManaged: 0,
+          eventsPreservedLocalEdits: 0,
+          skippedSyncManagedDetails: [],
+          errorMessage: null,
+        },
+      });
+
+      registerAuthorizedFileRoute();
+
+      const response = await request(testApp(router))
+        .post('/handler')
+        .attach('file', Buffer.from(VALID_ICS), {
+          filename: 'calendar.ics',
+          contentType: 'text/calendar',
+        });
+
+      expect(response.status).toBe(201);
+      expect(createStub.calledOnce).toBe(true);
     });
   });
 

--- a/src/server/calendar/test/integration/import_source_file_upload.test.ts
+++ b/src/server/calendar/test/integration/import_source_file_upload.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EventEmitter } from 'events';
+
+import { Account } from '@/common/model/account';
+import { Calendar } from '@/common/model/calendar';
+import { EventEntity } from '@/server/calendar/entity/event';
+import { EventImportOriginEntity } from '@/server/calendar/entity/event_import_origin';
+import { ImportSourceEntity } from '@/server/calendar/entity/import_source';
+import CalendarInterface from '@/server/calendar/interface';
+import { ImportSourceParseError } from '@/common/exceptions/import';
+import AccountService from '@/server/accounts/service/account';
+import ConfigurationInterface from '@/server/configuration/interface';
+import SetupInterface from '@/server/setup/interface';
+import { TestEnvironment } from '@/server/common/test/lib/test_environment';
+
+/**
+ * Real-DB integration tests for the file-upload import path (pv-84da.1.4 +
+ * fix round). Exercises `createSourceFromFile` end-to-end through the interface
+ * against a real SQLite database (real node-ical parse, real EventService,
+ * real transaction), so the transactional rollback and the calendar-wide dedup
+ * scoping are verified against actual persistence rather than stubs.
+ */
+describe('ImportSource file upload integration', () => {
+  let env: TestEnvironment;
+  let calendarInterface: CalendarInterface;
+  let account: Account;
+  let calendarA: Calendar;
+  let calendarB: Calendar;
+  let eventBus: EventEmitter;
+
+  beforeAll(async () => {
+    env = new TestEnvironment();
+    await env.init();
+
+    eventBus = new EventEmitter();
+    calendarInterface = new CalendarInterface(eventBus);
+    calendarInterface.setActivityPubInterface({
+      getSharedEventStatusMap: async () => new Map(),
+    } as never);
+
+    const configurationInterface = new ConfigurationInterface();
+    const setupInterface = new SetupInterface();
+    const accountService = new AccountService(eventBus, configurationInterface, setupInterface);
+
+    const accountInfo = await accountService._setupAccount('fileupload@pavillion.dev', 'testpassword');
+    account = accountInfo.account;
+    calendarA = await calendarInterface.createCalendar(account, 'fileuploadcala');
+    calendarB = await calendarInterface.createCalendar(account, 'fileuploadcalb');
+  });
+
+  afterAll(async () => {
+    if (eventBus) {
+      eventBus.removeAllListeners();
+    }
+    await env.cleanup();
+  });
+
+  /** Build a minimal single-VEVENT ICS body for the given uid + summary. */
+  function icsWith(uid: string, summary: string): Buffer {
+    return Buffer.from(
+      'BEGIN:VCALENDAR\r\n'
+      + 'VERSION:2.0\r\n'
+      + 'PRODID:-//pavillion//test//EN\r\n'
+      + 'BEGIN:VEVENT\r\n'
+      + `UID:${uid}\r\n`
+      + 'DTSTAMP:20260422T100000Z\r\n'
+      + 'DTSTART:20260422T100000Z\r\n'
+      + 'DTEND:20260422T110000Z\r\n'
+      + `SUMMARY:${summary}\r\n`
+      + 'END:VEVENT\r\n'
+      + 'END:VCALENDAR\r\n',
+    );
+  }
+
+  // --------------------------------------------------------------------------
+  // Rollback leaves no orphan source row
+  // --------------------------------------------------------------------------
+
+  describe('transactional rollback', () => {
+    it('leaves no orphan source row when the upload yields zero usable VEVENTs', async () => {
+      const sourcesBefore = await ImportSourceEntity.count({ where: { calendar_id: calendarA.id } });
+      const eventsBefore = await EventEntity.count({ where: { calendar_id: calendarA.id } });
+
+      // Valid VCALENDAR (passes the BEGIN:VCALENDAR sniff and parses) but with
+      // no VEVENTs — createSourceFromFile must throw 422 and roll the source
+      // row insert back so no orphan source is left behind.
+      const emptyCalendar = Buffer.from(
+        'BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//pavillion//test//EN\r\nEND:VCALENDAR\r\n',
+      );
+
+      await expect(
+        calendarInterface.createImportSourceFromFile(account, calendarA.id, emptyCalendar, 'empty.ics'),
+      ).rejects.toBeInstanceOf(ImportSourceParseError);
+
+      const sourcesAfter = await ImportSourceEntity.count({ where: { calendar_id: calendarA.id } });
+      const eventsAfter = await EventEntity.count({ where: { calendar_id: calendarA.id } });
+
+      // Rollback is atomic: no source row, no event rows added.
+      expect(sourcesAfter).toBe(sourcesBefore);
+      expect(eventsAfter).toBe(eventsBefore);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Cross-calendar dedup isolation (gap carried from pv-84da.1.3)
+  // --------------------------------------------------------------------------
+
+  describe('cross-calendar dedup isolation', () => {
+    it('does not touch another calendar\'s event or origin sharing the same external_uid', async () => {
+      const SHARED_UID = 'shared-uid@example.test';
+
+      // Seed calendar B with an imported event carrying SHARED_UID.
+      const bResult = await calendarInterface.createImportSourceFromFile(
+        account,
+        calendarB.id,
+        icsWith(SHARED_UID, 'Calendar B Event'),
+        'b.ics',
+      );
+      expect(bResult.run.eventsCreated).toBe(1);
+      const sourceBId = bResult.source.id;
+
+      // Snapshot calendar B's origin row + event before the calendar-A upload.
+      const bOriginBefore = await EventImportOriginEntity.findOne({
+        where: { import_source_id: sourceBId, external_uid: SHARED_UID },
+      });
+      expect(bOriginBefore).not.toBeNull();
+      const bEventId = bOriginBefore!.event_id;
+      const bEventBefore = await EventEntity.findByPk(bEventId);
+      expect(bEventBefore).not.toBeNull();
+
+      // Upload a file to calendar A carrying the SAME external_uid. Calendar-wide
+      // dedup is scoped to the uploading calendar (joined through
+      // import_source.calendar_id), so calendar B's origin is NOT in calendar A's
+      // dedup map: A must CREATE its own event, never update or re-point B's.
+      const aResult = await calendarInterface.createImportSourceFromFile(
+        account,
+        calendarA.id,
+        icsWith(SHARED_UID, 'Calendar A Event'),
+        'a.ics',
+      );
+      expect(aResult.run.eventsCreated).toBe(1);
+      expect(aResult.run.eventsUpdated).toBe(0);
+      const sourceAId = aResult.source.id;
+
+      // Calendar A got its own separate event + origin.
+      const aOrigin = await EventImportOriginEntity.findOne({
+        where: { import_source_id: sourceAId, external_uid: SHARED_UID },
+      });
+      expect(aOrigin).not.toBeNull();
+      expect(aOrigin!.event_id).not.toBe(bEventId);
+
+      // Calendar B's origin row is UNTOUCHED: still owned by source B (not
+      // re-pointed to source A) and still bound to the same event.
+      const bOriginAfter = await EventImportOriginEntity.findOne({
+        where: { external_uid: SHARED_UID, event_id: bEventId },
+      });
+      expect(bOriginAfter).not.toBeNull();
+      expect(bOriginAfter!.import_source_id).toBe(sourceBId);
+      expect(bOriginAfter!.event_id).toBe(bEventId);
+
+      // And calendar B's event still exists (content preserved, not deleted).
+      const bEventAfter = await EventEntity.findByPk(bEventId);
+      expect(bEventAfter).not.toBeNull();
+      expect(bEventAfter!.calendar_id).toBe(calendarB.id);
+    });
+  });
+});

--- a/src/server/calendar/test/service/import/import_source_service.test.ts
+++ b/src/server/calendar/test/service/import/import_source_service.test.ts
@@ -330,6 +330,23 @@ describe('ImportSourceService', () => {
       ).rejects.toThrow(/maximum of 10 import sources/);
     });
 
+    it('counts only url sync sources toward the cap (ephemeral file uploads excluded)', async () => {
+      const countStub = sandbox.stub(ImportSourceEntity, 'count').resolves(0);
+      sandbox.stub(ImportSourceEntity, 'findOne').resolves(null);
+      sandbox.stub(ImportSourceEntity, 'build').returns({
+        save: sandbox.stub().resolves(),
+        toModel: () => ({ id: 'x', calendarId: CAL_ID } as any),
+      } as unknown as ImportSourceEntity);
+
+      await service.createSource(account, CAL_ID, VALID_URL);
+
+      expect(countStub.calledOnce).toBe(true);
+      expect((countStub.firstCall.args[0] as any).where).toMatchObject({
+        calendar_id: CAL_ID,
+        source_type: 'url',
+      });
+    });
+
     it('rejects duplicate URL on the same calendar', async () => {
       sandbox.stub(ImportSourceEntity, 'count').resolves(2);
       // findOne returns an existing row for the duplicate check
@@ -528,6 +545,21 @@ describe('ImportSourceService', () => {
       await expect(
         wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
       ).rejects.toBeInstanceOf(ImportSourceCapExceededError);
+    });
+
+    it('excludes file sources from the cap count (a file upload does not count itself)', async () => {
+      const { wired } = wireFileService();
+
+      await wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME);
+
+      const countStub = ImportSourceEntity.count as unknown as sinon.SinonStub;
+      expect(countStub.calledOnce).toBe(true);
+      // Only url sync sources fill the cap; ephemeral file rows must not, or
+      // repeated uploads would lock the calendar out of its own imports.
+      expect((countStub.firstCall.args[0] as any).where).toMatchObject({
+        calendar_id: CAL_ID,
+        source_type: 'url',
+      });
     });
 
     it('rolls back (rejects with ImportSourceFileBadFormatError) when the parser fails', async () => {

--- a/src/server/calendar/test/service/import/import_source_service.test.ts
+++ b/src/server/calendar/test/service/import/import_source_service.test.ts
@@ -39,6 +39,12 @@ import {
   ImportSourceDnsVerificationError,
   ImportSourceRelMeVerificationError,
   ImportSourceSsrfBlockedError,
+  ImportSourceParseError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
   IMPORT_DNS_NOT_FOUND,
   IMPORT_RELME_HOSTNAME_MISMATCH,
   IMPORT_RELME_LINK_NOT_FOUND,
@@ -47,6 +53,7 @@ import {
   IMPORT_RELME_PSL_VIOLATION,
 } from '@/common/exceptions/import';
 import { ImportSourceEntity } from '@/server/calendar/entity/import_source';
+import db from '@/server/common/entity/db';
 import ImportSourceService, {
   HtmlFetcher,
   HtmlFetchResult,
@@ -331,6 +338,254 @@ describe('ImportSourceService', () => {
       await expect(
         service.createSource(account, CAL_ID, VALID_URL),
       ).rejects.toThrow(/already exists/);
+    });
+  });
+
+  // --------------------------------------------------------------------
+  // createSourceFromFile
+  // --------------------------------------------------------------------
+
+  describe('createSourceFromFile', () => {
+    const VALID_ICS = Buffer.from(
+      'BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:a@x\nEND:VEVENT\nEND:VCALENDAR\n',
+    );
+    const FILENAME = 'calendar.ics';
+
+    function fileRunResult(overrides: Partial<SyncResult> = {}): SyncResult {
+      return {
+        runId: 'run-file',
+        startedAt: new Date('2026-07-08T10:00:00Z'),
+        outcome: 'success',
+        eventsCreated: 1,
+        eventsUpdated: 0,
+        eventsSkippedLocallyEdited: 0,
+        eventsDisappeared: 0,
+        eventsSkippedSyncManaged: 0,
+        eventsPreservedLocalEdits: 0,
+        skippedSyncManagedDetails: [],
+        errorMessage: null,
+        ...overrides,
+      };
+    }
+
+    /**
+     * Wire a service with a fake SyncService and stub the DB seams:
+     *  - db.transaction passes a sentinel tx straight to the callback (and
+     *    rejects if the callback throws — modeling managed-transaction rollback)
+     *  - ImportSourceEntity.count / create are stubbed
+     * Returns the process stub + create stub so tests can assert on them.
+     */
+    function wireFileService(opts: {
+      count?: number;
+      processResult?: SyncResult;
+      processImpl?: sinon.SinonStub;
+    } = {}) {
+      sandbox.stub(ImportSourceEntity, 'count').resolves(opts.count ?? 0);
+
+      const createStub = sandbox.stub(ImportSourceEntity, 'create').callsFake(async (values: any) => {
+        const model = new ImportSource(values.id, values.calendar_id, values.url);
+        model.sourceType = values.source_type;
+        model.originalFilename = values.original_filename;
+        model.verificationState = values.verification_state;
+        model.verifiedAt = values.verified_at ?? null;
+        model.contentHash = values.content_hash;
+        model.lastStatus = values.last_status;
+        return {
+          id: values.id,
+          calendar_id: values.calendar_id,
+          toModel: () => model,
+        } as unknown as ImportSourceEntity;
+      });
+
+      const processStub = opts.processImpl
+        ?? sandbox.stub().resolves(opts.processResult ?? fileRunResult());
+      const fakeSyncService = { processIcsBuffer: processStub } as unknown as SyncService;
+
+      sandbox.stub(db, 'transaction').callsFake(async (arg: unknown) => {
+        if (typeof arg === 'function') {
+          return (arg as (tx: unknown) => unknown)({ LEVEL: 'test' });
+        }
+        throw new Error('unsupported transaction usage in test');
+      });
+
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        fakeSyncService,
+      );
+      return { wired, createStub, processStub };
+    }
+
+    it('creates a pre-verified file source and runs the calendar-scoped pipeline', async () => {
+      const { wired, createStub, processStub } = wireFileService();
+
+      const result = await wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME);
+
+      // Source row is built as a file source per the spec field table.
+      const createArgs = createStub.firstCall.args[0] as any;
+      expect(createArgs.source_type).toBe('file');
+      expect(createArgs.url).toBeNull();
+      expect(createArgs.original_filename).toBe(FILENAME);
+      expect(createArgs.verification_state).toBe('verified');
+      expect(createArgs.verification_type).toBeNull();
+      expect(createArgs.verification_expires_at).toBeNull();
+      expect(createArgs.last_status).toBe('ok');
+      expect(typeof createArgs.content_hash).toBe('string');
+      expect(createArgs.content_hash).toHaveLength(64);
+      // Insert enlists the transaction.
+      expect((createStub.firstCall.args[1] as any).transaction).toMatchObject({ LEVEL: 'test' });
+
+      // Pipeline runs calendar-scoped, in the same transaction.
+      expect(processStub.calledOnce).toBe(true);
+      const [bufArg, sourceArg, optsArg, txArg] = processStub.firstCall.args;
+      expect(bufArg).toBe(VALID_ICS);
+      expect(sourceArg).toBeDefined();
+      expect(optsArg.dedupScope).toBe('calendar');
+      expect(optsArg.account).toBe(account);
+      // The file path passes a VEVENT-count ceiling (DoS bound); the URL path
+      // never does.
+      expect(optsArg.maxEvents).toBe(10000);
+      expect(txArg).toMatchObject({ LEVEL: 'test' });
+
+      // Returns both the model and the run summary.
+      expect(result.source.sourceType).toBe('file');
+      expect(result.source.url).toBeNull();
+      expect(result.run.eventsCreated).toBe(1);
+    });
+
+    it('rejects when the account lacks edit access', async () => {
+      calendarService.userCanModifyCalendar.resolves(false);
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        { processIcsBuffer: sandbox.stub() } as unknown as SyncService,
+      );
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toBeInstanceOf(CalendarEditorPermissionError);
+    });
+
+    it('rejects an empty buffer with ImportSourceFileEmptyError', async () => {
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        { processIcsBuffer: sandbox.stub() } as unknown as SyncService,
+      );
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, Buffer.alloc(0), FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceFileEmptyError);
+    });
+
+    it('rejects an oversized buffer with ImportSourceFileTooLargeError', async () => {
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        { processIcsBuffer: sandbox.stub() } as unknown as SyncService,
+      );
+      // 10 MiB + 1 byte, still starting with the signature so size is the only failure.
+      const oversized = Buffer.concat([
+        Buffer.from('BEGIN:VCALENDAR\n'),
+        Buffer.alloc(10 * 1024 * 1024 + 1),
+      ]);
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, oversized, FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceFileTooLargeError);
+    });
+
+    it('rejects a payload without the BEGIN:VCALENDAR signature', async () => {
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        { processIcsBuffer: sandbox.stub() } as unknown as SyncService,
+      );
+
+      await expect(
+        wired.createSourceFromFile(
+          account,
+          CAL_ID,
+          Buffer.from('<html>not a calendar</html>'),
+          FILENAME,
+        ),
+      ).rejects.toBeInstanceOf(ImportSourceFileBadFormatError);
+    });
+
+    it('accepts a payload with a leading BOM + whitespace before the signature', async () => {
+      const { wired } = wireFileService();
+      const withBom = Buffer.concat([
+        Buffer.from('\uFEFF  \n'),
+        VALID_ICS,
+      ]);
+
+      const result = await wired.createSourceFromFile(account, CAL_ID, withBom, FILENAME);
+      expect(result.source.sourceType).toBe('file');
+    });
+
+    it('rejects with ImportSourceCapExceededError when the per-calendar cap is reached', async () => {
+      const wired = new ImportSourceService(
+        calendarService as unknown as CalendarService,
+        { processIcsBuffer: sandbox.stub() } as unknown as SyncService,
+      );
+      sandbox.stub(ImportSourceEntity, 'count').resolves(10);
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceCapExceededError);
+    });
+
+    it('rolls back (rejects with ImportSourceFileBadFormatError) when the parser fails', async () => {
+      const { wired, processStub } = wireFileService({
+        processResult: fileRunResult({ outcome: 'parse_error', eventsCreated: 0, errorMessage: 'IMPORT_PARSE_ERROR' }),
+      });
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceFileBadFormatError);
+      // The pipeline was invoked inside the (now rolled-back) transaction.
+      expect(processStub.calledOnce).toBe(true);
+    });
+
+    it('rolls back with ImportSourceParseError (422) when no usable VEVENTs are found', async () => {
+      const { wired } = wireFileService({
+        processResult: fileRunResult({ eventsCreated: 0, eventsUpdated: 0 }),
+      });
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceParseError);
+    });
+
+    it('throws a guard error when the SyncService is not wired', async () => {
+      sandbox.stub(ImportSourceEntity, 'count').resolves(0);
+      // Service constructed without a SyncService.
+      await expect(
+        service.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toThrow(/SyncService wiring/);
+    });
+
+    it('propagates ImportSourceFileTooManyEventsError from the pipeline (rolls back)', async () => {
+      // The DoS bound: when the parsed file exceeds the per-file VEVENT ceiling,
+      // processIcsBuffer throws inside the transaction. The service must let it
+      // propagate (so the source-row insert rolls back) rather than swallowing.
+      const { wired, processStub } = wireFileService({
+        processImpl: sandbox.stub().rejects(
+          new ImportSourceFileTooManyEventsError({ parsedEvents: 20000, maxEvents: 10000 }),
+        ),
+      });
+
+      await expect(
+        wired.createSourceFromFile(account, CAL_ID, VALID_ICS, FILENAME),
+      ).rejects.toBeInstanceOf(ImportSourceFileTooManyEventsError);
+      expect(processStub.calledOnce).toBe(true);
+    });
+
+    it('truncates an over-length original_filename to 255 chars before insert', async () => {
+      const { wired, createStub } = wireFileService();
+      // The column is VARCHAR(255); a longer name would raise a raw DB error.
+      const longName = 'a'.repeat(300) + '.ics';
+
+      await wired.createSourceFromFile(account, CAL_ID, VALID_ICS, longName);
+
+      const createArgs = createStub.firstCall.args[0] as any;
+      expect(createArgs.original_filename).toHaveLength(255);
+      expect(createArgs.original_filename).toBe(longName.slice(0, 255));
     });
   });
 

--- a/src/server/calendar/test/service/import/sync.test.ts
+++ b/src/server/calendar/test/service/import/sync.test.ts
@@ -6,6 +6,7 @@ import type { VEvent, DateWithTimeZone } from 'node-ical';
 import { Account } from '@/common/model/account';
 import {
   ImportSourceFetchError,
+  ImportSourceFileTooManyEventsError,
   ImportSourceNotFoundError,
   ImportSourceNotVerifiedError,
   ImportSourceSsrfBlockedError,
@@ -1093,19 +1094,305 @@ describe('SyncService', () => {
       expect(saveArgs).toMatchObject({ transaction: callerTx });
     });
 
-    it("throws when dedupScope is 'calendar' (implemented in pv-84da.1.3)", async () => {
+    it('throws ImportSourceFileTooManyEventsError when the VEVENT count exceeds maxEvents, before any write', async () => {
+      // DoS bound (pv-84da fix round item 2): the ceiling is enforced after
+      // extraction but BEFORE the create loop / transaction, so nothing is
+      // written and — on the file path — the caller's transaction rolls back.
       const src = makeSourceEntity();
-      const svc = makeProcessService([makeVEvent()]);
+      const svc = makeProcessService([
+        makeVEvent({ uid: 'cap-a@example.test' }),
+        makeVEvent({ uid: 'cap-b@example.test' }),
+      ]);
 
       await expect(
         svc.processIcsBuffer(
           Buffer.from('BEGIN:VCALENDAR'),
           src,
-          { dedupScope: 'calendar', account, startedAt: new Date() },
+          { dedupScope: 'calendar', account, startedAt: new Date('2026-04-22T10:00:00Z'), maxEvents: 1 },
         ),
-      ).rejects.toThrow(/not implemented/);
-      // Nothing should have been parsed or written.
+      ).rejects.toBeInstanceOf(ImportSourceFileTooManyEventsError);
+
+      // The throw is BEFORE the create loop and the transaction: no event write,
+      // and the orchestrator never opened a transaction.
       expect(eventService.createEvent.called).toBe(false);
+      expect((db.transaction as sinon.SinonStub).called).toBe(false);
+    });
+
+    it('does not enforce maxEvents when the count is within the ceiling', async () => {
+      const src = makeSourceEntity();
+      const svc = makeProcessService([makeVEvent({ uid: 'cap-ok@example.test' })]);
+      eventService.createEvent.callsFake(async () => ({ id: 'evt-cap-ok' } as never));
+
+      const result = await svc.processIcsBuffer(
+        Buffer.from('BEGIN:VCALENDAR'),
+        src,
+        { dedupScope: 'source', account, startedAt: new Date('2026-04-22T10:00:00Z'), maxEvents: 10 },
+      );
+
+      expect(result.outcome).toBe('success');
+      expect(result.eventsCreated).toBe(1);
+    });
+
+    it('skips the standalone status save on a caller-tx parse error (item 4)', async () => {
+      // On the file-upload path the source row is created inside the caller's
+      // still-uncommitted transaction. A standalone save() on a parse failure
+      // would match zero visible rows (silently lost) — so when a tx is
+      // supplied, updateSourceOnFetchFailure mutates the entity but skips the
+      // write. The enclosing transaction rolls the row back anyway.
+      const src = makeSourceEntity({ etag: 'W/"keep"', content_hash: 'KEEP-HASH' });
+      const svc = new SyncService({
+        eventService: eventService as unknown as EventService,
+        calendarService: calendarService as unknown as CalendarService,
+        fetcher: fetcher as unknown as Fetcher,
+        rateLimiter,
+        parseICS: () => { throw new Error('malformed calendar'); },
+      });
+
+      const callerTx = { LEVEL: 'caller-tx' } as unknown as Transaction;
+      const result = await svc.processIcsBuffer(
+        Buffer.from('junk'),
+        src,
+        { dedupScope: 'calendar', account, startedAt: new Date('2026-04-22T10:00:00Z') },
+        callerTx,
+      );
+
+      expect(result.outcome).toBe('parse_error');
+      // In-memory bookkeeping still reflects the failure...
+      expect(src.last_status).toBe('parse_error');
+      // ...but no standalone write was issued against the doomed row.
+      expect((src.save as sinon.SinonStub).called).toBe(false);
+    });
+
+    // ------------------------------------------------------------------------
+    // Calendar-wide dedup (dedupScope: 'calendar') — pv-84da.1.3
+    // ------------------------------------------------------------------------
+    describe('calendar-wide dedup', () => {
+      const UPLOAD_SRC_ID = 'file-upload-src';
+
+      // The uploading source is always a file source on this path.
+      function makeUploadSource(): ImportSourceEntity {
+        return makeSourceEntity({
+          id: UPLOAD_SRC_ID,
+          source_type: 'file',
+          url: null,
+          original_filename: 'export.ics',
+        });
+      }
+
+      // A calendar-wide origin row, tagged with its owning source's type + url
+      // via the eager-joined ImportSourceEntity the orchestrator reads.
+      function makeCalendarOrigin(fields: {
+        event_id: string;
+        external_uid: string;
+        import_source_id: string;
+        ownerType: 'file' | 'url';
+        ownerUrl?: string | null;
+        locally_edited?: boolean;
+      }): EventImportOriginEntity {
+        return makeOriginEntity({
+          event_id: fields.event_id,
+          external_uid: fields.external_uid,
+          import_source_id: fields.import_source_id,
+          locally_edited: fields.locally_edited ?? false,
+          importSource: {
+            id: fields.import_source_id,
+            source_type: fields.ownerType,
+            url: fields.ownerUrl ?? null,
+          },
+        } as unknown as Partial<EventImportOriginEntity>);
+      }
+
+      function runCalendar(svc: SyncService, src: ImportSourceEntity) {
+        return svc.processIcsBuffer(
+          Buffer.from('BEGIN:VCALENDAR'),
+          src,
+          { dedupScope: 'calendar', account, startedAt: new Date('2026-04-22T10:00:00Z') },
+        );
+      }
+
+      it('bulk-loads calendar-wide origins joined through import_source.calendar_id', async () => {
+        const src = makeUploadSource();
+        const svc = makeProcessService([makeVEvent({ uid: 'cal-new@example.test' })]);
+        eventService.createEvent.callsFake(async () => ({ id: 'evt-new' } as never));
+
+        await runCalendar(svc, src);
+
+        const findAllStub = EventImportOriginEntity.findAll as sinon.SinonStub;
+        expect(findAllStub.calledOnce).toBe(true);
+        const args = findAllStub.firstCall.args[0] as Record<string, unknown>;
+        // Calendar scope filters via the required INNER JOIN on the owning
+        // source, NOT a top-level import_source_id where clause.
+        expect(args.where).toBeUndefined();
+        const include = args.include as Array<Record<string, unknown>>;
+        expect(include).toEqual(expect.arrayContaining([
+          expect.objectContaining({ model: EventEntity }),
+          expect.objectContaining({
+            model: ImportSourceEntity,
+            required: true,
+            where: { calendar_id: src.calendar_id },
+          }),
+        ]));
+      });
+
+      it('rule: new UID → creates event + stamps origin on the uploading source', async () => {
+        const src = makeUploadSource();
+        const svc = makeProcessService([makeVEvent({ uid: 'cal-new@example.test' })], []);
+        eventService.createEvent.callsFake(async () => ({ id: 'evt-new' } as never));
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.eventsCreated).toBe(1);
+        expect(result.eventsUpdated).toBe(0);
+        expect(result.eventsSkippedSyncManaged).toBe(0);
+        expect(result.eventsPreservedLocalEdits).toBe(0);
+        expect(eventService.createEvent.calledOnce).toBe(true);
+        // Origin stamped onto the uploading source.
+        expect(originUpsertStub.calledOnce).toBe(true);
+        const values = originUpsertStub.firstCall.args[0] as Record<string, unknown>;
+        expect(values.import_source_id).toBe(UPLOAD_SRC_ID);
+      });
+
+      it('rule: file-source-owned → updates event and re-points origin to the uploading source', async () => {
+        const src = makeUploadSource();
+        // Owned by a DIFFERENT file source on the same calendar.
+        const existing = makeCalendarOrigin({
+          event_id: 'evt-file-owned',
+          external_uid: 'cal-file@example.test',
+          import_source_id: 'other-file-src',
+          ownerType: 'file',
+        });
+        const svc = makeProcessService(
+          [makeVEvent({ uid: 'cal-file@example.test' })],
+          [existing],
+        );
+        eventService.updateEvent.resolves({ id: 'evt-file-owned' } as never);
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.eventsUpdated).toBe(1);
+        expect(result.eventsCreated).toBe(0);
+        expect(eventService.updateEvent.calledOnce).toBe(true);
+        // Update targets the matched event.
+        expect(eventService.updateEvent.firstCall.args[1]).toBe('evt-file-owned');
+        // Re-point: the origin upsert rewrites import_source_id to the uploader.
+        expect(originUpsertStub.calledOnce).toBe(true);
+        const values = originUpsertStub.firstCall.args[0] as Record<string, unknown>;
+        expect(values.event_id).toBe('evt-file-owned');
+        expect(values.import_source_id).toBe(UPLOAD_SRC_ID);
+      });
+
+      it('rule: URL-sync-owned → skips untouched and reports the owning source URL', async () => {
+        const src = makeUploadSource();
+        const existing = makeCalendarOrigin({
+          event_id: 'evt-sync-owned',
+          external_uid: 'cal-sync@example.test',
+          import_source_id: 'url-sync-src',
+          ownerType: 'url',
+          ownerUrl: 'https://feeds.example.test/city.ics',
+        });
+        const svc = makeProcessService(
+          [makeVEvent({ uid: 'cal-sync@example.test' })],
+          [existing],
+        );
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.eventsSkippedSyncManaged).toBe(1);
+        expect(result.eventsCreated).toBe(0);
+        expect(result.eventsUpdated).toBe(0);
+        // The sync-owned event + origin are left completely untouched.
+        expect(eventService.updateEvent.called).toBe(false);
+        expect(eventService.createEvent.called).toBe(false);
+        expect(originUpsertStub.called).toBe(false);
+        expect((existing.save as sinon.SinonStub).called).toBe(false);
+        // Owning source URL surfaced in the run detail.
+        expect(result.skippedSyncManagedDetails).toEqual([
+          { externalUid: 'cal-sync@example.test', sourceUrl: 'https://feeds.example.test/city.ics' },
+        ]);
+      });
+
+      it('rule: locally_edited match → preserves the edit, skips content update', async () => {
+        const src = makeUploadSource();
+        // A file-owned match that would otherwise update — locally_edited wins.
+        const existing = makeCalendarOrigin({
+          event_id: 'evt-edited',
+          external_uid: 'cal-edited@example.test',
+          import_source_id: 'other-file-src',
+          ownerType: 'file',
+          locally_edited: true,
+        });
+        const svc = makeProcessService(
+          [makeVEvent({ uid: 'cal-edited@example.test' })],
+          [existing],
+        );
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.eventsPreservedLocalEdits).toBe(1);
+        expect(result.eventsUpdated).toBe(0);
+        expect(result.eventsSkippedSyncManaged).toBe(0);
+        expect(eventService.updateEvent.called).toBe(false);
+        expect(eventService.createEvent.called).toBe(false);
+        // Preserved means untouched: no origin write at all.
+        expect(originUpsertStub.called).toBe(false);
+        expect((existing.save as sinon.SinonStub).called).toBe(false);
+      });
+
+      it('prefers the uploading source\'s own origin on a key collision (no unique-index clash on re-point)', async () => {
+        const src = makeUploadSource();
+        // Two origins share (uid, recurrence): one already owned by the
+        // uploading source, one owned by another file source. The map must
+        // keep the uploader's own row so the re-point is a self-update and
+        // never collides with the (import_source_id, uid, recurrence) index.
+        const ownRow = makeCalendarOrigin({
+          event_id: 'evt-own',
+          external_uid: 'cal-dup@example.test',
+          import_source_id: UPLOAD_SRC_ID,
+          ownerType: 'file',
+        });
+        const foreignRow = makeCalendarOrigin({
+          event_id: 'evt-foreign',
+          external_uid: 'cal-dup@example.test',
+          import_source_id: 'other-file-src',
+          ownerType: 'file',
+        });
+        // Foreign row listed first so a naive last-write-wins map would pick it.
+        const svc = makeProcessService(
+          [makeVEvent({ uid: 'cal-dup@example.test' })],
+          [foreignRow, ownRow],
+        );
+        eventService.updateEvent.resolves({ id: 'evt-own' } as never);
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.eventsUpdated).toBe(1);
+        // The uploader's own event is the one updated — not the foreign row's.
+        expect(eventService.updateEvent.firstCall.args[1]).toBe('evt-own');
+      });
+
+      it('records a success run without counting disappeared events for other calendar sources', async () => {
+        const src = makeUploadSource();
+        // A calendar origin the upload does NOT mention — must not be flagged
+        // as disappeared (file upload is a partial snapshot).
+        const untouched = makeCalendarOrigin({
+          event_id: 'evt-untouched',
+          external_uid: 'cal-absent@example.test',
+          import_source_id: 'url-sync-src',
+          ownerType: 'url',
+          ownerUrl: 'https://feeds.example.test/other.ics',
+        });
+        const svc = makeProcessService(
+          [makeVEvent({ uid: 'cal-new@example.test' })],
+          [untouched],
+        );
+        eventService.createEvent.callsFake(async () => ({ id: 'evt-new' } as never));
+
+        const result = await runCalendar(svc, src);
+
+        expect(result.outcome).toBe('success');
+        expect(result.eventsCreated).toBe(1);
+        expect(result.eventsDisappeared).toBe(0);
+      });
     });
   });
 

--- a/src/server/common/test/rate-limit-coverage.test.ts
+++ b/src/server/common/test/rate-limit-coverage.test.ts
@@ -138,6 +138,10 @@ const HIGH_ABUSE_RISK_ROUTES: { method: string; path: string }[] = [
   // signature verification per DEC-013 ingest-boundary posture).
   { method: 'POST', path: '/calendars/:urlname/inbox' },
   { method: 'POST', path: '/users/:username/inbox' },
+  // ICS file upload — buffers a 10 MiB body into memory then CPU-parses it and
+  // materializes event rows in one transaction (amplifiable side effect);
+  // per-account limited (limitWidgetConfigByAccount).
+  { method: 'POST', path: '/api/v1/calendars/:calendarId/import-sources/file' },
 ];
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Second of four stacked PRs adding ICS **file-upload** import. This PR is the functional backend: calendar-wide deduplication for uploaded files, and the service + HTTP endpoint that accepts an uploaded `.ics` and runs it through the existing import pipeline. Still no UI (that's PRs C/D).

**Stacked on #420** (`feat/ics-upload-backend-foundation`) — review/merge that first.

## Approach

Two commits:

1. **`feat(calendar): add calendar-wide dedup scope for file imports`** — Implements `dedupScope:'calendar'` in `processIcsBuffer` (replacing the foundation PR's placeholder throw). Builds the dedup map by joining `event_import_origin` → `import_source` on `calendar_id`, keyed on `(external_uid, recurrence)` and tagged with the owner's `source_type`. Four match rules: new UID → create + stamp origin on the uploader; file-source-owned → update + re-point origin; URL-sync-owned → **skip untouched and report** (a migration upload can't clobber a federated sync-managed event); locally-edited → preserve. Calendar scope skips the disappeared-events pass (a file is a partial snapshot, not an authoritative feed). Also adds an optional `maxEvents` ceiling and makes the parse-failure status write transaction-aware. The `dedupScope:'source'` (URL-sync) path is byte-for-byte unchanged.

2. **`feat(calendar): add ICS file-upload service and endpoint`** — `createSourceFromFile` validates editor access → non-empty → 10 MiB cap → `BEGIN:VCALENDAR` signature sniff → per-calendar cap, then in one transaction inserts a pre-verified file-source row (`source_type='file'`, `url=null`) and runs `processIcsBuffer` in calendar-dedup mode; any failure rolls the source row back. `POST /api/v1/calendars/:calendarId/import-sources/file` uses multer memory storage behind a pre-buffer editor-access preflight, the existing rate limiter, a MIME/extension allowlist, and the shared `handleError` mapper. The 10 MiB cap / sniff window / signature / MIME allowlist are now shared from `fetcher.ts` so the URL and file intake paths can't drift.

Reviewed pre-merge by security, consistency, complexity, testing, and architecture auditors. A testing FAIL (the new route broke the rate-limit completeness CI guard) and a security MEDIUM (unbounded VEVENT count → DoS) were found and fixed before this PR opened; re-audited to PASS. Security hardening in this PR: a `MAX_EVENTS_PER_FILE_IMPORT = 10000` ceiling (throws 422, rolls back — **tunable, flagged for sign-off**), authorization before multer buffering, transaction-scoped status write, and bounded `original_filename`.

Two intentional, spec-backed choices carried forward consciously: the per-calendar source cap returns **400 on the URL path but 409 on the file path** (so the client can discriminate cap-exceeded by `errorName`); and a distinct `ImportSourceCapExceededError` exists for that reason. One open product question for a follow-up: when two *different* sources on one calendar share an `external_uid`, the dedup map currently drops the loser silently — rare and outside the spec's match-rule table.

## Validation

- `npm run lint`: pass (0 errors; the 1 warning is a pre-existing unrelated baseline).
- Unit: **8536 pass** (full suite).
- `npm run build` / tsc: pass.
- Integration: 704 pass. The single failure (`cancel_event_occurrence.test.ts`, a date-relative pagination flake) is **pre-existing on `main`**, untouched by this branch.
- New real-DB integration test proves (a) a malformed/empty upload leaves **no orphan source row** and (b) an upload to calendar A does **not** match or re-point calendar B's origins (cross-calendar isolation).
- New coverage: four dedup match rules + unique-index collision guard, the VEVENT cap at service/pipeline/API (422) tiers, five new exception classes with wire-serialization leak checks, pre-buffer auth rejection, and the full error-code surface (400/403/404/409/422).
- E2E failures in this run are environmental (missing Docker-federation TLS cert, test-server startup timeouts), not code regressions.

---

**Stacked PR 2 of 4** — base `feat/ics-upload-backend-foundation` (#420). Merge after #420; re-target this PR's base to `main` once #420 lands. Next: `feat/ics-upload-client-service` → `feat/ics-upload-form-integration`.
