### PR TITLE
feat(client): add ICS file-upload import service and error mapping

### DIFF
--- a/src/client/service/import_source.ts
+++ b/src/client/service/import_source.ts
@@ -9,6 +9,11 @@ import {
   ImportSourceDnsVerificationError,
   ImportSourceRelMeVerificationError,
   ImportSourceVerifyRateLimitError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
 } from '@/common/exceptions/import';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
@@ -63,9 +68,24 @@ const errorMap = {
   ImportSourceDnsVerificationError,
   ImportSourceRelMeVerificationError,
   ImportSourceVerifyRateLimitError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
   UnauthenticatedError,
   ValidationError,
   UnknownError,
+};
+
+/**
+ * Success envelope for the file-upload create path
+ * (`POST /import-sources/file`, HTTP 201). Bundles the newly persisted source
+ * with a summary of the synchronous import run the upload triggered.
+ */
+export type ImportSourceFileResult = {
+  source: ImportSource;
+  run: ImportRunSummary;
 };
 
 /**
@@ -122,6 +142,50 @@ export default class ImportSourceService {
         { url },
       );
       return ImportSource.fromObject(response.data);
+    }
+    catch (error: unknown) {
+      handleApiError(error, errorMap);
+    }
+  }
+
+  /**
+   * Create a new import source from an uploaded .ics file.
+   *
+   * Wraps the file in a multipart `FormData` under the `file` field (the
+   * multer field name the endpoint reads) and POSTs it. The multipart
+   * `Content-Type` and boundary are intentionally left to the browser — a
+   * manually-set header would omit the boundary and break parsing on the
+   * server.
+   *
+   * Returns the persisted source together with a summary of the synchronous
+   * import run the upload kicked off.
+   *
+   * @param calendarId - UUID of the owning calendar
+   * @param file - The `.ics` file selected by the user
+   * @returns The newly persisted source and its import-run summary
+   */
+  async createSourceFromFile(
+    calendarId: string,
+    file: File,
+  ): Promise<ImportSourceFileResult> {
+    const encodedCalendarId = validateAndEncodeId(calendarId, 'Calendar ID');
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const response = await axios.post(
+        `/api/v1/calendars/${encodedCalendarId}/import-sources/file`,
+        formData,
+      );
+      const data = response.data as {
+        source: Record<string, unknown>;
+        run: ImportRunSummary;
+      };
+      return {
+        source: ImportSource.fromObject(data.source),
+        run: data.run,
+      };
     }
     catch (error: unknown) {
       handleApiError(error, errorMap);

--- a/src/client/test/service/import_source.test.ts
+++ b/src/client/test/service/import_source.test.ts
@@ -12,12 +12,19 @@ import {
   ImportSourceNotFoundError,
   ImportSourceFetchError,
   ImportSourceSsrfBlockedError,
+  ImportSourceParseError,
   ImportSourceDnsVerificationError,
   ImportSourceVerifyRateLimitError,
+  ImportSourceFileEmptyError,
+  ImportSourceFileTooLargeError,
+  ImportSourceFileBadFormatError,
+  ImportSourceFileTooManyEventsError,
+  ImportSourceCapExceededError,
   IMPORT_DNS_NOT_FOUND,
 } from '@/common/exceptions/import';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
 import { CalendarEditorPermissionError } from '@/common/exceptions/editor';
+import { ValidationError } from '@/common/exceptions/base';
 
 // Mock axios so every test starts with fresh stubs
 vi.mock('axios');
@@ -126,6 +133,96 @@ describe('ImportSourceService', () => {
       await expect(
         service.createSource(CALENDAR_ID, 'https://example.com/x.ics'),
       ).rejects.toThrow(CalendarEditorPermissionError);
+    });
+  });
+
+  describe('createSourceFromFile', () => {
+    /** Build the `{ source, run }` wire shape the file endpoint returns on 201. */
+    function fileResultPayload(): Record<string, unknown> {
+      return {
+        source: sourcePayload({
+          sourceType: 'file',
+          url: null,
+          originalFilename: 'calendar.ics',
+          verificationState: 'verified',
+        }),
+        run: {
+          id: '44444444-4444-4444-4444-444444444444',
+          importSourceId: SOURCE_ID,
+          startedAt: '2026-05-17T00:00:00.000Z',
+          finishedAt: '2026-05-17T00:00:01.000Z',
+          outcome: 'success',
+          eventsCreated: 3,
+          eventsUpdated: 0,
+          eventsSkippedLocallyEdited: 0,
+          eventsDisappeared: 0,
+          errorMessage: null,
+        },
+      };
+    }
+
+    function icsFile(): File {
+      return new File(['BEGIN:VCALENDAR\nEND:VCALENDAR'], 'calendar.ics', {
+        type: 'text/calendar',
+      });
+    }
+
+    it('POSTs multipart FormData with the file under field name "file"', async () => {
+      const postStub = sandbox.stub(axios, 'post').resolves({ data: fileResultPayload() });
+      const file = icsFile();
+
+      await service.createSourceFromFile(CALENDAR_ID, file);
+
+      expect(postStub.calledOnce).toBe(true);
+      expect(postStub.firstCall.args[0]).toBe(
+        `/api/v1/calendars/${CALENDAR_ID}/import-sources/file`,
+      );
+      const body = postStub.firstCall.args[1];
+      expect(body).toBeInstanceOf(FormData);
+      expect((body as FormData).get('file')).toBe(file);
+      // The browser must set the multipart Content-Type/boundary itself; the
+      // service must not pass a config that overrides it.
+      expect(postStub.firstCall.args[2]).toBeUndefined();
+    });
+
+    it('decodes the { source, run } envelope', async () => {
+      sandbox.stub(axios, 'post').resolves({ data: fileResultPayload() });
+
+      const result = await service.createSourceFromFile(CALENDAR_ID, icsFile());
+
+      expect(result.source).toBeInstanceOf(ImportSource);
+      expect(result.source.id).toBe(SOURCE_ID);
+      expect(result.run.outcome).toBe('success');
+      expect(result.run.eventsCreated).toBe(3);
+    });
+
+    it('validates the calendarId before issuing a request', async () => {
+      const postStub = sandbox.stub(axios, 'post');
+
+      await expect(service.createSourceFromFile('   ', icsFile())).rejects.toThrow(
+        'Calendar ID cannot be empty',
+      );
+      expect(postStub.called).toBe(false);
+    });
+
+    it.each([
+      ['ImportSourceFileEmptyError', ImportSourceFileEmptyError],
+      ['ImportSourceFileTooLargeError', ImportSourceFileTooLargeError],
+      ['ImportSourceFileBadFormatError', ImportSourceFileBadFormatError],
+      ['ImportSourceFileTooManyEventsError', ImportSourceFileTooManyEventsError],
+      ['ImportSourceParseError', ImportSourceParseError],
+      ['ImportSourceCapExceededError', ImportSourceCapExceededError],
+      ['CalendarEditorPermissionError', CalendarEditorPermissionError],
+      ['CalendarNotFoundError', CalendarNotFoundError],
+      ['ValidationError', ValidationError],
+    ])('maps errorName %s to its typed exception', async (errorName, ctor) => {
+      sandbox.stub(axios, 'post').rejects({
+        response: { data: { errorName } },
+      });
+
+      await expect(
+        service.createSourceFromFile(CALENDAR_ID, icsFile()),
+      ).rejects.toBeInstanceOf(ctor);
     });
   });
 


### PR DESCRIPTION
## Motivation

Third of four stacked PRs adding ICS **file-upload** import. This is the small, additive client-side integration: a service method that calls the upload endpoint and maps its errors. It ships separately from the tabbed-form UI (PR 4) specifically so this slice is independently mergeable and non-breaking — it adds a new method and error-map entries without changing any existing behavior.

**Stacked on #423** (`feat/ics-upload-backend-import`) — review/merge that first.

## Approach

One commit. Adds `createSourceFromFile(calendarId, file)` to the client import-source service: it builds a multipart `FormData` with the file under the `file` field, POSTs to `/api/v1/calendars/:calendarId/import-sources/file` **without** a manual `Content-Type` (so the browser sets the multipart boundary — setting it by hand omits the boundary and breaks server-side parsing; this is asserted by a test), and decodes the `{ source, run }` response into the `ImportSource` model and run summary.

The shared `errorName` → exception-class `errorMap` gains the five file-upload exceptions (empty, too-large, bad-format, too-many-events, cap-exceeded) and reuses the existing parse/permission/not-found/validation entries — covering every error the endpoint actually returns. The method mirrors the existing `createSource` shape (id validation, axios, decode, `handleApiError`); no existing methods change.

Reviewed pre-merge by consistency, testing, and architecture auditors — all pass. One carry-forward for PR 4: the shared `ImportRunSummary` client type does not yet model the calendar-wide-dedup counters (`skipped_sync_managed` / `preserved_local_edits`), so PR 4 will extend it to render "N skipped (managed by sync)". A separate observation (not in this diff): `client/service/media.ts` sets `Content-Type` manually on its FormData upload — the actual latent bug the new code correctly avoids — worth a follow-up cleanup.

## Validation

- `npm run lint`: pass (0 errors; 1 pre-existing unrelated warning).
- Unit: **8548 pass** (full suite), including a new `createSourceFromFile` block: happy-path FormData/URL/no-config assertions, `{ source, run }` decode, pre-request id validation, and a parameterized table covering all 9 errorName mappings.
- `npm run build` / tsc: pass.
- Integration/e2e failures in this run are pre-existing or environmental (the `cancel_event_occurrence` date flake, a `category_management` server-side count flake, a test-server port conflict, and the missing Docker-federation TLS cert). This branch changes **only two client files**, so none are attributable to it.

---

**Stacked PR 3 of 4** — base `feat/ics-upload-backend-import` (#423). Merge after #423; re-target to `main` as the stack lands. Next: `feat/ics-upload-form-integration` (tabbed form + section integration).
