### PR TITLE
chore: migrate SCSS off deprecated Sass global functions

### DIFF
--- a/src/client/assets/style/mixins/_logical-properties.scss
+++ b/src/client/assets/style/mixins/_logical-properties.scss
@@ -3,6 +3,8 @@
  * SCSS mixins and functions to support consistent logical property usage
  */
 
+@use 'sass:map';
+
 /* ===== LOGICAL SPACING MIXINS ===== */
 
 /**
@@ -183,8 +185,8 @@
     'text-align: right': 'text-align: end'
   );
   
-  @if map-has-key($logical-map, $property) {
-    @return map-get($logical-map, $property);
+  @if map.has-key($logical-map, $property) {
+    @return map.get($logical-map, $property);
   }
   
   @return $property;

--- a/src/client/assets/style/tokens/_borders.scss
+++ b/src/client/assets/style/tokens/_borders.scss
@@ -3,6 +3,8 @@
  * Border widths, radii, styles, and colors
  */
 
+@use 'sass:map';
+
 :root {
   /* Border Widths */
   --pav-border-width-0: 0;
@@ -99,14 +101,14 @@ $pav-border-radius-semantic: (
 
 // Border utility mixin
 @mixin pav-border($width: 1, $style: solid, $color: medium) {
-  $border-width: map-get($pav-border-widths, $width);
+  $border-width: map.get($pav-border-widths, $width);
 
   border: $border-width $style var(--pav-border-color-#{$color});
 }
 
 // Border radius utility mixin
 @mixin pav-border-radius($size: md) {
-  $radius: map-get($pav-border-radii, $size);
+  $radius: map.get($pav-border-radii, $size);
 
   border-radius: $radius;
 }

--- a/src/client/assets/style/tokens/_breakpoint-mixins.scss
+++ b/src/client/assets/style/tokens/_breakpoint-mixins.scss
@@ -4,14 +4,15 @@
  * Pure @use world — consumers must @use this file directly.
  */
 
+@use 'sass:map';
 @use 'breakpoint-vars' as *;
 
 /* Core Responsive Mixins */
 
 // Media query mixin (mobile-first)
 @mixin pav-media($breakpoint) {
-  @if map-has-key($pav-breakpoints, $breakpoint) {
-    @media (min-width: map-get($pav-breakpoints, $breakpoint)) {
+  @if map.has-key($pav-breakpoints, $breakpoint) {
+    @media (min-width: map.get($pav-breakpoints, $breakpoint)) {
       @content;
     }
   } @else {
@@ -21,8 +22,8 @@
 
 // Media query mixin (desktop-first, max-width)
 @mixin pav-media-down($breakpoint) {
-  @if map-has-key($pav-breakpoints, $breakpoint) {
-    $breakpoint-value: map-get($pav-breakpoints, $breakpoint);
+  @if map.has-key($pav-breakpoints, $breakpoint) {
+    $breakpoint-value: map.get($pav-breakpoints, $breakpoint);
 
     @media (width <= calc(#{$breakpoint-value} - 1px)) {
       @content;

--- a/src/client/assets/style/tokens/_elevation.scss
+++ b/src/client/assets/style/tokens/_elevation.scss
@@ -3,6 +3,8 @@
  * Z-index scale for proper layering and stacking context
  */
 
+@use 'sass:map';
+
 :root {
   /* Z-Index Scale (powers of 10 for easy insertion) */
   --pav-z-index-base: 0;           /* Base layer - normal content */
@@ -63,8 +65,8 @@ $pav-z-index-semantic: (
 
 // Z-index utility mixin
 @mixin pav-z-index($level: base) {
-  @if map-has-key($pav-z-indices, $level) {
-    z-index: map-get($pav-z-indices, $level);
+  @if map.has-key($pav-z-indices, $level) {
+    z-index: map.get($pav-z-indices, $level);
   } @else {
     @error "Z-index level #{$level} not found in $pav-z-indices map.";
   }
@@ -73,13 +75,13 @@ $pav-z-index-semantic: (
 // Layer utility mixin (combines z-index with position)
 @mixin pav-layer($z-level: base, $position: relative) {
   position: $position;
-  z-index: map-get($pav-z-indices, $z-level);
+  z-index: map.get($pav-z-indices, $z-level);
 }
 
 // Stacking context mixin
 @mixin pav-stacking-context($z-level: base) {
   position: relative;
-  z-index: map-get($pav-z-indices, $z-level);
+  z-index: map.get($pav-z-indices, $z-level);
   
   // Create new stacking context
   transform: translateZ(0);

--- a/src/client/assets/style/tokens/_shadows.scss
+++ b/src/client/assets/style/tokens/_shadows.scss
@@ -3,6 +3,8 @@
  * Elevation system with box shadows for depth and layering
  */
 
+@use 'sass:map';
+
 :root {
   /* Elevation Shadow Scale (progressive depth system) */
   --pav-shadow-0: none;
@@ -91,8 +93,8 @@ $pav-shadow-semantic: (
 
 // Shadow utility mixin
 @mixin pav-shadow($level: 2) {
-  @if map-has-key($pav-shadows, $level) {
-    box-shadow: map-get($pav-shadows, $level);
+  @if map.has-key($pav-shadows, $level) {
+    box-shadow: map.get($pav-shadows, $level);
   } @else {
     @error "Shadow level #{$level} not found in $pav-shadows map.";
   }
@@ -100,10 +102,10 @@ $pav-shadow-semantic: (
 
 // Hover shadow transition mixin
 @mixin pav-shadow-transition($base-level: 2, $hover-level: 3) {
-  box-shadow: map-get($pav-shadows, $base-level);
+  box-shadow: map.get($pav-shadows, $base-level);
   transition: box-shadow 0.2s ease-in-out;
   
   &:hover {
-    box-shadow: map-get($pav-shadows, $hover-level);
+    box-shadow: map.get($pav-shadows, $hover-level);
   }
 }

--- a/src/client/assets/style/tokens/_typography.scss
+++ b/src/client/assets/style/tokens/_typography.scss
@@ -4,6 +4,8 @@
  * Font families, sizes, weights, and line heights
  */
 
+@use 'sass:map';
+
 :root {
   /* Font Families */
   --pav-font-family-primary: 'Creato Display', -apple-system, blinkmacsystemfont, 'Segoe UI', roboto, sans-serif;
@@ -146,9 +148,9 @@ $pav-letter-spacings: (
 
 // Typography mixins for consistent application
 @mixin pav-typography($semantic-level: body, $weight: regular) {
-  $size-key: map-get($pav-typography-semantic, $semantic-level);
-  $font-size: map-get($pav-font-sizes, $size-key);
-  $font-weight: map-get($pav-font-weights, $weight);
+  $size-key: map.get($pav-typography-semantic, $semantic-level);
+  $font-size: map.get($pav-font-sizes, $size-key);
+  $font-weight: map.get($pav-font-weights, $weight);
   
   font-family: $pav-font-family-primary;
   font-size: $font-size;
@@ -156,17 +158,17 @@ $pav-letter-spacings: (
   
   // Apply appropriate line height and letter spacing based on semantic level
   @if $semantic-level == display or $semantic-level == h1 or $semantic-level == h2 {
-    line-height: map-get($pav-line-heights, tight);
-    letter-spacing: map-get($pav-letter-spacings, tighter);
+    line-height: map.get($pav-line-heights, tight);
+    letter-spacing: map.get($pav-letter-spacings, tighter);
   } @else if $semantic-level == h3 or $semantic-level == h4 or $semantic-level == h5 or $semantic-level == h6 {
-    line-height: map-get($pav-line-heights, snug);
-    letter-spacing: map-get($pav-letter-spacings, tight);
+    line-height: map.get($pav-line-heights, snug);
+    letter-spacing: map.get($pav-letter-spacings, tight);
   } @else if $semantic-level == caption or $semantic-level == small {
-    line-height: map-get($pav-line-heights, normal);
-    letter-spacing: map-get($pav-letter-spacings, wide);
+    line-height: map.get($pav-line-heights, normal);
+    letter-spacing: map.get($pav-letter-spacings, wide);
   } @else {
-    line-height: map-get($pav-line-heights, normal);
-    letter-spacing: map-get($pav-letter-spacings, normal);
+    line-height: map.get($pav-line-heights, normal);
+    letter-spacing: map.get($pav-letter-spacings, normal);
   }
 }
 
@@ -176,8 +178,8 @@ $pav-letter-spacings: (
   
   // Scale up typography at larger breakpoints
   @media (width >= 768px) {
-    $size-key: map-get($pav-typography-semantic, $semantic-level);
-    $base-size: map-get($pav-font-sizes, $size-key);
+    $size-key: map.get($pav-typography-semantic, $semantic-level);
+    $base-size: map.get($pav-font-sizes, $size-key);
 
     font-size: calc(#{$base-size} * #{$scale-factor});
   }

--- a/src/site/assets/mixins.scss
+++ b/src/site/assets/mixins.scss
@@ -15,13 +15,15 @@
 // Created: 2025-12-14
 // ================================================================
 
+@use 'sass:color';
+
 // ===== COLOR TOKENS =====
 
 // Primary brand accent (warmer, more welcoming)
 $public-accent-light: #ff9131;
 $public-accent-dark: #C86002;
-$public-accent-hover-light: darken(#ff9131, 5%);
-$public-accent-hover-dark: lighten(#C86002, 5%);
+$public-accent-hover-light: color.adjust(#ff9131, $lightness: -5%);
+$public-accent-hover-dark: color.adjust(#C86002, $lightness: 5%);
 
 // Emit the four accent CSS custom properties on a root selector so
 // widgets and the public site can override them via inline styles

--- a/src/site/components/search-filter-public.vue
+++ b/src/site/components/search-filter-public.vue
@@ -733,6 +733,7 @@ onUnmounted(() => {
 </script>
 
 <style scoped lang="scss">
+@use 'sass:color';
 @use '../assets/mixins' as *;
 
 .search-filter-public {
@@ -960,8 +961,8 @@ onUnmounted(() => {
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 
       &:hover {
-        background-color: darken($light-mode-button-background, 5%);
-        border-color: darken($light-mode-button-background, 5%);
+        background-color: color.adjust($light-mode-button-background, $lightness: -5%);
+        border-color: color.adjust($light-mode-button-background, $lightness: -5%);
       }
 
       @include dark-mode {
@@ -970,8 +971,8 @@ onUnmounted(() => {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 
         &:hover {
-          background-color: lighten($dark-mode-button-background, 5%);
-          border-color: lighten($dark-mode-button-background, 5%);
+          background-color: color.adjust($dark-mode-button-background, $lightness: 5%);
+          border-color: color.adjust($dark-mode-button-background, $lightness: 5%);
         }
       }
 
@@ -1114,7 +1115,7 @@ onUnmounted(() => {
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 
         &:hover {
-          background-color: darken($light-mode-button-background, 5%);
+          background-color: color.adjust($light-mode-button-background, $lightness: -5%);
         }
 
         @include dark-mode {
@@ -1123,7 +1124,7 @@ onUnmounted(() => {
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 
           &:hover {
-            background-color: lighten($dark-mode-button-background, 5%);
+            background-color: color.adjust($dark-mode-button-background, $lightness: 5%);
           }
         }
       }


### PR DESCRIPTION
## Motivation

The dev server and production build emitted ~200 Dart Sass deprecation
warnings on every stylesheet compile — persistent log noise that buries
real output and signals an upcoming break in Dart Sass 3.0. Two deprecated
APIs were the sole sources:

- Global map builtins (`map-get`, `map-has-key`) in the client design-token
  and mixin partials — deprecated in favor of the `sass:map` module.
- `darken()` / `lighten()` color functions in the public site design
  system — deprecated in favor of `sass:color`.

The inflated per-warning counts (e.g. `_tabs.scss` reported 56 times) were
just call-site fan-out; the actual deprecated calls live in 8 shared files.

## Approach

Added the relevant `@use 'sass:map'` / `@use 'sass:color'` imports and
switched to module-qualified calls:

- `map-get` → `map.get`, `map-has-key` → `map.has-key` in
  `_logical-properties.scss`, `_borders.scss`, `_shadows.scss`,
  `_typography.scss`, `_elevation.scss`, and `_breakpoint-mixins.scss`.
- `darken($c, 5%)` → `color.adjust($c, $lightness: -5%)` and
  `lighten($c, 5%)` → `color.adjust($c, $lightness: 5%)` in
  `site/assets/mixins.scss` and `search-filter-public.vue`.

`color.adjust` with an explicit `$lightness` delta is the exact HSL
equivalent of `darken`/`lighten`, so compiled color values are unchanged.
No behavior or visual change — purely a syntax migration.

## Validation

- `npm run build` now compiles with **0 deprecation warnings** (was ~200).
- Verified `color.adjust` output is byte-identical to `darken`/`lighten`
  by compiling both forms side by side (`rgb(255, 131.383…, 23.5)` etc.
  match exactly).
- Loaded login, admin calendar, and public calendar-view pages through
  the live dev-server pipeline via Playwright — 0 SCSS warnings in the
  dev log across on-demand compilation.
- Lint (ESLint + stylelint) and the build pass. Unit and integration
  suites show no new failures attributable to this change; the handful of
  red tests are pre-existing issues in the moderation and federation
  domains (an authorization assertion, a flaky navigation timeout, and a
  missing federation TLS cert in the e2e environment) — none touch styling.