### PR TITLE
chore: adopt Graphite stacked-PR tooling and conventions (stage 1)

### DIFF
--- a/.claude/commands/clear-backlog.md
+++ b/.claude/commands/clear-backlog.md
@@ -203,17 +203,20 @@ Dispatch a **general-purpose** subagent per bead. The prompt MUST include:
   branch/commit/PR; conventional commits; no invented scope) and
   `standards-routing` (find and follow the relevant project standards). Follow
   TDD where it applies.
-- **Branch off `origin/main`**: `git fetch origin && git checkout -b
-  <branchname> origin/main` (name per `git-workflow` `branches.md`).
+- **Branch off `main`**: `git fetch origin && gt create <branchname> --onto
+  main` (name per `git-workflow` `branches.md`; command patterns per
+  `git-workflow` `stacking.md`).
 - **Pre-close checklist (in order), NEVER the full suite**:
   1. `pkill -f "vitest" 2>/dev/null || true`
   2. `npm run lint`
   3. Targeted tests only: `npx vitest run <files>` — **no `--maxThreads` flag**
      (unsupported in the repo's current vitest). For integration files, run the
      single file rather than the whole `test:integration` suite.
-- **Ship it**: commit (conventional, no bead ID), push, `gh pr create --base
-  main` (concise title/body, no bead ID), then `bd update <id> --notes "PR:
-  <url>"` and `bd close <id>` — **only if lint + targeted tests passed.**
+- **Ship it**: commit (conventional, no bead ID), then `gt submit
+  --no-interactive --publish` + `gh pr edit <num> --title --body` (concise
+  title/body, no bead ID; see `git-workflow` `stacking.md`), then `bd update
+  <id> --notes "PR: <url>"` and `bd close <id>` — **only if lint + targeted
+  tests passed.**
 - **Refuse-and-report on blockers.** If the bead turns out NOT to be a small
   leaf chore (real ripples, ambiguous scope, premise doesn't match current
   code, a needed dependency is missing), STOP: do not close the bead, leave the

--- a/.claude/commands/clear-backlog.md
+++ b/.claude/commands/clear-backlog.md
@@ -203,20 +203,22 @@ Dispatch a **general-purpose** subagent per bead. The prompt MUST include:
   branch/commit/PR; conventional commits; no invented scope) and
   `standards-routing` (find and follow the relevant project standards). Follow
   TDD where it applies.
-- **Branch off `main`**: `git fetch origin && gt create <branchname> --onto
-  main` (name per `git-workflow` `branches.md`; command patterns per
-  `git-workflow` `stacking.md`).
+- **Branch off `main`**: `git fetch origin`, then create the branch (name per
+  `git-workflow` `branches.md`). This command's beads are independent leaf
+  chores, not a dependency chain, so branching is the plain `git checkout -b`
+  path in `git-workflow` `stacking.md` — no `gh stack` involved.
 - **Pre-close checklist (in order), NEVER the full suite**:
   1. `pkill -f "vitest" 2>/dev/null || true`
   2. `npm run lint`
   3. Targeted tests only: `npx vitest run <files>` — **no `--maxThreads` flag**
      (unsupported in the repo's current vitest). For integration files, run the
      single file rather than the whole `test:integration` suite.
-- **Ship it**: commit (conventional, no bead ID), then `gt submit
-  --no-interactive --publish` + `gh pr edit <num> --title --body` (concise
-  title/body, no bead ID; see `git-workflow` `stacking.md`), then `bd update
-  <id> --notes "PR: <url>"` and `bd close <id>` — **only if lint + targeted
-  tests passed.**
+- **Ship it**: commit (conventional, no bead ID), push, and open the PR per
+  `git-workflow` `pull-requests.md`/`stacking.md` (this command's beads are
+  independent, so the single-branch path applies, not `gh stack`), then
+  `gh pr edit <num> --title --body` (concise title/body, no bead ID), then
+  `bd update <id> --notes "PR: <url>"` and `bd close <id>` — **only if lint +
+  targeted tests passed.**
 - **Refuse-and-report on blockers.** If the bead turns out NOT to be a small
   leaf chore (real ripples, ambiguous scope, premise doesn't match current
   code, a needed dependency is missing), STOP: do not close the bead, leave the

--- a/.claude/commands/restack.md
+++ b/.claude/commands/restack.md
@@ -1,0 +1,43 @@
+# Restack
+
+Post-merge stack maintenance. Runs after one or more stacked PRs have been
+squash-merged in GitHub: syncs trunk, deletes merged branches, restacks the
+remaining stack, reports what moved, and re-submits the updated stack.
+
+Conventions and command semantics live in the `git-workflow` skill's
+`stacking.md` — that file is the source of truth; this command is a thin
+wrapper. Loop-friendly: during a bottom-up merge session, run it after each
+merge (may be driven via `/loop`). There is no standing automation because
+merges are manual.
+
+## Steps
+
+1. **Sync and restack.** Run the `syncAndRestack` helper from
+   `.claude/orchestrators/lib/helpers.ts` (wraps `gt sync -f --no-interactive`):
+
+   ```bash
+   npx tsx -e "import { syncAndRestack } from './.claude/orchestrators/lib/helpers.js'; console.log(JSON.stringify(syncAndRestack(), null, 2));"
+   ```
+
+2. **Report what moved.** From the structured result:
+   - `restacked` — branches restacked cleanly onto their new parent.
+   - `conflicted` — branches gt skipped because restacking would conflict.
+     For each, resolve from the checkout that holds the branch:
+     `gt restack --branch <name>`, fix conflicts, `gt add` + `gt continue`
+     (or `gt abort -f` to back out). Re-run build validation on any branch
+     that had conflicts resolved before re-submitting it.
+   - `skippedWorktree` — branches checked out in another worktree; re-run
+     the sync (or `gt restack`) from that worktree.
+   - Also note any merged branches gt deleted (visible in `rawOutput`).
+
+3. **Re-submit the stack.** Retarget and update the remaining PRs:
+
+   ```bash
+   gt submit --stack --no-interactive --publish
+   ```
+
+   GitHub CI re-validates each retargeted PR. Local build-guardian re-runs
+   are only needed for branches that had conflicts (step 2).
+
+4. **Summarize.** Report: branches deleted (merged), branches restacked,
+   branches needing manual conflict resolution, PRs updated/retargeted.

--- a/.claude/commands/restack.md
+++ b/.claude/commands/restack.md
@@ -30,7 +30,9 @@ merges are manual.
      the sync (or `gt restack`) from that worktree.
    - Also note any merged branches gt deleted (visible in `rawOutput`).
 
-3. **Re-submit the stack.** Retarget and update the remaining PRs:
+3. **Re-submit the stack.** Retarget and update the remaining PRs, using the
+   submit pattern defined by stacking.md's merge + restack ritual (quoted
+   here for execution, defined there):
 
    ```bash
    gt submit --stack --no-interactive --publish

--- a/.claude/commands/restack.md
+++ b/.claude/commands/restack.md
@@ -1,45 +1,40 @@
 # Restack
 
-Post-merge stack maintenance. Runs after one or more stacked PRs have been
-squash-merged in GitHub: syncs trunk, deletes merged branches, restacks the
-remaining stack, reports what moved, and re-submits the updated stack.
+Post-merge local catch-up. Run after one or more stacked PRs have been merged
+in GitHub: sync local state against the reworked stack and report what moved
+or conflicted. Nothing more — GitHub performs the restack server-side at
+merge time (`VERIFY:` per `git-workflow/stacking.md`; local build-guardian
+re-validation of the retargeted level is the conservative default until that
+cascade behavior is confirmed), so this command does not re-submit the stack
+or drive a merge session.
 
 Conventions and command semantics live in the `git-workflow` skill's
 `stacking.md` — that file is the source of truth; this command is a thin
-wrapper. Loop-friendly: during a bottom-up merge session, run it after each
-merge (may be driven via `/loop`). There is no standing automation because
-merges are manual.
+wrapper over the `syncAndRestack` helper in
+`.claude/orchestrators/lib/helpers.ts`. It does not restate `gh stack` syntax.
 
 ## Steps
 
-1. **Sync and restack.** Run the `syncAndRestack` helper from
-   `.claude/orchestrators/lib/helpers.ts` (wraps `gt sync -f --no-interactive`):
+1. **Sync.** Run the `syncAndRestack` helper:
 
    ```bash
    npx tsx -e "import { syncAndRestack } from './.claude/orchestrators/lib/helpers.js'; console.log(JSON.stringify(syncAndRestack(), null, 2));"
    ```
 
-2. **Report what moved.** From the structured result:
-   - `restacked` — branches restacked cleanly onto their new parent.
-   - `conflicted` — branches gt skipped because restacking would conflict.
-     For each, resolve from the checkout that holds the branch:
-     `gt restack --branch <name>`, fix conflicts, `gt add` + `gt continue`
-     (or `gt abort -f` to back out). Re-run build validation on any branch
-     that had conflicts resolved before re-submitting it.
-   - `skippedWorktree` — branches checked out in another worktree; re-run
-     the sync (or `gt restack`) from that worktree.
-   - Also note any merged branches gt deleted (visible in `rawOutput`).
+2. **Report what moved and what conflicted**, from the structured result:
+   - Branches synced cleanly.
+   - Branches that conflicted and need manual resolution — for each, resolve
+     from the checkout that owns the branch, per the merge/sync ritual in
+     `git-workflow/stacking.md`. Re-run local build-guardian validation on any
+     branch that had conflicts resolved.
+   - Any branches pruned as part of the sync (merged PRs cleaned up locally).
 
-3. **Re-submit the stack.** Retarget and update the remaining PRs, using the
-   submit pattern defined by stacking.md's merge + restack ritual (quoted
-   here for execution, defined there):
+3. **Summarize.** Report: branches synced, branches needing manual conflict
+   resolution, branches pruned. If the cascade-retarget claim in
+   `stacking.md` is still unconfirmed, note that build-guardian re-validation
+   of the retargeted level(s) is recommended before further work on the
+   stack.
 
-   ```bash
-   gt submit --stack --no-interactive --publish
-   ```
-
-   GitHub CI re-validates each retargeted PR. Local build-guardian re-runs
-   are only needed for branches that had conflicts (step 2).
-
-4. **Summarize.** Report: branches deleted (merged), branches restacked,
-   branches needing manual conflict resolution, PRs updated/retargeted.
+There is no re-submit step and no merge-session loop here — see
+`stacking.md` for the merge ritual itself (web-UI-only, bottom-up default,
+whole-stack atomic option).

--- a/.claude/commands/workflow-reference.md
+++ b/.claude/commands/workflow-reference.md
@@ -163,7 +163,7 @@ bd update <id> --status=in_progress
 bd close <id>
 bd close <id1> <id2> <id3>      # Batch close
 
-# Sync (ephemeral branches)
+# Sync (per-bead branches, including stack levels — see git-workflow/stacking.md)
 bd sync --from-main
 ```
 
@@ -218,9 +218,9 @@ This re-reads all beads and refreshes the notes with updated dependency graph an
 
 ### With Git
 
-- Work happens on ephemeral branch per epic (usually)
+- Work happens on a branch per bead; a dependency chain among sibling beads becomes a stacked branch chain (conventions: `git-workflow/stacking.md`; scheduling: `bead-wave-orchestration` skill)
 - Run `bd sync --from-main` before merging
-- Each completed epic = one PR typically
+- Each completed bead = one PR; an epic lands as its chains' stacked PRs
 
 ### With CI/CD
 

--- a/.claude/orchestrators/README.md
+++ b/.claude/orchestrators/README.md
@@ -52,6 +52,9 @@ per phase and a `run.jsonl` trace. The logs directory is gitignored.
 
 ## Tests
 
+The root `vitest.config.ts` only includes `src/**` projects, so this suite
+needs its own config. Run from the repo root:
+
 ```bash
-npx vitest run .claude/orchestrators/
+npx vitest run --config .claude/orchestrators/vitest.config.ts
 ```

--- a/.claude/orchestrators/lib/dispatch.ts
+++ b/.claude/orchestrators/lib/dispatch.ts
@@ -77,6 +77,11 @@ export interface DispatchOptions {
   fallbackModel?: boolean;
   /** Override spawn function (for testing). */
   spawnFn?: typeof nodeSpawn;
+  /**
+   * Working directory for the spawned agent. Used when an agent must run
+   * inside a chain's git worktree instead of the main checkout.
+   */
+  cwd?: string;
 }
 
 /**
@@ -204,6 +209,7 @@ function runSingleDispatch<T>(
   const child: ChildProcess = spawnFn(claudeBin, args, {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: { ...process.env },
+    ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
   });
 
   // Write prompt to stdin for initial dispatch

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -33,6 +33,7 @@ import {
   discoverAgents,
   commitMsg,
   prBody,
+  stackSubmit,
   type MatchedAgent as HelperMatchedAgent,
 } from './helpers.js';
 import { buildAgentSelectorPrompt, parseAgentSelectorVerdict } from './phases.js';
@@ -102,6 +103,19 @@ export interface ExecuteDeps {
   changedFilesForBead?: (beadId: string) => string[];
   timeoutMs?: number;
   retryContext?: RetryContext;
+  /**
+   * Working directory for spawned agents and git/gt commands. Set by the
+   * chain scheduler when a chain runs in its own git worktree (hybrid
+   * concurrency model — see git-workflow/stacking.md). Undefined means the
+   * main checkout.
+   */
+  cwd?: string;
+  /**
+   * Diff base for audit/verification prompts and probes. Defaults to `main`.
+   * The chain scheduler sets this to the stack level's parent branch so
+   * auditors review only that level's delta.
+   */
+  diffBase?: string;
   /** Override auditor selection (for testing). */
   selectAuditorsFn?: (
     changedFiles: string[],
@@ -139,10 +153,12 @@ export const PR_MESSAGES = {
     `prBody helper failed (exit ${code}): ${stderr.trim()}`,
   commitMsgFailed: (code: number, stderr: string) =>
     `commitMsg helper failed (exit ${code}): ${stderr.trim()}`,
-  pushFailed: (branch: string, stderr: string) =>
-    `git push failed for branch "${branch}": ${stderr.trim()}`,
-  ghPrFailed: (code: number, stderr: string) =>
-    `gh pr create failed (exit ${code}): ${stderr.trim()}`,
+  submitFailed: (branch: string, stderr: string) =>
+    `gt submit failed for branch "${branch}": ${stderr.trim()}`,
+  ghPrViewFailed: (branch: string, code: number, stderr: string) =>
+    `gh pr view failed for branch "${branch}" (exit ${code}): ${stderr.trim()}`,
+  ghPrEditFailed: (code: number, stderr: string) =>
+    `gh pr edit failed (exit ${code}): ${stderr.trim()}`,
   branchDetectFailed: (stderr: string) =>
     `git branch --show-current failed: ${stderr.trim()}`,
 } as const;
@@ -1637,6 +1653,48 @@ export function parseBeadJson(raw: string): BeadJson | null {
 }
 
 /**
+ * Resolve a branch's PR number and URL via `gh pr view <branch> --json url,number`.
+ *
+ * Used after `stackSubmit` — gt creates/updates the PR but the orchestrator
+ * needs the PR number for `gh pr edit` and the URL for reporting. Returns
+ * null when gh fails or its output is unparseable.
+ */
+export function fetchPrInfo(
+  branch: string,
+  logger: RunLogger,
+  logTag: PhaseName,
+  spawnFn: typeof nodeSpawnSync,
+): { url: string; number: number } | null {
+  const result = spawnCmd(
+    'gh', ['pr', 'view', branch, '--json', 'url,number'], logger, logTag, spawnFn,
+  );
+  if (result.exitCode !== 0 || !result.stdout) return null;
+
+  try {
+    const parsed = JSON.parse(result.stdout) as { url?: unknown; number?: unknown };
+    if (typeof parsed.url !== 'string' || typeof parsed.number !== 'number') return null;
+    return { url: parsed.url, number: parsed.number };
+  }
+  catch {
+    return null;
+  }
+}
+
+/**
+ * Insert the stacked-PR marker at the top of a PR body's Motivation section.
+ *
+ * Per git-workflow/stacking.md, stacked PRs open Motivation with a one-line
+ * "Stacked on #N." pointing at the parent PR; bottom-of-stack PRs omit it.
+ */
+export function withStackedPrefix(body: string, parentPrNumber: number): string {
+  const heading = '## Motivation\n\n';
+  if (body.startsWith(heading)) {
+    return `${heading}Stacked on #${parentPrNumber}.\n\n${body.slice(heading.length)}`;
+  }
+  return `Stacked on #${parentPrNumber}.\n\n${body}`;
+}
+
+/**
  * Derive PR title from the bead.
  */
 export function derivePrTitleFromBead(
@@ -1775,32 +1833,41 @@ export async function runPR(
     prTitle = commitMsg(bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
   }
 
-  // Step 4: Push branch
-  const pushResult = spawnCmd(
-    'git', ['push', '-u', 'origin', branchName], logger, PhaseName.PR, spawnFn,
-  );
+  // Step 4: Submit branch via gt (pushes and creates the PR; command
+  // conventions live in git-workflow/stacking.md, operations in helpers.ts).
+  const submitResult = stackSubmit(branchName, { spawnFn: spawnFn as never, cwd: deps.cwd });
 
-  if (pushResult.exitCode !== 0) {
-    const msg = PR_MESSAGES.pushFailed(branchName, pushResult.stderr);
+  if (!submitResult.ok) {
+    const msg = PR_MESSAGES.submitFailed(branchName, submitResult.stderr);
     console.error(msg);
     logger.writePhaseLog(PhaseName.PR, 'err', msg + '\n');
     return { next: 'halt', ctx };
   }
 
-  // Step 5: Create PR via gh
-  const ghResult = spawnCmd(
-    'gh', ['pr', 'create', '--title', prTitle, '--body', generatedPrBody],
+  // Step 5: Resolve the PR number/URL, then canonicalize title + body via
+  // gh pr edit (gt submit does not know the project's PR template).
+  const prInfo = fetchPrInfo(branchName, logger, PhaseName.PR, spawnFn);
+
+  if (!prInfo) {
+    const msg = PR_MESSAGES.ghPrViewFailed(branchName, 1, 'could not resolve PR number/url after gt submit');
+    console.error(msg);
+    logger.writePhaseLog(PhaseName.PR, 'err', msg + '\n');
+    return { next: 'halt', ctx };
+  }
+
+  const editResult = spawnCmd(
+    'gh', ['pr', 'edit', String(prInfo.number), '--title', prTitle, '--body', generatedPrBody],
     logger, PhaseName.PR, spawnFn,
   );
 
-  if (ghResult.exitCode !== 0) {
-    const msg = PR_MESSAGES.ghPrFailed(ghResult.exitCode, ghResult.stderr);
+  if (editResult.exitCode !== 0) {
+    const msg = PR_MESSAGES.ghPrEditFailed(editResult.exitCode, editResult.stderr);
     console.error(msg);
     logger.writePhaseLog(PhaseName.PR, 'err', msg + '\n');
     return { next: 'halt', ctx };
   }
 
-  const prUrl = ghResult.stdout;
+  const prUrl = prInfo.url;
 
   logger.appendRunJson({
     event: 'pr_finalize_complete',

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -713,6 +713,31 @@ export function extractFinalJsonBlock(text: string): unknown | null {
   return null;
 }
 
+// =============================================================================
+// Build-guardian serialization (cross-chain mutex)
+// =============================================================================
+//
+// NEVER more than one build-guardian at a time (bead-wave-orchestration hard
+// rule): the guardian's `pkill -f vitest` prelude would kill a sibling
+// guardian's in-flight suite, and shared test resources (DB, ports) contend —
+// a cross-killed suite reads as FAIL and truncates a healthy chain. Chains run
+// concurrently, so the build gate — and ONLY the build gate — is serialized
+// through this in-process promise-queue lock; implementers and auditors in
+// other chains stay concurrent.
+
+let buildGuardianQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Run `task` exclusively with respect to every other build-guardian dispatch.
+ * Tasks queue FIFO; a rejected task never poisons the queue (the tail promise
+ * always settles resolved).
+ */
+export function withBuildGuardianLock<T>(task: () => Promise<T>): Promise<T> {
+  const result = buildGuardianQueue.then(() => task());
+  buildGuardianQueue = result.then(() => undefined, () => undefined);
+  return result;
+}
+
 async function dispatchBuildGuardian(
   epicId: string,
   waveNumber: number,
@@ -870,8 +895,9 @@ async function runLevelBuildGate(
   let retries = 0;
 
   for (let attempt = 0; attempt <= MAX_WAVE_RETRIES; attempt++) {
-    const buildResult = await dispatchBuildGuardian(
-      epicId, waveNumber, ctx, deps, { beadId, branch },
+    // Serialized across concurrent chains — see withBuildGuardianLock.
+    const buildResult = await withBuildGuardianLock(() =>
+      dispatchBuildGuardian(epicId, waveNumber, ctx, deps, { beadId, branch }),
     );
 
     if (buildResult.verdict === 'pass') {
@@ -1828,10 +1854,16 @@ async function runChain(
     parentPrNumber = outcome.prNumber ?? null;
   }
 
-  // Per-chain verification pass (advisory, matching prior wave-end behavior:
-  // verdicts are logged, not gated on). Runs from the chain's checkout, where
-  // HEAD sits at the chain top, so `main...HEAD` covers the whole chain delta
-  // — the right base for reviewing cross-bead integration within the chain.
+  // Per-chain verification pass — advisory BY DESIGN, a deliberate departure
+  // from the old wave-end chain (which gated on these verdicts): per-level
+  // submission means the chain's levels are already pushed when a whole-chain
+  // review can first run, so it cannot act as a pre-push gate. Blocking
+  // integration/architecture verification relocates to the epic-completion
+  // sweep (bead-wave-orchestration), and the manual bottom-up merge ritual
+  // (git-workflow/stacking.md) is the human checkpoint before main.
+  // Runs from the chain's checkout, where HEAD sits at the chain top, so
+  // `main...HEAD` covers the whole chain delta — the right base for reviewing
+  // cross-bead integration within the chain.
   if (result.completed.length > 1) {
     await dispatchVerifier(
       'cross-bead-integration-verifier',

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -27,13 +27,21 @@ import {
   DispatchTimeoutError,
   type DispatchOptions,
 } from './dispatch.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   bdEscalate,
   bdEnrichmentCheck,
+  bdShowJson,
   discoverAgents,
+  branchName as deriveBranchName,
   commitMsg,
   prBody,
+  stackCreate,
   stackSubmit,
+  stackPlan,
+  type DependencyEdge,
+  type StackPlanResult,
   type MatchedAgent as HelperMatchedAgent,
 } from './helpers.js';
 import { buildAgentSelectorPrompt, parseAgentSelectorVerdict } from './phases.js';
@@ -91,6 +99,20 @@ export interface EpicExecutionResult {
   escalatedBeads: string[];
   totalRetries: number;
   warnings: string[];
+  /** URLs of the per-level PRs submitted during the wave loop, in submit order. */
+  prUrls: string[];
+}
+
+/** Result of running one dependency chain to completion (or truncation). */
+export interface ChainExecutionResult {
+  /** The chain as scheduled (blocker-first bead ids). */
+  chain: string[];
+  completed: string[];
+  failed: string[];
+  escalated: string[];
+  retries: number;
+  warnings: string[];
+  prUrls: string[];
 }
 
 /**
@@ -183,12 +205,6 @@ interface BeadReadyEntry {
   status: string;
 }
 
-interface WaveEndResult {
-  outcome: 'pass' | 'escalated';
-  failedBeads: string[];
-  retries: number;
-}
-
 interface BuildGuardianResult {
   verdict: 'pass' | 'fail';
   concerns: string[];
@@ -274,33 +290,33 @@ Please address each concern listed above and re-run the implementation. This is 
 
 /**
  * Build the context string for auditor selection from git.
- * Combines `git diff --stat` and `git log --oneline` for the branch-vs-main delta.
+ * Combines `git diff --stat` and `git log --oneline` for the branch's delta
+ * against its diff base (`main`, or the parent stack level for chain levels).
  */
 function buildAuditorContext(
   ctx: RunContext,
-  deps: { scriptSpawnFn?: typeof nodeSpawnSync },
+  deps: { scriptSpawnFn?: typeof nodeSpawnSync; diffBase?: string; cwd?: string },
 ): string {
   const spawn = deps.scriptSpawnFn ?? nodeSpawnSync;
-  const stat = spawn('git', ['diff', '--stat', 'main...HEAD'], {
+  const base = deps.diffBase ?? 'main';
+  const spawnOpts = {
     encoding: 'buffer' as never,
     shell: true,
     timeout: 30_000,
-  });
-  const log = spawn('git', ['log', '--oneline', 'main..HEAD'], {
-    encoding: 'buffer' as never,
-    shell: true,
-    timeout: 30_000,
-  });
+    ...(deps.cwd !== undefined ? { cwd: deps.cwd } : {}),
+  };
+  const stat = spawn('git', ['diff', '--stat', `${base}...HEAD`], spawnOpts);
+  const log = spawn('git', ['log', '--oneline', `${base}..HEAD`], spawnOpts);
 
   const statOut = (stat.stdout?.toString('utf-8') ?? '').trim();
   const logOut = (log.stdout?.toString('utf-8') ?? '').trim();
 
   return [
-    'Changed files (`git diff --stat main...HEAD`):',
+    `Changed files (\`git diff --stat ${base}...HEAD\`):`,
     '',
     statOut || '_(no changes)_',
     '',
-    'Commits in this branch (`git log --oneline main..HEAD`):',
+    `Commits in this branch (\`git log --oneline ${base}..HEAD\`):`,
     '',
     logOut || '_(no commits)_',
     '',
@@ -336,6 +352,7 @@ async function selectAuditors(
       ctx,
       logTag: PhaseName.Leaf,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
 
     const verdict = parseAgentSelectorVerdict(raw);
@@ -380,15 +397,16 @@ async function dispatchAuditor(
   beadId: string,
   auditor: MatchedAgent,
   ctx: RunContext,
-  deps: { spawnFn?: typeof nodeSpawn },
+  deps: { spawnFn?: typeof nodeSpawn; diffBase?: string; cwd?: string },
 ): Promise<AuditorVerdict> {
+  const base = deps.diffBase ?? 'main';
   const prompt = `# Audit changes for bead: ${beadId}
 
 You are the ${auditor.name} running in post-code mode. Review the
 changes landed on the current branch:
 
 \`\`\`bash
-git diff main...HEAD
+git diff ${base}...HEAD
 \`\`\`
 
 Apply your normal audit process. Emit one of the \`review-mode-auditor\`
@@ -403,6 +421,7 @@ verdicts (PASS / PASS WITH WARNINGS / FAIL) per
       ctx,
       logTag: PhaseName.Leaf,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
 
     // dispatch returns raw string when no schemaPath; parse it ourselves
@@ -445,11 +464,21 @@ function filterEnrichedBeads(
   });
 }
 
-function findNextWaveBeads(
+/**
+ * Query the currently-ready descendant beads of an epic via
+ * `bd ready --parent <epic> --json`.
+ *
+ * In chain scheduling this remains the source of CROSS-CHAIN unblocking
+ * (e.g. a chain head that was blocked by a bead outside its own chain), but
+ * scheduling filters the result to chain HEADS only — mid-chain beads are
+ * owned by their chain runner and must never be re-injected as standalone
+ * wave entries.
+ */
+function findReadyBeadIds(
   epicId: string,
   ctx: RunContext,
   deps: ExecuteDeps,
-): string[] {
+): Set<string> {
   const spawnSync = deps.scriptSpawnFn ?? nodeSpawnSync;
 
   // Scope ready-set to descendants of the current epic; without --parent, bd
@@ -465,7 +494,7 @@ function findNextWaveBeads(
   const exitCode = result.status ?? 1;
 
   if (exitCode !== 0 || !stdout.trim()) {
-    return [];
+    return new Set();
   }
 
   try {
@@ -475,13 +504,71 @@ function findNextWaveBeads(
       phase: PhaseName.Epic,
       readyCount: beads.length,
     });
-    return beads.map(b => b.id);
+    return new Set(beads.map(b => b.id));
   }
   catch {
     ctx.logger.writePhaseLog(PhaseName.Epic, 'err',
       `Failed to parse bd ready output: ${stdout}\n`);
-    return [];
+    return new Set();
   }
+}
+
+/**
+ * Gather an epic's full child set and the blocks-edges among them, then plan
+ * dependency-chain stacks via the pure `stackPlan` helper.
+ *
+ * `bd ready --parent` is NOT sufficient here: it returns only UNBLOCKED
+ * children, but chain planning needs the full sibling set including
+ * mid-chain (currently blocked) beads. Children already closed are excluded;
+ * dropping a closed blocker's edge correctly promotes its dependent to a
+ * chain head. Returns null when the epic has no open children (or bd fails).
+ */
+export function gatherStackPlan(
+  epicId: string,
+  ctx: RunContext,
+  deps: ExecuteDeps,
+): StackPlanResult | null {
+  const spawnDeps = { spawnFn: deps.scriptSpawnFn };
+  const epic = bdShowJson(epicId, spawnDeps);
+  if (!epic) return null;
+
+  const childIds = (epic.children ?? [])
+    .map(c => c?.id)
+    .filter((id): id is string => typeof id === 'string');
+
+  const openChildren: string[] = [];
+  const edges: DependencyEdge[] = [];
+
+  for (const childId of childIds) {
+    const child = bdShowJson(childId, spawnDeps);
+    if (!child) continue;
+    const status = (child.status ?? '').toLowerCase();
+    if (status.includes('closed') || status.includes('done')) continue;
+
+    openChildren.push(childId);
+    for (const dep of child.dependencies ?? []) {
+      // Only blocks-edges participate; stackPlan additionally drops edges
+      // pointing outside the sibling set (e.g. cross-epic blockers).
+      if (dep.dependency_type === 'blocks' && typeof dep.id === 'string') {
+        edges.push({ blocker: dep.id, blocked: childId, dependencyType: 'blocks' });
+      }
+    }
+  }
+
+  if (openChildren.length === 0) return null;
+
+  const plan = stackPlan(openChildren, edges);
+
+  ctx.logger.appendRunJson({
+    event: 'stack-plan',
+    phase: PhaseName.Epic,
+    epicId,
+    chains: plan.chains,
+    flat: plan.flat,
+    warnings: plan.warnings,
+  });
+
+  return plan;
 }
 
 function escalateBead(
@@ -507,7 +594,7 @@ function escalateBead(
 }
 
 // =============================================================================
-// Private helpers — wave-end chain (epic)
+// Private helpers — chain verification (epic)
 // =============================================================================
 
 function buildVerifierPrompt(
@@ -515,17 +602,18 @@ function buildVerifierPrompt(
   waveNumber: number,
   beadIds: string[],
   kind: 'integration' | 'architecture',
+  diffBase = 'main',
 ): string {
   if (kind === 'integration') {
     return `# Cross-bead integration verification
 
 Epic: ${epicId}, Wave: ${waveNumber}
-Beads in this wave: ${beadIds.join(', ')}
+Beads in this chain: ${beadIds.join(', ')}
 
-Review the combined changes from all beads in this wave:
+Review the combined changes from all beads in this chain:
 
 \`\`\`bash
-git diff main...HEAD
+git diff ${diffBase}...HEAD
 \`\`\`
 
 Look for conflicts, duplications, and inconsistencies between the beads'
@@ -535,13 +623,13 @@ changes that per-bead auditors miss because each bead was verified in isolation.
   return `# Architecture auditor (light pass)
 
 Epic: ${epicId}, Wave: ${waveNumber}
-Beads in this wave: ${beadIds.join(', ')}
+Beads in this chain: ${beadIds.join(', ')}
 
-Review the wave's combined changes for vision drift, decision violations,
+Review the chain's combined changes for vision drift, decision violations,
 and conceptual fragmentation:
 
 \`\`\`bash
-git diff main...HEAD
+git diff ${diffBase}...HEAD
 \`\`\`
 
 Read product docs (mission.md, decisions.md, roadmap.md) and flag any issues.`;
@@ -561,6 +649,7 @@ async function dispatchVerifier(
       ctx,
       logTag: PhaseName.Epic,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
     // dispatch returns raw string when no schemaPath; parse it ourselves
     if (typeof raw === 'string') {
@@ -628,10 +717,14 @@ async function dispatchBuildGuardian(
   waveNumber: number,
   ctx: RunContext,
   deps: ExecuteDeps,
+  level?: { beadId: string; branch: string },
 ): Promise<BuildGuardianResult> {
+  const levelContext = level
+    ? `\nStack level: branch \`${level.branch}\` (bead ${level.beadId}), validated at its stack position.`
+    : '';
   const prompt = `# Build Guardian — Wave ${waveNumber}
 
-Epic: ${epicId}
+Epic: ${epicId}${levelContext}
 
 Run the full sequential verification suite:
 
@@ -668,6 +761,7 @@ introduced the failures (empty if you cannot attribute).`;
       ctx,
       logTag: PhaseName.Epic,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
   }
   catch (err) {
@@ -731,8 +825,8 @@ ${concerns.map(c => `- ${c}`).join('\n')}
 Investigate the failures using:
 
 \`\`\`bash
-git log --oneline main...HEAD
-git diff main...HEAD
+git log --oneline ${deps.diffBase ?? 'main'}...HEAD
+git diff ${deps.diffBase ?? 'main'}...HEAD
 \`\`\`
 
 Identify which bead's commit is responsible and suggest a fix.`;
@@ -745,6 +839,7 @@ Identify which bead's commit is responsible and suggest a fix.`;
       ctx,
       logTag: PhaseName.Epic,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
     // dispatch returns raw string when no schemaPath; parse it ourselves
     if (typeof raw === 'string') {
@@ -757,89 +852,64 @@ Identify which bead's commit is responsible and suggest a fix.`;
   }
 }
 
-async function runWaveEndChain(
+/**
+ * Per-level build gate: build-guardian runs once per STACK LEVEL, on that
+ * branch at its stack position, BEFORE that level's `gt submit`
+ * (independently-green invariant — see git-workflow/stacking.md).
+ *
+ * On failure the responsible bead is known by construction (it is this
+ * level), so the test-failure-investigator is dispatched for diagnosis and
+ * the level's implementer retries with the concerns, up to MAX_WAVE_RETRIES.
+ * Parse failures are terminal — there is no verdict to retry against.
+ */
+async function runLevelBuildGate(
   epicId: string,
   waveNumber: number,
-  waveState: WaveState,
+  beadId: string,
+  branch: string,
   ctx: RunContext,
   deps: ExecuteDeps,
-): Promise<WaveEndResult> {
-  const completedBeads = waveState.beadsCompleted;
+): Promise<{ ok: boolean; reason?: string; retries: number }> {
   let retries = 0;
 
   for (let attempt = 0; attempt <= MAX_WAVE_RETRIES; attempt++) {
-    // Step A: cross-bead-integration-verifier (conditional)
-    if (completedBeads.length > 1) {
-      await dispatchVerifier(
-        'cross-bead-integration-verifier',
-        buildVerifierPrompt(epicId, waveNumber, completedBeads, 'integration'),
-        ctx,
-        deps,
-      );
-    }
-
-    // Step B: architecture-auditor (light pass)
-    await dispatchVerifier(
-      'architecture-auditor',
-      buildVerifierPrompt(epicId, waveNumber, completedBeads, 'architecture'),
-      ctx,
-      deps,
+    const buildResult = await dispatchBuildGuardian(
+      epicId, waveNumber, ctx, deps, { beadId, branch },
     );
 
-    // Step C: build-guardian
-    const buildResult = await dispatchBuildGuardian(epicId, waveNumber, ctx, deps);
-
     if (buildResult.verdict === 'pass') {
-      return { outcome: 'pass', failedBeads: [], retries };
+      return { ok: true, retries };
     }
 
-    // Build-guardian failed — log and decide whether retry is meaningful.
     ctx.logger.appendRunJson({
       event: 'build-guardian-fail',
       phase: PhaseName.Epic,
       epicId,
       waveNumber,
+      beadId,
+      branch,
       attempt: attempt + 1,
       concerns: buildResult.concerns,
       parseFailed: buildResult.parseFailed ?? false,
     });
 
-    // Parse failures are terminal: there is no signal about which bead is
-    // responsible, so retrying just spawns implementers with no bead id and
-    // loops the orchestrator. Escalate immediately.
+    // Parse failures are terminal: retrying without a verdict just loops.
     if (buildResult.parseFailed) {
-      const failedBeads = buildResult.beadsFailed.length > 0
-        ? buildResult.beadsFailed
-        : completedBeads;
-      for (const beadId of failedBeads) {
-        escalateBead(beadId, 'Build-guardian output unparseable; manual investigation required', ctx, deps);
-      }
-      return { outcome: 'escalated', failedBeads, retries };
+      return {
+        ok: false,
+        reason: 'Build-guardian output unparseable; manual investigation required',
+        retries,
+      };
     }
 
-    // Build-guardian failed — investigate and retry
     if (attempt < MAX_WAVE_RETRIES) {
-      const investigatorResult = await dispatchTestFailureInvestigator(
+      // Diagnosis only — the responsible bead is this level by construction.
+      await dispatchTestFailureInvestigator(
         epicId, waveNumber, buildResult.concerns, ctx, deps,
       );
 
-      const responsibleBead = investigatorResult.responsibleBead ?? completedBeads[0];
-
-      // Without a responsibleBead we cannot dispatch a meaningful retry;
-      // the dispatchImplementer guard would refuse, but we'd still loop
-      // through this branch. Escalate instead.
-      if (!responsibleBead) {
-        const failedBeads = buildResult.beadsFailed.length > 0
-          ? buildResult.beadsFailed
-          : completedBeads;
-        for (const beadId of failedBeads) {
-          escalateBead(beadId, 'Build-guardian failed and no responsible bead could be identified', ctx, deps);
-        }
-        return { outcome: 'escalated', failedBeads, retries };
-      }
-
       retries++;
-      await dispatchImplementer(responsibleBead, ctx, {
+      await dispatchImplementer(beadId, ctx, {
         ...deps,
         retryContext: {
           concerns: buildResult.concerns,
@@ -847,26 +917,21 @@ async function runWaveEndChain(
         },
       });
 
-      const changedFiles = deps.changedFilesForBead?.(responsibleBead) ?? [];
-      await runAudit(responsibleBead, ctx, { ...deps, changedFiles });
+      const changedFiles = deps.changedFilesForBead?.(beadId) ?? [];
+      await runAudit(beadId, ctx, { ...deps, changedFiles });
 
       continue;
     }
 
-    // Exhausted retries — escalate
-    const failedBeads = buildResult.beadsFailed.length > 0
-      ? buildResult.beadsFailed
-      : completedBeads;
-
-    for (const beadId of failedBeads) {
-      escalateBead(beadId, `Build-guardian failed after ${MAX_WAVE_RETRIES} retries`, ctx, deps);
-    }
-
-    return { outcome: 'escalated', failedBeads, retries };
+    return {
+      ok: false,
+      reason: `Build-guardian failed after ${MAX_WAVE_RETRIES} retries`,
+      retries,
+    };
   }
 
   // Defensive fallback
-  return { outcome: 'escalated', failedBeads: completedBeads, retries };
+  return { ok: false, reason: 'build gate exhausted', retries };
 }
 
 // =============================================================================
@@ -944,6 +1009,7 @@ export async function dispatchImplementer(
       ctx,
       logTag: PhaseName.Leaf,
       spawnFn: deps.spawnFn as typeof nodeSpawn,
+      cwd: deps.cwd,
     });
     return { ok: true };
   }
@@ -1047,25 +1113,30 @@ export function extractExpectedFiles(
  * uncommitted edits on a file outside this bead's scope.
  *
  * Base branch defaults to `main`; override via `GIT_SAFE_MAIN_BRANCH` env var
- * (consistent with preflight checks in `helpers.ts`).
+ * (consistent with preflight checks in `helpers.ts`) or the `baseBranch`
+ * parameter — the chain scheduler passes the level's parent branch so the
+ * gate measures only that level's delta.
  */
 export function verifyImplementerCompletion(
   ctx: RunContext,
   deps: ExecuteDeps,
   expectedFiles?: string[],
+  baseBranchOverride?: string,
 ): VerificationResult {
   const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
-  const baseBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  const baseBranch = baseBranchOverride ?? process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  const spawnOpts = {
+    encoding: 'buffer' as never,
+    shell: false,
+    timeout: 10_000,
+    ...(deps.cwd !== undefined ? { cwd: deps.cwd } : {}),
+  };
 
   const statusArgs = ['status', '--porcelain'];
   if (expectedFiles && expectedFiles.length > 0) {
     statusArgs.push('--', ...expectedFiles);
   }
-  const statusResult = spawnFn('git', statusArgs, {
-    encoding: 'buffer' as never,
-    shell: false,
-    timeout: 10_000,
-  });
+  const statusResult = spawnFn('git', statusArgs, spawnOpts);
   if (statusResult.status !== 0 || statusResult.error) {
     const stderrSnippet = (statusResult.stderr?.toString('utf-8') ?? '').trim()
       || statusResult.error?.message
@@ -1092,11 +1163,7 @@ export function verifyImplementerCompletion(
     return { passed: false, reason };
   }
 
-  const revResult = spawnFn('git', ['rev-list', '--count', `${baseBranch}..HEAD`], {
-    encoding: 'buffer' as never,
-    shell: false,
-    timeout: 10_000,
-  });
+  const revResult = spawnFn('git', ['rev-list', '--count', `${baseBranch}..HEAD`], spawnOpts);
   if (revResult.status !== 0 || revResult.error) {
     const stderrSnippet = (revResult.stderr?.toString('utf-8') ?? '').trim()
       || revResult.error?.message
@@ -1123,11 +1190,7 @@ export function verifyImplementerCompletion(
     return { passed: false, reason };
   }
 
-  const diffResult = spawnFn('git', ['diff', '--name-only', `${baseBranch}...HEAD`], {
-    encoding: 'buffer' as never,
-    shell: false,
-    timeout: 10_000,
-  });
+  const diffResult = spawnFn('git', ['diff', '--name-only', `${baseBranch}...HEAD`], spawnOpts);
   if (diffResult.status !== 0 || diffResult.error) {
     const stderrSnippet = (diffResult.stderr?.toString('utf-8') ?? '').trim()
       || diffResult.error?.message
@@ -1238,7 +1301,7 @@ export async function runAudit(
   }
 
   const verdictPromises = matchedAuditors.map(auditor =>
-    dispatchAuditor(beadId, auditor, ctx, { spawnFn }),
+    dispatchAuditor(beadId, auditor, ctx, { spawnFn, diffBase: deps.diffBase, cwd: deps.cwd }),
   );
 
   const verdicts = await Promise.all(verdictPromises);
@@ -1441,15 +1504,370 @@ export async function runWithConcurrencyCap<T>(
 }
 
 // =============================================================================
+// Private helpers — chain worktree lifecycle (hybrid concurrency model)
+// =============================================================================
+//
+// Per-bead stack branches mean parallel chains can no longer share one
+// checkout (gt create checks out the new branch, yanking HEAD out from under
+// a sibling). Hybrid model: the FIRST chain of a wave runs in the main
+// checkout (the common single-chain case pays no worktree overhead); each
+// ADDITIONAL concurrent chain gets its own git worktree, with agents and
+// git/gt commands dispatched at that cwd (gt-in-worktrees is the permanent
+// mode — see git-workflow/stacking.md). The orchestrator owns the worktree
+// lifecycle: create before the chain starts, remove when it finishes.
+
+interface ChainWorktree {
+  path: string;
+  /** Throwaway checkout branch the worktree starts on; never a stack level. */
+  worktreeBranch: string;
+}
+
+function createChainWorktree(
+  waveNumber: number,
+  chainIndex: number,
+  ctx: RunContext,
+  deps: ExecuteDeps,
+): ChainWorktree | null {
+  const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const base = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  const slug = `orch-wt-${ctx.runId}-w${waveNumber}-c${chainIndex}`;
+  const path = join(tmpdir(), slug);
+
+  // The auto-created branch is only the worktree's initial checkout; chain
+  // levels are created directly on their parent via `gt create --onto`.
+  const result = spawnCmd(
+    'git', ['worktree', 'add', '-b', slug, path, base],
+    ctx.logger, PhaseName.Epic, spawnFn,
+  );
+
+  const ok = result.exitCode === 0;
+  ctx.logger.appendRunJson({
+    event: ok ? 'chain-worktree-created' : 'chain-worktree-create-failed',
+    phase: PhaseName.Epic,
+    waveNumber,
+    chainIndex,
+    path,
+    ...(ok ? {} : { stderr: result.stderr }),
+  });
+
+  return ok ? { path, worktreeBranch: slug } : null;
+}
+
+function removeChainWorktree(
+  worktree: ChainWorktree,
+  ctx: RunContext,
+  deps: ExecuteDeps,
+): void {
+  const spawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const removeResult = spawnCmd(
+    'git', ['worktree', 'remove', '--force', worktree.path],
+    ctx.logger, PhaseName.Epic, spawnFn,
+  );
+  // Drop the throwaway checkout branch too (it has no commits of its own).
+  spawnCmd(
+    'git', ['branch', '-D', worktree.worktreeBranch],
+    ctx.logger, PhaseName.Epic, spawnFn,
+  );
+  ctx.logger.appendRunJson({
+    event: 'chain-worktree-removed',
+    phase: PhaseName.Epic,
+    path: worktree.path,
+    success: removeResult.exitCode === 0,
+  });
+}
+
+// =============================================================================
+// Private helpers — chain execution
+// =============================================================================
+
+interface ChainLevelOutcome {
+  ok: boolean;
+  reason?: string;
+  branch?: string;
+  prUrl?: string;
+  prNumber?: number;
+  retries: number;
+  warnings: string[];
+}
+
+/**
+ * Execute one stack level of a chain:
+ *
+ *   stackCreate(branch, parent) → implementer → verification gate (base =
+ *   parent) → per-bead audit (one retry) → per-level build-guardian gate →
+ *   stackSubmit → gh pr edit (canonical title/body, "Stacked on #N." for
+ *   upstack levels).
+ *
+ * The build gate runs BEFORE submit — no level is pushed until it is green
+ * at its own stack position.
+ */
+async function runChainLevel(
+  epicId: string,
+  waveNumber: number,
+  beadId: string,
+  parentBranch: string,
+  parentPrNumber: number | null,
+  ctx: RunContext,
+  deps: ExecuteDeps,
+): Promise<ChainLevelOutcome> {
+  const warnings: string[] = [];
+  let retries = 0;
+  const scriptSpawnFn = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const spawnDeps = { spawnFn: deps.scriptSpawnFn, cwd: deps.cwd };
+  const beadCtx: RunContext = { ...ctx, beadId };
+  // Audits and gates for this level measure the delta against the parent
+  // stack level, not main.
+  const levelDeps: ExecuteDeps = { ...deps, diffBase: parentBranch };
+  const fail = (reason: string): ChainLevelOutcome => {
+    ctx.logger.appendRunJson({
+      event: 'chain-level-failed',
+      phase: PhaseName.Epic,
+      epicId,
+      waveNumber,
+      beadId,
+      reason,
+    });
+    return { ok: false, reason, retries, warnings };
+  };
+
+  // Belt-and-braces enrichment check: wave entry only vets chain heads;
+  // mid-chain beads are checked here at dispatch time.
+  if (!bdEnrichmentCheck(beadId, { spawnFn: deps.scriptSpawnFn })) {
+    return fail('bead is not enriched (no Implementation Context)');
+  }
+
+  const bead = bdShowJson(beadId, { spawnFn: deps.scriptSpawnFn });
+  if (!bead) {
+    return fail('bd show --json failed; cannot derive branch name');
+  }
+
+  const title = typeof bead.title === 'string' ? bead.title : beadId;
+  const issueType = bead.issue_type ?? 'task';
+  const branch = deriveBranchName(title, issueType);
+
+  // 1. Create this level's branch on its parent (main for the chain bottom).
+  const created = stackCreate(branch, parentBranch, spawnDeps);
+  if (!created.ok) {
+    return fail(`gt create ${branch} --onto ${parentBranch} failed: ${created.stderr}`);
+  }
+  ctx.logger.appendRunJson({
+    event: 'chain-level-branch-created',
+    phase: PhaseName.Epic,
+    beadId,
+    branchName: branch,
+    baseBranch: parentBranch,
+  });
+
+  // 2. Implementer + verification gate + per-bead audit (single retry).
+  const implResult = await dispatchImplementer(beadId, ctx, levelDeps);
+  if (!implResult.ok) {
+    return fail(`implementer failure: ${implResult.reason}`);
+  }
+
+  const expectedFiles = extractExpectedFiles(beadId, deps);
+  const gate = verifyImplementerCompletion(beadCtx, levelDeps, expectedFiles, parentBranch);
+  if (!gate.passed) {
+    reopenBead(beadId, beadCtx, deps, 'verification-gate-epic-escalate');
+    return fail(`verification gate failed: ${gate.reason}`);
+  }
+
+  let auditResult = await runAudit(beadId, ctx, {
+    ...levelDeps,
+    changedFiles: gate.changedFiles,
+  });
+  warnings.push(...auditResult.warnings);
+
+  if (!auditResult.passed) {
+    const retryResult = await dispatchImplementer(beadId, ctx, {
+      ...levelDeps,
+      retryContext: { concerns: auditResult.concerns, attempt: 2 },
+    });
+    if (!retryResult.ok) {
+      return fail(`retry implementer failure: ${retryResult.reason}`);
+    }
+
+    const retryGate = verifyImplementerCompletion(beadCtx, levelDeps, expectedFiles, parentBranch);
+    if (!retryGate.passed) {
+      reopenBead(beadId, beadCtx, deps, 'verification-gate-epic-escalate');
+      return fail(`verification gate failed after retry: ${retryGate.reason}`);
+    }
+
+    retries++;
+    auditResult = await runAudit(beadId, ctx, {
+      ...levelDeps,
+      changedFiles: retryGate.changedFiles,
+    });
+    warnings.push(...auditResult.warnings);
+
+    if (!auditResult.passed) {
+      return fail(`audit retry exhausted: ${auditResult.concerns.join('; ')}`);
+    }
+  }
+
+  // 3. Per-level build gate BEFORE submit (independently-green invariant).
+  const buildOutcome = await runLevelBuildGate(epicId, waveNumber, beadId, branch, ctx, levelDeps);
+  retries += buildOutcome.retries;
+  if (!buildOutcome.ok) {
+    return fail(buildOutcome.reason ?? 'build gate failed');
+  }
+
+  // 4. Submit this level, then canonicalize the PR via gh.
+  const submitted = stackSubmit(branch, spawnDeps);
+  if (!submitted.ok) {
+    return fail(`gt submit failed: ${submitted.stderr}`);
+  }
+
+  const prInfo = fetchPrInfo(branch, ctx.logger, PhaseName.Epic, scriptSpawnFn);
+  if (!prInfo) {
+    return fail(`could not resolve PR number/url for branch ${branch} after gt submit`);
+  }
+
+  const prTitle = commitMsg(title, issueType);
+  let generatedBody = prBody(title, typeof bead.description === 'string' ? bead.description : '');
+  if (parentPrNumber !== null) {
+    generatedBody = withStackedPrefix(generatedBody, parentPrNumber);
+  }
+
+  const editResult = spawnCmd(
+    'gh', ['pr', 'edit', String(prInfo.number), '--title', prTitle, '--body', generatedBody],
+    ctx.logger, PhaseName.Epic, scriptSpawnFn,
+  );
+  if (editResult.exitCode !== 0) {
+    return fail(`gh pr edit failed (exit ${editResult.exitCode}): ${editResult.stderr}`);
+  }
+
+  ctx.logger.appendRunJson({
+    event: 'chain-level-complete',
+    phase: PhaseName.Epic,
+    epicId,
+    waveNumber,
+    beadId,
+    branchName: branch,
+    prUrl: prInfo.url,
+    prNumber: prInfo.number,
+  });
+
+  return {
+    ok: true,
+    branch,
+    prUrl: prInfo.url,
+    prNumber: prInfo.number,
+    retries,
+    warnings,
+  };
+}
+
+/**
+ * Run one dependency chain: beads strictly sequentially, each level branching
+ * from its predecessor. A failed level halts the chain — downstream levels
+ * build on the broken branch and cannot proceed past it, so the remainder is
+ * escalated (chain truncation) rather than retried at wave granularity.
+ */
+async function runChain(
+  epicId: string,
+  waveNumber: number,
+  chain: string[],
+  ctx: RunContext,
+  deps: ExecuteDeps,
+): Promise<ChainExecutionResult> {
+  const result: ChainExecutionResult = {
+    chain,
+    completed: [],
+    failed: [],
+    escalated: [],
+    retries: 0,
+    warnings: [],
+    prUrls: [],
+  };
+
+  let parentBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  let parentPrNumber: number | null = null;
+
+  for (let level = 0; level < chain.length; level++) {
+    const beadId = chain[level];
+    const outcome = await runChainLevel(
+      epicId, waveNumber, beadId, parentBranch, parentPrNumber, ctx, deps,
+    );
+    result.retries += outcome.retries;
+    result.warnings.push(...outcome.warnings);
+
+    if (!outcome.ok) {
+      const reason = outcome.reason ?? 'chain level failed';
+      escalateBead(beadId, reason, ctx, deps);
+      result.failed.push(beadId);
+      result.escalated.push(beadId);
+
+      // Truncate the chain: escalate the un-run remainder instead of
+      // skipping past a broken parent. (bd blocking already prevents these
+      // beads from becoming ready, but the escalation records why.)
+      for (const remainder of chain.slice(level + 1)) {
+        escalateBead(
+          remainder,
+          `chain truncated: upstream level ${beadId} failed (${reason})`,
+          ctx, deps,
+        );
+        result.failed.push(remainder);
+        result.escalated.push(remainder);
+      }
+
+      ctx.logger.appendRunJson({
+        event: 'chain-halted',
+        phase: PhaseName.Epic,
+        epicId,
+        waveNumber,
+        failedBead: beadId,
+        truncatedBeads: chain.slice(level + 1),
+      });
+      return result;
+    }
+
+    result.completed.push(beadId);
+    if (outcome.prUrl) result.prUrls.push(outcome.prUrl);
+    parentBranch = outcome.branch ?? parentBranch;
+    parentPrNumber = outcome.prNumber ?? null;
+  }
+
+  // Per-chain verification pass (advisory, matching prior wave-end behavior:
+  // verdicts are logged, not gated on). Runs from the chain's checkout, where
+  // HEAD sits at the chain top, so `main...HEAD` covers the whole chain delta
+  // — the right base for reviewing cross-bead integration within the chain.
+  if (result.completed.length > 1) {
+    await dispatchVerifier(
+      'cross-bead-integration-verifier',
+      buildVerifierPrompt(epicId, waveNumber, result.completed, 'integration'),
+      ctx,
+      deps,
+    );
+  }
+  if (result.completed.length > 0) {
+    await dispatchVerifier(
+      'architecture-auditor',
+      buildVerifierPrompt(epicId, waveNumber, result.completed, 'architecture'),
+      ctx,
+      deps,
+    );
+  }
+
+  return result;
+}
+
+// =============================================================================
 // Exported: runEpicExecution
 // =============================================================================
 
 /**
- * Execute the full epic wave lifecycle.
+ * Execute the full epic wave lifecycle over a stackPlan chain forest.
+ *
+ * Waves are built from CHAINS, not beads: each wave schedules every
+ * remaining chain whose head bead is currently ready (per
+ * `bd ready --parent`), the 3-implementer cap (MAX_IMPLEMENTER_SLOTS)
+ * applies to chains, and independent chains run in parallel under the
+ * hybrid worktree model. Within a chain, beads run strictly sequentially
+ * with per-level branches, build gates, and PR submission (see runChain).
  */
 export async function runEpicExecution(
   epicId: string,
-  initialBeads: string[],
+  plan: StackPlanResult,
   ctx: RunContext,
   deps: ExecuteDeps = {},
 ): Promise<EpicExecutionResult> {
@@ -1457,151 +1875,118 @@ export async function runEpicExecution(
   const allFailed: string[] = [];
   const escalated: string[] = [];
   const allWarnings: string[] = [];
+  const prUrls: string[] = [];
   let wavesCompleted = 0;
   let totalRetries = 0;
 
-  let readyBeads = [...initialBeads];
+  let remainingChains = plan.chains.map(chain => [...chain]);
 
   ctx.logger.appendRunJson({
     event: 'epic-execution-start',
     phase: PhaseName.Epic,
     epicId,
-    initialBeadCount: initialBeads.length,
+    chainCount: remainingChains.length,
+    flat: plan.flat,
+    planWarnings: plan.warnings,
   });
 
-  while (readyBeads.length > 0) {
-    const waveNumber = wavesCompleted + 1;
+  while (remainingChains.length > 0) {
+    const readyIds = findReadyBeadIds(epicId, ctx, deps);
 
-    ctx.logger.appendRunJson({
-      event: 'wave-start',
-      phase: PhaseName.Epic,
-      epicId,
-      waveNumber,
-      beadCount: readyBeads.length,
-      beadIds: readyBeads,
-    });
+    // Schedule chains whose HEAD is ready. bd remains the cross-chain
+    // unblocking source; mid-chain beads are owned by their chain runner
+    // and are never scheduled directly even when bd reports them ready.
+    const readyChains = remainingChains.filter(chain => readyIds.has(chain[0]));
+    if (readyChains.length === 0) {
+      break;
+    }
 
-    const enrichedBeads = filterEnrichedBeads(readyBeads, ctx, deps);
+    // Enrichment pre-filter on chain heads (mid-chain beads are re-checked
+    // at dispatch time inside runChainLevel).
+    const waveChains = readyChains.filter(
+      chain => filterEnrichedBeads([chain[0]], ctx, deps).length > 0,
+    );
 
-    if (enrichedBeads.length === 0) {
+    if (waveChains.length === 0) {
       ctx.logger.appendRunJson({
         event: 'wave-skip-no-enriched',
         phase: PhaseName.Epic,
-        waveNumber,
+        waveNumber: wavesCompleted + 1,
       });
       break;
     }
 
-    // Spawn implementers (max 3 in parallel)
+    remainingChains = remainingChains.filter(chain => !waveChains.includes(chain));
+    const waveNumber = wavesCompleted + 1;
+
     const waveState: WaveState = {
       epicId,
       waveNumber,
-      beadsInProgress: [...enrichedBeads],
+      chains: waveChains.map(chain => [...chain]),
+      beadsInProgress: waveChains.flat(),
       beadsCompleted: [],
       beadsFailed: [],
       implementerSlots: [],
       cascadeQueue: [],
     };
 
-    const implementerTasks = enrichedBeads.map(beadId => async () => {
-      const result = await dispatchImplementer(beadId, ctx, deps);
-      return { beadId, result };
+    ctx.logger.appendRunJson({
+      event: 'wave-start',
+      phase: PhaseName.Epic,
+      epicId,
+      waveNumber,
+      chainCount: waveChains.length,
+      chains: waveState.chains,
     });
 
-    const implementerResults = await runWithConcurrencyCap(
-      implementerTasks,
-      MAX_IMPLEMENTER_SLOTS,
-    );
+    // Hybrid concurrency: chain 0 runs in the main checkout; each additional
+    // chain gets its own worktree for the duration of the chain.
+    const chainTasks = waveChains.map((chain, chainIndex) => async () => {
+      let worktree: ChainWorktree | null = null;
 
-    // Per-bead auditor cascade
-    for (const { beadId, result } of implementerResults) {
-      if (!result.ok) {
-        waveState.beadsFailed.push(beadId);
-        continue;
-      }
-
-      // Verification gate — mirror leaf-path enforcement. Scope ctx.beadId to
-      // the child bead so gate/reopen log events identify the bead, not the epic.
-      // Pass the bead's expected file set so the dirty-tree check ignores
-      // pending edits from parallel siblings on unrelated files.
-      // Epic wave loop handles retries at the wave level via MAX_WAVE_RETRIES;
-      // here we just mark this bead as failed for this wave and move on.
-      const beadCtx: RunContext = { ...ctx, beadId };
-      const expectedFiles = extractExpectedFiles(beadId, deps);
-      const gate = verifyImplementerCompletion(beadCtx, deps, expectedFiles);
-      if (!gate.passed) {
-        reopenBead(beadId, beadCtx, deps, 'verification-gate-epic-escalate');
-        waveState.beadsFailed.push(beadId);
-        continue;
-      }
-
-      const auditResult = await runAudit(beadId, ctx, {
-        ...deps,
-        changedFiles: gate.changedFiles,
-      });
-      allWarnings.push(...auditResult.warnings);
-
-      if (auditResult.passed) {
-        waveState.beadsCompleted.push(beadId);
-      }
-      else {
-        const retryResult = await dispatchImplementer(beadId, ctx, {
-          ...deps,
-          retryContext: { concerns: auditResult.concerns, attempt: 2 },
-        });
-
-        if (retryResult.ok) {
-          const retryAudit = await runAudit(beadId, ctx, {
-            ...deps,
-            changedFiles: gate.changedFiles,
-          });
-          allWarnings.push(...retryAudit.warnings);
-
-          if (retryAudit.passed) {
-            waveState.beadsCompleted.push(beadId);
-            totalRetries++;
+      if (chainIndex > 0) {
+        worktree = createChainWorktree(waveNumber, chainIndex, ctx, deps);
+        if (!worktree) {
+          const result: ChainExecutionResult = {
+            chain,
+            completed: [],
+            failed: [...chain],
+            escalated: [...chain],
+            retries: 0,
+            warnings: [],
+            prUrls: [],
+          };
+          for (const beadId of chain) {
+            escalateBead(beadId, 'could not create git worktree for parallel chain', ctx, deps);
           }
-          else {
-            waveState.beadsFailed.push(beadId);
-          }
-        }
-        else {
-          waveState.beadsFailed.push(beadId);
+          return result;
         }
       }
+
+      const chainDeps: ExecuteDeps = worktree ? { ...deps, cwd: worktree.path } : deps;
+      try {
+        return await runChain(epicId, waveNumber, chain, ctx, chainDeps);
+      }
+      finally {
+        if (worktree) removeChainWorktree(worktree, ctx, deps);
+      }
+    });
+
+    const chainResults = await runWithConcurrencyCap(chainTasks, MAX_IMPLEMENTER_SLOTS);
+
+    const waveEscalated: string[] = [];
+    for (const chainResult of chainResults) {
+      waveState.beadsCompleted.push(...chainResult.completed);
+      waveState.beadsFailed.push(...chainResult.failed);
+      waveEscalated.push(...chainResult.escalated);
+      totalRetries += chainResult.retries;
+      allWarnings.push(...chainResult.warnings);
+      prUrls.push(...chainResult.prUrls);
     }
 
-    // Wave-end verification chain
-    const waveEndResult = await runWaveEndChain(epicId, waveNumber, waveState, ctx, deps);
-
-    if (waveEndResult.outcome === 'escalated') {
-      escalated.push(...waveEndResult.failedBeads);
-      allFailed.push(...waveEndResult.failedBeads);
-      allCompleted.push(...waveState.beadsCompleted);
-
-      ctx.logger.appendRunJson({
-        event: 'epic-escalated',
-        phase: PhaseName.Epic,
-        epicId,
-        waveNumber,
-        escalatedBeads: waveEndResult.failedBeads,
-      });
-
-      return {
-        outcome: 'escalated',
-        wavesCompleted,
-        beadsCompleted: allCompleted,
-        beadsFailed: allFailed,
-        escalatedBeads: escalated,
-        totalRetries: totalRetries + waveEndResult.retries,
-        warnings: allWarnings,
-      };
-    }
-
-    totalRetries += waveEndResult.retries;
-    wavesCompleted++;
     allCompleted.push(...waveState.beadsCompleted);
     allFailed.push(...waveState.beadsFailed);
+    escalated.push(...waveEscalated);
 
     ctx.logger.appendRunJson({
       event: 'wave-complete',
@@ -1612,8 +1997,28 @@ export async function runEpicExecution(
       beadsFailed: waveState.beadsFailed,
     });
 
-    // Cascade — find newly unblocked beads
-    readyBeads = findNextWaveBeads(epicId, ctx, deps);
+    if (waveEscalated.length > 0) {
+      ctx.logger.appendRunJson({
+        event: 'epic-escalated',
+        phase: PhaseName.Epic,
+        epicId,
+        waveNumber,
+        escalatedBeads: waveEscalated,
+      });
+
+      return {
+        outcome: 'escalated',
+        wavesCompleted,
+        beadsCompleted: allCompleted,
+        beadsFailed: allFailed,
+        escalatedBeads: escalated,
+        totalRetries,
+        warnings: allWarnings,
+        prUrls,
+      };
+    }
+
+    wavesCompleted++;
   }
 
   ctx.logger.appendRunJson({
@@ -1632,6 +2037,7 @@ export async function runEpicExecution(
     escalatedBeads: escalated,
     totalRetries,
     warnings: allWarnings,
+    prUrls,
   };
 }
 
@@ -1901,50 +2307,31 @@ export const leafPhase: PhaseRunner = async (ctx, deps = {}) => {
 };
 
 /**
- * Epic phase runner: discovers initial beads, runs epic execution, routes to PR.
+ * Epic phase runner: gathers the epic's full child set + dependency edges,
+ * plans dependency-chain stacks via stackPlan, and runs the chain-based
+ * wave lifecycle.
+ *
+ * On completion it routes to Report, NOT to the PR phase: chain levels
+ * submit their own per-level PRs inside the wave loop, so a trailing
+ * epic-wide PR would be both redundant and wrong.
  */
 export const epicPhase: PhaseRunner = async (ctx, deps = {}) => {
-  const spawnSync = deps.scriptSpawnFn ?? nodeSpawnSync;
+  const plan = gatherStackPlan(ctx.beadId, ctx, deps);
 
-  // Discover initial ready beads for the epic via `bd ready --parent <epic> --json`.
-  // The --parent filter is essential: without it, bd ready returns the entire
-  // globally-ready set and unrelated beads from other epics get swept into wave 1.
-  const result = spawnSync('bd', ['ready', '--parent', ctx.beadId, '--json'], {
-    encoding: 'buffer' as never,
-    shell: true,
-    timeout: 30_000,
-  });
-
-  const stdout = result.stdout?.toString('utf-8') ?? '';
-  const exitCode = result.status ?? 1;
-
-  if (exitCode !== 0 || !stdout.trim()) {
+  if (!plan) {
     ctx.logger.writePhaseLog(PhaseName.Epic, 'err',
-      'No ready beads found for epic execution\n');
+      'No open child beads found for epic execution\n');
     return { next: 'halt', ctx };
   }
 
-  let initialBeads: string[];
-  try {
-    const beads = JSON.parse(stdout) as BeadReadyEntry[];
-    initialBeads = beads.map(b => b.id);
-  }
-  catch {
-    ctx.logger.writePhaseLog(PhaseName.Epic, 'err',
-      `Failed to parse bd ready output: ${stdout}\n`);
-    return { next: 'halt', ctx };
-  }
-
-  if (initialBeads.length === 0) {
-    ctx.logger.writePhaseLog(PhaseName.Epic, 'err',
-      'No ready beads found for epic execution\n');
-    return { next: 'halt', ctx };
-  }
-
-  const epicResult = await runEpicExecution(ctx.beadId, initialBeads, ctx, deps);
+  const epicResult = await runEpicExecution(ctx.beadId, plan, ctx, deps);
 
   if (epicResult.outcome === 'complete') {
-    return { next: PhaseName.PR, ctx };
+    if (epicResult.prUrls.length > 0) {
+      ctx.prUrl = epicResult.prUrls.join(', ');
+    }
+    ctx.beadsClosed = [ctx.beadId, ...epicResult.beadsCompleted];
+    return { next: PhaseName.Report, ctx };
   }
 
   return { next: 'halt', ctx };

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -7,7 +7,7 @@
  * Exports:
  *  - dispatchImplementer, runAudit, runLeafExecution  (from 7b)
  *  - runWithConcurrencyCap, runEpicExecution           (from 7a)
- *  - parseBeadJson, fetchPrInfo, withStackedPrefix, runPR (from 8)
+ *  - parseBeadJson, fetchPrInfo, runPR                 (from 8)
  *  - leafPhase, epicPhase, prPhase                     (PhaseRunner wrappers)
  */
 
@@ -126,10 +126,10 @@ export interface ExecuteDeps {
   timeoutMs?: number;
   retryContext?: RetryContext;
   /**
-   * Working directory for spawned agents and git/gt commands. Set by the
-   * chain scheduler when a chain runs in its own git worktree (hybrid
-   * concurrency model — see git-workflow/stacking.md). Undefined means the
-   * main checkout.
+   * Working directory for spawned agents and git/gh-stack commands. Set by
+   * the chain scheduler when a chain runs in its own git worktree (native
+   * gh-stack-in-worktrees model — see git-workflow/stacking.md). Undefined
+   * means the main checkout.
    */
   cwd?: string;
   /**
@@ -176,7 +176,7 @@ export const PR_MESSAGES = {
   commitMsgFailed: (code: number, stderr: string) =>
     `commitMsg helper failed (exit ${code}): ${stderr.trim()}`,
   submitFailed: (branch: string, stderr: string) =>
-    `gt submit failed for branch "${branch}": ${stderr.trim()}`,
+    `stackSubmit failed for branch "${branch}": ${stderr.trim()}`,
   ghPrViewFailed: (branch: string, code: number, stderr: string) =>
     `gh pr view failed for branch "${branch}" (exit ${code}): ${stderr.trim()}`,
   ghPrEditFailed: (code: number, stderr: string) =>
@@ -876,7 +876,7 @@ Identify which bead's commit is responsible and suggest a fix.`;
 
 /**
  * Per-level build gate: build-guardian runs once per STACK LEVEL, on that
- * branch at its stack position, BEFORE that level's `gt submit`
+ * branch at its stack position, BEFORE that level's `stackSubmit`
  * (independently-green invariant — see git-workflow/stacking.md).
  *
  * On failure the responsible bead is known by construction (it is this
@@ -1531,13 +1531,16 @@ export async function runWithConcurrencyCap<T>(
 // =============================================================================
 //
 // Per-bead stack branches mean parallel chains can no longer share one
-// checkout (gt create checks out the new branch, yanking HEAD out from under
-// a sibling). Hybrid model: the FIRST chain of a wave runs in the main
+// checkout (stackCreate checks out the new branch, yanking HEAD out from
+// under a sibling). Hybrid model: the FIRST chain of a wave runs in the main
 // checkout (the common single-chain case pays no worktree overhead); each
 // ADDITIONAL concurrent chain gets its own git worktree, with agents and
-// git/gt commands dispatched at that cwd (gt-in-worktrees is the permanent
-// mode — see git-workflow/stacking.md). The orchestrator owns the worktree
-// lifecycle: create before the chain starts, remove when it finishes.
+// git/gh-stack commands dispatched at that cwd (native gh-stack-in-worktrees
+// is the permanent mode — decision memo D2, see git-workflow/stacking.md:
+// gh-stack's state is a per-git-dir JSON file, not shared across worktrees,
+// so stack operations must run from the checkout that owns the branch). The
+// orchestrator owns the worktree lifecycle: create before the chain starts,
+// remove when it finishes.
 
 interface ChainWorktree {
   path: string;
@@ -1557,7 +1560,7 @@ function createChainWorktree(
   const path = join(tmpdir(), slug);
 
   // The auto-created branch is only the worktree's initial checkout; chain
-  // levels are created directly on their parent via `gt create --onto`.
+  // levels are created directly on their parent via `stackCreate`.
   const result = spawnCmd(
     'git', ['worktree', 'add', '-b', slug, path, base],
     ctx.logger, PhaseName.Epic, spawnFn,
@@ -1616,10 +1619,12 @@ interface ChainLevelOutcome {
 /**
  * Execute one stack level of a chain:
  *
- *   stackCreate(branch, parent) → implementer → verification gate (base =
- *   parent) → per-bead audit (one retry) → per-level build-guardian gate →
- *   stackSubmit → gh pr edit (canonical title/body, "Stacked on #N." for
- *   upstack levels).
+ *   stackCreate(branch, parent, chained) → implementer → verification gate
+ *   (base = parent) → per-bead audit (one retry) → per-level build-guardian
+ *   gate → stackSubmit(branch, chained) → gh pr edit (canonical title/body).
+ *
+ * The Graphite-era "Stacked on #N" body line is dropped — GitHub's Stack Map
+ * UI shows the stack hierarchy natively (see git-workflow/stacking.md).
  *
  * The build gate runs BEFORE submit — no level is pushed until it is green
  * at its own stack position.
@@ -1629,7 +1634,7 @@ async function runChainLevel(
   waveNumber: number,
   beadId: string,
   parentBranch: string,
-  parentPrNumber: number | null,
+  chained: boolean,
   ctx: RunContext,
   deps: ExecuteDeps,
 ): Promise<ChainLevelOutcome> {
@@ -1669,9 +1674,9 @@ async function runChainLevel(
   const branch = deriveBranchName(title, issueType);
 
   // 1. Create this level's branch on its parent (main for the chain bottom).
-  const created = stackCreate(branch, parentBranch, spawnDeps);
+  const created = stackCreate(branch, parentBranch, chained, spawnDeps);
   if (!created.ok) {
-    return fail(`gt create ${branch} --onto ${parentBranch} failed: ${created.stderr}`);
+    return fail(`stackCreate(${branch}, ${parentBranch}, chained=${chained}) failed: ${created.stderr}`);
   }
   ctx.logger.appendRunJson({
     event: 'chain-level-branch-created',
@@ -1739,21 +1744,18 @@ async function runChainLevel(
   }
 
   // 4. Submit this level, then canonicalize the PR via gh.
-  const submitted = stackSubmit(branch, spawnDeps);
+  const submitted = stackSubmit(branch, chained, spawnDeps);
   if (!submitted.ok) {
-    return fail(`gt submit failed: ${submitted.stderr}`);
+    return fail(`stackSubmit(${branch}, chained=${chained}) failed: ${submitted.stderr}`);
   }
 
   const prInfo = fetchPrInfo(branch, ctx.logger, PhaseName.Epic, scriptSpawnFn);
   if (!prInfo) {
-    return fail(`could not resolve PR number/url for branch ${branch} after gt submit`);
+    return fail(`could not resolve PR number/url for branch ${branch} after stackSubmit`);
   }
 
   const prTitle = commitMsg(title, issueType);
-  let generatedBody = prBody(title, typeof bead.description === 'string' ? bead.description : '');
-  if (parentPrNumber !== null) {
-    generatedBody = withStackedPrefix(generatedBody, parentPrNumber);
-  }
+  const generatedBody = prBody(title, typeof bead.description === 'string' ? bead.description : '');
 
   const editResult = spawnCmd(
     'gh', ['pr', 'edit', String(prInfo.number), '--title', prTitle, '--body', generatedBody],
@@ -1808,12 +1810,16 @@ async function runChain(
   };
 
   let parentBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
-  let parentPrNumber: number | null = null;
+  // A chain of length 1 is an independent bead (decision 5: stackPlan never
+  // stacks a singleton) — its level runs entirely outside gh-stack. Every
+  // level of a longer chain is chained=true, including the head (which uses
+  // `gh stack init` rather than a plain branch — see stackCreate).
+  const chained = chain.length > 1;
 
   for (let level = 0; level < chain.length; level++) {
     const beadId = chain[level];
     const outcome = await runChainLevel(
-      epicId, waveNumber, beadId, parentBranch, parentPrNumber, ctx, deps,
+      epicId, waveNumber, beadId, parentBranch, chained, ctx, deps,
     );
     result.retries += outcome.retries;
     result.warnings.push(...outcome.warnings);
@@ -1851,7 +1857,6 @@ async function runChain(
     result.completed.push(beadId);
     if (outcome.prUrl) result.prUrls.push(outcome.prUrl);
     parentBranch = outcome.branch ?? parentBranch;
-    parentPrNumber = outcome.prNumber ?? null;
   }
 
   // Per-chain verification pass — advisory BY DESIGN, a deliberate departure
@@ -2075,7 +2080,7 @@ export async function runEpicExecution(
 }
 
 // =============================================================================
-// Exported: parseBeadJson, fetchPrInfo, withStackedPrefix
+// Exported: parseBeadJson, fetchPrInfo
 // =============================================================================
 
 /**
@@ -2094,9 +2099,10 @@ export function parseBeadJson(raw: string): BeadJson | null {
 /**
  * Resolve a branch's PR number and URL via `gh pr view <branch> --json url,number`.
  *
- * Used after `stackSubmit` — gt creates/updates the PR but the orchestrator
- * needs the PR number for `gh pr edit` and the URL for reporting. Returns
- * null when gh fails or its output is unparseable.
+ * Used after `stackSubmit` — gh-stack (or plain `gh pr create`, for singles)
+ * creates/updates the PR but the orchestrator needs the PR number for
+ * `gh pr edit` and the URL for reporting. Returns null when gh fails or its
+ * output is unparseable.
  */
 export function fetchPrInfo(
   branch: string,
@@ -2119,27 +2125,18 @@ export function fetchPrInfo(
   }
 }
 
-/**
- * Insert the stacked-PR marker at the top of a PR body's Motivation section.
- *
- * Per git-workflow/stacking.md, stacked PRs open Motivation with a one-line
- * "Stacked on #N." pointing at the parent PR; bottom-of-stack PRs omit it.
- */
-export function withStackedPrefix(body: string, parentPrNumber: number): string {
-  const heading = '## Motivation\n\n';
-  if (body.startsWith(heading)) {
-    return `${heading}Stacked on #${parentPrNumber}.\n\n${body.slice(heading.length)}`;
-  }
-  return `Stacked on #${parentPrNumber}.\n\n${body}`;
-}
-
 // =============================================================================
 // Exported: runPR
 // =============================================================================
 
 /**
  * PR finalization phase for LEAF beads: verify the bead closed, generate PR
- * body/title, submit via gt, canonicalize via gh pr edit.
+ * body/title, submit via stackSubmit, canonicalize via gh pr edit.
+ *
+ * Standalone leaf beads are always singles (never part of a gh-stack chain
+ * — chain levels submit their own per-level PRs inside runChainLevel), so
+ * this always calls stackSubmit with chained=false: plain `git push` +
+ * `gh pr create`.
  *
  * Epics never reach this phase — epicPhase routes to Report because chain
  * levels submit their own per-level PRs inside the wave loop.
@@ -2226,9 +2223,11 @@ export async function runPR(
   // Step 3: Derive PR title
   const prTitle = commitMsg(bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
 
-  // Step 4: Submit branch via gt (pushes and creates the PR; command
-  // conventions live in git-workflow/stacking.md, operations in helpers.ts).
-  const submitResult = stackSubmit(branchName, { spawnFn: spawnFn as never, cwd: deps.cwd });
+  // Step 4: Submit branch (pushes and creates the PR; command conventions
+  // live in git-workflow/stacking.md, operations in helpers.ts). Standalone
+  // leaf beads are always singles, so chained=false: plain `git push` +
+  // `gh pr create`.
+  const submitResult = stackSubmit(branchName, false, { spawnFn: spawnFn as never, cwd: deps.cwd });
 
   if (!submitResult.ok) {
     const msg = PR_MESSAGES.submitFailed(branchName, submitResult.stderr);
@@ -2238,11 +2237,11 @@ export async function runPR(
   }
 
   // Step 5: Resolve the PR number/URL, then canonicalize title + body via
-  // gh pr edit (gt submit does not know the project's PR template).
+  // gh pr edit (stackSubmit does not know the project's PR template).
   const prInfo = fetchPrInfo(branchName, logger, PhaseName.PR, spawnFn);
 
   if (!prInfo) {
-    const msg = PR_MESSAGES.ghPrViewFailed(branchName, 1, 'could not resolve PR number/url after gt submit');
+    const msg = PR_MESSAGES.ghPrViewFailed(branchName, 1, 'could not resolve PR number/url after stackSubmit');
     console.error(msg);
     logger.writePhaseLog(PhaseName.PR, 'err', msg + '\n');
     return { next: 'halt', ctx };

--- a/.claude/orchestrators/lib/execute.ts
+++ b/.claude/orchestrators/lib/execute.ts
@@ -7,7 +7,7 @@
  * Exports:
  *  - dispatchImplementer, runAudit, runLeafExecution  (from 7b)
  *  - runWithConcurrencyCap, runEpicExecution           (from 7a)
- *  - parseBeadJson, derivePrTitleFromBead, runPR       (from 8)
+ *  - parseBeadJson, fetchPrInfo, withStackedPrefix, runPR (from 8)
  *  - leafPhase, epicPhase, prPhase                     (PhaseRunner wrappers)
  */
 
@@ -196,7 +196,6 @@ interface BeadJson {
   description?: string;
   status?: string;
   issue_type?: string;
-  children?: Array<{ id?: string }>;
 }
 
 interface BeadReadyEntry {
@@ -205,10 +204,12 @@ interface BeadReadyEntry {
   status: string;
 }
 
+// Note: no beadsFailed field — the per-level build gate knows the
+// responsible bead by construction (it is the level under test), so the
+// guardian is not asked to attribute failures.
 interface BuildGuardianResult {
   verdict: 'pass' | 'fail';
   concerns: string[];
-  beadsFailed: string[];
   /** True when the build-guardian response could not be parsed (terminal — do not retry). */
   parseFailed?: boolean;
 }
@@ -742,15 +743,14 @@ this block — without it, the run cannot continue.
 \`\`\`json
 {
   "verdict": "pass" | "fail",
-  "concerns": ["short error description", "..."],
-  "beadsFailed": ["pv-xxxx", "..."]
+  "concerns": ["short error description", "..."]
 }
 \`\`\`
 
 \`verdict\` is "pass" only when lint, tests, and build all succeed. \`concerns\`
 should list each failing check (one entry per failure) with file paths and
-test names where available. \`beadsFailed\` lists bead IDs whose changes
-introduced the failures (empty if you cannot attribute).`;
+test names where available. No failure attribution is needed — the gate runs
+per stack level, so the responsible bead is known by construction.`;
 
   let raw: unknown;
   try {
@@ -770,7 +770,6 @@ introduced the failures (empty if you cannot attribute).`;
     return {
       verdict: 'fail',
       concerns: [`build-guardian dispatch error: ${err instanceof Error ? err.message : String(err)}`],
-      beadsFailed: [],
       parseFailed: true,
     };
   }
@@ -796,7 +795,6 @@ introduced the failures (empty if you cannot attribute).`;
     return {
       verdict: 'fail',
       concerns: [reason],
-      beadsFailed: [],
       parseFailed: true,
     };
   }
@@ -804,7 +802,6 @@ introduced the failures (empty if you cannot attribute).`;
   return {
     verdict: result.verdict === 'pass' ? 'pass' : 'fail',
     concerns: result.concerns ?? [],
-    beadsFailed: result.beadsFailed ?? [],
   };
 }
 
@@ -1661,6 +1658,9 @@ async function runChainLevel(
   // 2. Implementer + verification gate + per-bead audit (single retry).
   const implResult = await dispatchImplementer(beadId, ctx, levelDeps);
   if (!implResult.ok) {
+    // Deliberately stricter than runLeafExecution's retry-once: chain
+    // truncation is the retry-equivalent here — a failed level is cheaper
+    // to reschedule than to retry in place while sibling chains wait.
     return fail(`implementer failure: ${implResult.reason}`);
   }
 
@@ -1668,6 +1668,7 @@ async function runChainLevel(
   const gate = verifyImplementerCompletion(beadCtx, levelDeps, expectedFiles, parentBranch);
   if (!gate.passed) {
     reopenBead(beadId, beadCtx, deps, 'verification-gate-epic-escalate');
+    // Deliberate asymmetry with the leaf path (no gate retry) — see above.
     return fail(`verification gate failed: ${gate.reason}`);
   }
 
@@ -2042,7 +2043,7 @@ export async function runEpicExecution(
 }
 
 // =============================================================================
-// Exported: parseBeadJson, derivePrTitleFromBead
+// Exported: parseBeadJson, fetchPrInfo, withStackedPrefix
 // =============================================================================
 
 /**
@@ -2100,25 +2101,16 @@ export function withStackedPrefix(body: string, parentPrNumber: number): string 
   return `Stacked on #${parentPrNumber}.\n\n${body}`;
 }
 
-/**
- * Derive PR title from the bead.
- */
-export function derivePrTitleFromBead(
-  title: string,
-  issueType: string,
-): string {
-  if (issueType === 'epic') {
-    return title.replace(/^Epic:\s*/i, '').trim();
-  }
-  return title;
-}
-
 // =============================================================================
 // Exported: runPR
 // =============================================================================
 
 /**
- * PR finalization phase: verify beads closed, generate PR body/title, push, create PR.
+ * PR finalization phase for LEAF beads: verify the bead closed, generate PR
+ * body/title, submit via gt, canonicalize via gh pr edit.
+ *
+ * Epics never reach this phase — epicPhase routes to Report because chain
+ * levels submit their own per-level PRs inside the wave loop.
  */
 export async function runPR(
   ctx: PhaseCtx,
@@ -2186,7 +2178,6 @@ export async function runPR(
     return { next: 'halt', ctx };
   }
 
-  const isEpic = bead.issue_type === 'epic';
   const beadsClosed: string[] = [ctx.beadId];
 
   const beadStatus = (bead.status ?? '').toLowerCase();
@@ -2197,47 +2188,11 @@ export async function runPR(
     return { next: 'halt', ctx };
   }
 
-  // For epics: verify all children are also closed
-  if (isEpic && bead.children && bead.children.length > 0) {
-    for (const child of bead.children) {
-      const childId = child.id;
-      if (!childId) continue;
-
-      beadsClosed.push(childId);
-
-      const childResult = spawnCmd(
-        'bd', ['show', '--json', childId], logger, PhaseName.PR, spawnFn,
-      );
-
-      if (childResult.exitCode !== 0) {
-        const msg = PR_MESSAGES.bdShowFailed(childId, childResult.exitCode, childResult.stderr);
-        console.error(msg);
-        return { next: 'halt', ctx };
-      }
-
-      const childBead = parseBeadJson(childResult.stdout);
-      const childStatus = (childBead?.status ?? '').toLowerCase();
-      if (!childStatus.includes('closed') && !childStatus.includes('done')) {
-        const msg = PR_MESSAGES.unclosedBead(childId, childBead?.status ?? 'unknown');
-        console.error(msg);
-        logger.writePhaseLog(PhaseName.PR, 'err', msg + '\n');
-        return { next: 'halt', ctx };
-      }
-    }
-  }
-
   // Step 2: Generate PR body (pure function)
   const generatedPrBody = prBody(bead.title ?? ctx.beadId, bead.description ?? '');
 
   // Step 3: Derive PR title
-  let prTitle: string;
-
-  if (isEpic) {
-    prTitle = derivePrTitleFromBead(bead.title ?? ctx.beadId, 'epic');
-  }
-  else {
-    prTitle = commitMsg(bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
-  }
+  const prTitle = commitMsg(bead.title ?? ctx.beadId, bead.issue_type ?? 'task');
 
   // Step 4: Submit branch via gt (pushes and creates the PR; command
   // conventions live in git-workflow/stacking.md, operations in helpers.ts).

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -6,7 +6,8 @@
  * for testing; pure functions have no I/O at all.
  *
  * Exports:
- *   CLI helpers: gitSafeToStart, preflight, bdTopReady, bdEscalate,
+ *   CLI helpers: gitSafeToStart, stackCreate, stackSubmit, syncAndRestack,
+ *                preflight, bdTopReady, bdEscalate,
  *                bdState, bdSizingCheck, bdEnrichmentCheck,
  *                discoverAgents
  *   Pure helpers: branchName, commitMsg, prBody,
@@ -38,6 +39,25 @@ export interface SpawnDeps {
 export interface GitSafeResult {
   ok: boolean;
   reason?: string;
+}
+
+export interface StackOpResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SyncAndRestackResult {
+  /** True when gt sync exited 0 and no branch hit a restack conflict. */
+  ok: boolean;
+  /** Branches gt restacked cleanly ("Restacked X on Y."). */
+  restacked: string[];
+  /** Branches skipped because their restack would conflict; resolve with `gt restack` from the checkout that holds them. */
+  conflicted: string[];
+  /** Branches gt skipped because they are checked out in another worktree; rerun sync/restack from that worktree. */
+  skippedWorktree: string[];
+  /** Combined raw stdout/stderr from gt sync, for diagnostics and reporting. */
+  rawOutput: string;
 }
 
 export interface PreflightFailure {
@@ -138,20 +158,31 @@ function run(
 // =============================================================================
 
 /**
- * Check that the working tree is clean and HEAD is current with origin/main.
+ * Check that the working tree is clean and HEAD is current with the base
+ * the next branch will be cut from.
  *
  *   - must be inside a git work tree
- *   - HEAD commit must equal origin/<mainBranch> (any branch name is fine)
+ *   - HEAD commit must equal the base ref (any branch name is fine)
  *   - working tree must be clean (git status --porcelain is empty)
  *
- * The "current with main" model (rather than "on main") supports worktree-based
+ * Without `parentBranch`, the base ref is `origin/<mainBranch>` — the
+ * "current with main" model (rather than "on main") supports worktree-based
  * workflows where each worktree's branch starts at origin/main and feature
  * branches are cut from there. The env var `GIT_SAFE_MAIN_BRANCH` still
  * configures the upstream branch name (default: `main`).
+ *
+ * With `parentBranch` (stacking case), HEAD is compared against the LOCAL
+ * parent branch tip — a mid-chain stack parent may not have been submitted
+ * yet, so it may not exist on origin at all. `origin/<mainBranch>` remains
+ * the comparison only for the trunk case.
  */
-export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
+export function gitSafeToStart(
+  parentBranch?: string,
+  deps: SpawnDeps = {},
+): GitSafeResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
   const mainBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+  const baseRef = parentBranch ?? `origin/${mainBranch}`;
 
   // Check inside work tree
   const insideRepo = run('git', ['rev-parse', '--is-inside-work-tree'], spawn);
@@ -159,22 +190,24 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
     return { ok: false, reason: 'not inside a git work tree' };
   }
 
-  // Check HEAD == origin/<mainBranch>
+  // Check HEAD == base ref
   const headSha = run('git', ['rev-parse', 'HEAD'], spawn);
   if (headSha.exitCode !== 0) {
     return { ok: false, reason: 'git rev-parse HEAD failed unexpectedly' };
   }
-  const baseSha = run('git', ['rev-parse', `origin/${mainBranch}`], spawn);
+  const baseSha = run('git', ['rev-parse', baseRef], spawn);
   if (baseSha.exitCode !== 0) {
     return {
       ok: false,
-      reason: `could not resolve origin/${mainBranch}; check remote access`,
+      reason: parentBranch
+        ? `could not resolve local parent branch ${parentBranch}`
+        : `could not resolve origin/${mainBranch}; check remote access`,
     };
   }
   if (headSha.stdout !== baseSha.stdout) {
     return {
       ok: false,
-      reason: `HEAD is not at origin/${mainBranch} (HEAD=${headSha.stdout.slice(0, 7)}, origin/${mainBranch}=${baseSha.stdout.slice(0, 7)})`,
+      reason: `HEAD is not at ${baseRef} (HEAD=${headSha.stdout.slice(0, 7)}, ${baseRef}=${baseSha.stdout.slice(0, 7)})`,
     };
   }
 
@@ -191,14 +224,121 @@ export function gitSafeToStart(deps: SpawnDeps = {}): GitSafeResult {
 }
 
 // =============================================================================
+// Graphite stack helpers
+// =============================================================================
+//
+// These three wrappers are the ONLY place gt operations are implemented
+// (anti-drift rule; conventions live in git-workflow/stacking.md). Command
+// shapes and output parsing are pinned to behavior observed on gt 1.8.6
+// (verified 2026-07-11).
+
+/**
+ * Create a stacked branch on top of `parent` via
+ * `gt create <branch> --onto <parent> --no-interactive`.
+ *
+ * `--onto` avoids checking out the parent first, which also sidesteps the
+ * untracked auto-generated branch a superset.sh-style worktree starts on.
+ * With a clean tree gt creates an empty branch (no commit), which is the
+ * expected pre-work state.
+ *
+ * PRECONDITION (not validated at runtime, asserted in tests): `branch` must
+ * be a branchName()-produced name. `parent` must be a gt-tracked branch
+ * (`main` or another stack level).
+ */
+export function stackCreate(
+  branch: string,
+  parent: string,
+  deps: SpawnDeps = {},
+): StackOpResult {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+  const result = run('gt', ['create', branch, '--onto', parent, '--no-interactive'], spawn);
+  return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
+}
+
+/**
+ * Submit a branch (and its downstack) via
+ * `gt submit --no-interactive --publish --branch <branch>`.
+ *
+ * `--publish` is load-bearing: on gt 1.8.6, `--no-interactive` creates new
+ * PRs in DRAFT mode unless `--publish` is passed, and the git-workflow skill
+ * forbids draft PRs. Title/body are canonicalized afterwards with
+ * `gh pr edit` (see git-workflow/stacking.md), so gt's own metadata prompts
+ * stay disabled.
+ */
+export function stackSubmit(branch: string, deps: SpawnDeps = {}): StackOpResult {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+  const result = run(
+    'gt',
+    ['submit', '--no-interactive', '--publish', '--branch', branch],
+    spawn,
+    { timeout: 120_000 },
+  );
+  return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
+}
+
+/**
+ * Run `gt sync -f --no-interactive` and report structured restack results.
+ *
+ * gt sync pulls trunk, deletes local branches whose PRs are merged/closed
+ * (`-f` skips the per-branch confirmation), and restacks every tracked
+ * branch it can. Branches that would conflict are SKIPPED with a warning —
+ * sync never leaves the repo mid-rebase — and branches checked out in
+ * another worktree are skipped with their own message (both observed on
+ * gt 1.8.6). Callers decide what to do with `conflicted` /
+ * `skippedWorktree`; this helper never attempts resolution.
+ */
+export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+  const result = run('gt', ['sync', '-f', '--no-interactive'], spawn, { timeout: 120_000 });
+  const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+
+  const restacked: string[] = [];
+  const conflicted: string[] = [];
+  const skippedWorktree: string[] = [];
+
+  for (const line of rawOutput.split('\n')) {
+    const clean = line.match(/^Restacked (\S+) on \S+\.$/);
+    if (clean) {
+      restacked.push(clean[1]);
+      continue;
+    }
+    const conflict = line.match(/^WARNING: (\S+) could not be restacked cleanly\.$/);
+    if (conflict) {
+      conflicted.push(conflict[1]);
+      continue;
+    }
+    const skipped = line.match(/^Did not restack branch (\S+) because it is checked out in worktree /);
+    if (skipped) {
+      skippedWorktree.push(skipped[1]);
+    }
+  }
+
+  return {
+    ok: result.exitCode === 0 && conflicted.length === 0,
+    restacked,
+    conflicted,
+    skippedWorktree,
+    rawOutput,
+  };
+}
+
+// =============================================================================
 // preflight
 // =============================================================================
 
 /**
  * Full preflight gate. Checks:
- *   - dirty_tree:     working tree has uncommitted changes
- *   - behind_main:    HEAD is not at origin/<mainBranch> (or fetch failed)
- *   - empty_backlog:  no ready beads excluding needs-human beads
+ *   - dirty_tree:              working tree has uncommitted changes
+ *   - behind_main:             HEAD is not at origin/<mainBranch> (or fetch failed)
+ *   - missing_gt:              the Graphite CLI (gt) is not installed
+ *   - gt_unauthenticated:      gt is installed but not authenticated
+ *   - gt_trunk_misconfigured:  gt's trunk is not <mainBranch>
+ *   - empty_backlog:           no ready beads excluding needs-human beads
+ *
+ * The gt failures are hard stops: all branch creation and PR submission goes
+ * through gt (git-workflow stacking.md), and there is deliberately no silent
+ * fallback to plain git. When gt itself is missing, the auth and trunk probes
+ * are skipped — they would only produce confusing follow-on noise.
  *
  * The branch name is not enforced: any branch is acceptable as long as HEAD
  * is at origin/main. This supports worktree workflows where each worktree's
@@ -240,6 +380,31 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
       failures.push({
         kind: 'behind_main',
         reason: `HEAD is not at origin/${mainBranch} (HEAD=${headSha.stdout.slice(0, 7)}, origin/${mainBranch}=${baseSha.stdout.slice(0, 7)}); pull, rebase, or check out a fresh branch from origin/${mainBranch}`,
+      });
+    }
+  }
+
+  // 3. Graphite CLI present, authenticated, trunk configured
+  const gtVersion = run('gt', ['--version'], spawn);
+  if (gtVersion.exitCode !== 0) {
+    failures.push({
+      kind: 'missing_gt',
+      reason: 'Graphite CLI (gt) not found; install gt and run `gt init` — all branch creation and PR submission goes through gt, with no plain-git fallback',
+    });
+  }
+  else {
+    const gtAuth = run('gt', ['auth', '--no-interactive'], spawn);
+    if (gtAuth.exitCode !== 0 || !gtAuth.stdout.includes('Authenticated as')) {
+      failures.push({
+        kind: 'gt_unauthenticated',
+        reason: 'gt is not authenticated; run `gt auth` interactively before autonomous work',
+      });
+    }
+    const gtTrunk = run('gt', ['trunk'], spawn);
+    if (gtTrunk.exitCode !== 0 || gtTrunk.stdout !== mainBranch) {
+      failures.push({
+        kind: 'gt_trunk_misconfigured',
+        reason: `gt trunk is not ${mainBranch} (got: ${gtTrunk.stdout || 'nothing'}); run \`gt init --trunk ${mainBranch}\``,
       });
     }
   }

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -344,6 +344,36 @@ export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
  * is at origin/main. This supports worktree workflows where each worktree's
  * branch starts at origin/main.
  */
+function checkGtPreflight(spawn: SpawnFn, mainBranch: string): PreflightFailure[] {
+  const failures: PreflightFailure[] = [];
+
+  const gtVersion = run('gt', ['--version'], spawn);
+  if (gtVersion.exitCode !== 0) {
+    failures.push({
+      kind: 'missing_gt',
+      reason: 'Graphite CLI (gt) not found; install gt and run `gt init` — all branch creation and PR submission goes through gt, with no plain-git fallback',
+    });
+    return failures;
+  }
+
+  const gtAuth = run('gt', ['auth', '--no-interactive'], spawn);
+  if (gtAuth.exitCode !== 0 || !gtAuth.stdout.includes('Authenticated as')) {
+    failures.push({
+      kind: 'gt_unauthenticated',
+      reason: 'gt is not authenticated; run `gt auth` interactively before autonomous work',
+    });
+  }
+  const gtTrunk = run('gt', ['trunk'], spawn);
+  if (gtTrunk.exitCode !== 0 || gtTrunk.stdout !== mainBranch) {
+    failures.push({
+      kind: 'gt_trunk_misconfigured',
+      reason: `gt trunk is not ${mainBranch} (got: ${gtTrunk.stdout || 'nothing'}); run \`gt init --trunk ${mainBranch}\``,
+    });
+  }
+
+  return failures;
+}
+
 export function preflight(deps: SpawnDeps = {}): PreflightResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
   const mainBranch = process.env.PREFLIGHT_MAIN_BRANCH ?? 'main';
@@ -385,29 +415,7 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
   }
 
   // 3. Graphite CLI present, authenticated, trunk configured
-  const gtVersion = run('gt', ['--version'], spawn);
-  if (gtVersion.exitCode !== 0) {
-    failures.push({
-      kind: 'missing_gt',
-      reason: 'Graphite CLI (gt) not found; install gt and run `gt init` — all branch creation and PR submission goes through gt, with no plain-git fallback',
-    });
-  }
-  else {
-    const gtAuth = run('gt', ['auth', '--no-interactive'], spawn);
-    if (gtAuth.exitCode !== 0 || !gtAuth.stdout.includes('Authenticated as')) {
-      failures.push({
-        kind: 'gt_unauthenticated',
-        reason: 'gt is not authenticated; run `gt auth` interactively before autonomous work',
-      });
-    }
-    const gtTrunk = run('gt', ['trunk'], spawn);
-    if (gtTrunk.exitCode !== 0 || gtTrunk.stdout !== mainBranch) {
-      failures.push({
-        kind: 'gt_trunk_misconfigured',
-        reason: `gt trunk is not ${mainBranch} (got: ${gtTrunk.stdout || 'nothing'}); run \`gt init --trunk ${mainBranch}\``,
-      });
-    }
-  }
+  failures.push(...checkGtPreflight(spawn, mainBranch));
 
   // 4. Backlog non-empty (excluding needs-human)
   const readyResult = run('bd', ['ready', `--limit=${readyLimit}`, '--json'], spawn);

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -10,7 +10,7 @@
  *                preflight, bdTopReady, bdEscalate,
  *                bdState, bdSizingCheck, bdEnrichmentCheck,
  *                discoverAgents
- *   Pure helpers: branchName, commitMsg, prBody,
+ *   Pure helpers: branchName, commitMsg, prBody, stackPlan,
  *                 classifyBeadState, classifySizing
  */
 
@@ -30,6 +30,13 @@ export type SpawnFn = typeof nodeSpawnSync;
 
 export interface SpawnDeps {
   spawnFn?: SpawnFn;
+  /**
+   * Working directory for spawned commands. Used by the gt stack helpers when
+   * a chain runs in its own git worktree (see git-workflow/stacking.md,
+   * "gt-in-worktrees"): gt operations must run from the checkout that holds
+   * the branch being operated on.
+   */
+  cwd?: string;
 }
 
 // =============================================================================
@@ -79,6 +86,7 @@ export interface BeadJson {
   parent?: string;
   dependencies?: BeadDependency[];
   dependents?: BeadDependency[];
+  children?: Array<{ id?: string }>;
   [key: string]: unknown;
 }
 
@@ -138,12 +146,13 @@ function run(
   cmd: string,
   args: string[],
   spawnFn: SpawnFn,
-  opts: { input?: string; timeout?: number } = {},
+  opts: { input?: string; timeout?: number; cwd?: string } = {},
 ): { stdout: string; stderr: string; exitCode: number } {
   const result = spawnFn(cmd, args, {
     encoding: 'buffer' as never,
     shell: true,
     timeout: opts.timeout ?? 30_000,
+    ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
     ...(opts.input !== undefined ? { input: Buffer.from(opts.input) } : {}),
   });
   return {
@@ -251,7 +260,7 @@ export function stackCreate(
   deps: SpawnDeps = {},
 ): StackOpResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
-  const result = run('gt', ['create', branch, '--onto', parent, '--no-interactive'], spawn);
+  const result = run('gt', ['create', branch, '--onto', parent, '--no-interactive'], spawn, { cwd: deps.cwd });
   return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
 }
 
@@ -271,7 +280,7 @@ export function stackSubmit(branch: string, deps: SpawnDeps = {}): StackOpResult
     'gt',
     ['submit', '--no-interactive', '--publish', '--branch', branch],
     spawn,
-    { timeout: 120_000 },
+    { timeout: 120_000, cwd: deps.cwd },
   );
   return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
 }
@@ -289,7 +298,7 @@ export function stackSubmit(branch: string, deps: SpawnDeps = {}): StackOpResult
  */
 export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
-  const result = run('gt', ['sync', '-f', '--no-interactive'], spawn, { timeout: 120_000 });
+  const result = run('gt', ['sync', '-f', '--no-interactive'], spawn, { timeout: 120_000, cwd: deps.cwd });
   const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
 
   const restacked: string[] = [];
@@ -1149,6 +1158,142 @@ export function prBody(
   ];
 
   return lines.join('\n');
+}
+
+// =============================================================================
+// stackPlan (pure)
+// =============================================================================
+
+/**
+ * A directed dependency edge between two sibling beads.
+ *
+ * `blocker` must complete before `blocked` can start (bd's "blocks"
+ * relationship, read from the blocked bead's `dependencies` array).
+ */
+export interface DependencyEdge {
+  /** The bead that must complete first. */
+  blocker: string;
+  /** The bead that is blocked until the blocker closes. */
+  blocked: string;
+  /**
+   * bd `dependency_type` for this edge. Only `'blocks'` edges participate in
+   * chain planning; anything else (e.g. `'parent-child'`) is ignored.
+   * Undefined is treated as `'blocks'`.
+   */
+  dependencyType?: string;
+}
+
+/**
+ * Result of stackPlan: an ordered forest of chains.
+ */
+export interface StackPlanResult {
+  /**
+   * Ordered forest of chains. Each chain is a linear blocker-first path
+   * (`chain[0]` has no in-set blocker; each subsequent bead is blocked by
+   * its predecessor). Independent beads are singleton chains.
+   */
+  chains: string[][];
+  /**
+   * True when the plan fell back to no-stack singletons because the edge
+   * graph was non-linear (cycle, fork, or join). A plan with no edges at
+   * all is NOT flat — it is a real plan that happens to have no stacking.
+   */
+  flat: boolean;
+  /** Human-readable reasons for a flat fallback (empty otherwise). */
+  warnings: string[];
+}
+
+/**
+ * Plan dependency-chain stacks for an epic's child beads. Pure function.
+ *
+ * Takes the sibling bead set and the "blocks" edges among them; returns an
+ * ordered forest of chains — the schedulable unit for wave orchestration
+ * (see git-workflow/stacking.md for the stacking conventions the chains
+ * feed). Edges referencing beads outside the sibling set, self-edges, and
+ * non-'blocks' edge types are ignored.
+ *
+ * Any non-linear structure — a cycle, a fork (one blocker with 2+ in-set
+ * dependents), or a join (one bead with 2+ in-set blockers) — falls back to
+ * a flat no-stack plan (every bead a singleton) with a warning for
+ * agent/human resolution. Output order is deterministic: chains appear in
+ * the input order of their head bead; within a chain, blocker-first.
+ *
+ * The dependency parameter is named `dependencyEdges`, never `deps` —
+ * `deps` is reserved codebase-wide for SpawnDeps injection.
+ */
+export function stackPlan(
+  beads: string[],
+  dependencyEdges: DependencyEdge[],
+): StackPlanResult {
+  const beadSet = new Set(beads);
+  const flatPlan = (warnings: string[]): StackPlanResult => ({
+    chains: beads.map(b => [b]),
+    flat: true,
+    warnings,
+  });
+
+  // Filter to in-set 'blocks' edges, dropping self-edges and duplicates.
+  const seen = new Set<string>();
+  const edges: Array<{ blocker: string; blocked: string }> = [];
+  for (const edge of dependencyEdges) {
+    if (edge.dependencyType !== undefined && edge.dependencyType !== 'blocks') continue;
+    if (!beadSet.has(edge.blocker) || !beadSet.has(edge.blocked)) continue;
+    if (edge.blocker === edge.blocked) continue;
+    const key = `${edge.blocker} ${edge.blocked}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    edges.push({ blocker: edge.blocker, blocked: edge.blocked });
+  }
+
+  // Successor / predecessor maps. Linearity requires at most one of each per bead.
+  const successor = new Map<string, string[]>();
+  const predecessor = new Map<string, string[]>();
+  for (const { blocker, blocked } of edges) {
+    successor.set(blocker, [...(successor.get(blocker) ?? []), blocked]);
+    predecessor.set(blocked, [...(predecessor.get(blocked) ?? []), blocker]);
+  }
+
+  const warnings: string[] = [];
+  for (const [blocker, blockedList] of successor) {
+    if (blockedList.length > 1) {
+      warnings.push(`fork at ${blocker}: blocks ${blockedList.join(', ')} — non-linear dependency graph, falling back to flat no-stack plan`);
+    }
+  }
+  for (const [blocked, blockerList] of predecessor) {
+    if (blockerList.length > 1) {
+      warnings.push(`join at ${blocked}: blocked by ${blockerList.join(', ')} — non-linear dependency graph, falling back to flat no-stack plan`);
+    }
+  }
+  if (warnings.length > 0) {
+    return flatPlan(warnings);
+  }
+
+  // Walk each chain from its head (a bead with no in-set blocker) following
+  // the unique successor. Chains are emitted in input order of their head.
+  const chains: string[][] = [];
+  const visited = new Set<string>();
+  for (const bead of beads) {
+    if (predecessor.has(bead)) continue; // mid-chain or tail — reached via its head
+    const chain: string[] = [];
+    let current: string | undefined = bead;
+    while (current !== undefined && !visited.has(current)) {
+      visited.add(current);
+      chain.push(current);
+      current = successor.get(current)?.[0];
+    }
+    chains.push(chain);
+  }
+
+  // Any edge-participating bead not reached from a head sits on a cycle
+  // (linear in/out degrees but no head to start from).
+  const unreached = beads.filter(b => !visited.has(b));
+  if (unreached.length > 0) {
+    return flatPlan([
+      `dependency cycle involving ${unreached.join(', ')} — falling back to flat no-stack plan`,
+    ]);
+  }
+
+  return { chains, flat: false, warnings: [] };
 }
 
 // =============================================================================

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -1239,7 +1239,7 @@ export function stackPlan(
     if (edge.dependencyType !== undefined && edge.dependencyType !== 'blocks') continue;
     if (!beadSet.has(edge.blocker) || !beadSet.has(edge.blocked)) continue;
     if (edge.blocker === edge.blocked) continue;
-    const key = `${edge.blocker} ${edge.blocked}`;
+    const key = `${edge.blocker}:${edge.blocked}`;
     if (seen.has(key)) continue;
     seen.add(key);
     edges.push({ blocker: edge.blocker, blocked: edge.blocked });

--- a/.claude/orchestrators/lib/helpers.ts
+++ b/.claude/orchestrators/lib/helpers.ts
@@ -31,10 +31,11 @@ export type SpawnFn = typeof nodeSpawnSync;
 export interface SpawnDeps {
   spawnFn?: SpawnFn;
   /**
-   * Working directory for spawned commands. Used by the gt stack helpers when
-   * a chain runs in its own git worktree (see git-workflow/stacking.md,
-   * "gt-in-worktrees"): gt operations must run from the checkout that holds
-   * the branch being operated on.
+   * Working directory for spawned commands. Used by the gh-stack helpers
+   * when a chain runs in its own git worktree (see git-workflow/stacking.md,
+   * "native gh-stack-in-worktrees" — decision memo D2): gh-stack state is a
+   * per-git-dir JSON file, NOT shared across worktrees, so stack operations
+   * must run from the checkout that holds the branch being operated on.
    */
   cwd?: string;
 }
@@ -55,15 +56,26 @@ export interface StackOpResult {
 }
 
 export interface SyncAndRestackResult {
-  /** True when gt sync exited 0 and no branch hit a restack conflict. */
+  /** True when `gh stack sync --prune` exited 0 (no rebase conflict, feature enabled). */
   ok: boolean;
-  /** Branches gt restacked cleanly ("Restacked X on Y."). */
-  restacked: string[];
-  /** Branches skipped because their restack would conflict; resolve with `gt restack` from the checkout that holds them. */
-  conflicted: string[];
-  /** Branches gt skipped because they are checked out in another worktree; rerun sync/restack from that worktree. */
-  skippedWorktree: string[];
-  /** Combined raw stdout/stderr from gt sync, for diagnostics and reporting. */
+  /**
+   * Raw exit code from `gh stack sync --prune`. gh-stack reports structured
+   * exit codes rather than the per-branch text gt produced: 3 = rebase
+   * conflict, 9 = feature disabled for this repo. Callers key off this
+   * directly rather than parsed per-branch messages (unverified for
+   * gh-stack — see `conflicted`/`featureDisabled` below).
+   */
+  exitCode: number;
+  /** True when the sync hit a rebase conflict (exit code 3). */
+  conflicted: boolean;
+  /**
+   * True when the private-preview feature is disabled for this repo (exit
+   * code 9). Per decision memo D5, this is a clean hard stop — `submit`/
+   * `sync` either fully succeed or wholesale refuse; there is no partial or
+   * corrupted state to recover from.
+   */
+  featureDisabled: boolean;
+  /** Combined raw stdout/stderr from the sync command, for diagnostics and reporting. */
   rawOutput: string;
 }
 
@@ -233,100 +245,172 @@ export function gitSafeToStart(
 }
 
 // =============================================================================
-// Graphite stack helpers
+// gh-stack helpers
 // =============================================================================
 //
-// These three wrappers are the ONLY place gt operations are implemented
+// These wrappers are the ONLY place gh-stack operations are implemented
 // (anti-drift rule; conventions live in git-workflow/stacking.md). Command
-// shapes and output parsing are pinned to behavior observed on gt 1.8.6
-// (verified 2026-07-11).
+// shapes are pinned to behavior observed on gh-stack 0.0.8 (spike verified
+// 2026-07-21; see the gh-stack verification spike report and decision memo).
+//
+// Tool surface (decision 5 / decision memo D2): a stack exists only for
+// dependency chains of 2+ beads or Stage-3 splits; independent single beads
+// never touch gh-stack — they use plain git + gh. `chained` (sourced from a
+// stackPlan() chain's length) is what lets stackCreate/stackSubmit route
+// correctly, since both a chain head and a single bead have `parent = trunk`
+// and cannot be told apart from `parent` alone.
 
 /**
- * Create a stacked branch on top of `parent` via
- * `gt create <branch> --onto <parent> --no-interactive`.
+ * Create a branch for one stack level (or a plain single-bead branch).
  *
- * `--onto` avoids checking out the parent first, which also sidesteps the
- * untracked auto-generated branch a superset.sh-style worktree starts on.
- * With a clean tree gt creates an empty branch (no commit), which is the
- * expected pre-work state.
+ * Routing (decision 5 / spec section 2):
+ *   - `parent` is a previously-created stack level (never trunk) → mid-chain:
+ *     `gh stack add <branch>`. `gh stack add` has no `--base` flag (spike
+ *     divergence #4) — it always adds on top of whatever is currently
+ *     checked out.
+ *   - `parent === trunk && chained` → chain head: `gh stack init --base
+ *     <parent> <branch>` starts a new stack. `--base` is passed explicitly
+ *     (rather than relying on gh-stack's own default) so a non-default
+ *     `GIT_SAFE_MAIN_BRANCH` is honored, matching gitSafeToStart.
+ *   - `parent === trunk && !chained` → single, unstacked bead: plain
+ *     `git checkout -b <branch> <parent>`, no gh-stack involvement.
  *
- * PRECONDITION (not validated at runtime, asserted in tests): `branch` must
- * be a branchName()-produced name. `parent` must be a gt-tracked branch
- * (`main` or another stack level).
+ * PRECONDITIONS (not validated at runtime, asserted in tests):
+ *   - `branch` must be a branchName()-produced name.
+ *   - For the mid-chain case, `parent` must be the current stack top AND
+ *     currently checked out — the orchestrator's sequential-within-chain
+ *     scheduling guarantees this (`gh stack add` requires it; spike
+ *     divergence #4).
  */
 export function stackCreate(
   branch: string,
   parent: string,
+  chained: boolean,
   deps: SpawnDeps = {},
 ): StackOpResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
-  const result = run('gt', ['create', branch, '--onto', parent, '--no-interactive'], spawn, { cwd: deps.cwd });
+  const mainBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+
+  if (parent !== mainBranch) {
+    const result = run('gh', ['stack', 'add', branch], spawn, { cwd: deps.cwd });
+    return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
+  }
+
+  if (chained) {
+    const result = run('gh', ['stack', 'init', '--base', parent, branch], spawn, { cwd: deps.cwd });
+    return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
+  }
+
+  const result = run('git', ['checkout', '-b', branch, parent], spawn, { cwd: deps.cwd });
   return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
 }
 
 /**
- * Submit a branch (and its downstack) via
- * `gt submit --no-interactive --publish --branch <branch>`.
+ * Submit a stack level (or a single-bead branch) and open/update its PR.
  *
- * `--publish` is load-bearing: on gt 1.8.6, `--no-interactive` creates new
- * PRs in DRAFT mode unless `--publish` is passed, and the git-workflow skill
- * forbids draft PRs. Title/body are canonicalized afterwards with
- * `gh pr edit` (see git-workflow/stacking.md), so gt's own metadata prompts
- * stay disabled.
- */
-export function stackSubmit(branch: string, deps: SpawnDeps = {}): StackOpResult {
-  const spawn = deps.spawnFn ?? nodeSpawnSync;
-  const result = run(
-    'gt',
-    ['submit', '--no-interactive', '--publish', '--branch', branch],
-    spawn,
-    { timeout: 120_000, cwd: deps.cwd },
-  );
-  return { ok: result.exitCode === 0, stdout: result.stdout, stderr: result.stderr };
-}
-
-/**
- * Run `gt sync -f --no-interactive` and report structured restack results.
+ * Chains (`chained = true`): `gh stack submit --auto --open`. `--auto` skips
+ * gh-stack's interactive editor; `--auto` alone creates new PRs as DRAFTS
+ * (spike-confirmed), which violates the standing no-draft-PRs convention, so
+ * `--open` is passed to suppress that. Title/body are canonicalized
+ * afterwards with `gh pr edit` by the caller (gh-stack submit is
+ * spike-confirmed idempotent and non-clobbering of `gh pr edit` changes
+ * across re-submits).
  *
- * gt sync pulls trunk, deletes local branches whose PRs are merged/closed
- * (`-f` skips the per-branch confirmation), and restacks every tracked
- * branch it can. Branches that would conflict are SKIPPED with a warning —
- * sync never leaves the repo mid-rebase — and branches checked out in
- * another worktree are skipped with their own message (both observed on
- * gt 1.8.6). Callers decide what to do with `conflicted` /
- * `skippedWorktree`; this helper never attempts resolution.
+ * `--open`'s behavior on a RE-submit (PRs that already exist) was not
+ * exercised by the spike — only PR *creation* was. As a safe interim
+ * (decision memo D3), pair `--open` with a `gh pr ready` sweep over every PR
+ * currently in the stack (via `gh stack view --json`); `gh pr ready` is a
+ * no-op on an already-ready PR, so the sweep cannot violate the no-draft
+ * invariant, only backstop it. Drop the sweep once `--open` is proven
+ * reliable on re-submits.
+ *
+ * Singles (`chained = false`): plain `git push -u origin <branch>` followed
+ * by `gh pr create --fill`. `--fill` (commit subject/body) is sufficient
+ * because the caller overwrites title/body via `gh pr edit` immediately
+ * after, exactly like the chain path.
  */
-export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
+export function stackSubmit(
+  branch: string,
+  chained: boolean,
+  deps: SpawnDeps = {},
+): StackOpResult {
   const spawn = deps.spawnFn ?? nodeSpawnSync;
-  const result = run('gt', ['sync', '-f', '--no-interactive'], spawn, { timeout: 120_000, cwd: deps.cwd });
-  const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
 
-  const restacked: string[] = [];
-  const conflicted: string[] = [];
-  const skippedWorktree: string[] = [];
+  if (!chained) {
+    const pushResult = run('git', ['push', '-u', 'origin', branch], spawn, { timeout: 60_000, cwd: deps.cwd });
+    if (pushResult.exitCode !== 0) {
+      return { ok: false, stdout: pushResult.stdout, stderr: pushResult.stderr };
+    }
+    const createResult = run('gh', ['pr', 'create', '--fill'], spawn, { timeout: 60_000, cwd: deps.cwd });
+    return {
+      ok: createResult.exitCode === 0,
+      stdout: [pushResult.stdout, createResult.stdout].filter(Boolean).join('\n'),
+      stderr: [pushResult.stderr, createResult.stderr].filter(Boolean).join('\n'),
+    };
+  }
 
-  for (const line of rawOutput.split('\n')) {
-    const clean = line.match(/^Restacked (\S+) on \S+\.$/);
-    if (clean) {
-      restacked.push(clean[1]);
-      continue;
+  const submitResult = run('gh', ['stack', 'submit', '--auto', '--open'], spawn, { timeout: 120_000, cwd: deps.cwd });
+  if (submitResult.exitCode !== 0) {
+    return { ok: false, stdout: submitResult.stdout, stderr: submitResult.stderr };
+  }
+
+  // D3 safe-interim sweep — see docstring above for the trim condition.
+  const sweepErrors: string[] = [];
+  const viewResult = run('gh', ['stack', 'view', '--json'], spawn, { timeout: 30_000, cwd: deps.cwd });
+  if (viewResult.exitCode === 0 && viewResult.stdout) {
+    try {
+      const parsed = JSON.parse(viewResult.stdout) as { branches?: Array<{ pr?: { number?: number } }> };
+      const prNumbers = (parsed.branches ?? [])
+        .map(b => b.pr?.number)
+        .filter((n): n is number => typeof n === 'number');
+      for (const prNumber of prNumbers) {
+        const readyResult = run('gh', ['pr', 'ready', String(prNumber)], spawn, { timeout: 30_000, cwd: deps.cwd });
+        if (readyResult.exitCode !== 0) sweepErrors.push(readyResult.stderr);
+      }
     }
-    const conflict = line.match(/^WARNING: (\S+) could not be restacked cleanly\.$/);
-    if (conflict) {
-      conflicted.push(conflict[1]);
-      continue;
+    catch {
+      sweepErrors.push('gh stack view --json unparseable; skipped gh pr ready sweep');
     }
-    const skipped = line.match(/^Did not restack branch (\S+) because it is checked out in worktree /);
-    if (skipped) {
-      skippedWorktree.push(skipped[1]);
-    }
+  }
+  else {
+    sweepErrors.push('gh stack view --json failed; skipped gh pr ready sweep');
   }
 
   return {
-    ok: result.exitCode === 0 && conflicted.length === 0,
-    restacked,
-    conflicted,
-    skippedWorktree,
+    ok: true,
+    stdout: submitResult.stdout,
+    stderr: [submitResult.stderr, ...sweepErrors].filter(Boolean).join('\n'),
+  };
+}
+
+/**
+ * Run `gh stack sync --prune` and report structured results keyed off
+ * gh-stack's exit codes (decision memo D5's clean-hard-stop model, not
+ * gt's per-branch text parsing — gh-stack's sync output shape was not
+ * captured in enough detail by the spike to parse robustly, and exit codes
+ * are the documented structured-automation surface per the spec's Tool
+ * model).
+ *
+ * `--prune` performs the full local catch-up ritual: fetch → reconcile →
+ * trunk update → cascade rebase → push → PR sync → prune merged branches
+ * (see git-workflow/stacking.md).
+ *
+ * Exit 3 = rebase conflict (`conflicted: true`). Exit 9 = the private-
+ * preview feature is disabled for this repo (`featureDisabled: true`) — per
+ * D5, this is a clean, pre-merge hard stop, never partial or corrupted
+ * state. Callers decide what to do with either; this helper never attempts
+ * resolution.
+ */
+export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
+  const spawn = deps.spawnFn ?? nodeSpawnSync;
+  const result = run('gh', ['stack', 'sync', '--prune'], spawn, { timeout: 120_000, cwd: deps.cwd });
+  const rawOutput = [result.stdout, result.stderr].filter(Boolean).join('\n');
+
+  return {
+    ok: result.exitCode === 0,
+    exitCode: result.exitCode,
+    conflicted: result.exitCode === 3,
+    featureDisabled: result.exitCode === 9,
     rawOutput,
   };
 }
@@ -337,46 +421,50 @@ export function syncAndRestack(deps: SpawnDeps = {}): SyncAndRestackResult {
 
 /**
  * Full preflight gate. Checks:
- *   - dirty_tree:              working tree has uncommitted changes
- *   - behind_main:             HEAD is not at origin/<mainBranch> (or fetch failed)
- *   - missing_gt:              the Graphite CLI (gt) is not installed
- *   - gt_unauthenticated:      gt is installed but not authenticated
- *   - gt_trunk_misconfigured:  gt's trunk is not <mainBranch>
- *   - empty_backlog:           no ready beads excluding needs-human beads
+ *   - dirty_tree:            working tree has uncommitted changes
+ *   - behind_main:           HEAD is not at origin/<mainBranch> (or fetch failed)
+ *   - missing_gh_stack:      the gh-stack extension is not installed
+ *   - gh_unauthenticated:    gh is installed but not authenticated
+ *   - empty_backlog:         no ready beads excluding needs-human beads
  *
- * The gt failures are hard stops: all branch creation and PR submission goes
- * through gt (git-workflow stacking.md), and there is deliberately no silent
- * fallback to plain git. When gt itself is missing, the auth and trunk probes
- * are skipped — they would only produce confusing follow-on noise.
+ * Per decision memo D5, this is deliberately a two-tier design: only CHEAP,
+ * LOCAL hard-gates run every preflight (extension present, gh authenticated).
+ * There is no confirmed cheap read-only probe for gh-stack's private-preview
+ * repo enablement — `gh stack view`/`--json` are local-only and cannot
+ * detect it, and the only operation that reliably surfaces enablement
+ * (`gh stack submit`) mutates the repo (creates real PRs), so it is not safe
+ * as a per-run probe. Enablement is instead treated as a one-shot,
+ * cutover-time fact, with the first real stackSubmit()'s exit-9 acting as a
+ * fail-safe runtime detector — a clean, pre-merge hard stop (see helpers.ts
+ * syncAndRestack / stackSubmit and stacking.md).
+ *
+ * The gh-stack failures below are hard stops: chain branch creation and PR
+ * submission go through gh-stack (git-workflow stacking.md), and there is
+ * deliberately no silent fallback to plain git for chain work. When the
+ * extension itself is missing, the auth probe is skipped — it would only
+ * produce confusing follow-on noise.
  *
  * The branch name is not enforced: any branch is acceptable as long as HEAD
  * is at origin/main. This supports worktree workflows where each worktree's
  * branch starts at origin/main.
  */
-function checkGtPreflight(spawn: SpawnFn, mainBranch: string): PreflightFailure[] {
+function checkGhStackPreflight(spawn: SpawnFn): PreflightFailure[] {
   const failures: PreflightFailure[] = [];
 
-  const gtVersion = run('gt', ['--version'], spawn);
-  if (gtVersion.exitCode !== 0) {
+  const ghStackVersion = run('gh', ['stack', '--version'], spawn);
+  if (ghStackVersion.exitCode !== 0) {
     failures.push({
-      kind: 'missing_gt',
-      reason: 'Graphite CLI (gt) not found; install gt and run `gt init` — all branch creation and PR submission goes through gt, with no plain-git fallback',
+      kind: 'missing_gh_stack',
+      reason: 'gh-stack extension not found; install it (gh extension install github/gh-stack) — chain branch creation and PR submission go through gh stack, with no plain-git fallback for chain work',
     });
     return failures;
   }
 
-  const gtAuth = run('gt', ['auth', '--no-interactive'], spawn);
-  if (gtAuth.exitCode !== 0 || !gtAuth.stdout.includes('Authenticated as')) {
+  const ghAuth = run('gh', ['auth', 'status'], spawn);
+  if (ghAuth.exitCode !== 0) {
     failures.push({
-      kind: 'gt_unauthenticated',
-      reason: 'gt is not authenticated; run `gt auth` interactively before autonomous work',
-    });
-  }
-  const gtTrunk = run('gt', ['trunk'], spawn);
-  if (gtTrunk.exitCode !== 0 || gtTrunk.stdout !== mainBranch) {
-    failures.push({
-      kind: 'gt_trunk_misconfigured',
-      reason: `gt trunk is not ${mainBranch} (got: ${gtTrunk.stdout || 'nothing'}); run \`gt init --trunk ${mainBranch}\``,
+      kind: 'gh_unauthenticated',
+      reason: 'gh is not authenticated; run `gh auth login` before autonomous work',
     });
   }
 
@@ -423,8 +511,8 @@ export function preflight(deps: SpawnDeps = {}): PreflightResult {
     }
   }
 
-  // 3. Graphite CLI present, authenticated, trunk configured
-  failures.push(...checkGtPreflight(spawn, mainBranch));
+  // 3. gh-stack extension present and gh authenticated
+  failures.push(...checkGhStackPreflight(spawn));
 
   // 4. Backlog non-empty (excluding needs-human)
   const readyResult = run('bd', ['ready', `--limit=${readyLimit}`, '--json'], spawn);

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -32,6 +32,7 @@ import {
   bdEscalate,
   bdCreateFollowup,
   branchName,
+  stackCreate,
   checkEpicPromotion,
   discoverAgents,
   type StateVerdict,
@@ -1401,12 +1402,23 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
     return { next: 'halt', ctx };
   }
 
-  // Step 5: Create branch if not already on it
-  if (currentCmd.stdout !== derivedBranchName) {
-    const checkoutCmd = spawnCmd('git', ['checkout', '-b', derivedBranchName], logger, PhaseName.Branch, spawn);
+  // Step 5: Create branch if not already on it.
+  //
+  // Epics skip branch creation entirely: chain levels create their own
+  // stacked branches inside the wave loop via stackCreate (see
+  // git-workflow/stacking.md and execute.ts runEpicExecution). A single
+  // epic-wide branch would sit empty and untracked by any PR.
+  if (issueType === 'epic') {
+    logger.appendRunJson({
+      event: 'branch_skipped_epic',
+      beadId: ctx.beadId,
+    });
+  }
+  else if (currentCmd.stdout !== derivedBranchName) {
+    const createResult = stackCreate(derivedBranchName, 'main', { spawnFn: spawn });
 
-    if (checkoutCmd.exitCode !== 0) {
-      const msg = `git checkout -b "${derivedBranchName}" failed: ${checkoutCmd.stderr.trim()}`;
+    if (!createResult.ok) {
+      const msg = `gt create "${derivedBranchName}" --onto main failed: ${createResult.stderr.trim()}`;
       console.error(msg);
       logger.writePhaseLog(PhaseName.Branch, 'err', msg + '\n');
       return { next: 'halt', ctx };

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -147,12 +147,10 @@ export const PREFLIGHT_MESSAGES: Record<string, string> = {
     'HEAD is not at origin/main \u2014 pull, rebase, or check out a fresh branch from origin/main before re-running /process-backlog.',
   empty_backlog:
     'No ready beads available (or every ready bead is labelled `needs-human`) \u2014 shape or unlabel a bead before re-running /process-backlog.',
-  missing_gt:
-    'Graphite CLI (gt) not found \u2014 install gt and run `gt init`; branch creation and PR submission go through gt with no plain-git fallback.',
-  gt_unauthenticated:
-    'gt is not authenticated \u2014 run `gt auth` interactively before re-running /process-backlog.',
-  gt_trunk_misconfigured:
-    'gt trunk is not configured to main \u2014 run `gt init --trunk main` before re-running /process-backlog.',
+  missing_gh_stack:
+    'gh-stack extension not found \u2014 install it (`gh extension install github/gh-stack`); chain branch creation and PR submission go through gh stack with no plain-git fallback for chain work.',
+  gh_unauthenticated:
+    'gh is not authenticated \u2014 run `gh auth login` before re-running /process-backlog.',
 };
 
 export const GIT_SAFE_MESSAGES: Record<number, string> = {
@@ -1418,10 +1416,13 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
     // Same main-branch override the other git probes honor (gitSafeToStart,
     // verification gate, preflight).
     const mainBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
-    const createResult = stackCreate(derivedBranchName, mainBranch, { spawnFn: spawn });
+    // This phase only ever runs for a single, standalone leaf bead — chain
+    // levels create their own stacked branches inside the wave loop (see the
+    // comment above). `chained` is therefore always false here.
+    const createResult = stackCreate(derivedBranchName, mainBranch, false, { spawnFn: spawn });
 
     if (!createResult.ok) {
-      const msg = `gt create "${derivedBranchName}" --onto ${mainBranch} failed: ${createResult.stderr.trim()}`;
+      const msg = `git checkout -b "${derivedBranchName}" ${mainBranch} failed: ${createResult.stderr.trim()}`;
       console.error(msg);
       logger.writePhaseLog(PhaseName.Branch, 'err', msg + '\n');
       return { next: 'halt', ctx };

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -146,6 +146,12 @@ export const PREFLIGHT_MESSAGES: Record<string, string> = {
     'HEAD is not at origin/main \u2014 pull, rebase, or check out a fresh branch from origin/main before re-running /process-backlog.',
   empty_backlog:
     'No ready beads available (or every ready bead is labelled `needs-human`) \u2014 shape or unlabel a bead before re-running /process-backlog.',
+  missing_gt:
+    'Graphite CLI (gt) not found \u2014 install gt and run `gt init`; branch creation and PR submission go through gt with no plain-git fallback.',
+  gt_unauthenticated:
+    'gt is not authenticated \u2014 run `gt auth` interactively before re-running /process-backlog.',
+  gt_trunk_misconfigured:
+    'gt trunk is not configured to main \u2014 run `gt init --trunk main` before re-running /process-backlog.',
 };
 
 export const GIT_SAFE_MESSAGES: Record<number, string> = {
@@ -981,7 +987,7 @@ export async function preflight(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Ph
   }
 
   // Step 2: Git safety check
-  const gitSafe = gitSafeToStart({ spawnFn: deps.spawnFn });
+  const gitSafe = gitSafeToStart(undefined, { spawnFn: deps.spawnFn });
   if (!gitSafe.ok) {
     const msg = gitSafe.reason ?? 'git safety check failed';
     console.error(msg);
@@ -1351,7 +1357,7 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
   });
 
   // Step 1: Safety re-check
-  const gitSafe = gitSafeToStart({ spawnFn: deps.spawnFn });
+  const gitSafe = gitSafeToStart(undefined, { spawnFn: deps.spawnFn });
   if (!gitSafe.ok) {
     const msg = `UNSAFE: git-safe-to-start failed \u2014 ${gitSafe.reason ?? 'working tree is dirty or not on main'}`;
     console.error(msg);

--- a/.claude/orchestrators/lib/phases.ts
+++ b/.claude/orchestrators/lib/phases.ts
@@ -1415,10 +1415,13 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
     });
   }
   else if (currentCmd.stdout !== derivedBranchName) {
-    const createResult = stackCreate(derivedBranchName, 'main', { spawnFn: spawn });
+    // Same main-branch override the other git probes honor (gitSafeToStart,
+    // verification gate, preflight).
+    const mainBranch = process.env.GIT_SAFE_MAIN_BRANCH ?? 'main';
+    const createResult = stackCreate(derivedBranchName, mainBranch, { spawnFn: spawn });
 
     if (!createResult.ok) {
-      const msg = `gt create "${derivedBranchName}" --onto main failed: ${createResult.stderr.trim()}`;
+      const msg = `gt create "${derivedBranchName}" --onto ${mainBranch} failed: ${createResult.stderr.trim()}`;
       console.error(msg);
       logger.writePhaseLog(PhaseName.Branch, 'err', msg + '\n');
       return { next: 'halt', ctx };
@@ -1427,7 +1430,7 @@ export async function branch(ctx: PhaseCtx, deps: PhaseDeps = {}): Promise<Phase
     logger.appendRunJson({
       event: 'branch_created',
       branchName: derivedBranchName,
-      baseBranch: 'main',
+      baseBranch: mainBranch,
     });
   }
   else {

--- a/.claude/orchestrators/lib/types.ts
+++ b/.claude/orchestrators/lib/types.ts
@@ -88,6 +88,12 @@ export interface WaveState {
   epicId: string;
   /** 1-indexed wave number. */
   waveNumber: number;
+  /**
+   * Dependency chains scheduled in this wave (see helpers.ts stackPlan).
+   * Each chain is a blocker-first bead-id path; the 3-implementer cap
+   * applies to chains, and within a chain beads run sequentially.
+   */
+  chains: string[][];
   /** Bead IDs currently being implemented (in-flight). */
   beadsInProgress: string[];
   /** Bead IDs that have been closed in this wave. */

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -101,21 +101,6 @@ describe('Integration: leaf happy path', () => {
     });
 
     // ---------------------------------------------------------------------------
-    // Unified gt handler
-    // Covers the preflight Graphite probes (gt --version, gt auth, gt trunk),
-    // the branch phase's gt create, and the PR phase's gt submit.
-    // ---------------------------------------------------------------------------
-    scripts.on('gt', (args) => {
-      const a = args.join(' ');
-      if (a.includes('--version')) return { exitCode: 0, stdout: '1.8.6', stderr: '' };
-      if (a.includes('auth')) return { exitCode: 0, stdout: 'Authenticated as: testuser', stderr: '' };
-      if (a.includes('trunk')) return { exitCode: 0, stdout: 'main', stderr: '' };
-      if (a.includes('create')) return { exitCode: 0, stdout: '', stderr: '' };
-      if (a.includes('submit')) return { exitCode: 0, stdout: '✅ Submitted.', stderr: '' };
-      return { exitCode: 0, stdout: '', stderr: '' };
-    });
-
-    // ---------------------------------------------------------------------------
     // Unified bd handler
     // Covers all bd calls across all phases.
     // ---------------------------------------------------------------------------
@@ -173,10 +158,15 @@ describe('Integration: leaf happy path', () => {
     });
 
     // ---------------------------------------------------------------------------
-    // gh handler (for PR phase): pr view resolves number/url, pr edit succeeds
+    // gh handler: preflight's gh-stack probes (D5: gh stack --version,
+    // gh auth status), and the PR phase's plain `gh pr create --fill` +
+    // `gh pr view` (this leaf bead is a single, chained=false, so PR
+    // submission never touches gh-stack) + `gh pr edit`.
     // ---------------------------------------------------------------------------
     scripts.on('gh', (args) => {
       const a = args.join(' ');
+      if (a.includes('stack --version')) return { exitCode: 0, stdout: 'gh stack version 0.0.8', stderr: '' };
+      if (a.includes('auth status')) return { exitCode: 0, stdout: 'Logged in to github.com as testuser', stderr: '' };
       if (a.includes('view')) {
         return {
           exitCode: 0,

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -97,23 +97,21 @@ describe('Integration: leaf happy path', () => {
       }
       // preflight fetch
       if (a.includes('fetch origin')) return { exitCode: 0, stdout: '', stderr: '' };
-      // branch phase: checkout
-      if (a.includes('checkout')) return { exitCode: 0, stdout: '', stderr: '' };
-      // PR phase: push
-      if (a.includes('push')) return { exitCode: 0, stdout: '', stderr: '' };
-
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
     // ---------------------------------------------------------------------------
     // Unified gt handler
-    // Covers the preflight Graphite probes: gt --version, gt auth, gt trunk.
+    // Covers the preflight Graphite probes (gt --version, gt auth, gt trunk),
+    // the branch phase's gt create, and the PR phase's gt submit.
     // ---------------------------------------------------------------------------
     scripts.on('gt', (args) => {
       const a = args.join(' ');
       if (a.includes('--version')) return { exitCode: 0, stdout: '1.8.6', stderr: '' };
       if (a.includes('auth')) return { exitCode: 0, stdout: 'Authenticated as: testuser', stderr: '' };
       if (a.includes('trunk')) return { exitCode: 0, stdout: 'main', stderr: '' };
+      if (a.includes('create')) return { exitCode: 0, stdout: '', stderr: '' };
+      if (a.includes('submit')) return { exitCode: 0, stdout: '✅ Submitted.', stderr: '' };
       return { exitCode: 0, stdout: '', stderr: '' };
     });
 
@@ -175,13 +173,19 @@ describe('Integration: leaf happy path', () => {
     });
 
     // ---------------------------------------------------------------------------
-    // gh handler (for PR phase)
+    // gh handler (for PR phase): pr view resolves number/url, pr edit succeeds
     // ---------------------------------------------------------------------------
-    scripts.on('gh', () => ({
-      exitCode: 0,
-      stdout: 'https://github.com/org/repo/pull/42',
-      stderr: '',
-    }));
+    scripts.on('gh', (args) => {
+      const a = args.join(' ');
+      if (a.includes('view')) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ number: 42, url: 'https://github.com/org/repo/pull/42' }),
+          stderr: '',
+        };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
 
     // --- Dispatch routes ---
     // Implementer returns empty (success = no error thrown)

--- a/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
+++ b/.claude/orchestrators/test/integration/leaf-happy-path.test.ts
@@ -106,6 +106,18 @@ describe('Integration: leaf happy path', () => {
     });
 
     // ---------------------------------------------------------------------------
+    // Unified gt handler
+    // Covers the preflight Graphite probes: gt --version, gt auth, gt trunk.
+    // ---------------------------------------------------------------------------
+    scripts.on('gt', (args) => {
+      const a = args.join(' ');
+      if (a.includes('--version')) return { exitCode: 0, stdout: '1.8.6', stderr: '' };
+      if (a.includes('auth')) return { exitCode: 0, stdout: 'Authenticated as: testuser', stderr: '' };
+      if (a.includes('trunk')) return { exitCode: 0, stdout: 'main', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    // ---------------------------------------------------------------------------
     // Unified bd handler
     // Covers all bd calls across all phases.
     // ---------------------------------------------------------------------------

--- a/.claude/orchestrators/test/integration/safeguards.test.ts
+++ b/.claude/orchestrators/test/integration/safeguards.test.ts
@@ -87,6 +87,30 @@ function mountPassingPreflight(scripts: ScriptRouter, beadId = 'pv-test.1'): voi
     }
     return { exitCode: 0, stdout: '', stderr: '' };
   });
+
+  mountPassingGt(scripts);
+}
+
+/**
+ * Mount passing Graphite CLI probes on a ScriptRouter.
+ *
+ * Covers the gt calls made by runPreflightCheck(): gt --version,
+ * gt auth --no-interactive, gt trunk.
+ */
+function mountPassingGt(scripts: ScriptRouter): void {
+  scripts.on('gt', (args) => {
+    const argStr = args.join(' ');
+    if (argStr.includes('--version')) {
+      return { exitCode: 0, stdout: '1.8.6', stderr: '' };
+    }
+    if (argStr.includes('auth')) {
+      return { exitCode: 0, stdout: 'Authenticated as: testuser', stderr: '' };
+    }
+    if (argStr.includes('trunk')) {
+      return { exitCode: 0, stdout: 'main', stderr: '' };
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  });
 }
 
 describe('Integration: safeguards', () => {
@@ -129,6 +153,7 @@ describe('Integration: safeguards', () => {
   it('should halt on empty backlog (exhausted)', async () => {
     // Preflight passes, but bdTopReady returns empty list
     let prefCalls = 0;
+    mountPassingGt(scripts);
     scripts.on('git', (args) => {
       const a = args.join(' ');
       if (a.includes('status --porcelain')) return { exitCode: 0, stdout: '', stderr: '' };

--- a/.claude/orchestrators/test/integration/safeguards.test.ts
+++ b/.claude/orchestrators/test/integration/safeguards.test.ts
@@ -88,26 +88,23 @@ function mountPassingPreflight(scripts: ScriptRouter, beadId = 'pv-test.1'): voi
     return { exitCode: 0, stdout: '', stderr: '' };
   });
 
-  mountPassingGt(scripts);
+  mountPassingGhStack(scripts);
 }
 
 /**
- * Mount passing Graphite CLI probes on a ScriptRouter.
+ * Mount passing gh-stack preflight probes on a ScriptRouter.
  *
- * Covers the gt calls made by runPreflightCheck(): gt --version,
- * gt auth --no-interactive, gt trunk.
+ * Covers the gh calls made by runPreflightCheck() (D5: two cheap local
+ * hard-gates only): gh stack --version, gh auth status.
  */
-function mountPassingGt(scripts: ScriptRouter): void {
-  scripts.on('gt', (args) => {
+function mountPassingGhStack(scripts: ScriptRouter): void {
+  scripts.on('gh', (args) => {
     const argStr = args.join(' ');
-    if (argStr.includes('--version')) {
-      return { exitCode: 0, stdout: '1.8.6', stderr: '' };
+    if (argStr.includes('stack --version')) {
+      return { exitCode: 0, stdout: 'gh stack version 0.0.8', stderr: '' };
     }
-    if (argStr.includes('auth')) {
-      return { exitCode: 0, stdout: 'Authenticated as: testuser', stderr: '' };
-    }
-    if (argStr.includes('trunk')) {
-      return { exitCode: 0, stdout: 'main', stderr: '' };
+    if (argStr.includes('auth status')) {
+      return { exitCode: 0, stdout: 'Logged in to github.com as testuser', stderr: '' };
     }
     return { exitCode: 0, stdout: '', stderr: '' };
   });
@@ -153,7 +150,7 @@ describe('Integration: safeguards', () => {
   it('should halt on empty backlog (exhausted)', async () => {
     // Preflight passes, but bdTopReady returns empty list
     let prefCalls = 0;
-    mountPassingGt(scripts);
+    mountPassingGhStack(scripts);
     scripts.on('git', (args) => {
       const a = args.join(' ');
       if (a.includes('status --porcelain')) return { exitCode: 0, stdout: '', stderr: '' };

--- a/.claude/orchestrators/test/unit/dispatch.test.ts
+++ b/.claude/orchestrators/test/unit/dispatch.test.ts
@@ -173,6 +173,28 @@ describe('dispatch', () => {
     expect(args).toContain('--fallback-model');
   });
 
+  it('should spawn the agent at opts.cwd when provided, and omit cwd otherwise', async () => {
+    const payload = { ok: true };
+    mockSpawnFn.mockReturnValue(
+      createMockChild(JSON.stringify(payload), '', 0),
+    );
+
+    await dispatch(baseOpts({ cwd: '/tmp/orch-wt-w1-c1' }));
+
+    let spawnOpts = mockSpawnFn.mock.calls[0][2] as Record<string, unknown>;
+    expect(spawnOpts.cwd).toBe('/tmp/orch-wt-w1-c1');
+
+    mockSpawnFn.mockClear();
+    mockSpawnFn.mockReturnValue(
+      createMockChild(JSON.stringify(payload), '', 0),
+    );
+
+    await dispatch(baseOpts());
+
+    spawnOpts = mockSpawnFn.mock.calls[0][2] as Record<string, unknown>;
+    expect('cwd' in spawnOpts).toBe(false);
+  });
+
   it('should not include --fallback-model when not provided', async () => {
     const payload = { ok: true };
     mockSpawnFn.mockReturnValue(

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -126,19 +126,6 @@ const CLOSED_LEAF_JSON = JSON.stringify([{
   issue_type: 'task',
 }]);
 
-const CLOSED_EPIC_JSON = JSON.stringify([{
-  title: 'Epic: Redesign dashboard',
-  status: 'closed',
-  issue_type: 'epic',
-  children: [{ id: 'pv-test-1.1' }, { id: 'pv-test-1.2' }],
-}]);
-
-const CLOSED_CHILD_JSON = JSON.stringify([{
-  title: 'Child bead',
-  status: 'closed',
-  issue_type: 'task',
-}]);
-
 const OPEN_BEAD_JSON = JSON.stringify([{
   title: 'Still open',
   status: 'in_progress',
@@ -793,6 +780,10 @@ describe('runEpicExecution', () => {
     readyIds?: string[];
     /** Shared ordered op log (gt/gh/agent events). */
     ops: string[];
+    /** Recorded gt/git-worktree calls with the spawn options' cwd. */
+    cwdCalls?: Array<{ op: string; cwd?: string }>;
+    /** When true, `git worktree add` fails. */
+    failWorktreeAdd?: boolean;
   }
 
   /**
@@ -802,7 +793,7 @@ describe('runEpicExecution', () => {
    */
   function makeChainScriptSpawn(opts: ChainHarnessOpts) {
     let prCounter = 10;
-    return vi.fn().mockImplementation((cmd: string, args: string[]) => {
+    return vi.fn().mockImplementation((cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
       const a = [cmd, ...(args ?? [])].join(' ');
       if (cmd === 'bd' && args[0] === 'ready') {
         const ids = opts.readyIds ?? Object.keys(opts.beads);
@@ -818,6 +809,7 @@ describe('runEpicExecution', () => {
       }
       if (cmd === 'gt') {
         opts.ops.push(a);
+        opts.cwdCalls?.push({ op: a, cwd: spawnOpts?.cwd });
         return fakeSpawnResult('', '', 0);
       }
       if (cmd === 'gh' && args[1] === 'view') {
@@ -834,6 +826,10 @@ describe('runEpicExecution', () => {
       }
       if (cmd === 'git' && args[0] === 'worktree') {
         opts.ops.push(`git worktree ${args[1]}`);
+        opts.cwdCalls?.push({ op: `git worktree ${args[1]}`, cwd: spawnOpts?.cwd });
+        if (args[1] === 'add' && opts.failWorktreeAdd) {
+          return fakeSpawnResult('', 'fatal: could not create work tree', 1);
+        }
         return fakeSpawnResult('', '', 0);
       }
       if (cmd === 'git' && args[0] === 'status') return fakeSpawnResult('', '', 0);
@@ -843,19 +839,19 @@ describe('runEpicExecution', () => {
     });
   }
 
-  /** Async dispatch spawn: records agent order, passes build-guardian. */
+  /** Async dispatch spawn: records agent order + spawn cwd, passes build-guardian. */
   function makeAgentSpawn(
     ops: string[],
-    children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }>,
-    guardianVerdict: () => string = () => JSON.stringify({ verdict: 'pass', concerns: [], beadsFailed: [] }),
+    children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }>,
+    guardianVerdict: () => string = () => JSON.stringify({ verdict: 'pass', concerns: [] }),
   ) {
-    return vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+    return vi.fn().mockImplementation((_cmd: string, args: string[], spawnOpts?: { cwd?: string }) => {
       const agent = args[args.indexOf('--agent') + 1] ?? 'unknown';
       ops.push(`agent:${agent}`);
       const child = agent === 'build-guardian'
         ? createMockChild(guardianVerdict(), '', 0)
         : createMockChild('done', '', 0);
-      children.push({ agent, child });
+      children.push({ agent, cwd: spawnOpts?.cwd, child });
       return child;
     });
   }
@@ -924,7 +920,7 @@ describe('runEpicExecution', () => {
 
     const ctx = makeEpicCtx();
     const ops: string[] = [];
-    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+    const children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }> = [];
 
     const scriptSpawnFn = makeChainScriptSpawn({
       beads: { 'pv-c.1': 'First bead', 'pv-c.2': 'Second bead' },
@@ -985,7 +981,7 @@ describe('runEpicExecution', () => {
 
     const ctx = makeEpicCtx();
     const ops: string[] = [];
-    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+    const children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }> = [];
 
     const beads: Record<string, string> = {
       'pv-p.1': 'Alpha work',
@@ -993,7 +989,8 @@ describe('runEpicExecution', () => {
       'pv-p.3': 'Gamma work',
       'pv-p.4': 'Delta work',
     };
-    const scriptSpawnFn = makeChainScriptSpawn({ beads, ops });
+    const cwdCalls: Array<{ op: string; cwd?: string }> = [];
+    const scriptSpawnFn = makeChainScriptSpawn({ beads, ops, cwdCalls });
     const spawnFn = makeAgentSpawn(ops, children);
 
     const result = await runEpicExecution(
@@ -1016,11 +1013,108 @@ describe('runEpicExecution', () => {
     expect(adds).toHaveLength(3);
     expect(removes).toHaveLength(3);
 
+    // cwd threading: chain 0's gt calls run in the main checkout (no cwd);
+    // each additional chain's gt calls carry that chain's worktree path.
+    const gtCwd = (branch: string) =>
+      cwdCalls.filter(c => c.op.includes(`gt create chore.${branch}`)).map(c => c.cwd);
+    expect(gtCwd('alpha-work')).toEqual([undefined]);
+    expect(gtCwd('beta-work')[0]).toContain('orch-wt-test-run-w1-c1');
+    expect(gtCwd('gamma-work')[0]).toContain('orch-wt-test-run-w1-c2');
+    expect(gtCwd('delta-work')[0]).toContain('orch-wt-test-run-w1-c3');
+
+    // Agent dispatches follow the same split: chain 0's implementer spawns
+    // without a cwd; the three worktree chains' implementers spawn at their
+    // worktree paths.
+    const implementerCwds = children
+      .filter(c => c.agent === 'implementer')
+      .map(c => c.cwd);
+    expect(implementerCwds).toHaveLength(4);
+    expect(implementerCwds.filter(c => c === undefined)).toHaveLength(1);
+    expect(
+      implementerCwds.filter(c => c !== undefined && c.includes('orch-wt-test-run-w1-c')),
+    ).toHaveLength(3);
+
     // All four chains ran in a single wave (cap applies to chains, queueing
     // the 4th chain behind the first free slot rather than a new wave).
     const waveStarts = logStub.runJsonEntries.filter(e => e.event === 'wave-start');
     expect(waveStarts).toHaveLength(1);
     expect((waveStarts[0].chains as string[][]).length).toBe(4);
+  });
+
+  it('removes a parallel chain worktree even when the chain fails mid-level', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }> = [];
+
+    // pv-w.2 is scheduled but has no bd show fixture -> its level fails at
+    // bead load, exercising the finally-based worktree cleanup.
+    const scriptSpawnFn = makeChainScriptSpawn({
+      beads: { 'pv-w.1': 'Good chain' },
+      readyIds: ['pv-w.1', 'pv-w.2'],
+      ops,
+    });
+    const spawnFn = makeAgentSpawn(ops, children);
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-w.1'], ['pv-w.2']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('escalated');
+    expect(result.escalatedBeads).toContain('pv-w.2');
+    expect(result.beadsCompleted).toContain('pv-w.1');
+
+    // The worktree was created for chain 1 and removed despite the failure.
+    expect(ops.filter(o => o === 'git worktree add')).toHaveLength(1);
+    expect(ops.filter(o => o === 'git worktree remove')).toHaveLength(1);
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({ event: 'chain-worktree-removed' }),
+    );
+  });
+
+  it('escalates the whole chain without dispatching implementers when git worktree add fails', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+    const helpers = await import('../../lib/helpers.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }> = [];
+
+    const scriptSpawnFn = makeChainScriptSpawn({
+      beads: { 'pv-w.1': 'Good chain', 'pv-w.2': 'Doomed chain' },
+      ops,
+      failWorktreeAdd: true,
+    });
+    const spawnFn = makeAgentSpawn(ops, children);
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-w.1'], ['pv-w.2']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('escalated');
+    expect(result.escalatedBeads).toEqual(['pv-w.2']);
+    expect(result.beadsCompleted).toContain('pv-w.1');
+
+    // No implementer ever ran for the doomed chain, and no worktree removal
+    // fired (nothing was created).
+    const implementerPrompts = children
+      .filter(c => c.agent === 'implementer')
+      .map(c => (c.child.stdin!.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string);
+    expect(implementerPrompts.some(p => p.includes('pv-w.2'))).toBe(false);
+    expect(ops.filter(o => o === 'git worktree remove')).toHaveLength(0);
+
+    const escalatedIds = vi.mocked(helpers.bdEscalate).mock.calls.map(c => c[0]);
+    expect(escalatedIds).toContain('pv-w.2');
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({ event: 'chain-worktree-create-failed' }),
+    );
   });
 
   it('halts a chain on persistent build-gate failure and escalates the truncated remainder', async () => {
@@ -1029,7 +1123,7 @@ describe('runEpicExecution', () => {
 
     const ctx = makeEpicCtx();
     const ops: string[] = [];
-    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+    const children: Array<{ agent: string; cwd?: string; child: ReturnType<typeof createMockChild> }> = [];
 
     const scriptSpawnFn = makeChainScriptSpawn({
       beads: { 'pv-h.1': 'Head bead', 'pv-h.2': 'Tail bead' },
@@ -1037,7 +1131,7 @@ describe('runEpicExecution', () => {
       ops,
     });
     const spawnFn = makeAgentSpawn(ops, children, () =>
-      JSON.stringify({ verdict: 'fail', concerns: ['lint broke'], beadsFailed: ['pv-h.1'] }),
+      JSON.stringify({ verdict: 'fail', concerns: ['lint broke'] }),
     );
 
     const result = await runEpicExecution(
@@ -1142,30 +1236,6 @@ describe('parseBeadJson', () => {
   it('should return null for empty array', async () => {
     const { parseBeadJson } = await import('../../lib/execute.js');
     expect(parseBeadJson('[]')).toBeNull();
-  });
-});
-
-// =============================================================================
-// derivePrTitleFromBead
-// =============================================================================
-
-describe('derivePrTitleFromBead', () => {
-  it('should strip "Epic:" prefix for epic beads', async () => {
-    const { derivePrTitleFromBead } = await import('../../lib/execute.js');
-    expect(derivePrTitleFromBead('Epic: Redesign dashboard', 'epic'))
-      .toBe('Redesign dashboard');
-  });
-
-  it('should pass through title for non-epic beads', async () => {
-    const { derivePrTitleFromBead } = await import('../../lib/execute.js');
-    expect(derivePrTitleFromBead('Fix alignment', 'task'))
-      .toBe('Fix alignment');
-  });
-
-  it('should handle missing "Epic:" prefix for epic beads', async () => {
-    const { derivePrTitleFromBead } = await import('../../lib/execute.js');
-    expect(derivePrTitleFromBead('Redesign dashboard', 'epic'))
-      .toBe('Redesign dashboard');
   });
 });
 
@@ -1303,33 +1373,6 @@ describe('runPR', () => {
     expect(result.ctx.beadsClosed).toEqual(['pv-test-1']);
   });
 
-  it('should submit a closed epic with closed children', async () => {
-    const { runPR } = await import('../../lib/execute.js');
-
-    const prUrl = 'https://github.com/owner/repo/pull/99';
-
-    // Sequence: git branch, bd show (epic), bd show (child1), bd show (child2),
-    //           gt submit, gh pr view, gh pr edit
-    const deps = makeDeps([
-      fakeSpawnResult('feat/branch', '', 0),
-      fakeSpawnResult(CLOSED_EPIC_JSON, '', 0),
-      fakeSpawnResult(CLOSED_CHILD_JSON, '', 0),
-      fakeSpawnResult(CLOSED_CHILD_JSON, '', 0),
-      fakeSpawnResult('✅ Submitted.', '', 0),
-      fakeSpawnResult(JSON.stringify({ number: 99, url: prUrl }), '', 0),
-      fakeSpawnResult('', '', 0),
-    ]);
-    const ctx = makePhaseCtx(logStub);
-
-    const result = await runPR(ctx, deps);
-
-    expect(result.next).toBe(PhaseName.Report);
-
-    const complete = logStub.runJsonEntries.find(e => e.event === 'pr_finalize_complete');
-    expect(complete!.prTitle).toBe('Redesign dashboard');
-    expect(complete!.beadsClosed).toEqual(['pv-test-1', 'pv-test-1.1', 'pv-test-1.2']);
-  });
-
   it('should halt when gt submit fails', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
@@ -1345,19 +1388,59 @@ describe('runPR', () => {
     expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gt submit failed'))).toBe(true);
   });
 
-  it('should halt when an epic child is not closed', async () => {
+  it('should halt when gh pr view fails after gt submit', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
+    // Sequence: git branch, bd show, gt submit ok, gh pr view fails
     const deps = makeDeps([
-      fakeSpawnResult('feat/branch', '', 0),
-      fakeSpawnResult(CLOSED_EPIC_JSON, '', 0),
-      fakeSpawnResult(CLOSED_CHILD_JSON, '', 0),
-      fakeSpawnResult(OPEN_BEAD_JSON, '', 0),
+      fakeSpawnResult('chore/fix-widget', '', 0),
+      fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
+      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('', 'no pull requests found for branch', 1),
     ]);
     const ctx = makePhaseCtx(logStub);
 
     const result = await runPR(ctx, deps);
     expect(result.next).toBe('halt');
+    expect(result.ctx.prUrl).toBeUndefined();
+    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gh pr view failed'))).toBe(true);
+  });
+
+  it('should halt when gh pr view returns unparseable output', async () => {
+    const { runPR } = await import('../../lib/execute.js');
+
+    // Sequence: git branch, bd show, gt submit ok, gh pr view garbage
+    const deps = makeDeps([
+      fakeSpawnResult('chore/fix-widget', '', 0),
+      fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
+      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('not json at all', '', 0),
+    ]);
+    const ctx = makePhaseCtx(logStub);
+
+    const result = await runPR(ctx, deps);
+    expect(result.next).toBe('halt');
+    expect(result.ctx.prUrl).toBeUndefined();
+    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gh pr view failed'))).toBe(true);
+  });
+
+  it('should halt when gh pr edit exits non-zero', async () => {
+    const { runPR } = await import('../../lib/execute.js');
+
+    // Sequence: git branch, bd show, gt submit ok, gh pr view ok, gh pr edit fails
+    const deps = makeDeps([
+      fakeSpawnResult('chore/fix-widget', '', 0),
+      fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
+      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult(JSON.stringify({ number: 42, url: 'https://github.com/o/r/pull/42' }), '', 0),
+      fakeSpawnResult('', 'GraphQL: Something went wrong', 1),
+    ]);
+    const ctx = makePhaseCtx(logStub);
+
+    const result = await runPR(ctx, deps);
+    expect(result.next).toBe('halt');
+    expect(result.ctx.prUrl).toBeUndefined();
+    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gh pr edit failed'))).toBe(true);
   });
 });
 
@@ -1537,5 +1620,92 @@ describe('epicPhase', () => {
     // routes to Report (per-level PRs happen inside the wave loop, so the
     // epic path never routes to the PR phase).
     expect(result.next).toBe(PhaseName.Report);
+  });
+});
+
+// =============================================================================
+// gatherStackPlan — closed-child exclusion
+// =============================================================================
+
+describe('gatherStackPlan', () => {
+  it('excludes closed children and promotes a closed blocker\'s dependent to chain head', async () => {
+    const { gatherStackPlan } = await import('../../lib/execute.js');
+
+    const logStub = stubLogger();
+    const ctx: RunContext = {
+      runId: 'test-run',
+      beadId: 'pv-epic',
+      logger: logStub.logger,
+      phaseHistory: [],
+    };
+
+    // pv-g.1 (blocker) is CLOSED; pv-g.2 is open and was blocked by it;
+    // pv-g.3 is open and blocked by pv-g.2. Dropping the closed blocker's
+    // edge must promote pv-g.2 to the head of a two-level chain.
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'bd' && args[0] === 'show') {
+        const beadId = args[1] === '--json' ? args[2] : args[1];
+        if (beadId === 'pv-epic') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-epic', issue_type: 'epic', status: 'open',
+            children: [{ id: 'pv-g.1' }, { id: 'pv-g.2' }, { id: 'pv-g.3' }],
+          }]), '', 0);
+        }
+        if (beadId === 'pv-g.1') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-g.1', title: 'Done already', issue_type: 'task', status: 'closed',
+          }]), '', 0);
+        }
+        if (beadId === 'pv-g.2') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-g.2', title: 'Second', issue_type: 'task', status: 'open',
+            dependencies: [{ id: 'pv-g.1', dependency_type: 'blocks' }],
+          }]), '', 0);
+        }
+        if (beadId === 'pv-g.3') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-g.3', title: 'Third', issue_type: 'task', status: 'open',
+            dependencies: [{ id: 'pv-g.2', dependency_type: 'blocks' }],
+          }]), '', 0);
+        }
+      }
+      return fakeSpawnResult('', '', 0);
+    });
+
+    const plan = gatherStackPlan('pv-epic', ctx, { scriptSpawnFn });
+
+    expect(plan).not.toBeNull();
+    expect(plan!.flat).toBe(false);
+    expect(plan!.chains).toEqual([['pv-g.2', 'pv-g.3']]);
+  });
+
+  it('returns null when every child is closed', async () => {
+    const { gatherStackPlan } = await import('../../lib/execute.js');
+
+    const logStub = stubLogger();
+    const ctx: RunContext = {
+      runId: 'test-run',
+      beadId: 'pv-epic',
+      logger: logStub.logger,
+      phaseHistory: [],
+    };
+
+    const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'bd' && args[0] === 'show') {
+        const beadId = args[1] === '--json' ? args[2] : args[1];
+        if (beadId === 'pv-epic') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-epic', issue_type: 'epic', status: 'open',
+            children: [{ id: 'pv-g.1' }],
+          }]), '', 0);
+        }
+        return fakeSpawnResult(JSON.stringify([{
+          id: beadId, title: 'Done', issue_type: 'task', status: 'closed',
+        }]), '', 0);
+      }
+      return fakeSpawnResult('', '', 0);
+    });
+
+    expect(gatherStackPlan('pv-epic', ctx, { scriptSpawnFn })).toBeNull();
   });
 });

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -930,6 +930,52 @@ describe('derivePrTitleFromBead', () => {
 });
 
 // =============================================================================
+// withStackedPrefix / fetchPrInfo
+// =============================================================================
+
+describe('withStackedPrefix', () => {
+  it('inserts "Stacked on #N." as the first Motivation line', async () => {
+    const { withStackedPrefix } = await import('../../lib/execute.js');
+    const body = '## Motivation\n\nWhy this change.\n\n## Approach\n\nHow.';
+    expect(withStackedPrefix(body, 42)).toBe(
+      '## Motivation\n\nStacked on #42.\n\nWhy this change.\n\n## Approach\n\nHow.',
+    );
+  });
+
+  it('prepends the marker when the body has no Motivation heading', async () => {
+    const { withStackedPrefix } = await import('../../lib/execute.js');
+    expect(withStackedPrefix('Free-form body.', 7)).toBe('Stacked on #7.\n\nFree-form body.');
+  });
+});
+
+describe('fetchPrInfo', () => {
+  it('parses url and number from gh pr view JSON', async () => {
+    const { fetchPrInfo } = await import('../../lib/execute.js');
+    const logStub = stubLogger();
+    const spawnFn = vi.fn().mockReturnValue(
+      fakeSpawnResult(JSON.stringify({ number: 12, url: 'https://github.com/o/r/pull/12' }), '', 0),
+    );
+
+    const info = fetchPrInfo('feat.branch', logStub.logger, PhaseName.PR, spawnFn as never);
+    expect(info).toEqual({ url: 'https://github.com/o/r/pull/12', number: 12 });
+    expect(spawnFn).toHaveBeenCalledWith(
+      'gh', ['pr', 'view', 'feat.branch', '--json', 'url,number'], expect.any(Object),
+    );
+  });
+
+  it('returns null when gh fails or output is unparseable', async () => {
+    const { fetchPrInfo } = await import('../../lib/execute.js');
+    const logStub = stubLogger();
+
+    const failSpawn = vi.fn().mockReturnValue(fakeSpawnResult('', 'no pull requests found', 1));
+    expect(fetchPrInfo('feat.x', logStub.logger, PhaseName.PR, failSpawn as never)).toBeNull();
+
+    const garbageSpawn = vi.fn().mockReturnValue(fakeSpawnResult('not json', '', 0));
+    expect(fetchPrInfo('feat.x', logStub.logger, PhaseName.PR, garbageSpawn as never)).toBeNull();
+  });
+});
+
+// =============================================================================
 // runPR
 // =============================================================================
 
@@ -994,18 +1040,19 @@ describe('runPR', () => {
     expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('UNCLOSED'))).toBe(true);
   });
 
-  it('should create PR and route to Report for a closed leaf bead', async () => {
+  it('should submit via gt, canonicalize via gh pr edit, and route to Report for a closed leaf bead', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
     const branchName = 'chore/fix-widget';
     const prUrl = 'https://github.com/owner/repo/pull/42';
 
-    // Sequence: git branch, bd show, git push, gh pr create
+    // Sequence: git branch, bd show, gt submit, gh pr view, gh pr edit
     const deps = makeDeps([
       fakeSpawnResult(branchName, '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
+      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult(JSON.stringify({ number: 42, url: prUrl }), '', 0),
       fakeSpawnResult('', '', 0),
-      fakeSpawnResult(prUrl, '', 0),
     ]);
     const ctx = makePhaseCtx(logStub);
 
@@ -1016,20 +1063,21 @@ describe('runPR', () => {
     expect(result.ctx.beadsClosed).toEqual(['pv-test-1']);
   });
 
-  it('should create PR for a closed epic with closed children', async () => {
+  it('should submit a closed epic with closed children', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
     const prUrl = 'https://github.com/owner/repo/pull/99';
 
     // Sequence: git branch, bd show (epic), bd show (child1), bd show (child2),
-    //           git push, gh pr create
+    //           gt submit, gh pr view, gh pr edit
     const deps = makeDeps([
       fakeSpawnResult('feat/branch', '', 0),
       fakeSpawnResult(CLOSED_EPIC_JSON, '', 0),
       fakeSpawnResult(CLOSED_CHILD_JSON, '', 0),
       fakeSpawnResult(CLOSED_CHILD_JSON, '', 0),
+      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult(JSON.stringify({ number: 99, url: prUrl }), '', 0),
       fakeSpawnResult('', '', 0),
-      fakeSpawnResult(prUrl, '', 0),
     ]);
     const ctx = makePhaseCtx(logStub);
 
@@ -1040,6 +1088,21 @@ describe('runPR', () => {
     const complete = logStub.runJsonEntries.find(e => e.event === 'pr_finalize_complete');
     expect(complete!.prTitle).toBe('Redesign dashboard');
     expect(complete!.beadsClosed).toEqual(['pv-test-1', 'pv-test-1.1', 'pv-test-1.2']);
+  });
+
+  it('should halt when gt submit fails', async () => {
+    const { runPR } = await import('../../lib/execute.js');
+
+    const deps = makeDeps([
+      fakeSpawnResult('chore/fix-widget', '', 0),
+      fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
+      fakeSpawnResult('', 'ERROR: Validation failed; branches need restack.', 1),
+    ]);
+    const ctx = makePhaseCtx(logStub);
+
+    const result = await runPR(ctx, deps);
+    expect(result.next).toBe('halt');
+    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gt submit failed'))).toBe(true);
   });
 
   it('should halt when an epic child is not closed', async () => {
@@ -1076,8 +1139,8 @@ describe('runPR backstop', () => {
       if (cmd === 'git' && args[0] === 'rev-list') {
         return fakeSpawnResult('0\n', '', 0);
       }
-      // Anything else (bd show, git push, gh pr create) must NOT be called.
-      // If it is, return failure so assertions catch the leak.
+      // Anything else (bd show, gt submit, gh pr view/edit) must NOT be
+      // called. If it is, return failure so assertions catch the leak.
       return fakeSpawnResult('', 'unexpected spawn', 1);
     });
 
@@ -1099,7 +1162,7 @@ describe('runPR backstop', () => {
       `${c[0]} ${c[1]?.[0] ?? ''}`);
     expect(cmds).toContain('git branch');
     expect(cmds).toContain('git rev-list');
-    expect(cmds).not.toContain('git push');
+    expect(cmds).not.toContain('gt submit');
     expect(cmds).not.toContain('gh pr');
     expect(cmds).not.toContain('bd show');
   });

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -755,7 +755,7 @@ describe('runLeafExecution', () => {
 });
 
 // =============================================================================
-// runEpicExecution
+// runEpicExecution — chain-based wave scheduling
 // =============================================================================
 
 describe('runEpicExecution', () => {
@@ -769,45 +769,131 @@ describe('runEpicExecution', () => {
     vi.mocked(helpers.bdEscalate).mockReturnValue(undefined);
     // Treat beads in this suite as enriched so they enter the implementer wave.
     vi.mocked(helpers.bdEnrichmentCheck).mockReturnValue(true);
+    vi.mocked(helpers.commitMsg).mockImplementation(
+      (summary: string) => `chore: ${summary}`,
+    );
+    vi.mocked(helpers.prBody).mockReturnValue(
+      '## Motivation\n\nWhy.\n\n## Approach\n\ntitle\n\n## Validation\n\n- [ ] checks\n',
+    );
   });
 
-  it('runs verification gate per bead in an epic wave and escalates on gate failure', async () => {
-    const { runEpicExecution } = await import('../../lib/execute.js');
-
-    const ctx: RunContext = {
+  function makeEpicCtx(): RunContext {
+    return {
       runId: 'test-run',
       beadId: 'epic-parent',
       logger: logStub.logger,
       phaseHistory: [],
     };
+  }
 
-    const initialBeads = ['pv-child.1'];
+  interface ChainHarnessOpts {
+    /** Bead id -> title, for bd show --json fixtures. */
+    beads: Record<string, string>;
+    /** Ids reported ready by `bd ready --parent`. Defaults to all beads. */
+    readyIds?: string[];
+    /** Shared ordered op log (gt/gh/agent events). */
+    ops: string[];
+  }
 
-    // Implementer + downstream verifier agents all return success.
-    // Build-guardian needs valid JSON for a pass verdict; return that uniformly
-    // so the wave-end chain passes cleanly and the per-bead gate-failure path
-    // is what drives the outcome.
+  /**
+   * scriptSpawnFn covering the whole chain pipeline: bd ready/show,
+   * gt create/submit, gh pr view/edit, git gate probes (clean tree, one
+   * commit, empty diff so audits skip), git worktree add/remove.
+   */
+  function makeChainScriptSpawn(opts: ChainHarnessOpts) {
+    let prCounter = 10;
+    return vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      const a = [cmd, ...(args ?? [])].join(' ');
+      if (cmd === 'bd' && args[0] === 'ready') {
+        const ids = opts.readyIds ?? Object.keys(opts.beads);
+        return fakeSpawnResult(JSON.stringify(ids.map(id => ({ id }))), '', 0);
+      }
+      if (cmd === 'bd' && args[0] === 'show') {
+        const beadId = args[1] === '--json' ? args[2] : args[1];
+        const title = opts.beads[beadId];
+        if (!title) return fakeSpawnResult('[]', '', 1);
+        return fakeSpawnResult(JSON.stringify([{
+          id: beadId, title, issue_type: 'task', status: 'open', notes: '',
+        }]), '', 0);
+      }
+      if (cmd === 'gt') {
+        opts.ops.push(a);
+        return fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'gh' && args[1] === 'view') {
+        prCounter++;
+        opts.ops.push(a);
+        return fakeSpawnResult(JSON.stringify({
+          number: prCounter,
+          url: `https://github.com/o/r/pull/${prCounter}`,
+        }), '', 0);
+      }
+      if (cmd === 'gh' && args[1] === 'edit') {
+        opts.ops.push(a);
+        return fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'git' && args[0] === 'worktree') {
+        opts.ops.push(`git worktree ${args[1]}`);
+        return fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'git' && args[0] === 'status') return fakeSpawnResult('', '', 0);
+      if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('1\n', '', 0);
+      if (cmd === 'git' && args[0] === 'diff') return fakeSpawnResult('', '', 0);
+      return fakeSpawnResult('', '', 0);
+    });
+  }
+
+  /** Async dispatch spawn: records agent order, passes build-guardian. */
+  function makeAgentSpawn(
+    ops: string[],
+    children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }>,
+    guardianVerdict: () => string = () => JSON.stringify({ verdict: 'pass', concerns: [], beadsFailed: [] }),
+  ) {
+    return vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      const agent = args[args.indexOf('--agent') + 1] ?? 'unknown';
+      ops.push(`agent:${agent}`);
+      const child = agent === 'build-guardian'
+        ? createMockChild(guardianVerdict(), '', 0)
+        : createMockChild('done', '', 0);
+      children.push({ agent, child });
+      return child;
+    });
+  }
+
+  it('runs verification gate per level and escalates the chain on gate failure', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx = makeEpicCtx();
+
+    // Gate fails with zero commits; bd/git calls otherwise cooperate.
     const spawnFn = vi.fn().mockImplementation(() =>
       createMockChild(JSON.stringify({ verdict: 'pass' }), '', 0),
     );
-
-    // Gate fails with zero commits; bd/git calls otherwise cooperate.
     const scriptSpawnFn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
       if (cmd === 'git' && args[0] === 'status')   return fakeSpawnResult('', '', 0);
       if (cmd === 'git' && args[0] === 'rev-list') return fakeSpawnResult('0\n', '', 0);
       if (cmd === 'git' && args[0] === 'diff')     return fakeSpawnResult('', '', 0);
-      // bd ready (cascade) returns no new beads so the while-loop exits.
-      if (cmd === 'bd' && args[0] === 'ready')     return fakeSpawnResult('[]', '', 0);
+      if (cmd === 'bd' && args[0] === 'ready') {
+        return fakeSpawnResult(JSON.stringify([{ id: 'pv-child.1' }]), '', 0);
+      }
+      if (cmd === 'bd' && args[0] === 'show') {
+        return fakeSpawnResult(JSON.stringify([{
+          id: 'pv-child.1', title: 'Child one', issue_type: 'task', status: 'open', notes: '',
+        }]), '', 0);
+      }
       if (cmd === 'bd')                            return fakeSpawnResult('', '', 0);
       return fakeSpawnResult('', '', 0);
     });
 
-    const result = await runEpicExecution('epic-parent', initialBeads, ctx, {
-      spawnFn,
-      scriptSpawnFn,
-    });
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-child.1']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
 
-    // Gate fired and reported the zero-commit failure for the child bead.
+    // Gate fired against the level's parent branch (main for the chain
+    // bottom) and reported the zero-commit failure for the child bead.
     expect(logStub.runJsonEntries).toContainEqual(
       expect.objectContaining({
         event: 'implementer-verification-failed',
@@ -825,12 +911,166 @@ describe('runEpicExecution', () => {
       }),
     );
 
-    // The bead ended up flagged as failed/escalated in the epic result.
+    expect(result.outcome).toBe('escalated');
     const failedLike = [
       ...(result.beadsFailed ?? []),
       ...(result.escalatedBeads ?? []),
     ];
     expect(failedLike).toContain('pv-child.1');
+  });
+
+  it('runs chain levels sequentially, stacking each branch on its predecessor with the build gate before submit', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+
+    const scriptSpawnFn = makeChainScriptSpawn({
+      beads: { 'pv-c.1': 'First bead', 'pv-c.2': 'Second bead' },
+      readyIds: ['pv-c.1'],
+      ops,
+    });
+    const spawnFn = makeAgentSpawn(ops, children);
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-c.1', 'pv-c.2']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('complete');
+    expect(result.beadsCompleted).toEqual(['pv-c.1', 'pv-c.2']);
+    expect(result.prUrls).toHaveLength(2);
+
+    // Level branches stack: level 1 on main, level 2 on level 1's branch.
+    expect(ops).toContainEqual(expect.stringContaining('gt create chore.first-bead --onto main'));
+    expect(ops).toContainEqual(expect.stringContaining('gt create chore.second-bead --onto chore.first-bead'));
+
+    // Per-level build gate runs BEFORE that level's submit.
+    const submit1 = ops.findIndex(o => o.includes('gt submit') && o.includes('chore.first-bead'));
+    const submit2 = ops.findIndex(o => o.includes('gt submit') && o.includes('chore.second-bead'));
+    const guardians = ops
+      .map((o, i) => ({ o, i }))
+      .filter(({ o }) => o === 'agent:build-guardian')
+      .map(({ i }) => i);
+    expect(guardians).toHaveLength(2);
+    expect(guardians[0]).toBeLessThan(submit1);
+    expect(guardians[1]).toBeGreaterThan(submit1);
+    expect(guardians[1]).toBeLessThan(submit2);
+
+    // Sequential levels: the second implementer is dispatched only after the
+    // first level's submit.
+    const implementerIdxs = ops
+      .map((o, i) => ({ o, i }))
+      .filter(({ o }) => o === 'agent:implementer')
+      .map(({ i }) => i);
+    expect(implementerIdxs).toHaveLength(2);
+    expect(implementerIdxs[1]).toBeGreaterThan(submit1);
+
+    // Stacked PR body: level 2's gh pr edit carries "Stacked on #<level1 PR>".
+    const editCalls = scriptSpawnFn.mock.calls.filter(
+      (c: [string, string[]]) => c[0] === 'gh' && c[1]?.[1] === 'edit',
+    );
+    expect(editCalls).toHaveLength(2);
+    const level2Body = editCalls[1][1][editCalls[1][1].indexOf('--body') + 1] as string;
+    expect(level2Body).toContain('Stacked on #11.');
+    const level1Body = editCalls[0][1][editCalls[0][1].indexOf('--body') + 1] as string;
+    expect(level1Body).not.toContain('Stacked on');
+  });
+
+  it('applies the 3-slot cap to chains and gives additional concurrent chains their own worktrees', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+
+    const beads: Record<string, string> = {
+      'pv-p.1': 'Alpha work',
+      'pv-p.2': 'Beta work',
+      'pv-p.3': 'Gamma work',
+      'pv-p.4': 'Delta work',
+    };
+    const scriptSpawnFn = makeChainScriptSpawn({ beads, ops });
+    const spawnFn = makeAgentSpawn(ops, children);
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      {
+        chains: [['pv-p.1'], ['pv-p.2'], ['pv-p.3'], ['pv-p.4']],
+        flat: false,
+        warnings: [],
+      },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('complete');
+    expect(result.beadsCompleted.sort()).toEqual(['pv-p.1', 'pv-p.2', 'pv-p.3', 'pv-p.4']);
+
+    // Hybrid model: chain 0 uses the main checkout; chains 1-3 get worktrees.
+    const adds = ops.filter(o => o === 'git worktree add');
+    const removes = ops.filter(o => o === 'git worktree remove');
+    expect(adds).toHaveLength(3);
+    expect(removes).toHaveLength(3);
+
+    // All four chains ran in a single wave (cap applies to chains, queueing
+    // the 4th chain behind the first free slot rather than a new wave).
+    const waveStarts = logStub.runJsonEntries.filter(e => e.event === 'wave-start');
+    expect(waveStarts).toHaveLength(1);
+    expect((waveStarts[0].chains as string[][]).length).toBe(4);
+  });
+
+  it('halts a chain on persistent build-gate failure and escalates the truncated remainder', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+    const helpers = await import('../../lib/helpers.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const children: Array<{ agent: string; child: ReturnType<typeof createMockChild> }> = [];
+
+    const scriptSpawnFn = makeChainScriptSpawn({
+      beads: { 'pv-h.1': 'Head bead', 'pv-h.2': 'Tail bead' },
+      readyIds: ['pv-h.1'],
+      ops,
+    });
+    const spawnFn = makeAgentSpawn(ops, children, () =>
+      JSON.stringify({ verdict: 'fail', concerns: ['lint broke'], beadsFailed: ['pv-h.1'] }),
+    );
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-h.1', 'pv-h.2']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('escalated');
+    expect(result.escalatedBeads).toContain('pv-h.1');
+    expect(result.escalatedBeads).toContain('pv-h.2');
+
+    // The failed level never submitted, and the truncated tail never ran.
+    expect(ops.some(o => o.includes('gt submit'))).toBe(false);
+    expect(ops.some(o => o.includes('gt create chore.tail-bead'))).toBe(false);
+    const implementerPrompts = children
+      .filter(c => c.agent === 'implementer')
+      .map(c => (c.child.stdin!.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string);
+    expect(implementerPrompts.some(p => p.includes('pv-h.2'))).toBe(false);
+
+    // Both the failed level and the truncated remainder were escalated.
+    const escalatedIds = vi.mocked(helpers.bdEscalate).mock.calls.map(c => c[0]);
+    expect(escalatedIds).toContain('pv-h.1');
+    expect(escalatedIds).toContain('pv-h.2');
+
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'chain-halted',
+        failedBead: 'pv-h.1',
+        truncatedBeads: ['pv-h.2'],
+      }),
+    );
   });
 });
 
@@ -1224,7 +1464,7 @@ describe('epicPhase', () => {
     vi.mocked(helpers.bdEnrichmentCheck).mockReturnValue(false);
   });
 
-  it('should halt when no ready beads found', async () => {
+  it('should halt when the epic has no open children', async () => {
     const { epicPhase } = await import('../../lib/execute.js');
 
     const mockSpawnSync = vi.fn().mockReturnValue({
@@ -1239,24 +1479,63 @@ describe('epicPhase', () => {
     expect(result.next).toBe('halt');
   });
 
-  it('scopes the bd ready query to descendants of the current epic via --parent', async () => {
+  it('gathers the full child set + blocks-edges via bd show --json and logs the stack plan', async () => {
     const { epicPhase } = await import('../../lib/execute.js');
 
-    const mockSpawnSync = vi.fn().mockReturnValue({
-      stdout: Buffer.from('[]'),
-      stderr: Buffer.from(''),
-      status: 0,
+    // Epic with two children where pv-e.2 is blocked by pv-e.1 — the full
+    // child set (NOT bd ready, which omits blocked children) must feed the
+    // plan, producing one two-level chain.
+    const mockSpawnSync = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'bd' && args[0] === 'show') {
+        const beadId = args[1] === '--json' ? args[2] : args[1];
+        if (beadId === 'pv-epic') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-epic', issue_type: 'epic', status: 'open',
+            children: [{ id: 'pv-e.1' }, { id: 'pv-e.2' }],
+          }]), '', 0);
+        }
+        if (beadId === 'pv-e.1') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-e.1', title: 'First', issue_type: 'task', status: 'open',
+            dependencies: [{ id: 'pv-epic', dependency_type: 'parent-child' }],
+          }]), '', 0);
+        }
+        if (beadId === 'pv-e.2') {
+          return fakeSpawnResult(JSON.stringify([{
+            id: 'pv-e.2', title: 'Second', issue_type: 'task', status: 'open',
+            dependencies: [
+              { id: 'pv-epic', dependency_type: 'parent-child' },
+              { id: 'pv-e.1', dependency_type: 'blocks' },
+            ],
+          }]), '', 0);
+        }
+      }
+      // bd ready returns nothing so the wave loop exits without executing.
+      if (cmd === 'bd' && args[0] === 'ready') return fakeSpawnResult('[]', '', 0);
+      return fakeSpawnResult('', '', 0);
     });
 
     const ctx = makePhaseCtx(logStub);
     ctx.beadId = 'pv-epic';
 
-    await epicPhase(ctx, { scriptSpawnFn: mockSpawnSync });
+    const result = await epicPhase(ctx, { scriptSpawnFn: mockSpawnSync });
 
+    // Full-child-set gathering, never bd ready alone.
     expect(mockSpawnSync).toHaveBeenCalledWith(
-      'bd',
-      ['ready', '--parent', 'pv-epic', '--json'],
-      expect.any(Object),
+      'bd', expect.arrayContaining(['show', 'pv-epic', '--json']), expect.any(Object),
     );
+    expect(logStub.runJsonEntries).toContainEqual(
+      expect.objectContaining({
+        event: 'stack-plan',
+        epicId: 'pv-epic',
+        chains: [['pv-e.1', 'pv-e.2']],
+        flat: false,
+      }),
+    );
+
+    // No chain became ready, so the epic completes with no PR work and
+    // routes to Report (per-level PRs happen inside the wave loop, so the
+    // epic path never routes to the PR phase).
+    expect(result.next).toBe(PhaseName.Report);
   });
 });

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -810,9 +810,9 @@ describe('runEpicExecution', () => {
     beads: Record<string, string>;
     /** Ids reported ready by `bd ready --parent`. Defaults to all beads. */
     readyIds?: string[];
-    /** Shared ordered op log (gt/gh/agent events). */
+    /** Shared ordered op log (gh-stack/git/agent events). */
     ops: string[];
-    /** Recorded gt/git-worktree calls with the spawn options' cwd. */
+    /** Recorded gh-stack/git-worktree calls with the spawn options' cwd. */
     cwdCalls?: Array<{ op: string; cwd?: string }>;
     /** When true, `git worktree add` fails. */
     failWorktreeAdd?: boolean;
@@ -820,8 +820,13 @@ describe('runEpicExecution', () => {
 
   /**
    * scriptSpawnFn covering the whole chain pipeline: bd ready/show,
-   * gt create/submit, gh pr view/edit, git gate probes (clean tree, one
+   * stackCreate/stackSubmit (both the `gh stack` chain path and the plain
+   * git/gh single path), gh pr view/edit, git gate probes (clean tree, one
    * commit, empty diff so audits skip), git worktree add/remove.
+   *
+   * `gh stack view --json` (the D3 gh-pr-ready sweep inside stackSubmit)
+   * returns an empty branch list so the sweep is a no-op in these
+   * fixtures — tested in isolation in helpers.test.ts.
    */
   function makeChainScriptSpawn(opts: ChainHarnessOpts) {
     let prCounter = 10;
@@ -839,12 +844,33 @@ describe('runEpicExecution', () => {
           id: beadId, title, issue_type: 'task', status: 'open', notes: '',
         }]), '', 0);
       }
-      if (cmd === 'gt') {
+      // stackCreate / stackSubmit chain path:
+      if (cmd === 'gh' && args[0] === 'stack') {
+        opts.ops.push(a);
+        opts.cwdCalls?.push({ op: a, cwd: spawnOpts?.cwd });
+        if (args[1] === 'view') {
+          return fakeSpawnResult(JSON.stringify({ branches: [] }), '', 0);
+        }
+        return fakeSpawnResult('', '', 0);
+      }
+      // stackCreate single path (chained=false):
+      if (cmd === 'git' && args[0] === 'checkout') {
         opts.ops.push(a);
         opts.cwdCalls?.push({ op: a, cwd: spawnOpts?.cwd });
         return fakeSpawnResult('', '', 0);
       }
-      if (cmd === 'gh' && args[1] === 'view') {
+      // stackSubmit single path (chained=false):
+      if (cmd === 'git' && args[0] === 'push') {
+        opts.ops.push(a);
+        opts.cwdCalls?.push({ op: a, cwd: spawnOpts?.cwd });
+        return fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'create') {
+        opts.ops.push(a);
+        opts.cwdCalls?.push({ op: a, cwd: spawnOpts?.cwd });
+        return fakeSpawnResult('', '', 0);
+      }
+      if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'view') {
         prCounter++;
         opts.ops.push(a);
         return fakeSpawnResult(JSON.stringify({
@@ -852,7 +878,7 @@ describe('runEpicExecution', () => {
           url: `https://github.com/o/r/pull/${prCounter}`,
         }), '', 0);
       }
-      if (cmd === 'gh' && args[1] === 'edit') {
+      if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'edit') {
         opts.ops.push(a);
         return fakeSpawnResult('', '', 0);
       }
@@ -972,13 +998,23 @@ describe('runEpicExecution', () => {
     expect(result.beadsCompleted).toEqual(['pv-c.1', 'pv-c.2']);
     expect(result.prUrls).toHaveLength(2);
 
-    // Level branches stack: level 1 on main, level 2 on level 1's branch.
-    expect(ops).toContainEqual(expect.stringContaining('gt create chore.first-bead --onto main'));
-    expect(ops).toContainEqual(expect.stringContaining('gt create chore.second-bead --onto chore.first-bead'));
+    // A chain of length 2 is chained=true at every level: level 1 starts a
+    // new stack off main (`gh stack init`); level 2 adds onto level 1's
+    // branch (`gh stack add`, which has no --base — it always adds on top
+    // of whatever is currently checked out).
+    expect(ops).toContainEqual('gh stack init --base main chore.first-bead');
+    expect(ops).toContainEqual('gh stack add chore.second-bead');
 
-    // Per-level build gate runs BEFORE that level's submit.
-    const submit1 = ops.findIndex(o => o.includes('gt submit') && o.includes('chore.first-bead'));
-    const submit2 = ops.findIndex(o => o.includes('gt submit') && o.includes('chore.second-bead'));
+    // Per-level build gate runs BEFORE that level's submit. `gh stack
+    // submit` carries no branch argument (unlike gt's `--branch`) — it
+    // submits whatever is tracked in the current stack — so submits are
+    // located by order rather than by embedded branch name.
+    const submits = ops
+      .map((o, i) => ({ o, i }))
+      .filter(({ o }) => o === 'gh stack submit --auto --open')
+      .map(({ i }) => i);
+    expect(submits).toHaveLength(2);
+    const [submit1, submit2] = submits;
     const guardians = ops
       .map((o, i) => ({ o, i }))
       .filter(({ o }) => o === 'agent:build-guardian')
@@ -997,15 +1033,16 @@ describe('runEpicExecution', () => {
     expect(implementerIdxs).toHaveLength(2);
     expect(implementerIdxs[1]).toBeGreaterThan(submit1);
 
-    // Stacked PR body: level 2's gh pr edit carries "Stacked on #<level1 PR>".
+    // The Graphite-era "Stacked on #N" body line is dropped (GitHub's Stack
+    // Map UI covers it) — neither level's PR body carries the marker.
     const editCalls = scriptSpawnFn.mock.calls.filter(
-      (c: [string, string[]]) => c[0] === 'gh' && c[1]?.[1] === 'edit',
+      (c: [string, string[]]) => c[0] === 'gh' && c[1]?.[0] === 'pr' && c[1]?.[1] === 'edit',
     );
     expect(editCalls).toHaveLength(2);
-    const level2Body = editCalls[1][1][editCalls[1][1].indexOf('--body') + 1] as string;
-    expect(level2Body).toContain('Stacked on #11.');
-    const level1Body = editCalls[0][1][editCalls[0][1].indexOf('--body') + 1] as string;
-    expect(level1Body).not.toContain('Stacked on');
+    for (const call of editCalls) {
+      const body = call[1][call[1].indexOf('--body') + 1] as string;
+      expect(body).not.toContain('Stacked on');
+    }
   });
 
   it('applies the 3-slot cap to chains and gives additional concurrent chains their own worktrees', async () => {
@@ -1045,14 +1082,17 @@ describe('runEpicExecution', () => {
     expect(adds).toHaveLength(3);
     expect(removes).toHaveLength(3);
 
-    // cwd threading: chain 0's gt calls run in the main checkout (no cwd);
-    // each additional chain's gt calls carry that chain's worktree path.
-    const gtCwd = (branch: string) =>
-      cwdCalls.filter(c => c.op.includes(`gt create chore.${branch}`)).map(c => c.cwd);
-    expect(gtCwd('alpha-work')).toEqual([undefined]);
-    expect(gtCwd('beta-work')[0]).toContain('orch-wt-test-run-w1-c1');
-    expect(gtCwd('gamma-work')[0]).toContain('orch-wt-test-run-w1-c2');
-    expect(gtCwd('delta-work')[0]).toContain('orch-wt-test-run-w1-c3');
+    // cwd threading: chain 0's branch-create call runs in the main checkout
+    // (no cwd); each additional chain's call carries that chain's worktree
+    // path. Every chain here is a singleton (chain.length === 1), so
+    // chained=false and branch creation is plain `git checkout -b`, not
+    // gh-stack.
+    const createCwd = (branch: string) =>
+      cwdCalls.filter(c => c.op === `git checkout -b chore.${branch} main`).map(c => c.cwd);
+    expect(createCwd('alpha-work')).toEqual([undefined]);
+    expect(createCwd('beta-work')[0]).toContain('orch-wt-test-run-w1-c1');
+    expect(createCwd('gamma-work')[0]).toContain('orch-wt-test-run-w1-c2');
+    expect(createCwd('delta-work')[0]).toContain('orch-wt-test-run-w1-c3');
 
     // Agent dispatches follow the same split: chain 0's implementer spawns
     // without a cwd; the three worktree chains' implementers spawn at their
@@ -1233,8 +1273,8 @@ describe('runEpicExecution', () => {
     expect(result.escalatedBeads).toContain('pv-h.2');
 
     // The failed level never submitted, and the truncated tail never ran.
-    expect(ops.some(o => o.includes('gt submit'))).toBe(false);
-    expect(ops.some(o => o.includes('gt create chore.tail-bead'))).toBe(false);
+    expect(ops.some(o => o.startsWith('gh stack submit'))).toBe(false);
+    expect(ops.some(o => o.includes('chore.tail-bead'))).toBe(false);
     const implementerPrompts = children
       .filter(c => c.agent === 'implementer')
       .map(c => (c.child.stdin!.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string);
@@ -1374,23 +1414,8 @@ describe('parseBeadJson', () => {
 });
 
 // =============================================================================
-// withStackedPrefix / fetchPrInfo
+// fetchPrInfo
 // =============================================================================
-
-describe('withStackedPrefix', () => {
-  it('inserts "Stacked on #N." as the first Motivation line', async () => {
-    const { withStackedPrefix } = await import('../../lib/execute.js');
-    const body = '## Motivation\n\nWhy this change.\n\n## Approach\n\nHow.';
-    expect(withStackedPrefix(body, 42)).toBe(
-      '## Motivation\n\nStacked on #42.\n\nWhy this change.\n\n## Approach\n\nHow.',
-    );
-  });
-
-  it('prepends the marker when the body has no Motivation heading', async () => {
-    const { withStackedPrefix } = await import('../../lib/execute.js');
-    expect(withStackedPrefix('Free-form body.', 7)).toBe('Stacked on #7.\n\nFree-form body.');
-  });
-});
 
 describe('fetchPrInfo', () => {
   it('parses url and number from gh pr view JSON', async () => {
@@ -1484,17 +1509,18 @@ describe('runPR', () => {
     expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('UNCLOSED'))).toBe(true);
   });
 
-  it('should submit via gt, canonicalize via gh pr edit, and route to Report for a closed leaf bead', async () => {
+  it('should submit via plain git push + gh pr create (single, chained=false), canonicalize via gh pr edit, and route to Report for a closed leaf bead', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
     const branchName = 'chore/fix-widget';
     const prUrl = 'https://github.com/owner/repo/pull/42';
 
-    // Sequence: git branch, bd show, gt submit, gh pr view, gh pr edit
+    // Sequence: git branch, bd show, git push, gh pr create, gh pr view, gh pr edit
     const deps = makeDeps([
       fakeSpawnResult(branchName, '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
-      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('', '', 0),
+      fakeSpawnResult('', '', 0),
       fakeSpawnResult(JSON.stringify({ number: 42, url: prUrl }), '', 0),
       fakeSpawnResult('', '', 0),
     ]);
@@ -1507,29 +1533,30 @@ describe('runPR', () => {
     expect(result.ctx.beadsClosed).toEqual(['pv-test-1']);
   });
 
-  it('should halt when gt submit fails', async () => {
+  it('should halt when git push fails (stackSubmit single path)', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
     const deps = makeDeps([
       fakeSpawnResult('chore/fix-widget', '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
-      fakeSpawnResult('', 'ERROR: Validation failed; branches need restack.', 1),
+      fakeSpawnResult('', 'fatal: could not read from remote repository', 128),
     ]);
     const ctx = makePhaseCtx(logStub);
 
     const result = await runPR(ctx, deps);
     expect(result.next).toBe('halt');
-    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('gt submit failed'))).toBe(true);
+    expect(logStub.logs.some(l => l.kind === 'err' && l.data.includes('stackSubmit failed'))).toBe(true);
   });
 
-  it('should halt when gh pr view fails after gt submit', async () => {
+  it('should halt when gh pr view fails after stackSubmit', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
-    // Sequence: git branch, bd show, gt submit ok, gh pr view fails
+    // Sequence: git branch, bd show, git push ok, gh pr create ok, gh pr view fails
     const deps = makeDeps([
       fakeSpawnResult('chore/fix-widget', '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
-      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('', '', 0),
+      fakeSpawnResult('', '', 0),
       fakeSpawnResult('', 'no pull requests found for branch', 1),
     ]);
     const ctx = makePhaseCtx(logStub);
@@ -1543,11 +1570,12 @@ describe('runPR', () => {
   it('should halt when gh pr view returns unparseable output', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
-    // Sequence: git branch, bd show, gt submit ok, gh pr view garbage
+    // Sequence: git branch, bd show, git push ok, gh pr create ok, gh pr view garbage
     const deps = makeDeps([
       fakeSpawnResult('chore/fix-widget', '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
-      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('', '', 0),
+      fakeSpawnResult('', '', 0),
       fakeSpawnResult('not json at all', '', 0),
     ]);
     const ctx = makePhaseCtx(logStub);
@@ -1561,11 +1589,12 @@ describe('runPR', () => {
   it('should halt when gh pr edit exits non-zero', async () => {
     const { runPR } = await import('../../lib/execute.js');
 
-    // Sequence: git branch, bd show, gt submit ok, gh pr view ok, gh pr edit fails
+    // Sequence: git branch, bd show, git push ok, gh pr create ok, gh pr view ok, gh pr edit fails
     const deps = makeDeps([
       fakeSpawnResult('chore/fix-widget', '', 0),
       fakeSpawnResult(CLOSED_LEAF_JSON, '', 0),
-      fakeSpawnResult('✅ Submitted.', '', 0),
+      fakeSpawnResult('', '', 0),
+      fakeSpawnResult('', '', 0),
       fakeSpawnResult(JSON.stringify({ number: 42, url: 'https://github.com/o/r/pull/42' }), '', 0),
       fakeSpawnResult('', 'GraphQL: Something went wrong', 1),
     ]);
@@ -1596,8 +1625,8 @@ describe('runPR backstop', () => {
       if (cmd === 'git' && args[0] === 'rev-list') {
         return fakeSpawnResult('0\n', '', 0);
       }
-      // Anything else (bd show, gt submit, gh pr view/edit) must NOT be
-      // called. If it is, return failure so assertions catch the leak.
+      // Anything else (bd show, git push, gh pr create/view/edit) must NOT
+      // be called. If it is, return failure so assertions catch the leak.
       return fakeSpawnResult('', 'unexpected spawn', 1);
     });
 
@@ -1619,7 +1648,7 @@ describe('runPR backstop', () => {
       `${c[0]} ${c[1]?.[0] ?? ''}`);
     expect(cmds).toContain('git branch');
     expect(cmds).toContain('git rev-list');
-    expect(cmds).not.toContain('gt submit');
+    expect(cmds).not.toContain('git push');
     expect(cmds).not.toContain('gh pr');
     expect(cmds).not.toContain('bd show');
   });

--- a/.claude/orchestrators/test/unit/execute.test.ts
+++ b/.claude/orchestrators/test/unit/execute.test.ts
@@ -82,6 +82,38 @@ function createMockChild(
   return child;
 }
 
+/**
+ * Like createMockChild, but the child stays "running" for `delayMs` before
+ * closing. Used to observe overlap (or enforced non-overlap) between
+ * concurrently dispatched agents. `onClose` fires just before the close event.
+ */
+function createDelayedMockChild(
+  stdout: string,
+  delayMs: number,
+  onClose?: () => void,
+): ChildProcess & EventEmitter {
+  const child = new EventEmitter() as ChildProcess & EventEmitter;
+
+  const stdoutStream = new Readable({ read() {} });
+  const stderrStream = new Readable({ read() {} });
+
+  child.stdin = { write: vi.fn(), end: vi.fn() } as unknown as ChildProcess['stdin'];
+  child.stdout = stdoutStream;
+  child.stderr = stderrStream;
+  child.pid = 12345;
+  child.kill = vi.fn().mockReturnValue(true);
+
+  setTimeout(() => {
+    if (stdout) stdoutStream.push(stdout);
+    stdoutStream.push(null);
+    stderrStream.push(null);
+    onClose?.();
+    child.emit('close', 0);
+  }, delayMs);
+
+  return child;
+}
+
 function fakeSpawnResult(
   stdout: string,
   stderr: string,
@@ -1117,6 +1149,61 @@ describe('runEpicExecution', () => {
     );
   });
 
+  it('serializes build-guardian dispatches across concurrent chains while implementers interleave', async () => {
+    const { runEpicExecution } = await import('../../lib/execute.js');
+
+    const ctx = makeEpicCtx();
+    const ops: string[] = [];
+    const events: string[] = [];
+
+    const scriptSpawnFn = makeChainScriptSpawn({
+      beads: { 'pv-m.1': 'Mutex one', 'pv-m.2': 'Mutex two' },
+      ops,
+    });
+
+    // Implementers and guardians both stay "running" for a while so any
+    // overlap would be observable in the event sequence.
+    const spawnFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      const agent = args[args.indexOf('--agent') + 1] ?? 'unknown';
+      if (agent === 'build-guardian') {
+        events.push('guardian-start');
+        return createDelayedMockChild(
+          JSON.stringify({ verdict: 'pass', concerns: [] }), 40,
+          () => events.push('guardian-end'),
+        );
+      }
+      if (agent === 'implementer') {
+        events.push('implementer-start');
+        return createDelayedMockChild('done', 40, () => events.push('implementer-end'));
+      }
+      return createMockChild('done', '', 0);
+    });
+
+    const result = await runEpicExecution(
+      'epic-parent',
+      { chains: [['pv-m.1'], ['pv-m.2']], flat: false, warnings: [] },
+      ctx,
+      { spawnFn, scriptSpawnFn },
+    );
+
+    expect(result.outcome).toBe('complete');
+    expect(result.beadsCompleted.sort()).toEqual(['pv-m.1', 'pv-m.2']);
+
+    // Implementers DID run concurrently: both chains' implementers started
+    // before either finished. This proves the lock scopes to the build gate
+    // only, not to chain execution as a whole.
+    const implEvents = events.filter(e => e.startsWith('implementer'));
+    expect(implEvents.slice(0, 2)).toEqual(['implementer-start', 'implementer-start']);
+
+    // Guardians NEVER overlapped: each dispatch ended before the next began
+    // (never-more-than-one-build-guardian invariant).
+    const guardianEvents = events.filter(e => e.startsWith('guardian'));
+    expect(guardianEvents).toEqual([
+      'guardian-start', 'guardian-end',
+      'guardian-start', 'guardian-end',
+    ]);
+  });
+
   it('halts a chain on persistent build-gate failure and escalates the truncated remainder', async () => {
     const { runEpicExecution } = await import('../../lib/execute.js');
     const helpers = await import('../../lib/helpers.js');
@@ -1165,6 +1252,53 @@ describe('runEpicExecution', () => {
         truncatedBeads: ['pv-h.2'],
       }),
     );
+  });
+});
+
+// =============================================================================
+// withBuildGuardianLock — cross-chain guardian serialization
+// =============================================================================
+
+describe('withBuildGuardianLock', () => {
+  it('runs tasks strictly one at a time in FIFO order', async () => {
+    const { withBuildGuardianLock } = await import('../../lib/execute.js');
+
+    const events: string[] = [];
+    const task = (name: string, delay: number) => () =>
+      new Promise<string>((resolve) => {
+        events.push(`${name}-start`);
+        setTimeout(() => {
+          events.push(`${name}-end`);
+          resolve(name);
+        }, delay);
+      });
+
+    // The slowest task is queued first — with any overlap, b/c would start
+    // (and even finish) before a ends.
+    const results = await Promise.all([
+      withBuildGuardianLock(task('a', 30)),
+      withBuildGuardianLock(task('b', 5)),
+      withBuildGuardianLock(task('c', 1)),
+    ]);
+
+    expect(results).toEqual(['a', 'b', 'c']);
+    expect(events).toEqual([
+      'a-start', 'a-end',
+      'b-start', 'b-end',
+      'c-start', 'c-end',
+    ]);
+  });
+
+  it('does not poison the queue when a task rejects', async () => {
+    const { withBuildGuardianLock } = await import('../../lib/execute.js');
+
+    await expect(
+      withBuildGuardianLock(() => Promise.reject(new Error('guardian boom'))),
+    ).rejects.toThrow('guardian boom');
+
+    await expect(
+      withBuildGuardianLock(async () => 'recovered'),
+    ).resolves.toBe('recovered');
   });
 });
 

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -25,6 +25,9 @@ import {
   branchName,
   commitMsg,
   prBody,
+  stackCreate,
+  stackSubmit,
+  syncAndRestack,
 } from '../../lib/helpers.js';
 
 // =============================================================================
@@ -66,7 +69,7 @@ describe('gitSafeToStart', () => {
       fakeSpawn('abc1234567890abcdef1234567890abcdef123456'),       // rev-parse origin/main
       fakeSpawn(''),                                                // git status --porcelain (clean)
     );
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(true);
     expect(result.reason).toBeUndefined();
   });
@@ -78,7 +81,7 @@ describe('gitSafeToStart', () => {
       fakeSpawn('def4567890abcdef1234567890abcdef12345678'),
       fakeSpawn(''),
     );
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(true);
   });
 
@@ -89,7 +92,7 @@ describe('gitSafeToStart', () => {
       fakeSpawn('bbbbbbb1234567890abcdef1234567890abcdef1'),       // origin/main differs
       fakeSpawn(''),
     );
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('origin/main');
   });
@@ -100,7 +103,7 @@ describe('gitSafeToStart', () => {
       fakeSpawn('abc1234'),                                         // HEAD ok
       fakeSpawn('', 'unknown ref', 128),                            // origin/main missing
     );
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('origin/main');
   });
@@ -112,16 +115,71 @@ describe('gitSafeToStart', () => {
       fakeSpawn('abc1234'),
       fakeSpawn(' M src/server/app.ts\n'),                          // dirty
     );
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('dirty');
   });
 
   it('returns ok=false when not inside a git repo', () => {
     const spawn = seqSpawn(fakeSpawn('', 'not a repo', 128));
-    const result = gitSafeToStart({ spawnFn: spawn as never });
+    const result = gitSafeToStart(undefined, { spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     expect(result.reason).toContain('work tree');
+  });
+
+  it('compares HEAD against the LOCAL parent tip when parentBranch is given', () => {
+    // A mid-chain stack parent may not exist on origin yet, so the
+    // comparison must use the local ref, never origin/<parent>.
+    const calls: string[] = [];
+    const results = [
+      fakeSpawn('true'),                                            // rev-parse --is-inside-work-tree
+      fakeSpawn('abc1234567890abcdef1234567890abcdef123456'),       // rev-parse HEAD
+      fakeSpawn('abc1234567890abcdef1234567890abcdef123456'),       // rev-parse chore.parent-branch
+      fakeSpawn(''),                                                // git status --porcelain (clean)
+    ];
+    let i = 0;
+    const spawn = (_cmd: string, args: string[], _opts: unknown) => {
+      calls.push((args as string[]).join(' '));
+      return results[i++] ?? fakeSpawn('', 'unexpected call', 1);
+    };
+    const result = gitSafeToStart('chore.parent-branch', { spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+    expect(calls.some(c => c.includes('rev-parse chore.parent-branch'))).toBe(true);
+    expect(calls.some(c => c.includes('origin/chore.parent-branch'))).toBe(false);
+  });
+
+  it('returns ok=false when HEAD differs from the local parent tip', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('true'),
+      fakeSpawn('aaaaaaa1234567890abcdef1234567890abcdef1'),       // HEAD
+      fakeSpawn('bbbbbbb1234567890abcdef1234567890abcdef1'),       // parent differs
+    );
+    const result = gitSafeToStart('chore.parent-branch', { spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('chore.parent-branch');
+  });
+
+  it('returns ok=false when the local parent branch cannot be resolved', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('true'),
+      fakeSpawn('abc1234'),                                         // HEAD ok
+      fakeSpawn('', 'unknown ref', 128),                            // parent missing locally
+    );
+    const result = gitSafeToStart('chore.parent-branch', { spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('chore.parent-branch');
+  });
+
+  it('still checks for a dirty tree in parentBranch mode', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('true'),
+      fakeSpawn('abc1234'),
+      fakeSpawn('abc1234'),
+      fakeSpawn(' M src/server/app.ts\n'),                          // dirty
+    );
+    const result = gitSafeToStart('chore.parent-branch', { spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('dirty');
   });
 });
 
@@ -130,9 +188,17 @@ describe('gitSafeToStart', () => {
 // =============================================================================
 
 describe('preflight', () => {
+  // gt probe responses shared by passing cases:
+  //   gt --version, gt auth --no-interactive, gt trunk
+  const gtOk = () => [
+    fakeSpawn('1.8.6'),
+    fakeSpawn('Authenticated as: someone\n✅ Ready to submit PRs.'),
+    fakeSpawn('main'),
+  ];
+
   it('returns ok=true when all checks pass', () => {
     // Calls in order: git status, git fetch, git rev-parse HEAD, git rev-parse origin/main,
-    // bd ready --json, bd label list (per bead)
+    // gt --version, gt auth, gt trunk, bd ready --json, bd label list (per bead)
     const beadsJson = JSON.stringify([
       { id: 'pv-abc1', priority: 1, created_at: '2026-01-01' },
     ]);
@@ -141,6 +207,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // git fetch origin main (success)
       fakeSpawn('abc1234'),           // git rev-parse HEAD
       fakeSpawn('abc1234'),           // git rev-parse origin/main (matches)
+      ...gtOk(),
       fakeSpawn(beadsJson),           // bd ready --json
       fakeSpawn('  - backlog'),       // bd label list pv-abc1 (no needs-human)
     );
@@ -158,6 +225,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('def5678'),           // HEAD
       fakeSpawn('def5678'),           // origin/main matches
+      ...gtOk(),
       fakeSpawn(beadsJson),
       fakeSpawn('  - other'),
     );
@@ -169,6 +237,7 @@ describe('preflight', () => {
     const spawn = seqSpawn(
       fakeSpawn(' M src/file.ts'),   // dirty
       fakeSpawn('', '', 1),           // fetch fails → behind_main
+      ...gtOk(),
       fakeSpawn('[]'),                // bd ready (empty → empty_backlog)
     );
     const result = preflight({ spawnFn: spawn as never });
@@ -185,6 +254,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('aaaaaaa'),           // HEAD
       fakeSpawn('bbbbbbb'),           // origin/main differs
+      ...gtOk(),
       fakeSpawn('[]'),                // bd ready (empty → empty_backlog too)
     );
     const result = preflight({ spawnFn: spawn as never });
@@ -199,11 +269,90 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('abc1234'),           // HEAD
       fakeSpawn('abc1234'),           // origin/main matches
+      ...gtOk(),
       fakeSpawn(beadsJson),           // bd ready
       fakeSpawn('  - needs-human'),   // label list: has needs-human
     );
     const result = preflight({ spawnFn: spawn as never });
     expect(result.failures.map(f => f.kind)).toContain('empty_backlog');
+  });
+
+  it('reports missing_gt and skips the auth/trunk probes when gt is absent', () => {
+    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
+    const calls: string[] = [];
+    const results = [
+      fakeSpawn(''),                        // clean tree
+      fakeSpawn(''),                        // fetch ok
+      fakeSpawn('abc1234'),                 // HEAD
+      fakeSpawn('abc1234'),                 // origin/main matches
+      fakeSpawn('', 'command not found: gt', 127), // gt --version fails
+      fakeSpawn(beadsJson),                 // bd ready (auth/trunk probes skipped)
+      fakeSpawn('  - backlog'),             // bd label list
+    ];
+    let i = 0;
+    const spawn = (cmd: string, args: string[], _opts: unknown) => {
+      calls.push([cmd, ...(args as string[])].join(' '));
+      return results[i++] ?? fakeSpawn('', 'unexpected call', 1);
+    };
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.failures.map(f => f.kind)).toContain('missing_gt');
+    // Hard stop on the tool itself: auth and trunk are not probed.
+    expect(calls.some(c => c.includes('auth'))).toBe(false);
+    expect(calls.some(c => c.includes('trunk'))).toBe(false);
+  });
+
+  it('reports gt_unauthenticated when the auth probe fails', () => {
+    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
+    const spawn = seqSpawn(
+      fakeSpawn(''),                        // clean tree
+      fakeSpawn(''),                        // fetch ok
+      fakeSpawn('abc1234'),                 // HEAD
+      fakeSpawn('abc1234'),                 // origin/main matches
+      fakeSpawn('1.8.6'),                   // gt --version ok
+      fakeSpawn('', 'Please authenticate', 1), // gt auth fails
+      fakeSpawn('main'),                    // gt trunk ok
+      fakeSpawn(beadsJson),
+      fakeSpawn('  - backlog'),
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.failures.map(f => f.kind)).toContain('gt_unauthenticated');
+  });
+
+  it('reports gt_unauthenticated when the auth probe output lacks an authenticated user', () => {
+    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
+    const spawn = seqSpawn(
+      fakeSpawn(''),
+      fakeSpawn(''),
+      fakeSpawn('abc1234'),
+      fakeSpawn('abc1234'),
+      fakeSpawn('1.8.6'),
+      fakeSpawn('Add your auth token to enable Graphite CLI'), // exit 0 but not authenticated
+      fakeSpawn('main'),
+      fakeSpawn(beadsJson),
+      fakeSpawn('  - backlog'),
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.failures.map(f => f.kind)).toContain('gt_unauthenticated');
+  });
+
+  it('reports gt_trunk_misconfigured when gt trunk is not the main branch', () => {
+    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
+    const spawn = seqSpawn(
+      fakeSpawn(''),
+      fakeSpawn(''),
+      fakeSpawn('abc1234'),
+      fakeSpawn('abc1234'),
+      fakeSpawn('1.8.6'),
+      fakeSpawn('Authenticated as: someone'),
+      fakeSpawn('develop'),                 // gt trunk mismatch
+      fakeSpawn(beadsJson),
+      fakeSpawn('  - backlog'),
+    );
+    const result = preflight({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.failures.map(f => f.kind)).toContain('gt_trunk_misconfigured');
   });
 });
 
@@ -765,5 +914,153 @@ describe('bdSizingCheck', () => {
     const spawn = seqSpawn(fakeSpawn(content));
     const result = bdSizingCheck('pv-abc1', { spawnFn: spawn as never });
     expect(result.needs_decomposition).toBe(true);
+  });
+});
+
+// =============================================================================
+// stackCreate
+// =============================================================================
+
+describe('stackCreate', () => {
+  it('runs gt create with --onto parent and --no-interactive', () => {
+    const calls: string[] = [];
+    const spawn = (cmd: string, args: string[], _opts: unknown) => {
+      calls.push([cmd, ...(args as string[])].join(' '));
+      return fakeSpawn('');
+    };
+    const result = stackCreate('feat.add-search', 'main', { spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('gt create feat.add-search');
+    expect(calls[0]).toContain('--onto main');
+    expect(calls[0]).toContain('--no-interactive');
+  });
+
+  it('accepts branchName()-produced names verbatim (documented precondition)', () => {
+    // stackCreate does not validate or rewrite branch names at runtime;
+    // callers must pass names produced by branchName(). This test asserts
+    // the precondition holds end to end: a branchName() output goes to gt
+    // unchanged and carries no bead IDs.
+    const name = branchName('Add calendar discovery surface', 'feature');
+    const calls: string[] = [];
+    const spawn = (cmd: string, args: string[], _opts: unknown) => {
+      calls.push([cmd, ...(args as string[])].join(' '));
+      return fakeSpawn('');
+    };
+    stackCreate(name, 'feat.parent-level', { spawnFn: spawn as never });
+    expect(calls[0]).toContain(`gt create ${name}`);
+    expect(calls[0]).not.toMatch(/pv-[a-z0-9]+/);
+  });
+
+  it('returns ok=false with stderr when gt create fails', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('', 'ERROR: Cannot perform this operation on untracked branch xyz.', 1),
+    );
+    const result = stackCreate('feat.add-search', 'main', { spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain('untracked branch');
+  });
+});
+
+// =============================================================================
+// stackSubmit
+// =============================================================================
+
+describe('stackSubmit', () => {
+  it('runs gt submit non-interactively with --publish and an explicit --branch', () => {
+    // --publish is load-bearing: on gt 1.8.6, --no-interactive submits new
+    // PRs as drafts unless --publish is passed (verified 2026-07-11), and
+    // the git-workflow skill forbids draft PRs.
+    const calls: string[] = [];
+    const spawn = (cmd: string, args: string[], _opts: unknown) => {
+      calls.push([cmd, ...(args as string[])].join(' '));
+      return fakeSpawn('✅ Submitted.');
+    };
+    const result = stackSubmit('feat.add-search', { spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('gt submit');
+    expect(calls[0]).toContain('--no-interactive');
+    expect(calls[0]).toContain('--publish');
+    expect(calls[0]).toContain('--branch feat.add-search');
+  });
+
+  it('returns ok=false with output when gt submit fails', () => {
+    const spawn = seqSpawn(
+      fakeSpawn('', 'ERROR: Validation failed; branches need restack.', 1),
+    );
+    const result = stackSubmit('feat.add-search', { spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain('restack');
+  });
+});
+
+// =============================================================================
+// syncAndRestack
+// =============================================================================
+
+describe('syncAndRestack', () => {
+  // Output lines below match observed gt 1.8.6 output (verified 2026-07-11).
+  const syncOutput = [
+    '🌲 Fetching branches from remote...',
+    'main is up to date.',
+    '',
+    '🥞 Restacking branches...',
+    'feat.level-one does not need to be restacked on main.',
+    'Restacked feat.level-two on feat.level-one.',
+    'WARNING: feat.level-three could not be restacked cleanly.',
+    'Did not restack branch feat.level-four because it is checked out in worktree /some/worktree/path.',
+    '',
+    'You can resolve conflicts with gt restack.',
+  ].join('\n');
+
+  it('runs gt sync -f --no-interactive', () => {
+    const calls: string[] = [];
+    const spawn = (cmd: string, args: string[], _opts: unknown) => {
+      calls.push([cmd, ...(args as string[])].join(' '));
+      return fakeSpawn('main is up to date.');
+    };
+    syncAndRestack({ spawnFn: spawn as never });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('gt sync');
+    expect(calls[0]).toContain('-f');
+    expect(calls[0]).toContain('--no-interactive');
+  });
+
+  it('returns structured clean / conflicted / worktree-skipped results', () => {
+    const spawn = seqSpawn(fakeSpawn(syncOutput));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.restacked).toEqual(['feat.level-two']);
+    expect(result.conflicted).toEqual(['feat.level-three']);
+    expect(result.skippedWorktree).toEqual(['feat.level-four']);
+    expect(result.rawOutput).toContain('Restacking branches');
+  });
+
+  it('reports ok=false when any branch conflicted', () => {
+    const spawn = seqSpawn(fakeSpawn(syncOutput));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+  });
+
+  it('reports ok=true on a fully clean sync', () => {
+    const clean = [
+      'main is up to date.',
+      '🥞 Restacking branches...',
+      'feat.level-one does not need to be restacked on main.',
+      'Restacked feat.level-two on feat.level-one.',
+    ].join('\n');
+    const spawn = seqSpawn(fakeSpawn(clean));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.ok).toBe(true);
+    expect(result.restacked).toEqual(['feat.level-two']);
+    expect(result.conflicted).toEqual([]);
+    expect(result.skippedWorktree).toEqual([]);
+  });
+
+  it('reports ok=false when gt sync itself exits non-zero', () => {
+    const spawn = seqSpawn(fakeSpawn('', 'ERROR: network failure', 1));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.rawOutput).toContain('network failure');
   });
 });

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -28,6 +28,8 @@ import {
   stackCreate,
   stackSubmit,
   syncAndRestack,
+  stackPlan,
+  type DependencyEdge,
 } from '../../lib/helpers.js';
 
 // =============================================================================
@@ -992,6 +994,110 @@ describe('stackSubmit', () => {
     const result = stackSubmit('feat.add-search', { spawnFn: spawn as never });
     expect(result.ok).toBe(false);
     expect(result.stderr).toContain('restack');
+  });
+});
+
+// =============================================================================
+// stackPlan
+// =============================================================================
+
+describe('stackPlan', () => {
+  const blocks = (blocker: string, blocked: string): DependencyEdge =>
+    ({ blocker, blocked, dependencyType: 'blocks' });
+
+  it('orders a linear chain blocker-first', () => {
+    const result = stackPlan(['b3', 'b1', 'b2'], [blocks('b1', 'b2'), blocks('b2', 'b3')]);
+    expect(result.flat).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(result.chains).toEqual([['b1', 'b2', 'b3']]);
+  });
+
+  it('returns multiple independent chains in input order of their heads', () => {
+    const result = stackPlan(
+      ['b1', 'b4', 'b5', 'b2', 'b6'],
+      [blocks('b1', 'b2'), blocks('b5', 'b6')],
+    );
+    expect(result.flat).toBe(false);
+    expect(result.chains).toEqual([['b1', 'b2'], ['b4'], ['b5', 'b6']]);
+  });
+
+  it('returns all singletons for an empty edge set without flagging flat', () => {
+    const result = stackPlan(['b1', 'b2', 'b3'], []);
+    expect(result.chains).toEqual([['b1'], ['b2'], ['b3']]);
+    expect(result.flat).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('falls back to a flat plan with a warning on a cycle', () => {
+    const result = stackPlan(
+      ['b1', 'b2', 'b3'],
+      [blocks('b1', 'b2'), blocks('b2', 'b1')],
+    );
+    expect(result.flat).toBe(true);
+    expect(result.chains).toEqual([['b1'], ['b2'], ['b3']]);
+    expect(result.warnings.some(w => /cycle/.test(w))).toBe(true);
+  });
+
+  it('falls back to a flat plan with a warning on a fork (one blocker, two dependents)', () => {
+    const result = stackPlan(
+      ['b1', 'b2', 'b3'],
+      [blocks('b1', 'b2'), blocks('b1', 'b3')],
+    );
+    expect(result.flat).toBe(true);
+    expect(result.chains).toEqual([['b1'], ['b2'], ['b3']]);
+    expect(result.warnings.some(w => /fork at b1/.test(w))).toBe(true);
+  });
+
+  it('falls back to a flat plan with a warning on a join (two blockers, one dependent)', () => {
+    const result = stackPlan(
+      ['b1', 'b2', 'b3'],
+      [blocks('b1', 'b3'), blocks('b2', 'b3')],
+    );
+    expect(result.flat).toBe(true);
+    expect(result.chains).toEqual([['b1'], ['b2'], ['b3']]);
+    expect(result.warnings.some(w => /join at b3/.test(w))).toBe(true);
+  });
+
+  it('ignores parent-child edges', () => {
+    const result = stackPlan(
+      ['b1', 'b2'],
+      [
+        { blocker: 'epic-1', blocked: 'b1', dependencyType: 'parent-child' },
+        { blocker: 'b1', blocked: 'b2', dependencyType: 'parent-child' },
+      ],
+    );
+    expect(result.chains).toEqual([['b1'], ['b2']]);
+    expect(result.flat).toBe(false);
+  });
+
+  it('ignores edges that reference beads outside the sibling set', () => {
+    const result = stackPlan(
+      ['b1', 'b2'],
+      [blocks('pv-external', 'b1'), blocks('b1', 'b2')],
+    );
+    expect(result.chains).toEqual([['b1', 'b2']]);
+    expect(result.flat).toBe(false);
+  });
+
+  it('does not treat duplicate edges as a fork or join', () => {
+    const result = stackPlan(
+      ['b1', 'b2'],
+      [blocks('b1', 'b2'), blocks('b1', 'b2')],
+    );
+    expect(result.flat).toBe(false);
+    expect(result.chains).toEqual([['b1', 'b2']]);
+  });
+
+  it('produces deterministic output for the same input', () => {
+    const beads = ['b2', 'b1', 'b9', 'b5'];
+    const edges = [blocks('b1', 'b2'), blocks('b9', 'b5')];
+    const first = stackPlan(beads, edges);
+    const second = stackPlan(beads, edges);
+    expect(first).toEqual(second);
+    // Head order follows input order: b2's chain head is b1 (first head
+    // encountered in input order is b1 via... b2 is not a head; heads in
+    // input order are b1 then b9).
+    expect(first.chains).toEqual([['b1', 'b2'], ['b9', 'b5']]);
   });
 });
 

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -965,6 +965,47 @@ describe('stackCreate', () => {
 });
 
 // =============================================================================
+// gt helpers — cwd forwarding (gt-in-worktrees)
+// =============================================================================
+
+describe('gt helpers cwd forwarding', () => {
+  function captureOpts() {
+    const optsSeen: Array<Record<string, unknown>> = [];
+    const spawn = (_cmd: string, _args: string[], opts: Record<string, unknown>) => {
+      optsSeen.push(opts);
+      return fakeSpawn('');
+    };
+    return { optsSeen, spawn };
+  }
+
+  it('forwards deps.cwd into the spawn options for stackCreate, stackSubmit, and syncAndRestack', () => {
+    const { optsSeen, spawn } = captureOpts();
+
+    stackCreate('feat.level-two', 'feat.level-one', { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
+    stackSubmit('feat.level-two', { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
+    syncAndRestack({ spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
+
+    expect(optsSeen).toHaveLength(3);
+    for (const opts of optsSeen) {
+      expect(opts.cwd).toBe('/tmp/orch-wt-1');
+    }
+  });
+
+  it('omits cwd from the spawn options when deps.cwd is not set (main checkout)', () => {
+    const { optsSeen, spawn } = captureOpts();
+
+    stackCreate('feat.level-one', 'main', { spawnFn: spawn as never });
+    stackSubmit('feat.level-one', { spawnFn: spawn as never });
+    syncAndRestack({ spawnFn: spawn as never });
+
+    expect(optsSeen).toHaveLength(3);
+    for (const opts of optsSeen) {
+      expect('cwd' in opts).toBe(false);
+    }
+  });
+});
+
+// =============================================================================
 // stackSubmit
 // =============================================================================
 
@@ -1068,6 +1109,13 @@ describe('stackPlan', () => {
     );
     expect(result.chains).toEqual([['b1'], ['b2']]);
     expect(result.flat).toBe(false);
+  });
+
+  it('ignores self-edges', () => {
+    const result = stackPlan(['b1', 'b2'], [blocks('b1', 'b1')]);
+    expect(result.chains).toEqual([['b1'], ['b2']]);
+    expect(result.flat).toBe(false);
+    expect(result.warnings).toEqual([]);
   });
 
   it('ignores edges that reference beads outside the sibling set', () => {

--- a/.claude/orchestrators/test/unit/helpers.test.ts
+++ b/.claude/orchestrators/test/unit/helpers.test.ts
@@ -190,17 +190,17 @@ describe('gitSafeToStart', () => {
 // =============================================================================
 
 describe('preflight', () => {
-  // gt probe responses shared by passing cases:
-  //   gt --version, gt auth --no-interactive, gt trunk
-  const gtOk = () => [
-    fakeSpawn('1.8.6'),
-    fakeSpawn('Authenticated as: someone\n✅ Ready to submit PRs.'),
-    fakeSpawn('main'),
+  // gh-stack probe responses shared by passing cases (D5: two cheap local
+  // hard-gates only — gh stack --version, gh auth status; no remote
+  // enablement probe).
+  const ghStackOk = () => [
+    fakeSpawn('gh stack version 0.0.8'),
+    fakeSpawn('Logged in to github.com as someone'),
   ];
 
   it('returns ok=true when all checks pass', () => {
     // Calls in order: git status, git fetch, git rev-parse HEAD, git rev-parse origin/main,
-    // gt --version, gt auth, gt trunk, bd ready --json, bd label list (per bead)
+    // gh stack --version, gh auth status, bd ready --json, bd label list (per bead)
     const beadsJson = JSON.stringify([
       { id: 'pv-abc1', priority: 1, created_at: '2026-01-01' },
     ]);
@@ -209,7 +209,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // git fetch origin main (success)
       fakeSpawn('abc1234'),           // git rev-parse HEAD
       fakeSpawn('abc1234'),           // git rev-parse origin/main (matches)
-      ...gtOk(),
+      ...ghStackOk(),
       fakeSpawn(beadsJson),           // bd ready --json
       fakeSpawn('  - backlog'),       // bd label list pv-abc1 (no needs-human)
     );
@@ -227,7 +227,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('def5678'),           // HEAD
       fakeSpawn('def5678'),           // origin/main matches
-      ...gtOk(),
+      ...ghStackOk(),
       fakeSpawn(beadsJson),
       fakeSpawn('  - other'),
     );
@@ -239,7 +239,7 @@ describe('preflight', () => {
     const spawn = seqSpawn(
       fakeSpawn(' M src/file.ts'),   // dirty
       fakeSpawn('', '', 1),           // fetch fails → behind_main
-      ...gtOk(),
+      ...ghStackOk(),
       fakeSpawn('[]'),                // bd ready (empty → empty_backlog)
     );
     const result = preflight({ spawnFn: spawn as never });
@@ -256,7 +256,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('aaaaaaa'),           // HEAD
       fakeSpawn('bbbbbbb'),           // origin/main differs
-      ...gtOk(),
+      ...ghStackOk(),
       fakeSpawn('[]'),                // bd ready (empty → empty_backlog too)
     );
     const result = preflight({ spawnFn: spawn as never });
@@ -271,7 +271,7 @@ describe('preflight', () => {
       fakeSpawn(''),                  // fetch ok
       fakeSpawn('abc1234'),           // HEAD
       fakeSpawn('abc1234'),           // origin/main matches
-      ...gtOk(),
+      ...ghStackOk(),
       fakeSpawn(beadsJson),           // bd ready
       fakeSpawn('  - needs-human'),   // label list: has needs-human
     );
@@ -279,7 +279,7 @@ describe('preflight', () => {
     expect(result.failures.map(f => f.kind)).toContain('empty_backlog');
   });
 
-  it('reports missing_gt and skips the auth/trunk probes when gt is absent', () => {
+  it('reports missing_gh_stack and skips the auth probe when the extension is absent', () => {
     const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
     const calls: string[] = [];
     const results = [
@@ -287,8 +287,8 @@ describe('preflight', () => {
       fakeSpawn(''),                        // fetch ok
       fakeSpawn('abc1234'),                 // HEAD
       fakeSpawn('abc1234'),                 // origin/main matches
-      fakeSpawn('', 'command not found: gt', 127), // gt --version fails
-      fakeSpawn(beadsJson),                 // bd ready (auth/trunk probes skipped)
+      fakeSpawn('', 'unknown command "stack" for "gh"', 1), // gh stack --version fails
+      fakeSpawn(beadsJson),                 // bd ready (auth probe skipped)
       fakeSpawn('  - backlog'),             // bd label list
     ];
     let i = 0;
@@ -298,63 +298,26 @@ describe('preflight', () => {
     };
     const result = preflight({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
-    expect(result.failures.map(f => f.kind)).toContain('missing_gt');
-    // Hard stop on the tool itself: auth and trunk are not probed.
+    expect(result.failures.map(f => f.kind)).toContain('missing_gh_stack');
+    // Hard stop on the extension itself: the auth probe is not run.
     expect(calls.some(c => c.includes('auth'))).toBe(false);
-    expect(calls.some(c => c.includes('trunk'))).toBe(false);
   });
 
-  it('reports gt_unauthenticated when the auth probe fails', () => {
+  it('reports gh_unauthenticated when the auth probe fails', () => {
     const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
     const spawn = seqSpawn(
       fakeSpawn(''),                        // clean tree
       fakeSpawn(''),                        // fetch ok
       fakeSpawn('abc1234'),                 // HEAD
       fakeSpawn('abc1234'),                 // origin/main matches
-      fakeSpawn('1.8.6'),                   // gt --version ok
-      fakeSpawn('', 'Please authenticate', 1), // gt auth fails
-      fakeSpawn('main'),                    // gt trunk ok
+      fakeSpawn('gh stack version 0.0.8'),  // gh stack --version ok
+      fakeSpawn('', 'You are not logged into any GitHub hosts', 1), // gh auth status fails
       fakeSpawn(beadsJson),
       fakeSpawn('  - backlog'),
     );
     const result = preflight({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
-    expect(result.failures.map(f => f.kind)).toContain('gt_unauthenticated');
-  });
-
-  it('reports gt_unauthenticated when the auth probe output lacks an authenticated user', () => {
-    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
-    const spawn = seqSpawn(
-      fakeSpawn(''),
-      fakeSpawn(''),
-      fakeSpawn('abc1234'),
-      fakeSpawn('abc1234'),
-      fakeSpawn('1.8.6'),
-      fakeSpawn('Add your auth token to enable Graphite CLI'), // exit 0 but not authenticated
-      fakeSpawn('main'),
-      fakeSpawn(beadsJson),
-      fakeSpawn('  - backlog'),
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.failures.map(f => f.kind)).toContain('gt_unauthenticated');
-  });
-
-  it('reports gt_trunk_misconfigured when gt trunk is not the main branch', () => {
-    const beadsJson = JSON.stringify([{ id: 'pv-x1', priority: 1, created_at: '2026-01-01' }]);
-    const spawn = seqSpawn(
-      fakeSpawn(''),
-      fakeSpawn(''),
-      fakeSpawn('abc1234'),
-      fakeSpawn('abc1234'),
-      fakeSpawn('1.8.6'),
-      fakeSpawn('Authenticated as: someone'),
-      fakeSpawn('develop'),                 // gt trunk mismatch
-      fakeSpawn(beadsJson),
-      fakeSpawn('  - backlog'),
-    );
-    const result = preflight({ spawnFn: spawn as never });
-    expect(result.ok).toBe(false);
-    expect(result.failures.map(f => f.kind)).toContain('gt_trunk_misconfigured');
+    expect(result.failures.map(f => f.kind)).toContain('gh_unauthenticated');
   });
 });
 
@@ -924,56 +887,90 @@ describe('bdSizingCheck', () => {
 // =============================================================================
 
 describe('stackCreate', () => {
-  it('runs gt create with --onto parent and --no-interactive', () => {
-    const calls: string[] = [];
-    const spawn = (cmd: string, args: string[], _opts: unknown) => {
-      calls.push([cmd, ...(args as string[])].join(' '));
-      return fakeSpawn('');
-    };
-    const result = stackCreate('feat.add-search', 'main', { spawnFn: spawn as never });
-    expect(result.ok).toBe(true);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('gt create feat.add-search');
-    expect(calls[0]).toContain('--onto main');
-    expect(calls[0]).toContain('--no-interactive');
+  describe('chain path (chained=true)', () => {
+    it('runs gh stack init with --base when parent is trunk (chain head)', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('');
+      };
+      const result = stackCreate('feat.add-search', 'main', true, { spawnFn: spawn as never });
+      expect(result.ok).toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toBe('gh stack init --base main feat.add-search');
+    });
+
+    it('runs gh stack add (no --base) when parent is a stack level, not trunk', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('');
+      };
+      const result = stackCreate('feat.level-two', 'feat.level-one', true, { spawnFn: spawn as never });
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual(['gh stack add feat.level-two']);
+    });
+
+    it('accepts branchName()-produced names verbatim (documented precondition)', () => {
+      // stackCreate does not validate or rewrite branch names at runtime;
+      // callers must pass names produced by branchName(). This test asserts
+      // the precondition holds end to end: a branchName() output goes to
+      // gh-stack unchanged and carries no bead IDs.
+      const name = branchName('Add calendar discovery surface', 'feature');
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('');
+      };
+      stackCreate(name, 'feat.parent-level', true, { spawnFn: spawn as never });
+      expect(calls[0]).toBe(`gh stack add ${name}`);
+      expect(calls[0]).not.toMatch(/pv-[a-z0-9]+/);
+    });
+
+    it('returns ok=false with stderr when gh stack init fails', () => {
+      const spawn = seqSpawn(
+        fakeSpawn('', 'current branch "main" is already part of a stack', 5),
+      );
+      const result = stackCreate('feat.add-search', 'main', true, { spawnFn: spawn as never });
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain('already part of a stack');
+    });
   });
 
-  it('accepts branchName()-produced names verbatim (documented precondition)', () => {
-    // stackCreate does not validate or rewrite branch names at runtime;
-    // callers must pass names produced by branchName(). This test asserts
-    // the precondition holds end to end: a branchName() output goes to gt
-    // unchanged and carries no bead IDs.
-    const name = branchName('Add calendar discovery surface', 'feature');
-    const calls: string[] = [];
-    const spawn = (cmd: string, args: string[], _opts: unknown) => {
-      calls.push([cmd, ...(args as string[])].join(' '));
-      return fakeSpawn('');
-    };
-    stackCreate(name, 'feat.parent-level', { spawnFn: spawn as never });
-    expect(calls[0]).toContain(`gt create ${name}`);
-    expect(calls[0]).not.toMatch(/pv-[a-z0-9]+/);
-  });
+  describe('single path (chained=false)', () => {
+    it('runs plain git checkout -b off trunk, never touching gh-stack', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('');
+      };
+      const result = stackCreate('chore.fix-widget', 'main', false, { spawnFn: spawn as never });
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual(['git checkout -b chore.fix-widget main']);
+      expect(calls.some(c => c.includes('gh stack'))).toBe(false);
+    });
 
-  it('returns ok=false with stderr when gt create fails', () => {
-    const spawn = seqSpawn(
-      fakeSpawn('', 'ERROR: Cannot perform this operation on untracked branch xyz.', 1),
-    );
-    const result = stackCreate('feat.add-search', 'main', { spawnFn: spawn as never });
-    expect(result.ok).toBe(false);
-    expect(result.stderr).toContain('untracked branch');
+    it('returns ok=false with stderr when git checkout -b fails', () => {
+      const spawn = seqSpawn(
+        fakeSpawn('', "fatal: a branch named 'chore.fix-widget' already exists", 128),
+      );
+      const result = stackCreate('chore.fix-widget', 'main', false, { spawnFn: spawn as never });
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain('already exists');
+    });
   });
 });
 
 // =============================================================================
-// gt helpers — cwd forwarding (gt-in-worktrees)
+// gh-stack helpers — cwd forwarding (native gh-stack-in-worktrees, D2)
 // =============================================================================
 
-describe('gt helpers cwd forwarding', () => {
+describe('gh-stack helpers cwd forwarding', () => {
   function captureOpts() {
     const optsSeen: Array<Record<string, unknown>> = [];
     const spawn = (_cmd: string, _args: string[], opts: Record<string, unknown>) => {
       optsSeen.push(opts);
-      return fakeSpawn('');
+      return fakeSpawn('{}');
     };
     return { optsSeen, spawn };
   }
@@ -981,11 +978,11 @@ describe('gt helpers cwd forwarding', () => {
   it('forwards deps.cwd into the spawn options for stackCreate, stackSubmit, and syncAndRestack', () => {
     const { optsSeen, spawn } = captureOpts();
 
-    stackCreate('feat.level-two', 'feat.level-one', { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
-    stackSubmit('feat.level-two', { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
+    stackCreate('feat.level-two', 'feat.level-one', true, { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
+    stackSubmit('feat.level-two', true, { spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
     syncAndRestack({ spawnFn: spawn as never, cwd: '/tmp/orch-wt-1' });
 
-    expect(optsSeen).toHaveLength(3);
+    expect(optsSeen.length).toBeGreaterThan(0);
     for (const opts of optsSeen) {
       expect(opts.cwd).toBe('/tmp/orch-wt-1');
     }
@@ -994,11 +991,11 @@ describe('gt helpers cwd forwarding', () => {
   it('omits cwd from the spawn options when deps.cwd is not set (main checkout)', () => {
     const { optsSeen, spawn } = captureOpts();
 
-    stackCreate('feat.level-one', 'main', { spawnFn: spawn as never });
-    stackSubmit('feat.level-one', { spawnFn: spawn as never });
+    stackCreate('feat.level-one', 'main', true, { spawnFn: spawn as never });
+    stackSubmit('feat.level-one', true, { spawnFn: spawn as never });
     syncAndRestack({ spawnFn: spawn as never });
 
-    expect(optsSeen).toHaveLength(3);
+    expect(optsSeen.length).toBeGreaterThan(0);
     for (const opts of optsSeen) {
       expect('cwd' in opts).toBe(false);
     }
@@ -1010,31 +1007,92 @@ describe('gt helpers cwd forwarding', () => {
 // =============================================================================
 
 describe('stackSubmit', () => {
-  it('runs gt submit non-interactively with --publish and an explicit --branch', () => {
-    // --publish is load-bearing: on gt 1.8.6, --no-interactive submits new
-    // PRs as drafts unless --publish is passed (verified 2026-07-11), and
-    // the git-workflow skill forbids draft PRs.
-    const calls: string[] = [];
-    const spawn = (cmd: string, args: string[], _opts: unknown) => {
-      calls.push([cmd, ...(args as string[])].join(' '));
-      return fakeSpawn('✅ Submitted.');
-    };
-    const result = stackSubmit('feat.add-search', { spawnFn: spawn as never });
-    expect(result.ok).toBe(true);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('gt submit');
-    expect(calls[0]).toContain('--no-interactive');
-    expect(calls[0]).toContain('--publish');
-    expect(calls[0]).toContain('--branch feat.add-search');
+  describe('chain path (chained=true)', () => {
+    it('runs gh stack submit --auto --open, then sweeps gh pr ready over the stack (D3 safe interim)', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        const call = [cmd, ...(args as string[])].join(' ');
+        calls.push(call);
+        if (cmd === 'gh' && args[0] === 'stack' && args[1] === 'view') {
+          return fakeSpawn(JSON.stringify({
+            branches: [
+              { name: 'feat.level-one', pr: { number: 10 } },
+              { name: 'feat.level-two', pr: { number: 11 } },
+            ],
+          }));
+        }
+        return fakeSpawn('✓ Stack created on GitHub with 2 PRs (stack #1)');
+      };
+      const result = stackSubmit('feat.level-two', true, { spawnFn: spawn as never });
+      expect(result.ok).toBe(true);
+      expect(calls[0]).toBe('gh stack submit --auto --open');
+      expect(calls).toContain('gh stack view --json');
+      expect(calls).toContain('gh pr ready 10');
+      expect(calls).toContain('gh pr ready 11');
+    });
+
+    it('does not sweep gh pr ready when the stack has no PRs yet', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        if (cmd === 'gh' && args[0] === 'stack' && args[1] === 'view') {
+          return fakeSpawn(JSON.stringify({ branches: [] }));
+        }
+        return fakeSpawn('');
+      };
+      stackSubmit('feat.level-one', true, { spawnFn: spawn as never });
+      expect(calls.some(c => c.startsWith('gh pr ready'))).toBe(false);
+    });
+
+    it('returns ok=false with output when gh stack submit fails, without sweeping', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('', 'feature disabled for this repo', 9);
+      };
+      const result = stackSubmit('feat.add-search', true, { spawnFn: spawn as never });
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain('feature disabled');
+      expect(calls).toEqual(['gh stack submit --auto --open']);
+    });
   });
 
-  it('returns ok=false with output when gt submit fails', () => {
-    const spawn = seqSpawn(
-      fakeSpawn('', 'ERROR: Validation failed; branches need restack.', 1),
-    );
-    const result = stackSubmit('feat.add-search', { spawnFn: spawn as never });
-    expect(result.ok).toBe(false);
-    expect(result.stderr).toContain('restack');
+  describe('single path (chained=false)', () => {
+    it('runs plain git push then gh pr create --fill, never touching gh-stack', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('');
+      };
+      const result = stackSubmit('chore.fix-widget', false, { spawnFn: spawn as never });
+      expect(result.ok).toBe(true);
+      expect(calls).toEqual([
+        'git push -u origin chore.fix-widget',
+        'gh pr create --fill',
+      ]);
+    });
+
+    it('returns ok=false without calling gh pr create when git push fails', () => {
+      const calls: string[] = [];
+      const spawn = (cmd: string, args: string[], _opts: unknown) => {
+        calls.push([cmd, ...(args as string[])].join(' '));
+        return fakeSpawn('', 'fatal: could not read from remote repository', 128);
+      };
+      const result = stackSubmit('chore.fix-widget', false, { spawnFn: spawn as never });
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain('remote repository');
+      expect(calls).toEqual(['git push -u origin chore.fix-widget']);
+    });
+
+    it('returns ok=false when gh pr create fails after a successful push', () => {
+      const spawn = seqSpawn(
+        fakeSpawn(''),
+        fakeSpawn('', 'a pull request for branch "chore.fix-widget" already exists', 1),
+      );
+      const result = stackSubmit('chore.fix-widget', false, { spawnFn: spawn as never });
+      expect(result.ok).toBe(false);
+      expect(result.stderr).toContain('already exists');
+    });
   });
 });
 
@@ -1154,67 +1212,50 @@ describe('stackPlan', () => {
 // =============================================================================
 
 describe('syncAndRestack', () => {
-  // Output lines below match observed gt 1.8.6 output (verified 2026-07-11).
-  const syncOutput = [
-    '🌲 Fetching branches from remote...',
-    'main is up to date.',
-    '',
-    '🥞 Restacking branches...',
-    'feat.level-one does not need to be restacked on main.',
-    'Restacked feat.level-two on feat.level-one.',
-    'WARNING: feat.level-three could not be restacked cleanly.',
-    'Did not restack branch feat.level-four because it is checked out in worktree /some/worktree/path.',
-    '',
-    'You can resolve conflicts with gt restack.',
-  ].join('\n');
-
-  it('runs gt sync -f --no-interactive', () => {
+  it('runs gh stack sync --prune', () => {
     const calls: string[] = [];
     const spawn = (cmd: string, args: string[], _opts: unknown) => {
       calls.push([cmd, ...(args as string[])].join(' '));
-      return fakeSpawn('main is up to date.');
+      return fakeSpawn('✓ Synced.');
     };
     syncAndRestack({ spawnFn: spawn as never });
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain('gt sync');
-    expect(calls[0]).toContain('-f');
-    expect(calls[0]).toContain('--no-interactive');
+    expect(calls).toEqual(['gh stack sync --prune']);
   });
 
-  it('returns structured clean / conflicted / worktree-skipped results', () => {
-    const spawn = seqSpawn(fakeSpawn(syncOutput));
-    const result = syncAndRestack({ spawnFn: spawn as never });
-    expect(result.restacked).toEqual(['feat.level-two']);
-    expect(result.conflicted).toEqual(['feat.level-three']);
-    expect(result.skippedWorktree).toEqual(['feat.level-four']);
-    expect(result.rawOutput).toContain('Restacking branches');
-  });
-
-  it('reports ok=false when any branch conflicted', () => {
-    const spawn = seqSpawn(fakeSpawn(syncOutput));
-    const result = syncAndRestack({ spawnFn: spawn as never });
-    expect(result.ok).toBe(false);
-  });
-
-  it('reports ok=true on a fully clean sync', () => {
-    const clean = [
-      'main is up to date.',
-      '🥞 Restacking branches...',
-      'feat.level-one does not need to be restacked on main.',
-      'Restacked feat.level-two on feat.level-one.',
-    ].join('\n');
-    const spawn = seqSpawn(fakeSpawn(clean));
+  it('reports ok=true on a clean sync (exit 0)', () => {
+    const spawn = seqSpawn(fakeSpawn('✓ Synced 2 branches.'));
     const result = syncAndRestack({ spawnFn: spawn as never });
     expect(result.ok).toBe(true);
-    expect(result.restacked).toEqual(['feat.level-two']);
-    expect(result.conflicted).toEqual([]);
-    expect(result.skippedWorktree).toEqual([]);
+    expect(result.exitCode).toBe(0);
+    expect(result.conflicted).toBe(false);
+    expect(result.featureDisabled).toBe(false);
   });
 
-  it('reports ok=false when gt sync itself exits non-zero', () => {
+  it('reports a rebase conflict on exit code 3', () => {
+    const spawn = seqSpawn(fakeSpawn('', 'rebase conflict on feat.level-two', 3));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(3);
+    expect(result.conflicted).toBe(true);
+    expect(result.featureDisabled).toBe(false);
+    expect(result.rawOutput).toContain('rebase conflict');
+  });
+
+  it('reports feature-disabled on exit code 9 (clean hard stop, per D5)', () => {
+    const spawn = seqSpawn(fakeSpawn('', 'feature disabled for this repo', 9));
+    const result = syncAndRestack({ spawnFn: spawn as never });
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(9);
+    expect(result.featureDisabled).toBe(true);
+    expect(result.conflicted).toBe(false);
+  });
+
+  it('reports ok=false when gh stack sync fails for any other reason', () => {
     const spawn = seqSpawn(fakeSpawn('', 'ERROR: network failure', 1));
     const result = syncAndRestack({ spawnFn: spawn as never });
     expect(result.ok).toBe(false);
+    expect(result.conflicted).toBe(false);
+    expect(result.featureDisabled).toBe(false);
     expect(result.rawOutput).toContain('network failure');
   });
 });

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -154,6 +154,9 @@ function preflightPassingSpawns(beadId = 'pv-abc-1'): SpawnSyncReturns<Buffer>[]
     fakeSpawn('', '', 0),                                  // git fetch origin main
     fakeSpawn('abc1234', '', 0),                           // git rev-parse HEAD
     fakeSpawn('abc1234', '', 0),                           // git rev-parse origin/main (matches)
+    fakeSpawn('1.8.6', '', 0),                             // gt --version
+    fakeSpawn('Authenticated as: testuser', '', 0),        // gt auth --no-interactive
+    fakeSpawn('main', '', 0),                              // gt trunk
     fakeSpawn(JSON.stringify([{ id: beadId }]), '', 0),    // bd ready --limit=50 --json
     fakeSpawn('- other-label', '', 0),                     // bd label list <id>
     // gitSafeToStart:
@@ -276,6 +279,9 @@ describe('preflight', () => {
       fakeSpawn('', '', 0),        // git fetch origin main
       fakeSpawn('abc1234', '', 0), // git rev-parse HEAD
       fakeSpawn('abc1234', '', 0), // git rev-parse origin/main (matches)
+      fakeSpawn('1.8.6', '', 0),   // gt --version
+      fakeSpawn('Authenticated as: testuser', '', 0), // gt auth --no-interactive
+      fakeSpawn('main', '', 0),    // gt trunk
       fakeSpawn('[]', '', 0),      // bd ready: empty array
       // gitSafeToStart passes:
       ...gitSafeOkSpawns(),
@@ -1151,9 +1157,10 @@ describe('branch', () => {
 // =============================================================================
 
 describe('message constants', () => {
-  it('should have exactly 3 preflight message kinds', () => {
+  it('should have exactly 6 preflight message kinds', () => {
     expect(Object.keys(PREFLIGHT_MESSAGES)).toEqual([
       'dirty_tree', 'behind_main', 'empty_backlog',
+      'missing_gt', 'gt_unauthenticated', 'gt_trunk_misconfigured',
     ]);
   });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -1142,6 +1142,42 @@ describe('branch', () => {
     expect(calls).toContain('gt create chore.a-task --onto main --no-interactive');
   });
 
+  it('honors GIT_SAFE_MAIN_BRANCH as the gt create base branch', async () => {
+    const prev = process.env.GIT_SAFE_MAIN_BRANCH;
+    process.env.GIT_SAFE_MAIN_BRANCH = 'develop';
+    try {
+      const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
+      const calls: string[] = [];
+      const results = [
+        // gitSafeToStart:
+        fakeSpawn('true', '', 0),
+        fakeSpawn('abc1234', '', 0),
+        fakeSpawn('abc1234', '', 0),
+        fakeSpawn('', '', 0),
+        // bd show --json:
+        fakeSpawn(bdShowJson, '', 0),
+        // git branch --show-current:
+        fakeSpawn('develop', '', 0),
+        // gt create <branch> --onto develop --no-interactive:
+        fakeSpawn('', '', 0),
+      ];
+      let i = 0;
+      const spawn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+        calls.push([cmd, ...(args ?? [])].join(' '));
+        return results[i++] ?? fakeSpawn('', 'unexpected call', 1);
+      });
+
+      const result = await branch(makeCtx(), { spawnFn: spawn as never });
+
+      expect(result.next).toBe(PhaseName.Leaf);
+      expect(calls).toContain('gt create chore.a-task --onto develop --no-interactive');
+    }
+    finally {
+      if (prev === undefined) delete process.env.GIT_SAFE_MAIN_BRANCH;
+      else process.env.GIT_SAFE_MAIN_BRANCH = prev;
+    }
+  });
+
   it('should halt when gt create fails', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
     const spawn = seqSpawn(

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -139,12 +139,12 @@ function gitSafeDirtySpawns(): SpawnSyncReturns<Buffer>[] {
 }
 
 // =============================================================================
-// Canonical seqSpawn sequences for preflight() / runPreflightCheck() (6 calls)
-// then gitSafeToStart() (4 calls) = 10 total for full success
+// Canonical seqSpawn sequences for preflight() / runPreflightCheck() (8 calls)
+// then gitSafeToStart() (4 calls) = 12 total for full success
 // =============================================================================
 
 /**
- * 10 spawn calls for a fully passing preflight() (runPreflightCheck + gitSafeToStart).
+ * 12 spawn calls for a fully passing preflight() (runPreflightCheck + gitSafeToStart).
  * Bead id used for label check is passed in.
  */
 function preflightPassingSpawns(beadId = 'pv-abc-1'): SpawnSyncReturns<Buffer>[] {
@@ -154,9 +154,8 @@ function preflightPassingSpawns(beadId = 'pv-abc-1'): SpawnSyncReturns<Buffer>[]
     fakeSpawn('', '', 0),                                  // git fetch origin main
     fakeSpawn('abc1234', '', 0),                           // git rev-parse HEAD
     fakeSpawn('abc1234', '', 0),                           // git rev-parse origin/main (matches)
-    fakeSpawn('1.8.6', '', 0),                             // gt --version
-    fakeSpawn('Authenticated as: testuser', '', 0),        // gt auth --no-interactive
-    fakeSpawn('main', '', 0),                              // gt trunk
+    fakeSpawn('gh stack version 0.0.8', '', 0),            // gh stack --version
+    fakeSpawn('Logged in to github.com as testuser', '', 0), // gh auth status
     fakeSpawn(JSON.stringify([{ id: beadId }]), '', 0),    // bd ready --limit=50 --json
     fakeSpawn('- other-label', '', 0),                     // bd label list <id>
     // gitSafeToStart:
@@ -279,9 +278,8 @@ describe('preflight', () => {
       fakeSpawn('', '', 0),        // git fetch origin main
       fakeSpawn('abc1234', '', 0), // git rev-parse HEAD
       fakeSpawn('abc1234', '', 0), // git rev-parse origin/main (matches)
-      fakeSpawn('1.8.6', '', 0),   // gt --version
-      fakeSpawn('Authenticated as: testuser', '', 0), // gt auth --no-interactive
-      fakeSpawn('main', '', 0),    // gt trunk
+      fakeSpawn('gh stack version 0.0.8', '', 0),      // gh stack --version
+      fakeSpawn('Logged in to github.com as testuser', '', 0), // gh auth status
       fakeSpawn('[]', '', 0),      // bd ready: empty array
       // gitSafeToStart passes:
       ...gitSafeOkSpawns(),
@@ -1110,10 +1108,10 @@ describe('branch', () => {
 
     expect(result.next).toBe(PhaseName.Epic);
     expect(spawn).toHaveBeenCalledTimes(6);
-    expect(calls.some(c => c.startsWith('gt create'))).toBe(false);
+    expect(calls.some(c => c.startsWith('git checkout -b'))).toBe(false);
   });
 
-  it('should route non-epic to Leaf phase, creating the branch via gt create', async () => {
+  it('should route non-epic to Leaf phase, creating the branch via plain git checkout -b (single, chained=false)', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
     const calls: string[] = [];
     const results = [
@@ -1126,7 +1124,7 @@ describe('branch', () => {
       fakeSpawn(bdShowJson, '', 0),
       // git branch --show-current:
       fakeSpawn('main', '', 0),
-      // gt create <branch> --onto main --no-interactive:
+      // git checkout -b <branch> main:
       fakeSpawn('', '', 0),
     ];
     let i = 0;
@@ -1139,10 +1137,11 @@ describe('branch', () => {
 
     expect(result.next).toBe(PhaseName.Leaf);
     // branchName('A Task', 'task') = 'chore.a-task'
-    expect(calls).toContain('gt create chore.a-task --onto main --no-interactive');
+    expect(calls).toContain('git checkout -b chore.a-task main');
+    expect(calls.some(c => c.includes('gh stack'))).toBe(false);
   });
 
-  it('honors GIT_SAFE_MAIN_BRANCH as the gt create base branch', async () => {
+  it('honors GIT_SAFE_MAIN_BRANCH as the checkout base branch', async () => {
     const prev = process.env.GIT_SAFE_MAIN_BRANCH;
     process.env.GIT_SAFE_MAIN_BRANCH = 'develop';
     try {
@@ -1158,7 +1157,7 @@ describe('branch', () => {
         fakeSpawn(bdShowJson, '', 0),
         // git branch --show-current:
         fakeSpawn('develop', '', 0),
-        // gt create <branch> --onto develop --no-interactive:
+        // git checkout -b <branch> develop:
         fakeSpawn('', '', 0),
       ];
       let i = 0;
@@ -1170,7 +1169,7 @@ describe('branch', () => {
       const result = await branch(makeCtx(), { spawnFn: spawn as never });
 
       expect(result.next).toBe(PhaseName.Leaf);
-      expect(calls).toContain('gt create chore.a-task --onto develop --no-interactive');
+      expect(calls).toContain('git checkout -b chore.a-task develop');
     }
     finally {
       if (prev === undefined) delete process.env.GIT_SAFE_MAIN_BRANCH;
@@ -1178,7 +1177,7 @@ describe('branch', () => {
     }
   });
 
-  it('should halt when gt create fails', async () => {
+  it('should halt when git checkout -b fails', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
     const spawn = seqSpawn(
       fakeSpawn('true', '', 0),
@@ -1187,8 +1186,8 @@ describe('branch', () => {
       fakeSpawn('', '', 0),
       fakeSpawn(bdShowJson, '', 0),
       fakeSpawn('main', '', 0),
-      // gt create fails:
-      fakeSpawn('', 'ERROR: Cannot perform this operation on untracked branch xyz.', 1),
+      // git checkout -b fails:
+      fakeSpawn('', "fatal: a branch named 'chore.a-task' already exists", 128),
     );
 
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -1227,10 +1226,10 @@ describe('branch', () => {
 // =============================================================================
 
 describe('message constants', () => {
-  it('should have exactly 6 preflight message kinds', () => {
+  it('should have exactly 5 preflight message kinds', () => {
     expect(Object.keys(PREFLIGHT_MESSAGES)).toEqual([
       'dirty_tree', 'behind_main', 'empty_backlog',
-      'missing_gt', 'gt_unauthenticated', 'gt_trunk_misconfigured',
+      'missing_gh_stack', 'gh_unauthenticated',
     ]);
   });
 

--- a/.claude/orchestrators/test/unit/phases.test.ts
+++ b/.claude/orchestrators/test/unit/phases.test.ts
@@ -1085,9 +1085,10 @@ describe('branch', () => {
     expect(result.next).toBe('halt');
   });
 
-  it('should create branch and route epic to Epic phase', async () => {
+  it('should skip branch creation for epics and route to Epic phase', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'epic', title: 'My Epic Feature' }]);
-    const spawn = seqSpawn(
+    const calls: string[] = [];
+    const results = [
       // gitSafeToStart (4 calls):
       fakeSpawn('true', '', 0),            // git rev-parse --is-inside-work-tree
       fakeSpawn('abc1234', '', 0),         // git rev-parse HEAD
@@ -1097,18 +1098,25 @@ describe('branch', () => {
       fakeSpawn(bdShowJson, '', 0),
       // git branch --show-current:
       fakeSpawn('main', '', 0),
-      // git checkout -b <branch>:
-      fakeSpawn('', '', 0),
-    );
+      // NO branch creation — chain levels create their own stacked branches.
+    ];
+    let i = 0;
+    const spawn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      calls.push([cmd, ...(args ?? [])].join(' '));
+      return results[i++] ?? fakeSpawn('', 'unexpected call', 1);
+    });
 
-    const result = await branch(makeCtx(), { spawnFn: spawn });
+    const result = await branch(makeCtx(), { spawnFn: spawn as never });
 
     expect(result.next).toBe(PhaseName.Epic);
+    expect(spawn).toHaveBeenCalledTimes(6);
+    expect(calls.some(c => c.startsWith('gt create'))).toBe(false);
   });
 
-  it('should route non-epic to Leaf phase', async () => {
+  it('should route non-epic to Leaf phase, creating the branch via gt create', async () => {
     const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
-    const spawn = seqSpawn(
+    const calls: string[] = [];
+    const results = [
       // gitSafeToStart:
       fakeSpawn('true', '', 0),
       fakeSpawn('abc1234', '', 0),
@@ -1118,13 +1126,39 @@ describe('branch', () => {
       fakeSpawn(bdShowJson, '', 0),
       // git branch --show-current:
       fakeSpawn('main', '', 0),
-      // git checkout -b:
+      // gt create <branch> --onto main --no-interactive:
       fakeSpawn('', '', 0),
-    );
+    ];
+    let i = 0;
+    const spawn = vi.fn().mockImplementation((cmd: string, args: string[]) => {
+      calls.push([cmd, ...(args ?? [])].join(' '));
+      return results[i++] ?? fakeSpawn('', 'unexpected call', 1);
+    });
 
-    const result = await branch(makeCtx(), { spawnFn: spawn });
+    const result = await branch(makeCtx(), { spawnFn: spawn as never });
 
     expect(result.next).toBe(PhaseName.Leaf);
+    // branchName('A Task', 'task') = 'chore.a-task'
+    expect(calls).toContain('gt create chore.a-task --onto main --no-interactive');
+  });
+
+  it('should halt when gt create fails', async () => {
+    const bdShowJson = JSON.stringify([{ issue_type: 'task', title: 'A Task' }]);
+    const spawn = seqSpawn(
+      fakeSpawn('true', '', 0),
+      fakeSpawn('abc1234', '', 0),
+      fakeSpawn('abc1234', '', 0),
+      fakeSpawn('', '', 0),
+      fakeSpawn(bdShowJson, '', 0),
+      fakeSpawn('main', '', 0),
+      // gt create fails:
+      fakeSpawn('', 'ERROR: Cannot perform this operation on untracked branch xyz.', 1),
+    );
+
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await branch(makeCtx(), { spawnFn: spawn });
+
+    expect(result.next).toBe('halt');
   });
 
   it('should skip checkout if already on target branch', async () => {

--- a/.claude/orchestrators/vitest.config.ts
+++ b/.claude/orchestrators/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config for the orchestrator workflow-tooling suite.
+ *
+ * The root vitest.config.ts only includes src/** projects, so these tests
+ * are invisible to a bare `npx vitest run`. Run this suite from the repo
+ * root with:
+ *
+ *   npx vitest run --config .claude/orchestrators/vitest.config.ts
+ */
+export default defineConfig({
+  test: {
+    include: ['.claude/orchestrators/test/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/.claude/skills/bead-backlog-selection/SKILL.md
+++ b/.claude/skills/bead-backlog-selection/SKILL.md
@@ -42,12 +42,11 @@ Before `/process-backlog` begins, `preflight()` must return `{ok: true}`. Every 
 |---|---|---|
 | `dirty_tree` | `git status --porcelain` non-empty | Commit or stash first. |
 | `behind_main` | HEAD is not at `origin/main`, or `git fetch origin main` failed | Pull/rebase onto `origin/main` (or fix remote access). Any branch name is fine as long as HEAD matches. |
-| `missing_gt` | Graphite CLI (`gt`) not installed | Install gt and run `gt init`. Hard stop — no silent fallback to plain git. |
-| `gt_unauthenticated` | gt installed but not authenticated | Run `gt auth` interactively. Hard stop. |
-| `gt_trunk_misconfigured` | gt trunk is not `main` | Run `gt init --trunk main`. Hard stop. |
+| `missing_gh_stack` | `gh stack` extension not installed | See `git-workflow/stacking.md`'s preflight section — remediation is one of the local hard-gates it defines. Hard stop — no silent fallback to plain git for chain work. |
+| `gh_unauthenticated` | `gh` not authenticated | See `git-workflow/stacking.md`'s preflight section. Hard stop. |
 | `empty_backlog` | No READY beads exist that aren't `needs-human`-labelled | Shape or enrich more beads, or unlabel one. |
 
-The three gt kinds exist because all branch creation and PR submission goes through gt — command patterns and stacking rules live in the `git-workflow` skill's `stacking.md` (sole source of truth; not restated here).
+The two `gh_stack`-related kinds exist because chain branch creation and PR submission go through `gh stack` — command patterns and stacking rules live in the `git-workflow` skill's `stacking.md` (sole source of truth; not restated here). These cover only the cheap local hard-gates; repo-level feature enablement is **not** a preflight kind — per `stacking.md`, no confirmed cheap read-only probe for it exists, so it surfaces instead as a hard stop (exit code 9) at the first real chain submit during execution, not at preflight time.
 
 The preflight check NEVER auto-fixes any of these. It reports what's wrong; the human (or the orchestrator's exit message) decides what to do. Auto-fix is an anti-pattern here because the fix depends on intent: a dirty tree could be in-progress work the user forgot about, and silently stashing it would surprise them.
 
@@ -97,7 +96,7 @@ The skill refuses autonomous work in these situations, via `preflight()` returni
 
 - **Dirty working tree** — would conflate user work with automation output.
 - **HEAD behind `origin/main`** — branching off a stale base makes PRs that conflict with recent merges and forces rebases.
-- **gt missing, unauthenticated, or trunk misconfigured** — branch creation and PR submission require a working Graphite setup; falling back to plain git silently would fork the workflow.
+- **`gh stack` missing or `gh` unauthenticated** — chain branch creation and PR submission require a working `gh stack` setup (see `git-workflow/stacking.md`); falling back to plain git silently for chain work would fork the workflow.
 - **Empty backlog** — nothing to do. Also triggered when every READY bead is `needs-human`-labelled.
 
 The orchestrator surfaces these reasons to the user verbatim and exits. It does NOT prompt, retry, or auto-fix. The human sees the failure and acts, or invokes `/process-backlog` again once the condition clears.

--- a/.claude/skills/bead-backlog-selection/SKILL.md
+++ b/.claude/skills/bead-backlog-selection/SKILL.md
@@ -36,16 +36,20 @@ The `bdTopReady()` function filters out beads with the `needs-human` label via t
 
 ## Preconditions for autonomous work
 
-Before `/process-backlog` begins, `preflight.sh` must return `{ok: true}`. Every failure carries a `kind` field so the orchestrator can route user-facing messaging:
+Before `/process-backlog` begins, `preflight()` must return `{ok: true}`. Every failure carries a `kind` field so the orchestrator can route user-facing messaging:
 
 | `kind` | Meaning | User action |
 |---|---|---|
 | `dirty_tree` | `git status --porcelain` non-empty | Commit or stash first. |
-| `wrong_branch` | Current branch is not `main` | Return to `main` (or finish the current branch's PR). |
-| `stale_main` | Local `main` differs from `origin/main`, or `git fetch origin main` failed | `git pull` (or fix remote access). |
+| `behind_main` | HEAD is not at `origin/main`, or `git fetch origin main` failed | Pull/rebase onto `origin/main` (or fix remote access). Any branch name is fine as long as HEAD matches. |
+| `missing_gt` | Graphite CLI (`gt`) not installed | Install gt and run `gt init`. Hard stop — no silent fallback to plain git. |
+| `gt_unauthenticated` | gt installed but not authenticated | Run `gt auth` interactively. Hard stop. |
+| `gt_trunk_misconfigured` | gt trunk is not `main` | Run `gt init --trunk main`. Hard stop. |
 | `empty_backlog` | No READY beads exist that aren't `needs-human`-labelled | Shape or enrich more beads, or unlabel one. |
 
-The preflight script NEVER auto-fixes any of these. It reports what's wrong; the human (or the orchestrator's exit message) decides what to do. Auto-fix is an anti-pattern here because the fix depends on intent: a dirty tree could be in-progress work the user forgot about, and silently stashing it would surprise them.
+The three gt kinds exist because all branch creation and PR submission goes through gt — command patterns and stacking rules live in the `git-workflow` skill's `stacking.md` (sole source of truth; not restated here).
+
+The preflight check NEVER auto-fixes any of these. It reports what's wrong; the human (or the orchestrator's exit message) decides what to do. Auto-fix is an anti-pattern here because the fix depends on intent: a dirty tree could be in-progress work the user forgot about, and silently stashing it would surprise them.
 
 The default main branch is `main`. Override via `PREFLIGHT_MAIN_BRANCH=<name>` if you run this in a fork with a differently-named default branch. The default `bd ready` sample size is 50; override via `PREFLIGHT_READY_LIMIT=<n>`.
 
@@ -89,11 +93,11 @@ This fallback is not wired up today because the live bd fully supports labels. L
 
 ## When to refuse to start
 
-The skill refuses autonomous work in these situations, via `preflight.sh` returning `ok: false`:
+The skill refuses autonomous work in these situations, via `preflight()` returning `ok: false`:
 
 - **Dirty working tree** — would conflate user work with automation output.
-- **Wrong branch** — branching off anything other than `main` would produce a PR with unrelated commits.
-- **Stale `main`** — branching off a stale base makes PRs that conflict with recent merges and forces rebases.
+- **HEAD behind `origin/main`** — branching off a stale base makes PRs that conflict with recent merges and forces rebases.
+- **gt missing, unauthenticated, or trunk misconfigured** — branch creation and PR submission require a working Graphite setup; falling back to plain git silently would fork the workflow.
 - **Empty backlog** — nothing to do. Also triggered when every READY bead is `needs-human`-labelled.
 
 The orchestrator surfaces these reasons to the user verbatim and exits. It does NOT prompt, retry, or auto-fix. The human sees the failure and acts, or invokes `/process-backlog` again once the condition clears.

--- a/.claude/skills/bead-branch-and-pr/SKILL.md
+++ b/.claude/skills/bead-branch-and-pr/SKILL.md
@@ -75,23 +75,24 @@ Without `parentBranch`, HEAD is compared against `origin/<mainBranch>` (the trun
 
 The expected main-branch name defaults to `main` and can be overridden by the `GIT_SAFE_MAIN_BRANCH` env var for test rigs.
 
-### Stack helpers: `stackCreate`, `stackSubmit`, `syncAndRestack`
+### Stack helpers: `stackPlan`, `stackCreate`, `stackSubmit`, `syncAndRestack`
 
-Graphite (gt) wrappers, also in `.claude/orchestrators/lib/helpers.ts` — the only place gt operations are implemented. Conventions and command patterns live in `git-workflow/stacking.md`; the jsdoc on each helper records the gt-1.8.6-verified behavior. Signatures:
+The chain planner and the Graphite (gt) wrappers, also in `.claude/orchestrators/lib/helpers.ts` — the only place gt operations are implemented. Conventions and command patterns live in `git-workflow/stacking.md`; the jsdoc on each helper records the gt-1.8.6-verified behavior. Signatures:
 
+- `stackPlan(beads, dependencyEdges)` — pure; plans dependency-chain stacks from an epic's child beads and the bd "blocks" edges among them. Returns an ordered forest of chains as `{ chains, flat, warnings }`; a cycle or any cross-chain join falls back to a flat no-stack plan with a warning. (The edge parameter is named `dependencyEdges`, never `deps` — `deps` is reserved codebase-wide for `SpawnDeps` injection.)
 - `stackCreate(branch, parent, deps?)` — creates a stacked branch on `parent`. Precondition (asserted in tests, not validated at runtime): `branch` is a `branchName()`-produced name.
 - `stackSubmit(branch, deps?)` — submits a branch and its downstack as published (non-draft) PRs.
 - `syncAndRestack(deps?)` — post-merge sync + restack; returns structured `{ restacked, conflicted, skippedWorktree }` results so callers can decide re-validation.
 
-All three take the trailing `deps: SpawnDeps = {}` used by every CLI-shelling helper in the file.
+The CLI-shelling helpers take the trailing `deps: SpawnDeps = {}` used by every CLI-shelling helper in the file; `stackPlan` is pure and takes no `deps`.
 
 ## Push gate: build-guardian before submit
 
-A branch may not be submitted (pushed / PR opened) until the wave's build-guardian agent has reported PASS. This is enforced by the orchestrator's pipeline, not by these helpers, but it is documented here because it is the rule that closes the loop on safe branch handling:
+A branch may not be submitted (pushed / PR opened) until build-guardian has reported PASS for that branch **at its stack position** — every stack level is independently green (invariant: `git-workflow/stacking.md`). This is enforced by the orchestrator's pipeline, not by these helpers, but it is documented here because it is the rule that closes the loop on safe branch handling:
 
-1. Implementers land commits on the branch.
+1. Implementers land commits on the level's branch.
 2. Per-bead auditors run.
-3. Build-guardian runs once per wave across all committed changes.
+3. Build-guardian runs once per stack level, before that level's submit (lifecycle: `bead-wave-orchestration`).
 4. Only after build-guardian PASS does the orchestrator submit the branch and finalize the PR (command patterns: `git-workflow/stacking.md`).
 
 If build-guardian reports FAIL, do not submit. Fix locally, re-run build-guardian, and submit only once it passes.

--- a/.claude/skills/bead-branch-and-pr/SKILL.md
+++ b/.claude/skills/bead-branch-and-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Orchestrator-internal helper functions that turn a bead into a bran
 
 This skill documents the deterministic helper functions that orchestrators call when they need to turn a bead into git artifacts. The conventions those artifacts must follow are defined elsewhere — this skill is purely about the helper API.
 
-**Source of truth for git/PR conventions:** the `git-workflow` skill at `.claude/skills/git-workflow/`. That skill defines branch naming, commit format, PR template, and the foundational principle that GitHub artifacts must be self-contained for GitHub readers (no bead IDs in branches, commits, or PR bodies).
+**Source of truth for git/PR conventions:** the `git-workflow` skill at `.claude/skills/git-workflow/`. That skill defines branch naming, commit format, PR template, stacking rules and gt command patterns (`stacking.md`), and the foundational principle that GitHub artifacts must be self-contained for GitHub readers (no bead IDs in branches, commits, or PR bodies).
 
 ## When to use
 
@@ -19,9 +19,9 @@ Invoke this skill when:
 
 Do **not** use this skill to look up git or PR conventions. For those, read `git-workflow/branches.md`, `commits.md`, `pull-requests.md`, or `releases.md` directly.
 
-## The four helpers
+## The helpers
 
-The functions live in `.claude/orchestrators/lib/helpers.ts` and are pure (no I/O) except for `gitSafeToStart`, which shells out to `git`.
+The functions live in `.claude/orchestrators/lib/helpers.ts`. `branchName`, `commitMsg`, and `prBody` are pure (no I/O); `gitSafeToStart` shells out to `git`, and the stack helpers shell out to `gt`.
 
 ### `branchName(title, issueType)`
 
@@ -67,22 +67,34 @@ Returns a markdown body with the three sections defined by the `git-workflow` PR
 
 No Summary section, no Beads-closed list, no Test plan — those would either duplicate template content or leak local tracker references into a GitHub-visible artifact.
 
-### `gitSafeToStart(deps?)`
+### `gitSafeToStart(parentBranch?, deps?)`
 
-Returns `{ ok: boolean, reason?: string }`. The orchestrator calls this at the branch-creation step as a narrow re-check (clean tree + on `main`). It is intentionally cheaper than the full `preflight()` that runs at the start of `/process-backlog`.
+Returns `{ ok: boolean, reason?: string }`. The orchestrator calls this at the branch-creation step as a narrow re-check (clean tree + HEAD current with the branch base). It is intentionally cheaper than the full `preflight()` that runs at the start of `/process-backlog`.
+
+Without `parentBranch`, HEAD is compared against `origin/<mainBranch>` (the trunk case). With `parentBranch` (stacking), HEAD is compared against the **local** parent branch tip — a mid-chain parent may not exist on origin yet. Semantics and rationale: `git-workflow/stacking.md` and the jsdoc in `helpers.ts`.
 
 The expected main-branch name defaults to `main` and can be overridden by the `GIT_SAFE_MAIN_BRANCH` env var for test rigs.
 
-## Push gate: build-guardian before `git push`
+### Stack helpers: `stackCreate`, `stackSubmit`, `syncAndRestack`
 
-A branch may not be pushed to `origin` until the wave's build-guardian agent has reported PASS. This is enforced by the orchestrator's pipeline, not by these helpers, but it is documented here because it is the rule that closes the loop on safe branch handling:
+Graphite (gt) wrappers, also in `.claude/orchestrators/lib/helpers.ts` — the only place gt operations are implemented. Conventions and command patterns live in `git-workflow/stacking.md`; the jsdoc on each helper records the gt-1.8.6-verified behavior. Signatures:
+
+- `stackCreate(branch, parent, deps?)` — creates a stacked branch on `parent`. Precondition (asserted in tests, not validated at runtime): `branch` is a `branchName()`-produced name.
+- `stackSubmit(branch, deps?)` — submits a branch and its downstack as published (non-draft) PRs.
+- `syncAndRestack(deps?)` — post-merge sync + restack; returns structured `{ restacked, conflicted, skippedWorktree }` results so callers can decide re-validation.
+
+All three take the trailing `deps: SpawnDeps = {}` used by every CLI-shelling helper in the file.
+
+## Push gate: build-guardian before submit
+
+A branch may not be submitted (pushed / PR opened) until the wave's build-guardian agent has reported PASS. This is enforced by the orchestrator's pipeline, not by these helpers, but it is documented here because it is the rule that closes the loop on safe branch handling:
 
 1. Implementers land commits on the branch.
 2. Per-bead auditors run.
 3. Build-guardian runs once per wave across all committed changes.
-4. Only after build-guardian PASS does the orchestrator `git push -u origin <branch>` and open the PR.
+4. Only after build-guardian PASS does the orchestrator submit the branch and finalize the PR (command patterns: `git-workflow/stacking.md`).
 
-If build-guardian reports FAIL, do not push. Fix locally, re-run build-guardian, and push only once it passes.
+If build-guardian reports FAIL, do not submit. Fix locally, re-run build-guardian, and submit only once it passes.
 
 ## Testing
 

--- a/.claude/skills/bead-branch-and-pr/SKILL.md
+++ b/.claude/skills/bead-branch-and-pr/SKILL.md
@@ -7,7 +7,7 @@ description: Orchestrator-internal helper functions that turn a bead into a bran
 
 This skill documents the deterministic helper functions that orchestrators call when they need to turn a bead into git artifacts. The conventions those artifacts must follow are defined elsewhere — this skill is purely about the helper API.
 
-**Source of truth for git/PR conventions:** the `git-workflow` skill at `.claude/skills/git-workflow/`. That skill defines branch naming, commit format, PR template, stacking rules and gt command patterns (`stacking.md`), and the foundational principle that GitHub artifacts must be self-contained for GitHub readers (no bead IDs in branches, commits, or PR bodies).
+**Source of truth for git/PR conventions:** the `git-workflow` skill at `.claude/skills/git-workflow/`. That skill defines branch naming, commit format, PR template, stacking rules and `gh stack` command patterns (`stacking.md`), and the foundational principle that GitHub artifacts must be self-contained for GitHub readers (no bead IDs in branches, commits, or PR bodies).
 
 ## When to use
 
@@ -21,7 +21,7 @@ Do **not** use this skill to look up git or PR conventions. For those, read `git
 
 ## The helpers
 
-The functions live in `.claude/orchestrators/lib/helpers.ts`. `branchName`, `commitMsg`, and `prBody` are pure (no I/O); `gitSafeToStart` shells out to `git`, and the stack helpers shell out to `gt`.
+The functions live in `.claude/orchestrators/lib/helpers.ts`. `branchName`, `commitMsg`, and `prBody` are pure (no I/O); `gitSafeToStart` shells out to `git`, and the stack helpers shell out to `gh`/`gh stack` (routing singles to plain `git`/`gh` — see `git-workflow/stacking.md`).
 
 ### `branchName(title, issueType)`
 
@@ -77,12 +77,12 @@ The expected main-branch name defaults to `main` and can be overridden by the `G
 
 ### Stack helpers: `stackPlan`, `stackCreate`, `stackSubmit`, `syncAndRestack`
 
-The chain planner and the Graphite (gt) wrappers, also in `.claude/orchestrators/lib/helpers.ts` — the only place gt operations are implemented. Conventions and command patterns live in `git-workflow/stacking.md`; the jsdoc on each helper records the gt-1.8.6-verified behavior. Signatures:
+The chain planner and the `gh stack` wrappers, also in `.claude/orchestrators/lib/helpers.ts` — the only place `gh stack` operations are implemented. Conventions and command patterns live in `git-workflow/stacking.md`; the jsdoc on each helper records the gh-stack-0.0.8-verified behavior. Signatures:
 
 - `stackPlan(beads, dependencyEdges)` — pure; plans dependency-chain stacks from an epic's child beads and the bd "blocks" edges among them. Returns an ordered forest of chains as `{ chains, flat, warnings }`; a cycle or any cross-chain join falls back to a flat no-stack plan with a warning. (The edge parameter is named `dependencyEdges`, never `deps` — `deps` is reserved codebase-wide for `SpawnDeps` injection.)
-- `stackCreate(branch, parent, deps?)` — creates a stacked branch on `parent`. Precondition (asserted in tests, not validated at runtime): `branch` is a `branchName()`-produced name.
-- `stackSubmit(branch, deps?)` — submits a branch and its downstack as published (non-draft) PRs.
-- `syncAndRestack(deps?)` — post-merge sync + restack; returns structured `{ restacked, conflicted, skippedWorktree }` results so callers can decide re-validation.
+- `stackCreate(branch, parent, chained, deps?)` — routes by `chained` (from the caller's `stackPlan` result) and `parent`: chain head off trunk → `gh stack init`; parent is a stack branch → `gh stack add`; single off trunk → plain `git checkout -b`. Precondition (asserted in tests, not validated at runtime): `branch` is a `branchName()`-produced name.
+- `stackSubmit(branch, chained, deps?)` — chains submit as ready-for-review (non-draft) PRs via `gh stack`; singles use the plain `git push` + `gh pr create` path. See `git-workflow/stacking.md` for the exact flags.
+- `syncAndRestack(deps?)` — post-merge sync; runs `gh stack sync --prune` and returns structured `{ ok, exitCode, conflicted, featureDisabled, rawOutput }` results so callers can decide re-validation. `conflicted` is true on exit code 3 (rebase conflict); `featureDisabled` is true on exit code 9 (private-preview feature disabled for this repo).
 
 The CLI-shelling helpers take the trailing `deps: SpawnDeps = {}` used by every CLI-shelling helper in the file; `stackPlan` is pure and takes no `deps`.
 

--- a/.claude/skills/bead-wave-orchestration/SKILL.md
+++ b/.claude/skills/bead-wave-orchestration/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: bead-wave-orchestration
-description: Wave lifecycle pattern for executing enriched beads in parallel under a hard 3-implementer cap. Use this skill when orchestrating an epic (or a multi-bead run) through spawn → per-bead audits → wave-end verification → build-guardian → cascade, when deciding how many implementers to spawn concurrently, when resolving implementer failures through retry versus escalation, or when running the epic-completion sweep after every wave has closed.
+description: Wave lifecycle pattern for executing enriched beads as dependency chains under a hard 3-chain cap. Use this skill when orchestrating an epic (or a multi-bead run) through chain scheduling → per-bead audits → per-level build gate → submit → cascade, when deciding how many chains to run concurrently, when resolving implementer failures through retry versus chain truncation, or when running the epic-completion sweep after every wave has closed.
 ---
 
 # Bead Wave Orchestration
 
 This skill captures the **wave lifecycle** that drives epic (or multi-bead)
-execution. It is the source of truth for how many implementers may run
+execution. It is the source of truth for how many chains may run
 concurrently, how per-bead audits cascade off each implementer's close, how
-wave-end verification is sequenced, how failures are recovered, and how the
-epic-completion sweep finalizes the run.
+per-level build gates and chain verification are sequenced, how failures
+are recovered, and how the epic-completion sweep finalizes the run.
 
 This is a prose-only skill. There are no scripts. Orchestration logic lives
 in the consuming commands; this skill is what those commands reference so the
@@ -40,10 +40,13 @@ Depends on / cross-references:
 These invariants hold across every wave, every run, every consumer. Breaking
 any of them corrupts the orchestration contract.
 
-1. **Maximum 3 parallel implementers.** Never spawn a 4th implementer while
-   three are still in flight. If more than 3 beads are ready, the extras
-   queue and the orchestrator spawns them into slots as earlier implementers
-   close.
+1. **Maximum 3 parallel implementers — and the cap applies to CHAINS.**
+   Waves are built from dependency chains (`stackPlan` in
+   `.claude/orchestrators/lib/helpers.ts`), not individual beads. Within a
+   chain, beads run strictly sequentially (each level's branch stacks on
+   its predecessor per `git-workflow/stacking.md`), so a chain occupies
+   one implementer slot for its whole duration. Never run a 4th chain
+   while three are still in flight; extras queue for the next free slot.
 2. **Per-bead auditors do NOT count against the 3-slot implementer budget.**
    Auditors are read-only code-analysis agents. They run in parallel with
    each other and in parallel with other waves' implementers as long as
@@ -55,8 +58,10 @@ any of them corrupts the orchestration contract.
    The orchestrator checks this before spawn; the implementer re-checks as
    a belt-and-braces refusal (see `implementer-prompt-template`).
 4. **Never more than one build-guardian at a time.** Test suites must not
-   run concurrently. Exactly one build-guardian runs per wave, and it runs
-   only after all implementers in that wave have closed and all per-bead
+   run concurrently. Build-guardian runs once per STACK LEVEL, on that
+   level's branch at its stack position, BEFORE that level is submitted —
+   the independently-green invariant (`git-workflow/stacking.md`). It runs
+   only after that level's implementer has closed and its per-bead
    auditors have reported.
 5. **Kill stale vitest processes before any test run.** Every agent that
    runs tests — implementers in their pre-close checklist and the
@@ -68,50 +73,60 @@ any of them corrupts the orchestration contract.
    mysterious hangs.
 6. **Never run the full suite outside build-guardian.** Implementers run
    lint + targeted tests only. The full suite (lint → unit → integration →
-   build → e2e) is the build-guardian's job, once per wave. This is how the
-   "no concurrent test suites" invariant is enforced.
-7. **Sequential wave-end verification chain.** The wave-end chain
-   (cross-bead-integration-verifier → architecture-auditor →
-   build-guardian) runs **in order, not in parallel**. Each step waits for
-   the prior to report. Parallelizing this chain would let the
-   build-guardian start while integration issues are still unresolved.
+   build → e2e) is the build-guardian's job, once per stack level. This is
+   how the "no concurrent test suites" invariant is enforced.
+7. **Per-level gate, per-chain verification.** Each stack level runs its
+   own build-guardian gate before submit; the chain-end verification pass
+   (cross-bead-integration-verifier when the chain has >1 bead, then
+   architecture-auditor) runs after a chain's levels complete. Steps run
+   **in order, not in parallel** within a level and within the chain-end
+   pass.
 
 ## Wave lifecycle
 
-A wave is a set of ready, enriched beads that the orchestrator spawns
-together, followed by the verification that proves the wave's combined
-output is safe to build on top of. Each wave proceeds through these
-stages in order.
+A wave is a set of ready, enriched dependency CHAINS that the orchestrator
+runs together. Chains come from the `stackPlan` helper
+(`.claude/orchestrators/lib/helpers.ts`), which turns an epic's full child
+set plus the bd "blocks" edges among them into an ordered forest of chains;
+non-linear graphs (cycles, forks, joins) fall back to a flat plan of
+singleton chains with a warning. Branch/stack conventions the chains
+follow: `git-workflow/stacking.md`.
 
-### 1. Identify ready + enriched beads
+### 1. Identify ready + enriched chains
 
 Before spawning anything, the orchestrator:
 
-1. Reads the ready set (`bd ready` for the epic's children, or the single
-   bead for `/process-backlog` single-leaf Branch B).
-2. For each candidate, runs `bead-state-assessment/bd-enrichment-check.sh`
-   (exit 0 = enriched, exit 1 = missing Implementation Context).
-3. Splits the candidates into **enriched** (ready to dispatch) and
-   **unenriched** (must be enriched before dispatch).
-4. For any unenriched bead, spawns a **general-purpose enrichment
-   subagent** that populates the Implementation Context via the
-   `/analyze-bead` Phase 4 flow, then re-checks. **Enrichment does NOT
-   count against the 3-slot implementer budget** and **does NOT count as
-   a retry against the bead's retry limit.** It is a precondition, not
-   an attempt.
+1. Plans chains once per epic from the FULL child set (not `bd ready`,
+   which omits blocked mid-chain beads).
+2. Each wave, reads the ready set (`bd ready --parent <epic>`) and
+   schedules the remaining chains whose HEAD bead is ready. `bd` stays the
+   source of cross-chain unblocking, but mid-chain beads are owned by
+   their chain runner and are never scheduled directly.
+3. Checks enrichment on chain heads before spawn (mid-chain beads are
+   re-checked at dispatch time). For any unenriched bead, spawns a
+   **general-purpose enrichment subagent** that populates the
+   Implementation Context via the `/analyze-bead` Phase 4 flow, then
+   re-checks. **Enrichment does NOT count against the 3-slot implementer
+   budget** and **does NOT count as a retry against the bead's retry
+   limit.** It is a precondition, not an attempt.
 
-### 2. Spawn implementers (max 3 in parallel)
+### 2. Run chains (max 3 in parallel)
 
-With only enriched beads in hand, the orchestrator dispatches implementers
-using the canonical prompt from
-[`implementer-prompt-template`](../implementer-prompt-template/SKILL.md):
+The orchestrator runs ready chains under the 3-slot cap; independent
+chains run in parallel, and within a chain beads run strictly
+sequentially, each level's branch stacking on its predecessor
+(operations: `stackCreate`/`stackSubmit` in
+`.claude/orchestrators/lib/helpers.ts`; conventions:
+`git-workflow/stacking.md`).
 
-1. If ≤ 3 enriched beads remain: spawn all in one parallel Task batch.
-2. If > 3: spawn the first 3 (typically by bead priority / age), queue the
-   remainder.
-3. As each implementer closes (via `bd close`), pop from the queue and
-   spawn the next, maintaining the 3-in-flight cap.
+Concurrency model (hybrid): the first chain of a wave runs in the main
+checkout; each ADDITIONAL concurrent chain gets its own git worktree,
+with its agents dispatched at that cwd. The orchestrator owns the
+worktree lifecycle (create before the chain starts, remove when it
+finishes).
 
+Implementers receive the canonical prompt from
+[`implementer-prompt-template`](../implementer-prompt-template/SKILL.md).
 Each implementer independently runs its own pre-close checklist
 (`pkill -f "vitest"`, `npm run lint`, `npx vitest run <file1> <file2>
 --maxThreads=2`) and calls `bd close {bead_id}` only when lint and
@@ -150,52 +165,20 @@ Apply [`review-mode-auditor`](../review-mode-auditor/SKILL.md) verdicts:
 | **PASS WITH WARNINGS** | Record warnings in wave summary / PR body; do NOT block. |
 | **FAIL** | Return findings to the implementer for a single retry round. If a second audit still FAILs, escalate per [`bead-backlog-selection`](../bead-backlog-selection/SKILL.md) via `bd-escalate.sh`. |
 
-A wave is not ready for the wave-end chain until **every** bead in the
-wave has closed and **every** matched per-bead auditor for those beads
-has reported a resolved verdict (PASS or PASS WITH WARNINGS after any
-required retry).
+A stack level is not ready for its build gate until its bead has closed
+and **every** matched per-bead auditor for that bead has reported a
+resolved verdict (PASS or PASS WITH WARNINGS after any required retry).
 
-### 4. Wave-end verification chain (sequential, not parallel)
+### 4. Per-level build gate + per-chain verification
 
-After all beads in the wave have closed and all per-bead auditors have
-resolved, the orchestrator runs the following chain **in order**. Each
-step must complete and pass before the next step starts. Never
-parallelize this chain.
-
-**Step A — cross-bead-integration-verifier** (conditional)
-
-- Run **only if the wave size > 1.** A single-bead wave has nothing to
-  cross-verify; skip this step.
-- Spawn exactly one `cross-bead-integration-verifier` subagent.
-- It looks for conflicts, duplications, and inconsistencies that
-  per-bead auditors miss because each bead was verified in isolation.
-- Verdict handling:
-  - 🔴 Conflicts → spawn a follow-up implementer with the conflict
-    details, re-run the affected per-bead auditors, then re-run this
-    step. Do NOT proceed to Step B.
-  - 🟡 Duplications / inconsistencies → address if a quick fix;
-    otherwise note for end-of-epic cleanup and proceed.
-  - 🟢 Clean → proceed to Step B.
-
-**Step B — architecture-auditor (light pass)** (always)
-
-- Spawn exactly one `architecture-auditor`, configured for a light
-  pass (not a deep audit).
-- It reads product docs (mission.md, decisions.md, roadmap.md), diffs
-  the wave's changes, and flags vision drift, decision violations, and
-  conceptual fragmentation.
-- Verdict handling:
-  - 🔴 HIGH (decision violation, vision misalignment) → resolve before
-    proceeding. Spawn a follow-up implementer if needed.
-  - 🟡 MEDIUM / LOW → note in the wave summary; address if quick.
-  - 🟢 PASS → proceed to Step C.
-
-**Step C — build-guardian** (always, exactly once per wave)
+**Per-level build gate — build-guardian (once per stack level, BEFORE
+that level's submit)**
 
 - **NEVER more than one build-guardian at a time.** Test suites must
   not run concurrently.
-- Spawn exactly one `build-guardian` subagent. It runs the full
-  sequential suite internally:
+- Spawn exactly one `build-guardian` subagent per stack level, on that
+  level's branch at its stack position. It runs the full sequential
+  suite internally:
   ```
   pkill -f "vitest" 2>/dev/null || true
   npm run lint
@@ -204,23 +187,45 @@ parallelize this chain.
   npm run build
   (e2e as applicable)
   ```
-- Build-guardian is the single point where the full test suite runs
-  for this wave's combined changes. The implementers' targeted tests
-  proved each bead's local correctness; build-guardian proves the
-  integrated wave still passes.
+- Build-guardian is the single point where the full test suite runs for
+  a level's changes. The implementer's targeted tests proved the bead's
+  local correctness; build-guardian proves the level is independently
+  green at its stack position (`git-workflow/stacking.md`).
 - Verdict handling:
-  - 🟢 Pass → wave is complete; cascade to the next wave.
+  - 🟢 Pass → submit the level and continue to the next level in the
+    chain.
   - 🔴 Fail → see "Build-guardian failure" in failure handling below.
+    The level is NOT submitted while red.
+- After post-merge restacks, GitHub CI is the re-validator;
+  build-guardian re-runs locally only when `syncAndRestack` reports
+  conflicted branches.
+
+**Per-chain verification pass (after a chain's levels complete)**
+
+- **cross-bead-integration-verifier** — run only if the chain has > 1
+  bead. It looks for conflicts, duplications, and inconsistencies
+  between the chain's beads that per-bead auditors miss because each
+  bead was verified in isolation.
+- **architecture-auditor (light pass)** — always. It reads product docs
+  (mission.md, decisions.md, roadmap.md), diffs the chain's combined
+  changes, and flags vision drift, decision violations, and conceptual
+  fragmentation.
+- Verdict handling for both:
+  - 🔴 Conflicts / HIGH findings → spawn a follow-up implementer with
+    the details, re-run the affected per-bead auditors.
+  - 🟡 MEDIUM / LOW → note in the wave summary; address if quick.
+  - 🟢 Clean / PASS → chain is complete.
 
 ### 5. Cascade to the next wave
 
-Once the wave-end chain is green:
+Once every chain in the wave has finished:
 
-1. Run `bd ready` (or equivalent for `/process-backlog`) to find newly
-   unblocked beads.
-2. Return to step 1 of this lifecycle for the next wave.
-3. When no ready beads remain, proceed to the **Epic completion sweep**
-   (see below).
+1. Run `bd ready --parent <epic>` to find newly unblocked chain heads
+   (e.g. a chain that was waiting on a blocker outside its own chain).
+2. Return to step 1 of this lifecycle for the next wave of remaining
+   chains.
+3. When no remaining chain has a ready head, proceed to the **Epic
+   completion sweep** (see below).
 
 ## Failure handling
 
@@ -272,20 +277,22 @@ ambiguous requirement, unexpected codebase state, scope creep beyond
    - Skip the bead and continue the wave without it (only valid if the
      bead does not block other ready beads).
 
-### Build-guardian failure (wave-end)
+### Build-guardian failure (per-level gate)
 
-If build-guardian fails:
+If a level's build-guardian fails, the responsible bead is known by
+construction — it is that level:
 
-1. Spawn `test-failure-investigator` with the build-guardian's report.
-   The report includes `git log` output to help attribute failures to
-   specific beads' commits.
-2. Spawn a follow-up implementer for the responsible bead to fix the
-   issue (counts as a retry for that bead).
-3. Re-run the per-bead auditor cascade for the fixed bead.
-4. Re-run the wave-end chain from the start of Step A (in case the fix
-   introduced new integration issues, the integration verifier must see
-   the updated state).
-5. Only cascade to the next wave once build-guardian reports green.
+1. Spawn `test-failure-investigator` with the build-guardian's report
+   for diagnosis.
+2. Spawn a follow-up implementer for the level's bead to fix the issue
+   (counts as a retry for that bead).
+3. Re-run the per-bead auditor cascade for the fixed bead, then re-run
+   the level's build gate.
+4. The level is submitted only once its build-guardian reports green.
+5. If retries exhaust, the chain HALTS at that level: the failed bead
+   and the chain's un-run remainder are escalated (chain truncation) —
+   never skip past a broken parent level. Other chains in the wave are
+   unaffected.
 
 ### Retry limit
 
@@ -339,8 +346,8 @@ a final comprehensive sweep before declaring the epic done.
 5. **Collect verdicts.** PASS / PASS WITH WARNINGS surface in the final
    report; FAIL blocks closing the epic. For a FAIL at this stage, route
    through the same failure-handling flow as build-guardian failure
-   (investigator → implementer → rerun the wave-end chain for the
-   affected wave, then redo the sweep).
+   (investigator → implementer → rerun the affected level's build gate,
+   then redo the sweep).
 6. **Close the epic** via `bd close <epic-id>` once all comprehensive
    agents report resolved verdicts.
 
@@ -349,12 +356,12 @@ a final comprehensive sweep before declaring the epic done.
 When `/process-backlog` targets a single leaf bead (not an epic), the
 same lifecycle applies in its reduced form:
 
-- One wave. One bead. One implementer.
+- One wave. One singleton chain. One implementer.
 - The per-bead auditor cascade still runs after the implementer closes.
-- The wave-end chain runs with:
-  - `cross-bead-integration-verifier` **skipped** (wave size is 1).
+- The verification pass runs with:
+  - `cross-bead-integration-verifier` **skipped** (chain size is 1).
   - `architecture-auditor` light pass runs (always).
-  - `build-guardian` runs once (always).
+  - `build-guardian` runs once (always — one bead means one level).
 - The epic completion sweep collapses to the same build-guardian pass
   plus the `implementation-verifier` invocation (which is effectively
   the "wave" and "epic" stages merging, since the whole run is one
@@ -373,6 +380,13 @@ Before this skill existed, the wave lifecycle was inlined in
 Consumers should reference this skill by name instead of re-inlining the
 mechanics. Any behavioral change — new verification step, different
 retry semantics, changes to the 3-implementer cap, adjustments to the
-wave-end chain ordering — should be made **here first**, then
+per-level gate or chain scheduling — should be made **here first**, then
 propagated to consumers. Divergence between this skill and a consumer
 is a bug; the skill is authoritative.
+
+The skill is deliberately NOT the source of truth for two adjacent
+layers: stacking conventions live in `git-workflow/stacking.md`, and the
+executable chain/gt operations (`stackPlan`, `stackCreate`,
+`stackSubmit`, `syncAndRestack`, the wave scheduler itself) live in
+`.claude/orchestrators/lib/` — this skill cross-references both and
+restates neither.

--- a/.claude/skills/bead-wave-orchestration/SKILL.md
+++ b/.claude/skills/bead-wave-orchestration/SKILL.md
@@ -215,6 +215,14 @@ that level's submit)**
     the details, re-run the affected per-bead auditors.
   - 🟡 MEDIUM / LOW → note in the wave summary; address if quick.
   - 🟢 Clean / PASS → chain is complete.
+- **This pass is advisory at chain scope — a deliberate change from the
+  old wave-end chain, which gated on these verdicts.** Per-level
+  submission means the chain's levels are already pushed by the time a
+  whole-chain review can run, so it cannot serve as a pre-push gate.
+  Blocking integration/architecture verification lives in the
+  **epic-completion sweep** (below); the manual bottom-up merge ritual
+  (`git-workflow/stacking.md`) is the human checkpoint before anything
+  reaches `main`.
 
 ### 5. Cascade to the next wave
 

--- a/.claude/skills/bead-wave-orchestration/SKILL.md
+++ b/.claude/skills/bead-wave-orchestration/SKILL.md
@@ -196,8 +196,11 @@ that level's submit)**
     chain.
   - 🔴 Fail → see "Build-guardian failure" in failure handling below.
     The level is NOT submitted while red.
-- After post-merge restacks, GitHub CI is the re-validator;
-  build-guardian re-runs locally only when `syncAndRestack` reports
+- `VERIFY:` whether GitHub CI is the re-validator after a post-merge
+  cascade is unconfirmed (see `git-workflow/stacking.md`) — a human must
+  confirm the server-side cascade-retarget behaves as expected. Until
+  then, build-guardian re-runs locally on the retargeted level after
+  every merge, in addition to whenever `syncAndRestack` reports
   conflicted branches.
 
 **Per-chain verification pass (after a chain's levels complete)**
@@ -394,7 +397,7 @@ is a bug; the skill is authoritative.
 
 The skill is deliberately NOT the source of truth for two adjacent
 layers: stacking conventions live in `git-workflow/stacking.md`, and the
-executable chain/gt operations (`stackPlan`, `stackCreate`,
+executable chain/`gh stack` operations (`stackPlan`, `stackCreate`,
 `stackSubmit`, `syncAndRestack`, the wave scheduler itself) live in
 `.claude/orchestrators/lib/` — this skill cross-references both and
 restates neither.

--- a/.claude/skills/epic-bead-workflow/SKILL.md
+++ b/.claude/skills/epic-bead-workflow/SKILL.md
@@ -47,6 +47,12 @@ Epic (beads-001)
 - When a bead completes, check what it unblocks
 - Never work on a bead while its blockers are incomplete
 
+**Branches and PRs follow the dependency graph.** In autonomous
+orchestration, a dependency chain among sibling beads becomes a stacked
+branch chain with one PR per bead (scheduling: the `bead-wave-orchestration`
+skill; stacking conventions: `git-workflow/stacking.md`). Independent beads
+stay as parallel branches off `main`.
+
 ### 3. Beads Are Self-Contained Work Packages
 
 Each leaf bead should contain everything a subagent needs to implement it. The `/analyze-bead` command enriches bead notes with implementation context so subagents can work from the bead alone.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -19,6 +19,7 @@ GitHub artifacts must be self-contained for GitHub readers. Local-only reference
 | Writing a commit | [commits.md](commits.md) |
 | Pushing a branch to origin | [pull-requests.md](pull-requests.md) (also see local-vs-remote in [branches.md](branches.md)) |
 | Opening a pull request | [pull-requests.md](pull-requests.md) |
+| Working with a stacked branch / restacking | [stacking.md](stacking.md) |
 | Cutting a release | [releases.md](releases.md) |
 
 Read the relevant reference file for the operation you are doing. Each is self-contained — you do not need to read the others.

--- a/.claude/skills/git-workflow/branches.md
+++ b/.claude/skills/git-workflow/branches.md
@@ -45,7 +45,7 @@ Branch from `main`, or from the parent branch when stacking per [stacking.md](st
 
 The convention above applies to the **remote (`origin`) branch name** — the name GitHub readers see in the branch list, PR list, and merge-commit messages. Local branch names do not have to match.
 
-Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone, and never submit them: pushing goes through gt, which pushes the branch under its local name. Create a properly-named branch for the work instead — see the worktree guidance in [stacking.md](stacking.md).
+Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone, and never submit them: whatever pushes the branch — plain `git push` for a single, `gh stack submit` for a stack level (see [stacking.md](stacking.md)) — pushes it under its local name. Create a properly-named branch for the work instead — see the worktree guidance in [stacking.md](stacking.md).
 
 ## Disallowed
 

--- a/.claude/skills/git-workflow/branches.md
+++ b/.claude/skills/git-workflow/branches.md
@@ -39,21 +39,13 @@ Total branch name ≤ 60 characters. If the kebab-title alone would push the bra
 
 ## Branch base
 
-Branch from `main` by default. If there is a reason to branch from somewhere else, prompt the user before branching.
+Branch from `main`, or from the parent branch when stacking per [stacking.md](stacking.md). Stacking is pre-authorized — it needs no per-branch prompt. For any other non-stack, non-main base, prompt the user before branching.
 
 ## Local vs. remote branch names
 
 The convention above applies to the **remote (`origin`) branch name** — the name GitHub readers see in the branch list, PR list, and merge-commit messages. Local branch names do not have to match.
 
-Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone — but when pushing, push to a properly-named remote ref:
-
-```bash
-git push -u origin HEAD:feat.widget-powered-by-footer
-```
-
-This sets the upstream so subsequent `git push` calls go to the same remote name. Verify with `git branch -vv` after the first push: the local branch should show `[origin/feat.widget-powered-by-footer]` as its upstream.
-
-If the local branch name already conforms (e.g. you created it manually with `git checkout -b feat.<title>`), `git push -u origin HEAD` is fine — no rename needed.
+Some tooling (e.g. `superset.sh`) creates worktrees with auto-generated nonsense local branch names like `apple-father` or `abrupt-grapple`. Leave those local names alone, and never submit them: pushing goes through gt, which pushes the branch under its local name. Create a properly-named branch for the work instead — see the worktree guidance in [stacking.md](stacking.md).
 
 ## Disallowed
 

--- a/.claude/skills/git-workflow/pull-requests.md
+++ b/.claude/skills/git-workflow/pull-requests.md
@@ -41,22 +41,16 @@ In the PR body, place the reference wherever it reads naturally — top of Motiv
 
 ## Workflow
 
-- **No draft PRs.** Open a PR only when ready for merge.
+- **No draft PRs.** Open a PR only when ready for merge. When submitting through gt, this requires the `--publish` flag — see [stacking.md](stacking.md) for why. Stacked PRs are real PRs, individually ready for review; being upstack does not make a PR a draft.
 - **No auto-merge.** The user reviews and merges manually.
 - **Push to origin** only after build-guardian PASS (lint, unit, integration, build, e2e via build-guardian).
 - **Squash merge** on landing.
 
 ## Pushing to origin
 
-Before the first push, verify the local branch name conforms to [branches.md](branches.md). If it does **not** (for example, an auto-generated name from `superset.sh` like `apple-father` or `abrupt-grapple`), push with an explicit remote ref so the GitHub branch follows the convention:
+Pushing and PR creation go through the Graphite CLI: `gt submit` replaces `git push` + `gh pr create`. See [stacking.md](stacking.md) for the command patterns (submit flags, PR-shape follow-up via `gh pr edit`, and the merge/restack ritual).
 
-```bash
-git push -u origin HEAD:<type>.<kebab-title>
-```
-
-The `-u` flag wires the local branch's upstream to the renamed remote, so future pushes (`git push`) go to the same ref without re-specifying it.
-
-If the local branch already conforms, `git push -u origin HEAD` is sufficient.
+Branch-name conformance still applies before the first submit: the branch gt pushes is the name GitHub readers see, so it must follow [branches.md](branches.md). If you are working in a worktree with an auto-generated local branch name (`apple-father`, `abrupt-grapple`), do not submit that branch — create a properly-named branch for the work per the worktree guidance in [stacking.md](stacking.md).
 
 ## Disallowed
 

--- a/.claude/skills/git-workflow/pull-requests.md
+++ b/.claude/skills/git-workflow/pull-requests.md
@@ -41,16 +41,16 @@ In the PR body, place the reference wherever it reads naturally — top of Motiv
 
 ## Workflow
 
-- **No draft PRs.** Open a PR only when ready for merge. When submitting through gt, this requires the `--publish` flag — see [stacking.md](stacking.md) for why. Stacked PRs are real PRs, individually ready for review; being upstack does not make a PR a draft.
+- **No draft PRs.** Open a PR only when ready for merge. Singles satisfy this by never passing `--draft` to `gh pr create`. Chains satisfy it per [stacking.md](stacking.md) (`gh stack submit` needs an explicit flag to avoid its draft default). Stacked PRs are real PRs, individually ready for review; being upstack does not make a PR a draft.
 - **No auto-merge.** The user reviews and merges manually.
 - **Push to origin** only after build-guardian PASS (lint, unit, integration, build, e2e via build-guardian).
 - **Squash merge** on landing.
 
 ## Pushing to origin
 
-Pushing and PR creation go through the Graphite CLI: `gt submit` replaces `git push` + `gh pr create`. See [stacking.md](stacking.md) for the command patterns (submit flags, PR-shape follow-up via `gh pr edit`, and the merge/restack ritual).
+**Singles** (no stack involved) push and open PRs the plain way: `git push` + `gh pr create`. **Chains** (per [stacking.md](stacking.md)) go through `gh stack submit` instead — see [stacking.md](stacking.md) for the command patterns (submit flags, PR-shape follow-up via `gh pr edit`, and the merge ritual). No doc in this skill asserts that every push goes through `gh stack`; only stack levels do.
 
-Branch-name conformance still applies before the first submit: the branch gt pushes is the name GitHub readers see, so it must follow [branches.md](branches.md). If you are working in a worktree with an auto-generated local branch name (`apple-father`, `abrupt-grapple`), do not submit that branch — create a properly-named branch for the work per the worktree guidance in [stacking.md](stacking.md).
+Branch-name conformance applies before the first push either way: the branch that gets pushed — by `git push` or by `gh stack submit` — is the name GitHub readers see, so it must follow [branches.md](branches.md). If you are working in a worktree with an auto-generated local branch name (`apple-father`, `abrupt-grapple`), do not push that branch — create a properly-named branch for the work per the worktree guidance in [stacking.md](stacking.md).
 
 ## Disallowed
 

--- a/.claude/skills/git-workflow/stacking.md
+++ b/.claude/skills/git-workflow/stacking.md
@@ -4,8 +4,6 @@ All branch creation and PR submission goes through the Graphite CLI (`gt`), incl
 
 This file is the **sole source of truth** for gt command patterns and stacking rules. Other skills (`bead-branch-and-pr`, `bead-backlog-selection`, `bead-wave-orchestration`, etc.) cross-reference this file; they do not restate its contents. The corresponding gt operations for orchestrators are implemented only in `.claude/orchestrators/lib/helpers.ts` (`stackCreate`, `stackSubmit`, `syncAndRestack`).
 
-**Adoption status (transitional):** interactive sessions follow these conventions now. The autonomous orchestrator's branch/push/PR call sites (`phases.ts`, `execute.ts`) still use raw git/gh and adopt the gt helpers in Stage 2 of the rollout (spec: `agent-os/specs/2026-07-11-graphite-stacked-prs/`). Until then, preflight's gt checks assert readiness one stage ahead of the orchestrator's first gt use. Remove this note when Stage 2 lands.
-
 ## When a stack exists
 
 A stack exists when:

--- a/.claude/skills/git-workflow/stacking.md
+++ b/.claude/skills/git-workflow/stacking.md
@@ -4,6 +4,8 @@ All branch creation and PR submission goes through the Graphite CLI (`gt`), incl
 
 This file is the **sole source of truth** for gt command patterns and stacking rules. Other skills (`bead-branch-and-pr`, `bead-backlog-selection`, `bead-wave-orchestration`, etc.) cross-reference this file; they do not restate its contents. The corresponding gt operations for orchestrators are implemented only in `.claude/orchestrators/lib/helpers.ts` (`stackCreate`, `stackSubmit`, `syncAndRestack`).
 
+**Adoption status (transitional):** interactive sessions follow these conventions now. The autonomous orchestrator's branch/push/PR call sites (`phases.ts`, `execute.ts`) still use raw git/gh and adopt the gt helpers in Stage 2 of the rollout (spec: `agent-os/specs/2026-07-11-graphite-stacked-prs/`). Until then, preflight's gt checks assert readiness one stage ahead of the orchestrator's first gt use. Remove this note when Stage 2 lands.
+
 ## When a stack exists
 
 A stack exists when:
@@ -19,7 +21,7 @@ Independent pieces of work are **not** a stack: they stay as parallel branches o
 |---|---|
 | `git checkout -b <name>` | `gt create <name> -m "<msg>"` (or `gt create <name> --onto <parent>` before work starts) |
 | `git push` + `gh pr create` | `gt submit --no-interactive --publish` |
-| post-merge cleanup + rebase | `gt sync -f` then `gt submit --stack` |
+| post-merge cleanup + rebase | `gt sync -f` then `gt submit --stack --no-interactive --publish` |
 
 Rules:
 
@@ -50,7 +52,7 @@ Merges are manual, bottom-up, in GitHub:
 
 1. **Squash-merge the bottom PR** in the GitHub UI.
 2. **`gt sync -f`** — pulls trunk, detects the merged PR, deletes the merged local branch, restacks children onto `main`. `-f` skips the delete-confirmation prompt.
-3. **`gt submit --stack`** — retargets and updates the remaining PRs. GitHub CI re-validates each retargeted PR.
+3. **`gt submit --stack --no-interactive --publish`** — retargets and updates the remaining PRs (`--publish` per the load-bearing rule above). GitHub CI re-validates each retargeted PR.
 4. Repeat from step 1 for the next-lowest PR.
 
 The `/restack` command wraps steps 2–3 (via the `syncAndRestack` helper) and reports what moved: run it after merging one or more PRs. It is loop-friendly for a bottom-up merge session; there is no standing automation because merges are manual.

--- a/.claude/skills/git-workflow/stacking.md
+++ b/.claude/skills/git-workflow/stacking.md
@@ -1,79 +1,201 @@
-# Stacked Branches (Graphite)
+# Stacked Branches (gh-stack)
 
-All branch creation and PR submission goes through the Graphite CLI (`gt`), including single, unstacked beads. `gh` remains the tool for PR body edits, merging, and CI queries.
+Stack operations go through GitHub's native stacking extension, `gh stack`
+(private preview, pinned at **gh-stack 0.0.8** as of the 2026-07-21 spike).
+Singles — independent, unstacked work — **never touch `gh stack`**: they use
+plain `git checkout -b` / `git push` + `gh pr create`, exactly as before any
+stacking tool existed. `gh` itself (not `gh stack`) remains the tool for PR
+body edits, merging, and CI queries in both cases.
 
-This file is the **sole source of truth** for gt command patterns and stacking rules. Other skills (`bead-branch-and-pr`, `bead-backlog-selection`, `bead-wave-orchestration`, etc.) cross-reference this file; they do not restate its contents. The corresponding gt operations for orchestrators are implemented only in `.claude/orchestrators/lib/helpers.ts` (`stackCreate`, `stackSubmit`, `syncAndRestack`).
+This file is the **sole source of truth** for `gh stack` command patterns and
+stacking rules. Other skills (`bead-branch-and-pr`, `bead-backlog-selection`,
+`bead-wave-orchestration`, etc.) cross-reference this file; they do not
+restate its contents. The corresponding operations for orchestrators are
+implemented only in `.claude/orchestrators/lib/helpers.ts` (`stackCreate`,
+`stackSubmit`, `syncAndRestack`).
 
 ## When a stack exists
 
 A stack exists when:
 
-- **Dependency-driven:** a bd dependency chain among sibling beads — each bead's branch builds on its predecessor's.
-- **Size-driven:** an oversized single piece of work split at working checkpoints into reviewable levels.
+- **Dependency-driven:** a bd dependency chain among sibling beads — a chain
+  of **2 or more** beads linked by bd dependency edges, each bead's branch
+  building on its predecessor's.
+- **Size-driven:** an oversized single piece of work split at working
+  checkpoints into reviewable levels.
 
-Independent pieces of work are **not** a stack: they stay as parallel branches off `main`, each created via gt.
+Independent pieces of work are **not** a stack: a lone bead, or a bead with no
+chain, stays a plain branch off `main`, created and pushed with ordinary
+`git`/`gh` — it never runs any `gh stack` command.
 
-## gt command patterns
+## gh-stack command patterns
 
 | Old | New |
 |---|---|
-| `git checkout -b <name>` | `gt create <name> -m "<msg>"` (or `gt create <name> --onto <parent>` before work starts) |
-| `git push` + `gh pr create` | `gt submit --no-interactive --publish` |
-| post-merge cleanup + rebase | `gt sync -f` then `gt submit --stack --no-interactive --publish` |
+| `git checkout -b <name>` (chain head) | `gh stack init <name>` |
+| `git checkout -b <name>` (next chain level) | `gh stack add <name>`, run from the chain's current top |
+| `git push` + `gh pr create` | `gh stack submit --auto --open` |
+| post-merge cleanup + rebase | `gh stack sync --prune` |
 
 Rules:
 
-- **Branch names are always passed explicitly** — never auto-generated from commit messages, never `--ai`. Naming rules are unchanged: `<type>.<kebab-title>`, ≤60 chars, per [branches.md](branches.md).
-- `gt create <name> --onto <parent>` creates a branch on top of `<parent>` without checking the parent out first. With a clean tree it creates an empty branch — the normal pre-work state.
-- `--publish` on submit is **load-bearing**: on gt 1.8.6, `--no-interactive` creates new PRs in **draft** mode unless `--publish` is passed ("new PRs will be created in draft mode" is printed explicitly). The no-draft-PRs rule in [pull-requests.md](pull-requests.md) stands, so always pass `--publish`.
-- `gt submit` submits the current branch and its downstack; `gt submit --stack` also includes descendants. `--branch <name>` targets a branch without checking it out.
-- `gt submit --dry-run` previews what would be pushed/created without side effects — use it when unsure.
+- **Branch names are always passed explicitly** — never generated via `-m`
+  auto-naming, never left to a tool default. Naming rules are unchanged:
+  `<type>.<kebab-title>`, ≤60 chars, per [branches.md](branches.md).
+- `gh stack init <name>` starts a stack — the first branch of a chain, off
+  trunk. Bare `gh stack init <name>` defaults its base to `main`; the
+  orchestrator instead passes an explicit `--base <trunk>` (`gh stack init
+  --base <trunk> <name>`) so a non-default `GIT_SAFE_MAIN_BRANCH` is honored,
+  matching `gitSafeToStart`. The human command form (bare `<name>`) and the
+  orchestrator form (`--base <trunk> <name>`) are otherwise equivalent.
+  Existing branches passed to `init` are adopted **automatically**; there is
+  no `--adopt` flag in gh-stack 0.0.8 (it is deprecated/removed — invoking it
+  warns and then fails for missing branch args). Plain
+  `gh stack init <b1> <b2> <b3>` adopts a set of existing branches into a
+  stack in one command.
+- `gh stack add <name>` layers the next level onto the **current stack top**
+  and must be run from a checkout sitting on that top branch. `add` has
+  **no `--base` flag** — unlike `init` and `link`, which do take one — its
+  base is implicit from whatever is currently checked out. There is no way to
+  target a branch that isn't the checked-out top; if a chain was interrupted
+  and resumed, re-checkout the top first.
+- `gh stack submit --auto --open` pushes the chain's branches and
+  creates/updates their PRs. `--auto` skips the interactive editor;
+  **`--auto` creates drafts by default** — `--open` is required to satisfy the
+  standing no-draft-PRs rule (see [pull-requests.md](pull-requests.md)).
+  `--open`'s behavior on a re-submit (PRs that already exist) was not
+  exercised by the spike — only PR *creation* was. As a safe interim (decision
+  memo D3), every `submit` currently runs an unconditional `gh pr ready
+  <number>` sweep over the stack's PR numbers afterward (`gh stack view
+  --json`) — belt-and-suspenders while `--open`'s re-submit semantics are
+  unproven. `gh pr ready` on an already-ready PR is a no-op, so the sweep
+  cannot violate the no-draft invariant, only backstop it. This converges to
+  reserve-only (sweep only if a PR surfaces as draft despite `--open`) once
+  `--open` is proven reliable on re-submits — see the docstring on
+  `stackSubmit` in `helpers.ts` for the exact trim condition. `submit` is
+  confirmed idempotent on re-submit (no new commits, or new commits pushed)
+  and never clobbers a title/body already set via `gh pr edit`.
+- `gh stack view` / `gh stack view --json` / `gh stack view --short` inspect
+  the current checkout's stack — local-only, they do not touch the network or
+  prove repo enablement (see Preflight below).
 
 ## Independently-green invariant
 
-**Every PR is independently green.** No stack level is submitted until it passes validation at its own stack position. Consequence: split points are working checkpoints — each level builds, lints, and passes its tests on its own — not arbitrary diff slices. Broken builds never merge to `main`.
+**Every PR is independently green.** No stack level is submitted until it
+passes validation at its own stack position. Consequence: split points are
+working checkpoints — each level builds, lints, and passes its tests on its
+own — not arbitrary diff slices. Broken builds never merge to `main`. This is
+now reinforced server-side: GitHub runs CI on every stack PR, not just the
+bottom one.
 
 ## PR shape
 
-`gt submit` creates the PR; it does not know the project's PR template. Immediately after submitting, set title and body with `gh pr edit` so the Motivation/Approach/Validation template from [pull-requests.md](pull-requests.md) stays canonical:
+`gh stack submit` creates the PR; it does not know the project's PR template.
+Immediately after submitting, set title and body with `gh pr edit` so the
+Motivation/Approach/Validation template from
+[pull-requests.md](pull-requests.md) stays canonical:
 
 ```bash
-gt submit --no-interactive --publish
+gh stack submit --auto --open
 gh pr edit <num> --title "<type>(<scope>): <summary>" --body "$(cat pr-body.md)"
 ```
 
-Stacked PRs open their Motivation section with a one-line "Stacked on #N." pointing at the parent PR. Bottom-of-stack PRs (parented on `main`) omit it.
+Stacked PR bodies carry **no "Stacked on #N" line** — GitHub's Stack Map UI
+shows the hierarchy natively on every PR in the stack, so the body stays the
+plain, unconditional Motivation/Approach/Validation template with no
+stacking-specific section.
 
-## Merge + restack ritual
+## Merge ritual
 
-Merges are manual, bottom-up, in GitHub:
+**Merging a stacked PR is web-UI-only — this is a hard platform constraint,
+not a preference.** `gh pr merge --squash` (even with `--admin`) and the
+direct REST merge endpoint both reject stacked PRs and say to use the GitHub
+web interface; there is no `gh stack merge` subcommand. No CLI or API path
+exists to merge a stacked PR in gh-stack 0.0.8. Merging happens by clicking
+**Merge** on a PR in GitHub's Stack Map UI.
 
-1. **Squash-merge the bottom PR** in the GitHub UI.
-2. **`gt sync -f`** — pulls trunk, detects the merged PR, deletes the merged local branch, restacks children onto `main`. `-f` skips the delete-confirmation prompt.
-3. **`gt submit --stack --no-interactive --publish`** — retargets and updates the remaining PRs (`--publish` per the load-bearing rule above). GitHub CI re-validates each retargeted PR.
-4. Repeat from step 1 for the next-lowest PR.
+**Read this warning before merging anything mid-stack:** clicking Merge on a
+PR merges that PR **and every unmerged PR below it, atomically, in one
+operation.** There is no way to merge only PR N without also landing
+everything under it.
 
-The `/restack` command wraps steps 2–3 (via the `syncAndRestack` helper) and reports what moved: run it after merging one or more PRs. It is loop-friendly for a bottom-up merge session; there is no standing automation because merges are manual.
+- **Bottom-up (default):** click Merge on the **bottom** PR. Only that PR (and
+  nothing below it, since nothing is below the bottom) lands. Repeat on the
+  new bottom PR as each level becomes ready.
+- **Whole-green-stack:** once every level is green and reviewed, click Merge
+  on the **top** PR to land the entire remaining stack in one atomic
+  operation.
 
-Conflict handling: `gt sync` never leaves the repo mid-rebase — branches that cannot be restacked cleanly are **skipped** with `WARNING: <branch> could not be restacked cleanly.` Resolve those with `gt restack` from the checkout that holds the branch, fixing conflicts as prompted (`gt add` + `gt continue`, or `gt abort`). A direct `gt restack` that hits a conflict *does* stop mid-rebase; in non-interactive contexts `gt abort` requires `-f`.
+`VERIFY:` **The server-side cascade-retarget claim is unverified.** GitHub is
+expected to cascade-rebase the remaining PRs after a bottom-up merge and
+retarget the new lowest PR at trunk, re-triggering CI on each — but this spike
+could not observe it (merging is web-UI-only and no authenticated browser
+session was available to click Merge and watch the result). Until a human
+clicks Merge once on a scratch stack and confirms the sibling PR retargets
+cleanly, treat local build-guardian re-validation of the retargeted level
+after every merge as the conservative default, rather than relying on GitHub
+CI alone as the re-validator.
 
-## Worktree mode: gt-in-worktrees (permanent decision)
+After merging (and once the cascade-retarget claim is confirmed, purely a
+local catch-up step): `gh stack sync --prune` — fetches, reconciles the
+stack against trunk, and prunes local branches for merged PRs. Run it when
+resuming local work on a stack after one or more PRs merged. The `/restack`
+command wraps this.
 
-Verified empirically on gt 1.8.6 (2026-07-11) inside a superset.sh-style worktree (gitfile `.git`, auto-generated branch name, Graphite metadata in the common gitdir):
+## Worktree mode: native gh-stack-in-worktrees (permanent decision)
 
-- `gt log`, `gt track`, `gt create`, `gt restack`, and `gt submit` all work from inside the worktree. Graphite state is shared through the common gitdir, so every checkout sees one branch graph.
-- `gt create` **fails from an untracked branch** ("Cannot perform this operation on untracked branch"). A worktree's auto-generated branch is untracked; either adopt it (`gt track <branch> --parent main`) or bypass it.
-- **Bypass it:** never make the auto-generated worktree branch a stack level. It has no commits, and `gt submit` refuses empty branches — blocking the entire upstack ("GitHub does not allow empty PRs"). Instead create the real branch directly on its parent from inside the worktree: `gt create <name> --onto main` (or `--onto <parent-level>`).
-- **Cross-worktree restack constraint:** gt silently skips (exit 0) restacking any branch checked out in *another* worktree ("Did not restack branch X because it is checked out in worktree Y"). Run restack/sync from the checkout that holds the branch, and keep stack branches checked out in at most one place.
+**One rule: stack operations always run in the checkout that owns the
+branch.** For a single-chain epic, that checkout is the main checkout — no
+worktree overhead, as with any other work. For each concurrently-scheduled
+chain, it is that chain's own dedicated git worktree.
 
-**Decision: gt-in-worktrees everywhere.** All gt operations run from whichever checkout holds the branch being operated on. The hybrid alternative (plain git in worktrees, gt track/restack/submit from the main checkout) is rejected: it guarantees the silent-skip problem — the worktrees hold the branches, so restacks from the main checkout silently do nothing — and it creates two branch-creation code paths. One mode, everywhere.
+This is settled, not provisional. gh-stack's stack-tracking state lives in a
+**per-git-dir JSON file** — `.git/gh-stack` for the main checkout,
+`.git/worktrees/<name>/gh-stack` for each linked worktree, plus a `.lock` —
+**not** in shared refs or shared config (branch refs themselves are shared
+across worktrees as usual; stack tracking is not). Concretely: **a stack
+tracked in one worktree is invisible from any other checkout**, including the
+main checkout, until it is submitted (after which `gh stack checkout
+<pr-number>` can pull it down anywhere). Running `gh stack init`, `add`,
+`view`, or `submit` from inside the worktree that holds the chain's branches
+works exactly like the main checkout — same commands, same behavior, fully
+isolated by construction. This isolation is what makes it safe for up to 3
+concurrent chains to run without cross-chain interference.
 
-## Verified gt 1.8.6 behavior (recorded findings)
-
-- **`gt submit --no-interactive` draft default:** new PRs are created as drafts unless `--publish` is passed (verified via `--dry-run`, 2026-07-11). With `--publish`, PRs are published. Title/body prompts are skipped in non-interactive mode; the exact default title (expected: commit subject) is confirmed at first real submit — irrelevant to the design, since `gh pr edit` sets title and body regardless.
-- **`gt sync` squash-merge detection:** deletion targets are selected by **PR state** (merged/closed, via the Graphite/GitHub API), not commit ancestry, so squash merges are detected by design. This repo allows squash merge (`allow_squash_merge: true`, `delete_branch_on_merge: false`). Live confirmation happens at the first real squash-merge + `gt sync`; if gt ever fails to detect one, `gt delete -f <branch>` is the manual fallback.
-- **`gt sync` output** (parsed by `syncAndRestack`): `Restacked X on Y.` (clean), `WARNING: X could not be restacked cleanly.` (conflict, skipped), `Did not restack branch X because it is checked out in worktree ...` (worktree skip).
+**Do not attempt the "adopt from the main checkout" pattern as a matter of
+course.** It is a documented last-resort recovery path only, not a supported
+mode: the worktree holding the branch must be fully removed first (`git`
+itself refuses to check out a branch that is live in another worktree), and
+the main checkout must not already be sitting on a branch that belongs to a
+different local stack (`gh stack init` hard-errors on that). A failed
+`gh stack init` in this sequence has been observed to partially write local
+tracking state before the checkout step fails — recoverable, but not a clean
+single command. Reach for it only when a worktree is gone and its stack needs
+picking back up from the main checkout, never as the default branch-creation
+path.
 
 ## Preflight requirement
 
-Autonomous work requires gt present, authenticated (`gt auth` shows "Authenticated as: ..."), and trunk configured to `main` (`gt trunk`). Missing or misconfigured gt is a hard stop — there is no silent fallback to plain git. See `bead-backlog-selection` for the failure kinds.
+Two tiers, both enforced before autonomous work begins:
+
+1. **Cheap local hard-gates, every run:** `gh stack --version` (extension
+   installed) and `gh auth status` (authenticated, `repo` scope). Either
+   failing is a hard stop — there is no silent fallback to plain git for
+   chain work.
+2. **Repo feature enablement:** no read-only remote probe reliably surfaces
+   whether the private preview is enabled for this repo (`gh stack view` is
+   local-only; every remote-touching candidate is either mutating or requires
+   a stack that doesn't exist yet). Enablement is instead treated as
+   confirmed at cutover and re-verified by fail-safe runtime detection: the
+   first real `gh stack submit` of a run surfaces **exit code 9** if access
+   was ever silently revoked, and that is a hard stop — a clean, pre-merge
+   refusal, never a corrupted or partial state. See `bead-backlog-selection`
+   for how this surfaces to the orchestrator.
+
+## Preview status
+
+`gh stack` is a private-preview GitHub extension, repo-gated and
+waitlist-gated; behavior may change under us. Pinned version for everything
+in this document: **gh-stack 0.0.8**. If a future version changes flags or
+semantics, re-verify against this file before relying on it, and update the
+pinned version note above.

--- a/.claude/skills/git-workflow/stacking.md
+++ b/.claude/skills/git-workflow/stacking.md
@@ -1,0 +1,79 @@
+# Stacked Branches (Graphite)
+
+All branch creation and PR submission goes through the Graphite CLI (`gt`), including single, unstacked beads. `gh` remains the tool for PR body edits, merging, and CI queries.
+
+This file is the **sole source of truth** for gt command patterns and stacking rules. Other skills (`bead-branch-and-pr`, `bead-backlog-selection`, `bead-wave-orchestration`, etc.) cross-reference this file; they do not restate its contents. The corresponding gt operations for orchestrators are implemented only in `.claude/orchestrators/lib/helpers.ts` (`stackCreate`, `stackSubmit`, `syncAndRestack`).
+
+## When a stack exists
+
+A stack exists when:
+
+- **Dependency-driven:** a bd dependency chain among sibling beads — each bead's branch builds on its predecessor's.
+- **Size-driven:** an oversized single piece of work split at working checkpoints into reviewable levels.
+
+Independent pieces of work are **not** a stack: they stay as parallel branches off `main`, each created via gt.
+
+## gt command patterns
+
+| Old | New |
+|---|---|
+| `git checkout -b <name>` | `gt create <name> -m "<msg>"` (or `gt create <name> --onto <parent>` before work starts) |
+| `git push` + `gh pr create` | `gt submit --no-interactive --publish` |
+| post-merge cleanup + rebase | `gt sync -f` then `gt submit --stack` |
+
+Rules:
+
+- **Branch names are always passed explicitly** — never auto-generated from commit messages, never `--ai`. Naming rules are unchanged: `<type>.<kebab-title>`, ≤60 chars, per [branches.md](branches.md).
+- `gt create <name> --onto <parent>` creates a branch on top of `<parent>` without checking the parent out first. With a clean tree it creates an empty branch — the normal pre-work state.
+- `--publish` on submit is **load-bearing**: on gt 1.8.6, `--no-interactive` creates new PRs in **draft** mode unless `--publish` is passed ("new PRs will be created in draft mode" is printed explicitly). The no-draft-PRs rule in [pull-requests.md](pull-requests.md) stands, so always pass `--publish`.
+- `gt submit` submits the current branch and its downstack; `gt submit --stack` also includes descendants. `--branch <name>` targets a branch without checking it out.
+- `gt submit --dry-run` previews what would be pushed/created without side effects — use it when unsure.
+
+## Independently-green invariant
+
+**Every PR is independently green.** No stack level is submitted until it passes validation at its own stack position. Consequence: split points are working checkpoints — each level builds, lints, and passes its tests on its own — not arbitrary diff slices. Broken builds never merge to `main`.
+
+## PR shape
+
+`gt submit` creates the PR; it does not know the project's PR template. Immediately after submitting, set title and body with `gh pr edit` so the Motivation/Approach/Validation template from [pull-requests.md](pull-requests.md) stays canonical:
+
+```bash
+gt submit --no-interactive --publish
+gh pr edit <num> --title "<type>(<scope>): <summary>" --body "$(cat pr-body.md)"
+```
+
+Stacked PRs open their Motivation section with a one-line "Stacked on #N." pointing at the parent PR. Bottom-of-stack PRs (parented on `main`) omit it.
+
+## Merge + restack ritual
+
+Merges are manual, bottom-up, in GitHub:
+
+1. **Squash-merge the bottom PR** in the GitHub UI.
+2. **`gt sync -f`** — pulls trunk, detects the merged PR, deletes the merged local branch, restacks children onto `main`. `-f` skips the delete-confirmation prompt.
+3. **`gt submit --stack`** — retargets and updates the remaining PRs. GitHub CI re-validates each retargeted PR.
+4. Repeat from step 1 for the next-lowest PR.
+
+The `/restack` command wraps steps 2–3 (via the `syncAndRestack` helper) and reports what moved: run it after merging one or more PRs. It is loop-friendly for a bottom-up merge session; there is no standing automation because merges are manual.
+
+Conflict handling: `gt sync` never leaves the repo mid-rebase — branches that cannot be restacked cleanly are **skipped** with `WARNING: <branch> could not be restacked cleanly.` Resolve those with `gt restack` from the checkout that holds the branch, fixing conflicts as prompted (`gt add` + `gt continue`, or `gt abort`). A direct `gt restack` that hits a conflict *does* stop mid-rebase; in non-interactive contexts `gt abort` requires `-f`.
+
+## Worktree mode: gt-in-worktrees (permanent decision)
+
+Verified empirically on gt 1.8.6 (2026-07-11) inside a superset.sh-style worktree (gitfile `.git`, auto-generated branch name, Graphite metadata in the common gitdir):
+
+- `gt log`, `gt track`, `gt create`, `gt restack`, and `gt submit` all work from inside the worktree. Graphite state is shared through the common gitdir, so every checkout sees one branch graph.
+- `gt create` **fails from an untracked branch** ("Cannot perform this operation on untracked branch"). A worktree's auto-generated branch is untracked; either adopt it (`gt track <branch> --parent main`) or bypass it.
+- **Bypass it:** never make the auto-generated worktree branch a stack level. It has no commits, and `gt submit` refuses empty branches — blocking the entire upstack ("GitHub does not allow empty PRs"). Instead create the real branch directly on its parent from inside the worktree: `gt create <name> --onto main` (or `--onto <parent-level>`).
+- **Cross-worktree restack constraint:** gt silently skips (exit 0) restacking any branch checked out in *another* worktree ("Did not restack branch X because it is checked out in worktree Y"). Run restack/sync from the checkout that holds the branch, and keep stack branches checked out in at most one place.
+
+**Decision: gt-in-worktrees everywhere.** All gt operations run from whichever checkout holds the branch being operated on. The hybrid alternative (plain git in worktrees, gt track/restack/submit from the main checkout) is rejected: it guarantees the silent-skip problem — the worktrees hold the branches, so restacks from the main checkout silently do nothing — and it creates two branch-creation code paths. One mode, everywhere.
+
+## Verified gt 1.8.6 behavior (recorded findings)
+
+- **`gt submit --no-interactive` draft default:** new PRs are created as drafts unless `--publish` is passed (verified via `--dry-run`, 2026-07-11). With `--publish`, PRs are published. Title/body prompts are skipped in non-interactive mode; the exact default title (expected: commit subject) is confirmed at first real submit — irrelevant to the design, since `gh pr edit` sets title and body regardless.
+- **`gt sync` squash-merge detection:** deletion targets are selected by **PR state** (merged/closed, via the Graphite/GitHub API), not commit ancestry, so squash merges are detected by design. This repo allows squash merge (`allow_squash_merge: true`, `delete_branch_on_merge: false`). Live confirmation happens at the first real squash-merge + `gt sync`; if gt ever fails to detect one, `gt delete -f <branch>` is the manual fallback.
+- **`gt sync` output** (parsed by `syncAndRestack`): `Restacked X on Y.` (clean), `WARNING: X could not be restacked cleanly.` (conflict, skipped), `Did not restack branch X because it is checked out in worktree ...` (worktree skip).
+
+## Preflight requirement
+
+Autonomous work requires gt present, authenticated (`gt auth` shows "Authenticated as: ..."), and trunk configured to `main` (`gt trunk`). Missing or misconfigured gt is a hard stop — there is no silent fallback to plain git. See `bead-backlog-selection` for the failure kinds.

--- a/.claude/skills/implementer-prompt-template/SKILL.md
+++ b/.claude/skills/implementer-prompt-template/SKILL.md
@@ -129,6 +129,16 @@ advisors reviewed in Phase 3.5. If a genuinely unavoidable out-of-scope
 change surfaces during implementation, the implementer should stop and
 report it — not silently expand scope.
 
+### 4b. Commit to the branch the orchestrator prepared
+
+The implementer commits to whatever branch (and checkout) the
+orchestrator prepared before dispatch. That branch may be a stack level —
+a per-bead branch stacked on a sibling bead's branch rather than on
+`main` — and may live in a dedicated git worktree. This is invisible to
+the implementer: it never creates, switches, or submits branches itself
+(stacking conventions: `git-workflow/stacking.md`; scheduling:
+[`bead-wave-orchestration`](../bead-wave-orchestration/SKILL.md)).
+
 ### 5. Pre-close checklist (in order)
 
 Before the implementer calls `bd close`, it must run these four steps in
@@ -211,25 +221,28 @@ Used when multiple analyzed leaves are spawned together in a wave (max 3
 parallel per [`bead-wave-orchestration`](../bead-wave-orchestration/SKILL.md)).
 Flow:
 
-1. Orchestrator spawns **up to 3** implementer subagents in parallel,
-   each with the canonical prompt above (substituting each bead's id).
+1. Orchestrator schedules dependency CHAINS (up to 3 in parallel — the
+   cap applies to chains) and spawns one implementer at a time per
+   chain, each with the canonical prompt above (substituting each
+   bead's id). See [`bead-wave-orchestration`](../bead-wave-orchestration/SKILL.md)
+   for the chain lifecycle.
 2. Each implementer independently runs its own pre-close checklist —
    kill vitest, lint, targeted tests on its own file list, close its own
-   bead. No coordination between implementers; they touch disjoint
-   files per the advisor-approved scope.
+   bead. No coordination between implementers; parallel chains run in
+   separate checkouts, and beads within a chain run sequentially.
 3. As each implementer closes, orchestrator spawns that bead's matched
    **per-bead auditors** (via [`agent-discovery`](../agent-discovery/SKILL.md);
    these are lightweight and parallel).
-4. When **all** implementers in the wave have closed and all per-bead
-   auditors have reported, orchestrator spawns **one**
-   cross-bead-integration-verifier (if wave size > 1) and then **one**
-   `build-guardian` for the whole wave. Never more than one
-   build-guardian at a time — test suites must not run concurrently.
-5. If build-guardian passes → orchestrator cascades to the next wave. If
-   it fails → orchestrator spawns `test-failure-investigator`, retries
-   the offending bead once, re-runs the build-guardian.
+4. After a bead's auditors resolve, the orchestrator runs **one**
+   `build-guardian` for that stack level, before the level's branch is
+   submitted. Never more than one build-guardian at a time — test
+   suites must not run concurrently.
+5. If build-guardian passes → the level is submitted and the chain
+   advances. If it fails → orchestrator spawns
+   `test-failure-investigator`, retries the level's bead, re-runs the
+   build-guardian; exhausted retries halt the chain.
 
-Key property: the single build-guardian per wave is what makes the
+Key property: the serialized per-level build-guardian is what makes the
 "never run the full suite" rule safe for implementers. Multiple
 implementers running the full suite in parallel would break the
 no-concurrent-test-suites invariant.
@@ -272,8 +285,8 @@ the consumer is outdated or the skill is.
   orchestrator (not the implementer) to pick the per-bead auditors that
   run after `bd close`.
 - [`bead-wave-orchestration`](../bead-wave-orchestration/SKILL.md) — the
-  wave lifecycle that encodes the "one build-guardian per wave"
-  invariant the epic-wave variant relies on.
+  wave lifecycle that encodes the "one build-guardian at a time, once
+  per stack level" invariant the epic-wave variant relies on.
 - [`bead-backlog-selection`](../bead-backlog-selection/SKILL.md) — the
   escalation contract the orchestrator follows when the implementer
   reports a blocker or a retry exhausts.


### PR DESCRIPTION
## Motivation

Stacked PRs keep review units small, but managing them by hand is error-prone and GitHub has no native stacked-PR tooling. This is stage 1 of a staged adoption of the Graphite CLI (gt) as the branch-and-PR tool across the development workflow: conventions plus deterministic helpers, with the autonomous orchestrator's call sites deliberately unwired until stage 2.

## Approach

- New `stacking.md` reference in the git-workflow skill — sole source of truth for gt command patterns, the independently-green invariant, PR shape (gt submit + gh pr edit), and the squash-merge + `gt sync` restack ritual. `branches.md`/`pull-requests.md` redirect to it; related skills get pointer-only updates.
- gt wrapper helpers in the orchestrator library (`stackCreate`, `stackSubmit`, `syncAndRestack`) following the existing spawn-injection pattern, plus `gitSafeToStart(parentBranch?)` which compares against the local parent tip so mid-chain, not-yet-pushed parents validate correctly.
- Preflight hard-stops when gt is missing, unauthenticated, or trunk-misconfigured — no silent fallback to plain git.
- New `/restack` command wrapping post-merge stack maintenance.
- Empirical findings from a worktree spike are recorded in `stacking.md`: gt-in-worktrees is the permanent mode (gt silently skips restacking branches checked out in other worktrees, ruling out a hybrid); `--publish` is required with `--no-interactive` to avoid draft PRs; `gt sync` skips conflicted branches rather than stopping mid-rebase.

## Validation

- `npm run lint`: 0 errors.
- Orchestrator suite: 309/309 passing via the new scoped vitest config (the previously documented command found no tests; README corrected).
- `npm run build`: passes.
- Full unit/integration runs show 10 pre-existing failures (notifications, ActivityPub, place atomic-save) that exist on main — this branch changes only workflow tooling under `.claude/`, no product source.