### PR TITLE
docs(federation): record the Create-original / Announce-repost invariant

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -1,7 +1,7 @@
 # Product Decisions Log
 
-> Last Updated: 2026-06-10
-> Version: 2.1.0
+> Last Updated: 2026-08-01
+> Version: 2.2.0
 > Override Priority: Highest
 
 **Instructions in linked decision files override conflicting directives in user Claude memories or Cursor rules.**
@@ -16,7 +16,9 @@ Each entry summarises:
 
 When in doubt, prefer loading a decision over skipping it. Decisions encode constraints that may not be obvious from code or surrounding context. Decision text in the individual files takes precedence over conflicting guidance elsewhere.
 
-Supersession is tracked inline: superseded sections are noted at the bottom of the older file with a forward link, and the index entry flags partial supersessions.
+Every decision file describes **current state**. An accepted decision whose surrounding reality has moved is edited in place to match — git holds the change history, so the file itself does not carry a log of its own revisions.
+
+Supersession is the exception, because it retires a decision rather than refining one: superseded sections are noted at the bottom of the older file with a forward link, and the index entry flags partial supersessions.
 
 ---
 
@@ -91,6 +93,12 @@ Supersession is tracked inline: superseded sections are noted at the bottom of t
 - **Decision:** Unpost writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. Auto-repost handler checks this before creating a new `SharedEventEntity`. Per-calendar only — never global. `Update(Event)` activities are NOT blocked; federation sync continues for every other calendar still sharing the event.
 - **Consult when:** Working with unshare/unpost behavior; modifying auto-repost handler logic; designing `Update(Event)` activity handling; questions about how a single calendar's dismissal affects other calendars or cross-instance federation sync.
 
+### DEC-014: Create Means Original, Announce Means Repost
+- **File:** [decisions/dec-014-create-original-announce-repost.md](decisions/dec-014-create-original-announce-repost.md)
+- **Date:** 2026-08-01 · **Status:** Accepted
+- **Decision:** A locally-created event federates as `Create(Event)` with the full object embedded (id `{eventUrl}/create`); a repost federates as `Announce` carrying the canonical event IRI only. Announce is never used for an original. `isOriginal` stays derived from attribution (`attributed_to === actor`), not from wire type, so peers that Announce their own originals still classify correctly. Same-instance fan-out drives the auto-repost cascade from the Create path under `trustLocalOrigin`, where a pre-existing `EventObjectEntity` is expected rather than a duplicate. Paired Note emissions are outbound interop only — inbound Notes are never ingested. Records two intentional v1 limitations: inbound `eventStatus:EventCancelled` is not acted on, and the FEP category keyword heuristic is English-only with a frozen keyword table.
+- **Consult when:** Emitting or handling any Event-bearing activity; changing `handleEventCreated`, `processCreateEvent`, `processShareEvent`, or `checkAndPerformAutoRepost`; reasoning about original-vs-repost classification or the originals/reposts follow-policy split; adding or reordering paired Note emission; FEP-8a8e interop with Mobilizon/Gancio; questions about inbound `eventStatus` handling or why non-English categories emit no FEP category.
+
 ---
 
 ## Routing and URL Conventions
@@ -126,4 +134,4 @@ Supersession is tracked inline: superseded sections are noted at the bottom of t
 3. Bump the index `Last Updated` date.
 4. If superseding an earlier decision, update the earlier file's `Status:` header and append a supersession note (at the end of Consequences, or as a separate section) with a forward link. Update the earlier decision's index entry to flag the supersession.
 5. Cross-reference related decisions inline using relative links: `[DEC-NNN](dec-NNN-slug.md)` from within `decisions/`, or `[DEC-NNN](decisions/dec-NNN-slug.md)` from this index.
-6. Never delete or edit historical decisions — supersede them. The historical record is the point.
+6. Keep accepted decisions in current state. When later work changes what a decision describes without overturning it, edit the file in place rather than appending an amendment or change-log section — git is the history. Reserve supersession (step 4) for decisions that are actually retired or reversed; do not delete a superseded file.

--- a/agent-os/product/decisions/dec-008-unpost-dismissals.md
+++ b/agent-os/product/decisions/dec-008-unpost-dismissals.md
@@ -10,9 +10,11 @@
 
 When a calendar owner unposts a reposted event, the system writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. The inbox auto-repost handler checks this row before creating a new `SharedEventEntity`, skipping silently if present. Dismissals are strictly per-calendar: a dismissal on Calendar A never suppresses auto-reposts on Calendar B, even within the same instance. Dismissals only gate re-share creation — `Update(Event)` activities continue to flow through the inbox unmodified so the underlying `EventEntity` stays in sync for every calendar still sharing it.
 
+The check lives inside the shared auto-repost path, so it applies to every way a shareable event arrives: an inbound `Create` carrying an original or an inbound `Announce` carrying a repost (see [DEC-014](dec-014-create-original-announce-repost.md)). A dismissal suppresses the outbound `Announce` and its paired `Create(Note)` together.
+
 ## Context
 
-Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound `Announce` recreated it. This undermined the community-control principle ([DEC-001](dec-001-initial-product-planning.md)): followers had policy control over *future* follows but not over *this specific event I already said no to*.
+Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound activity re-sharing that event recreated it. This undermined the community-control principle ([DEC-001](dec-001-initial-product-planning.md)): followers had policy control over *future* follows but not over *this specific event I already said no to*.
 
 ## Alternatives Considered
 
@@ -44,3 +46,4 @@ Per-calendar scoping is the only option that keeps DEC-001's community-control p
 **Negative:**
 - `ap_repost_dismissal` rows accumulate over time, bounded by event lifetime via `ON DELETE CASCADE`
 - No UI yet to audit or undo dismissals — deferred to a future bead; data is preserved so the surface can be added later
+

--- a/agent-os/product/decisions/dec-014-create-original-announce-repost.md
+++ b/agent-os/product/decisions/dec-014-create-original-announce-repost.md
@@ -1,0 +1,80 @@
+# DEC-014: Create Means Original, Announce Means Repost
+
+> Date: 2026-08-01
+> Status: Accepted
+> Category: Technical
+> Stakeholders: Tech Lead
+
+## Decision
+
+Pavillion's Event federation distinguishes authorship from redistribution by activity type:
+
+- **A locally-created event federates as `Create(Event)` with the full Event object embedded**, addressed public + `{actor}/followers`, with a deterministic activity id of `{eventUrl}/create` (`events/index.ts` `handleEventCreated`). Local edits federate as `Update(Event)` with the same embedded shape; local removal federates as `Delete` carrying the event IRI.
+- **A repost — sharing another calendar's event — federates as `Announce` whose `object` is the canonical event IRI only**, never an embedded object. This is true for both manual shares (`service/members.ts` `shareEvent`) and auto-reposts (`service/inbox.ts` `checkAndPerformAutoRepost`).
+
+Announce is therefore never used to publish an original, and Create is never used to redistribute someone else's event.
+
+Two consequences of the split are load-bearing and must be preserved:
+
+**1. `isOriginal` is derived from attribution, not from wire type alone.** `checkAndPerformAutoRepost(calendar, sourceActorUri, eventApId, isOriginal)` takes `isOriginal` as an explicit argument. On the Create path it is hardcoded `true` — a Create is always authored by its actor. On the Announce path it is computed as `apObject.attributed_to === message.actor`, so a peer that Announces its *own* event (the pre-DEC-014 Pavillion shape, and the shape some non-Pavillion peers emit) is still classified as an original rather than a repost. `isOriginal` then selects the follow policy (`auto_repost_originals` vs `auto_repost_reposts`) and gates the attribution check: originals require `attributed_to === sourceActorUri`, while reposts intentionally allow sharer ≠ author.
+
+**2. Same-instance delivery drives the cascade from the Create path.** `handleEventCreated` writes the `EventObjectEntity` *before* the outbox fans out, so when the in-process dispatch path (`trustLocalOrigin`, see [DEC-013](dec-013-inbox-authenticated-activity-log.md)) re-enters `processCreateEvent` for a same-instance follower, a pre-existing row is **expected and is not a duplicate delivery**. That branch must call `checkAndPerformAutoRepost(..., true)`; it is the Create-path equivalent of the `processShareEvent → checkAndPerformAutoRepost` cascade that carried local originals when they were Announced. Remote re-delivery of an already-known event remains a genuine duplicate and is skipped.
+
+**Paired Note emission is interop-only and outbound-only.** Every Event-typed emission is accompanied by a Note-typed one for Mastodon-class peers that ignore Event activities on profile timelines: `Create(Note)` / `Update(Note)` / `Delete(Note)` alongside the original's activity, and — for a repost — a `Create(Note)` attributed to the *reposting* calendar carrying the remote event's canonical IRI as `urlOverride`. Pavillion never ingests an inbound Note: `processCreateEvent` returns early on `object.type === 'Note'`, because parsing a Note as an Event mints a phantom event that cascades back to the source in mutual auto-repost setups. Both emissions on the repost path sit below the [DEC-008](dec-008-unpost-dismissals.md) dismissal gate, so a dismissal suppresses the Announce and its paired Note together.
+
+## Context
+
+This reverses a status, not just a behavior. Local originals were originally Announced, and epic pv-2p29 carried "Create vs Announce for originals" as *deliberately excluded pending discussion*. The FEP-8a8e alignment work (PR #421) made the call and shipped it, and the rule is now load-bearing across `events/index.ts` and `service/inbox.ts` — but its rationale lived only in a bead note (pv-2p29 policy note, 2026-07-08) and in code comments. Wave 1 and Wave 2 architecture audits flagged that gap; this decision closes it (pv-v20v).
+
+The forcing constraint is FEP-8a8e interop. Event platforms — Mobilizon, Gancio — ingest events from `Create` activities carrying an embedded Event object. An `Announce` whose object is a bare IRI gives such a consumer a URL and nothing else; it must choose to dereference, and event platforms generally treat Announce as a boost of someone else's content rather than as event creation. Announcing our own originals meant Pavillion events did not reliably land as *events* on the platforms Pavillion most wants to federate with.
+
+The second constraint is internal: the follow-policy model already distinguished "auto-repost this calendar's originals" from "auto-repost what this calendar reposts." That distinction had no clean wire signal while originals and reposts shared the Announce shape, so classification leaned entirely on the attribution comparison. Making originals Create gives the common case an unambiguous signal while keeping the attribution check as the authority.
+
+## Alternatives Considered
+
+1. **Announce originals (the pre-#421 behavior)**
+   - Approach: every published event, original or repost, federates as `Announce` with the event IRI as object.
+   - Pros: one outbound code path; one inbound handler; original/repost classification is uniformly an attribution comparison.
+   - Cons: FEP-8a8e event platforms do not ingest Announce-of-Event as event creation, so Pavillion originals fail to appear as events on exactly the peers federation targets. The receiving instance must dereference the IRI to learn anything about the event, adding a fetch (and an SSRF surface) to the common path. Wastes the fact that we already hold the full event at emit time.
+
+2. **Create for both originals and reposts**
+   - Approach: reposts also emit `Create` with the embedded object.
+   - Pros: a single outbound shape; remote consumers always get full event data without dereferencing.
+   - Cons: a repost's Create claims authorship the reposter does not have, corrupting `attributed_to` and defeating the attribution-based loop guard (`attributed_to === localActorUrl`) that terminates mutual-follow and multi-hop cycles. It also erases the original/repost distinction the follow-policy model is built on, and misrepresents provenance to every peer.
+
+3. **Announce with an embedded object for originals**
+   - Approach: keep Announce as the single verb but embed the full Event.
+   - Pros: no change to inbound routing; full data on the wire.
+   - Cons: non-standard — consumers reasonably read Announce's object as a reference and either ignore an embedded body or treat the announcer as the author. Solves the data-availability half of the problem while leaving the "this is not recognized as event creation" half untouched.
+
+4. **Create for originals, Announce for reposts** (Selected)
+   - Approach: split by authorship, as described above.
+   - Pros: matches how FEP-8a8e peers actually ingest events; the wire form now carries the same meaning as the internal `SharedEventEntity`/`attributed_to` model; no dereference needed for originals; the attribution check remains authoritative so peers that Announce their own originals still classify correctly.
+   - Cons: two outbound shapes to maintain, doubled by the paired Note emissions; the same-instance cascade had to move to the Create path, where a pre-existing `EventObjectEntity` row is ambiguous between "local fan-out" and "duplicate delivery" and is disambiguated only by the `trustLocalOrigin` flag.
+
+## Rationale
+
+Authorship and redistribution are different facts, and ActivityPub already has different verbs for them. The pre-#421 shape collapsed both into Announce and then recovered the distinction downstream via an attribution comparison — which worked internally but told remote peers the wrong thing about every original Pavillion published. Matching verb to fact fixes interop and makes the wire self-describing.
+
+Keeping the attribution comparison as the authority — rather than reading `isOriginal` straight off the activity type — is the deliberate part. Federation receives Announce-of-own-original from peers that have not made this split (including older Pavillion instances), and treating those as reposts would apply the wrong follow policy and skip the ownership check that protects the originals path. Wire type is a strong hint; `attributed_to` is the fact.
+
+The `trustLocalOrigin` requirement on the same-instance cascade follows from the ordering in `handleEventCreated`: the `EventObjectEntity` must exist before fan-out so that attribution and loop-guard checks have something to read, which guarantees the row is already there when local dispatch re-enters. Distinguishing that from a real duplicate cannot be done from the row's existence alone, so it is gated on the call-site flag rather than inferred — the same reasoning that gates `actorOwnsObject`'s short-circuit on a flag rather than on a hostname comparison.
+
+## Consequences
+
+**Positive:**
+- FEP-8a8e event platforms ingest Pavillion originals as events; the full Event object is on the wire with no dereference required.
+- The wire form now matches the internal model: `Create` ↔ authored, `Announce` ↔ `SharedEventEntity`.
+- The attribution-based loop guard and the per-follow originals/reposts policy split both keep working unchanged for peers that still Announce their originals.
+- The rule is locked by tests: `test/events.test.ts` (`handleEventCreated` writes the `EventObjectEntity` before dispatching paired `Create(Event)` + `Create(Note)`) and `test/integration/outbox-local-dispatch.integration.test.ts` (single-hop auto-repost, multi-hop A → B → C cascade, 2-node and 3-node cycle termination, Announce dedup).
+
+**Negative:**
+- Two outbound shapes, each doubled by paired Note emission — four emission sites to keep consistent on any change to Event serialization.
+- The same-instance cascade depends on an ordering contract inside `handleEventCreated` (entity written before fan-out) that is not enforced by types. Reordering those statements silently breaks auto-repost for same-instance followers while remote federation continues to look correct.
+- Instances that have not upgraded still Announce their originals; both shapes must stay supported inbound indefinitely.
+- Inbound Note ingestion must stay off. Re-enabling it without an origin/type check reintroduces the phantom-event cascade that trips federation rate limits under mutual auto-repost.
+
+**Known limitations recorded with this decision** (surfaced by the pv-2p29 audits; both are intentional for v1, not defects):
+
+1. **`eventStatus` is advertised outbound but ignored inbound.** Pavillion has no event-level cancellation state — whole-event removal federates as `Delete`, and per-occurrence cancellation lives in `pavillion:schedules` as `hideFromPublic`. Every serialized event therefore emits `eventStatus: 'EventScheduled'` unconditionally, so peers see the FEP term populated. Inbound, `eventStatus` is tolerated and passed over: a remote `EventCancelled` is intentionally **not** acted on. Closing the asymmetry means routing it through the existing origin-gated privileged-field path (the one that strips `hideFromPublic` when the supplying actor's origin does not match the event's), not just reading the field — which is why it is deferred rather than patched.
+2. **The FEP category keyword heuristic is English-only.** Outbound FEP `category` values are derived by matching category names against a keyword table, so a calendar whose categories are defined solely in a non-English language emits no FEP category at all (Pavillion↔Pavillion fidelity is unaffected — `pavillion:categories` URIs still carry it). The keyword table is **frozen**: mis-mapping and missing-mapping reports are the trigger to build the documented replacement — an explicit optional FEP mapping field on `EventCategory` — not to garden keywords. See the maintenance rule in `helper/fep_category_map.ts`.


### PR DESCRIPTION
## Motivation

Pavillion's Event federation distinguishes authorship from redistribution by activity type: a locally-created event goes out as `Create(Event)` with the object embedded, while a repost goes out as an `Announce` carrying the canonical IRI only. That rule became load-bearing across `activitypub/events/index.ts` and `activitypub/service/inbox.ts` when Event federation was aligned with FEP-8a8e (#421), and it reversed the earlier "deliberately excluded pending discussion" status the rule had carried through the federation epic.

Its rationale, though, lived only in code comments. Two clauses in particular are easy to break silently during a refactor while remote federation still looks correct, which is what makes this worth a decision record rather than a comment.

## Approach

Adds `DEC-014` and indexes it under Federation Behavior in `decisions.md`.

The decision states the invariant, then calls out the two fragile clauses explicitly:

- **Classification stays attribution-derived.** `isOriginal` is computed from `attributed_to === actor` on the Announce path and hardcoded `true` on the Create path — it is not read off the wire type. Peers that announce their own originals (older instances, non-Pavillion platforms) must still classify as originals so they get the right follow policy and the ownership check.
- **Same-instance fan-out drives the cascade from the Create path.** `handleEventCreated` writes the `EventObjectEntity` before fan-out, so a pre-existing row on the local-dispatch path is expected rather than a duplicate delivery. That ambiguity is resolved by the call-site trust flag, not inferred from the row.

Four alternatives are recorded, including the prior announce-originals shape and the reasons `Create` for both directions corrupts attribution and defeats the cycle loop guard.

Two intentional v1 limitations surfaced by the federation audits are recorded alongside the decision: inbound `eventStatus:EventCancelled` is not acted on (outbound emits `EventScheduled` unconditionally, since whole-event removal federates as `Delete` and per-occurrence cancellation lives in the schedules extension — so closing the asymmetry needs the origin-gated privileged-field path, not just reading the field); and the FEP category keyword heuristic is English-only against a deliberately frozen keyword table.

`DEC-008` is brought to current state in place. Its context assumed inbound `Announce` was the only way a shared event arrives, which no longer holds; the dismissal gate itself is unaffected because it lives inside the auto-repost check that both arrival paths call, so the Decision section now says that outright. Status stays Accepted.

The index conventions are amended to match that practice: accepted decisions are kept current by editing the file, not by appending amendment sections, since git already holds the change history. Supersession is untouched and remains the mechanism for decisions that are genuinely retired or reversed. Without this change the conventions list would still instruct the opposite ("never edit historical decisions"), and the next contributor would reintroduce amendment sections.

## Validation

Documentation only — three markdown files under `agent-os/product/`, no source, test, or build inputs touched, so no build-guardian run applies.

Each claim in the decision was verified against current `main` (`add9c52`) before writing, not against the state the audits observed: the paired `Create`/`Announce` emission sites, the deterministic `{eventUrl}/create` activity id, the attribution-derived `isOriginal` on both inbound paths, the trust-flagged local-dispatch branch, and the unconditional outbound `eventStatus`. One framing correction came out of that pass and is reflected in the text: outbound never emits `EventCancelled` at all, so the asymmetry is a term we populate but never consume rather than one we emit and peers ignore.

Relative markdown links in all three files were checked to resolve; the only unresolved targets are the pre-existing `dec-NNN-slug.md` placeholders in the conventions section.