### PR TITLE
fix(client): let the browser set the multipart upload Content-Type

### DIFF
--- a/src/client/service/media.ts
+++ b/src/client/service/media.ts
@@ -316,6 +316,10 @@ export default class MediaService {
 
   /**
    * Performs upload with progress tracking using axios
+   *
+   * The multipart `Content-Type` and boundary are intentionally left to the
+   * browser — a manually-set header would omit the boundary and break parsing
+   * on the server.
    */
   private async uploadWithProgress(
     url: string,
@@ -326,9 +330,6 @@ export default class MediaService {
   ): Promise<Response> {
     try {
       const axiosResponse = await axios.post(url, formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
         onUploadProgress: (progressEvent) => {
           if (onProgress && progressEvent.total) {
             const progress: UploadProgress = {

--- a/src/client/test/service/media.test.ts
+++ b/src/client/test/service/media.test.ts
@@ -161,12 +161,29 @@ describe('MediaService', () => {
         '/api/v1/media/calendar-1',
         expect.any(FormData),
         expect.objectContaining({
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
           onUploadProgress: expect.any(Function),
         }),
       );
+    });
+
+    it('should leave the multipart Content-Type to the browser', async () => {
+      const validFile = new File(['test'], 'test.jpg', {
+        type: 'image/jpeg',
+      });
+
+      const axiosPost = vi.mocked(axios.post);
+      axiosPost.mockResolvedValue({
+        status: 200,
+        statusText: 'OK',
+        data: { media: { id: '1', filename: 'test.jpg' } },
+      });
+
+      await mediaService.uploadFile(validFile, 'calendar-1');
+
+      // A manually-set multipart Content-Type omits the boundary the server's
+      // multipart parser needs, so the request config must not carry one.
+      const config = axiosPost.mock.calls[0][2];
+      expect(config?.headers?.['Content-Type']).toBeUndefined();
     });
 
     it('should handle upload progress', async () => {


### PR DESCRIPTION
## Motivation

`src/client/service/media.ts` posted its upload `FormData` with an explicit `Content-Type: multipart/form-data` header. Axios only strips a manually set multipart header under its Node adapter; under the XHR adapter that runs in real browsers the header is passed through as written, without a `boundary` parameter. The media upload endpoint (`src/server/media/api/v1/media.ts`, `upload.single('file')`) relies on multer/busboy, which needs that boundary to split the body — so in-browser media uploads were relying on a header that cannot be parsed.

## Approach

Removed the `headers` block from the `axios.post` call in `uploadWithProgress`, leaving `onUploadProgress` intact. The browser now generates the `Content-Type` with a boundary. This matches `createSourceFromFile` in `src/client/service/import_source.ts`, which already passes `FormData` with no explicit content type for the same reason. Added an evergreen doc comment on `uploadWithProgress` recording why the header is deliberately absent, so it does not get re-added.

## Validation

Written test-first: the existing `uploadFile` assertion that pinned the manual header was updated, and a new test asserts the request config carries no `Content-Type`. The new test failed against the old code (`expected 'multipart/form-data' to be undefined`) and passes after the change.

- `npx vitest run src/client/test/service/media.test.ts` — 13 passed
- `npx vitest run src/client/test/image-upload.test.ts` — 12 passed
- `npm run lint` — 0 errors