### PR TITLE
fix(notifications): scrub reserved i18n: prefix from object_label

### DIFF
--- a/src/server/activitypub/test/integration/flag-inbox-federation.test.ts
+++ b/src/server/activitypub/test/integration/flag-inbox-federation.test.ts
@@ -240,6 +240,14 @@ describe('Federation Flag inbox — anonymization + no outbound side effect (int
     expect(activity.actor_display_url, 'actor_display_url is the instance root').toBe(
       `https://${REMOTE_HOST}`,
     );
+    // The display name is the server-generated i18n token carrying only the
+    // remote host. Asserting it end-to-end (not just in the anonymizer unit
+    // test) catches a regression in the host extraction — e.g. a future
+    // relaxation of validateApActorUri's RFC-1123 allowlist letting a
+    // crafted actor URI put something other than a bare hostname here.
+    expect(activity.actor_display_name, 'actor_display_name is the host-only i18n token').toBe(
+      `i18n:flag_actor_remote{host:${REMOTE_HOST}}`,
+    );
 
     // Object reference points at the created Report, not at the event.
     // The click-through target is the

--- a/src/server/notifications/service/notification.ts
+++ b/src/server/notifications/service/notification.ts
@@ -60,20 +60,26 @@ const OBJECT_LABEL_MAX_LEN = 512;
  * follow a local calendar, causing the recipient to see the Flag
  * attribution string applied to a Follow notification. `scrubReservedI18nPrefix`
  * blanks any such value before it reaches the row.
+ *
+ * The same reasoning covers `object.label`, which snapshots caller-supplied
+ * text (an event title on the report path). A federated peer titling an
+ * event `i18n:flag_actor_remote{host:victim.example}` would otherwise land
+ * that token in `object_label` verbatim, ready for any future client that
+ * resolves labels through the same localizer as display names.
  */
 const I18N_TOKEN_PREFIX = 'i18n:';
 
 /**
- * Returns an empty string if the caller-supplied display name uses the
+ * Returns an empty string if the caller-supplied snapshot text uses the
  * reserved `i18n:` prefix (which is for server-generated Flag tokens only);
  * otherwise returns the value unchanged (or `''` if nullish). The empty
- * fallback keeps `actor_display_name` non-null and falls through to the
- * downstream sanitize step.
+ * fallback keeps the column non-null and falls through to the downstream
+ * sanitize step.
  */
-function scrubReservedI18nPrefix(displayName: string | undefined): string {
-  if (displayName == null) return '';
-  if (displayName.startsWith(I18N_TOKEN_PREFIX)) return '';
-  return displayName;
+function scrubReservedI18nPrefix(text: string | undefined): string {
+  if (text == null) return '';
+  if (text.startsWith(I18N_TOKEN_PREFIX)) return '';
+  return text;
 }
 
 /**
@@ -325,9 +331,16 @@ class NotificationService {
     const actorRow = this.buildActorRow(input);
 
     // Sanitize snapshot text fields (defense-in-depth — clients must still
-    // render these as plain text).
+    // render these as plain text). The label runs through the reserved-prefix
+    // scrub first: unlike `actor_display_name`, no server-generated token
+    // ever legitimately lands in `object_label`, so the scrub is
+    // unconditional across verbs (the Flag path is where a poisoned event
+    // title actually arrives). `sanitize` deliberately stays prefix-agnostic
+    // — it is a generic HTML/bidi guard, and the `i18n:` reservation is a
+    // notifications-domain rule enforced at the call site, symmetric to the
+    // actor-side scrub in `buildActorRow`.
     const actor_display_name = sanitize(actorRow.actor_display_name, ACTOR_DISPLAY_NAME_MAX_LEN);
-    const object_label = sanitize(input.object.label, OBJECT_LABEL_MAX_LEN);
+    const object_label = sanitize(scrubReservedI18nPrefix(input.object.label), OBJECT_LABEL_MAX_LEN);
 
     const verb = input.verb;
     const origin = input.origin ?? 'local';

--- a/src/server/notifications/test/notification_service.test.ts
+++ b/src/server/notifications/test/notification_service.test.ts
@@ -632,6 +632,75 @@ describe('NotificationService.recordActivity', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Reserved `i18n:` prefix is scrubbed on object_label for every verb.
+  //
+  // The symmetric vector to the actor-side scrub above: a federated peer
+  // titles an event `i18n:flag_actor_remote{host:victim.example}`, a local
+  // user reports it, and the report handler snapshots the event title into
+  // `object.label`. Nothing on the server ever generates an `i18n:` token
+  // for a label — labels are always caller-supplied text — so the scrub is
+  // unconditional here, including on the Flag path where the poisoned title
+  // actually arrives.
+  // ---------------------------------------------------------------------------
+
+  describe('reserved i18n: prefix scrubbing for object_label', () => {
+    it('blanks an `i18n:`-prefixed object label on Flag (the reported-event-title vector)', async () => {
+      findOneStub.resolves(null);
+      resolveRoleAudienceStub.resolves([]);
+      activityCreateStub.resolves(buildActivityEntity({ verb: 'Flag' }));
+
+      await service.recordActivity({
+        verb: 'Flag',
+        actor: { kind: 'remote_actor', uri: 'https://example.org/users/alice' },
+        object: { type: 'report', id: uuidv4(), label: 'i18n:flag_actor_remote{host:victim.example}' },
+        audience: { kind: 'role', role: 'instance-admins' },
+      });
+
+      const inserted = activityCreateStub.firstCall.args[0];
+      expect(inserted.object_label).toBe('');
+      // The Flag anonymizer's legitimate actor token is untouched by the
+      // label-side scrub — the two fields are scrubbed independently.
+      expect(inserted.actor_display_name).toBe('i18n:flag_actor_remote{host:example.org}');
+    });
+
+    it('blanks an `i18n:`-prefixed object label on a non-Flag verb', async () => {
+      findOneStub.resolves(null);
+      resolveRoleAudienceStub.resolves([]);
+      activityCreateStub.resolves(buildActivityEntity({ verb: 'Announce' }));
+
+      await service.recordActivity({
+        verb: 'Announce',
+        actor: { kind: 'account', accountId: uuidv4() },
+        object: { type: 'event', id: uuidv4(), label: 'i18n:flag_actor_anonymous' },
+        audience: { kind: 'role', role: 'calendar-owners', objectRef: { type: 'calendar', id: uuidv4() } },
+        actorDisplayName: 'Alice',
+      });
+
+      const inserted = activityCreateStub.firstCall.args[0];
+      expect(inserted.object_label).toBe('');
+    });
+
+    it('leaves plain-text object labels unchanged (regression guard)', async () => {
+      findOneStub.resolves(null);
+      resolveRoleAudienceStub.resolves([]);
+      activityCreateStub.resolves(buildActivityEntity({ verb: 'Follow' }));
+
+      await service.recordActivity({
+        verb: 'Follow',
+        actor: { kind: 'account', accountId: uuidv4() },
+        object: { type: 'calendar', id: uuidv4(), label: 'Talks about i18n:tokens' },
+        audience: { kind: 'role', role: 'calendar-editors', objectRef: { type: 'calendar', id: uuidv4() } },
+        actorDisplayName: 'Alice',
+      });
+
+      const inserted = activityCreateStub.firstCall.args[0];
+      // The scrub is start-anchored — a label that merely mentions the
+      // prefix later in the string must survive intact.
+      expect(inserted.object_label).toBe('Talks about i18n:tokens');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Transaction wiring
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Motivation

The notification write path already blanks a caller-supplied actor display name that starts with the reserved `i18n:` prefix, so a federated peer cannot set their AP display name to `i18n:flag_actor_remote{host:victim.example}`, follow a local calendar, and have the recipient see the Flag attribution string on a Follow notification.

The symmetric vector was unguarded. An event titled `i18n:flag_actor_remote{host:victim.example}` arrives over federation; a local user reports it; the report handler's label resolver returns the title verbatim and it is stored in `object_label`. `sanitize` strips HTML and bidi controls but does not check the reserved prefix.

No current client renders `object.label` through the token resolver, so this is inert today. The notifications design frames labels as content a client may localize at render time, so the natural symmetric client change would turn a stored poisoned label into a rendered spoof (presentational, not XSS — Vue and i18next escape).

## Approach

Apply the existing `scrubReservedI18nPrefix` helper to `input.object.label` in `recordActivity`, at the call site, symmetric to the actor-side scrub in `buildActorRow`. `sanitize` deliberately stays prefix-agnostic — it is a generic HTML/bidi guard, while the `i18n:` reservation is a notifications-domain rule.

Unlike `actor_display_name`, no server-generated token ever legitimately lands in `object_label` — labels are always caller-supplied text — so the scrub is unconditional across verbs, including Flag, which is the path a poisoned event title actually travels. The helper's doc comment and parameter name are generalized off "display name" accordingly.

Also adds the missing end-to-end assertion on the anonymized `actor_display_name` in the federation Flag inbox test, so a future regression in remote-host extraction (e.g. relaxing the RFC-1123 allowlist in actor URI validation) is caught outside the anonymizer's unit test.

## Validation

Test-first: three new cases in the notification service suite — the Flag/reported-title vector, a non-Flag verb, and a start-anchored regression guard confirming a label that merely mentions `i18n:` later in the string survives. The first two failed before the fix and pass after.

- `npm run lint` — 0 errors
- `npx vitest run` on the notifications service, sanitize, anonymize-flag-actor, event-handlers, api, and activity-entity suites — 177 passed
- `npx vitest run --config vitest.integration.config.ts` on `flag-inbox-federation.test.ts` and `record-activity.test.ts` — 11 passed