### PR TITLE
docs(calendar): document inbound Space re-pin source-of-truth rule

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -91,7 +91,7 @@ Supersession is the exception, because it retires a decision rather than refinin
 - **File:** [decisions/dec-008-unpost-dismissals.md](decisions/dec-008-unpost-dismissals.md)
 - **Date:** 2026-04-11 · **Status:** Accepted
 - **Decision:** Unpost writes a sticky `RepostDismissalEntity` row scoped to `(event_id, calendar_id)`. Auto-repost handler checks this before creating a new `SharedEventEntity`. Per-calendar only — never global. `Update(Event)` activities are NOT blocked; federation sync continues for every other calendar still sharing the event.
-- **Consult when:** Working with unshare/unpost behavior; modifying auto-repost handler logic; designing `Update(Event)` activity handling; questions about how a single calendar's dismissal affects other calendars or cross-instance federation sync.
+- **Consult when:** Working with unshare/unpost behavior; modifying auto-repost handler logic; designing `Update(Event)` activity handling; questions about how a single calendar's dismissal affects other calendars or cross-instance federation sync; deciding whether some other cleared local state should resist an inbound activity that re-sets it.
 
 ### DEC-014: Create Means Original, Announce Means Repost
 - **File:** [decisions/dec-014-create-original-announce-repost.md](decisions/dec-014-create-original-announce-repost.md)

--- a/agent-os/product/decisions/dec-008-unpost-dismissals.md
+++ b/agent-os/product/decisions/dec-008-unpost-dismissals.md
@@ -12,6 +12,8 @@ When a calendar owner unposts a reposted event, the system writes a sticky `Repo
 
 The check lives inside the shared auto-repost path, so it applies to every way a shareable event arrives: an inbound `Create` carrying an original or an inbound `Announce` carrying a repost (see [DEC-014](dec-014-create-original-announce-repost.md)). A dismissal suppresses the outbound `Announce` and its paired `Create(Note)` together.
 
+Stickiness is scoped to state that records an explicit user choice. Where local state changed without an intent signal, the federated source stays authoritative: when a local `Space` row is deleted and the FK `SET NULL` clears `events.space_id`, a later inbound `Update` re-referencing the same `pavillion:space` re-creates the local row and re-pins the event. That null is automatic plumbing, not a decision, so it is not sticky. The behavior is pinned by `src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts`.
+
 ## Context
 
 Before this decision, unposting a reposted event was fragile: if the source calendar re-broadcast or edited the event, the auto-repost handler would silently re-share it on the same calendar. Calendar owners had no durable way to say "no, not this one." The previous `unshareEvent` path destroyed the `SharedEventEntity` row but left no record of the owner's intent, so the next inbound activity re-sharing that event recreated it. This undermined the community-control principle ([DEC-001](dec-001-initial-product-planning.md)): followers had policy control over *future* follows but not over *this specific event I already said no to*.

--- a/src/server/calendar/service/events.ts
+++ b/src/server/calendar/service/events.ts
@@ -1576,6 +1576,12 @@ class EventService {
       }
       // Update space: explicit resolution wins; if the inbound payload
       // dropped the space (no eventParams.space), clear space_id.
+      //
+      // Federation is source-of-truth on re-pin: an inbound Update that
+      // re-references a Space whose local row was destroyed (FK SET NULL
+      // cleared space_id) re-creates the row and re-pins the event. That null
+      // is not sticky — unlike DEC-008 dismissals it carries no user intent.
+      // Pinned by activitypub/test/place-spaces-atomic-save-federation.test.ts
       if (resolved.space) {
         eventEntity.space_id = resolved.space.id;
       }


### PR DESCRIPTION
## Motivation

When a federated event is Space-pinned and the local `Space` row is later deleted, the FK `SET NULL` clears `events.space_id`. A later inbound `Update` that re-references the same `pavillion:space` re-creates the local row and re-pins the event — the local null is deliberately not sticky, because it records no user intent (in contrast to DEC-008 unpost dismissals, which do).

That rule was documented only in a docblock inside `src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts`. A maintainer auditing `updateRemoteEvent` had no reason to land on the test file, and could plausibly introduce sticky-null semantics on the next refactor.

## Approach

- Added a five-line comment at the inbound `space_id` write in `updateRemoteEvent` (`src/server/calendar/service/events.ts`) stating the source-of-truth rule and pointing at the regression test.
- Recorded the same scope boundary in `agent-os/product/decisions/dec-008-unpost-dismissals.md`, so the sticky-versus-source-of-truth distinction is reachable from the decision that establishes stickiness, plus a matching trigger in the decisions index.

Only the `updateRemoteEvent` write site is documented. The other `space_id = resolved.space.id` assignment lives in `addRemoteEvent`, which is the initial-create path and never encounters a pre-existing cleared FK.

Comment and documentation only; no behavior change.

## Validation

- `npm run lint` — 0 errors (1 pre-existing unrelated warning).
- `npx vitest run src/server/activitypub/test/place-spaces-atomic-save-federation.test.ts` — 4/4 passed.
- `npx vitest run src/server/calendar/test/EventService` — 208/208 passed.