### PR TITLE
chore(admin): descope PayPal for v1 and record the decision

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -1,6 +1,6 @@
 # Product Decisions Log
 
-> Last Updated: 2026-08-01
+> Last Updated: 2026-08-08
 > Version: 2.2.0
 > Override Priority: Highest
 
@@ -39,8 +39,8 @@ Supersession is the exception, because it retires a decision rather than refinin
 ### DEC-007: Community Funding Model and Stripe Product Choice
 - **File:** [decisions/dec-007-community-funding-model.md](decisions/dec-007-community-funding-model.md)
 - **Date:** 2026-03-15 · **Status:** Accepted
-- **Decision:** Voluntary "funding plans" (NPR/Wikipedia model) using Stripe Embedded Checkout — instance admins enter their own Stripe keys; not Stripe Connect. Term "funding plan" used in place of "subscription" to avoid ActivityPub terminology collision.
-- **Consult when:** Implementing or modifying payment/billing flows; configuring Stripe; CSP changes for payment iframes; deciding terminology around funding/subscription/payment; questions about why we don't use Connect OAuth.
+- **Decision:** Voluntary "funding plans" (NPR/Wikipedia model) using Stripe Embedded Checkout — instance admins enter their own Stripe keys; not Stripe Connect. Stripe is the only provider in v1; PayPal is descoped, its scaffolding left inert and hidden from the admin UI. Term "funding plan" used in place of "subscription" to avoid ActivityPub terminology collision; the access-gating platform is "funding access", with `SubscriptionRequiredError` frozen as the one legacy wire exception.
+- **Consult when:** Implementing or modifying payment/billing flows; configuring Stripe; adding or re-enabling a payment provider; CSP changes for payment iframes; naming anything in the funding or access-gating vocabulary; deciding terminology around funding/subscription/payment/entitlement; questions about why we don't use Connect OAuth, or why PayPal code exists but is unreachable.
 
 ### DEC-009: ICS Import Funding-Gate Posture
 - **File:** [decisions/dec-009-ics-import-funding-gate-posture.md](decisions/dec-009-ics-import-funding-gate-posture.md)

--- a/agent-os/product/decisions/dec-007-community-funding-model.md
+++ b/agent-os/product/decisions/dec-007-community-funding-model.md
@@ -9,11 +9,20 @@
 
 Pavillion will support optional community funding plans that allow calendar owners to collect contributions from their community to sustain calendar infrastructure. The feature uses Stripe Embedded Checkout for payment processing, with instance administrators entering Stripe API keys directly rather than using Stripe Connect OAuth. The term "funding plan" is used instead of "subscription" throughout the codebase and UI to avoid terminology collision with ActivityPub's use of "subscription" for follow relationships.
 
+**Stripe is the only payment provider in v1.** PayPal is descoped: the scaffolding (adapter, factory branch, admin credential form, config modal, seeded provider row) stays in the tree, inert. The admin funding settings page filters the provider list to Stripe, so PayPal is never offered in the add-provider wizard nor shown as a connected provider, and checkout resolves an enabled Stripe provider only — there is no reachable PayPal payment path. PayPal completion is deferred, not cancelled; when it returns, the descope filter is the single site to change.
+
+### Terminology
+
+- The access-gating platform built on top of funding plans is called **funding access** — `checkFundingAccess`, `useFundingAccess`, `FundingStatus`. "Entitlement" is not used as an identifier anywhere in the codebase.
+- `SubscriptionRequiredError` is the one documented **legacy wire exception**. Gated endpoints keep returning `402` with `errorName: 'SubscriptionRequiredError'` so existing clients continue to recognise the response. That name is frozen at the wire boundary; no new identifier — service method, model field, API field, translation key, or UI copy — may propagate "subscription" into the funding vocabulary.
+
 ## Context
 
 Running a Pavillion instance requires ongoing costs for hosting, maintenance, and community development. Rather than monetizing the platform through advertising or data collection, Pavillion adopts a community-supported funding model analogous to NPR or Wikipedia donation drives. Calendar owners can create funding plans that invite voluntary contributions from community members who benefit from the calendar. This approach directly aligns with the economic gardening mission ([DEC-001](dec-001-initial-product-planning.md)) by keeping community infrastructure community-funded rather than commercially driven.
 
-The initial implementation used Stripe Connect with OAuth, which is designed for marketplace platforms that route payments between multiple parties. This was the wrong product for Pavillion's use case, where each instance collects payments directly on behalf of its own calendars. Stripe Embedded Checkout is the correct product: it handles payment processing via an iframe embedded in the page, the user never leaves the site, and the instance owner maintains a direct relationship with Stripe using their own API keys (similar to how PayPal integration works).
+The initial implementation used Stripe Connect with OAuth, which is designed for marketplace platforms that route payments between multiple parties. This was the wrong product for Pavillion's use case, where each instance collects payments directly on behalf of its own calendars. Stripe Embedded Checkout is the correct product: it handles payment processing via an iframe embedded in the page, the user never leaves the site, and the instance owner maintains a direct relationship with Stripe using their own API keys — the same direct-credential shape the PayPal scaffolding was built around before PayPal was descoped for v1.
+
+Multi-provider support was designed in early (a provider adapter interface, a factory, and per-provider admin credential forms) with Stripe and PayPal as the two implementations. Only the Stripe path reached the correctness bar needed to gate paid features on it: PayPal's checkout completion, webhook handling, and lifecycle reconciliation were never finished or validated. Shipping a half-wired second provider in the admin UI would let an instance administrator connect PayPal and end up with a funding configuration that silently fails to renew, suspend, or cancel.
 
 ## Alternatives Considered
 
@@ -42,6 +51,8 @@ The community funding model was chosen because:
 3. **Correct Stripe product** - Embedded Checkout is the right product for direct payment collection. Connect OAuth is designed for platforms that facilitate payments between third parties (marketplaces), which is not what Pavillion does. Each instance owner has their own Stripe account and collects payments directly.
 4. **Terminology clarity** - Using "funding plan" instead of "subscription" avoids confusion with ActivityPub terminology where "subscription" refers to following an actor or calendar. This distinction is important in a federated system where ActivityPub concepts are core to the architecture.
 5. **Privacy consistency** - The funding model maintains Pavillion's privacy-first principles ([DEC-004](dec-004-privacy-first-public-access.md)). Payment processing is handled by Stripe; Pavillion stores only the minimum metadata needed to track funding plan status, not payment details.
+6. **One provider, correct** - Gating features on funding access means the payment lifecycle has to be trustworthy. One fully-validated provider is worth more than two partially-wired ones, and hiding PayPal costs nothing today because no instance has ever been able to complete a PayPal checkout. Removing the scaffolding instead of hiding it would throw away the adapter abstraction that makes a second provider cheap to finish later.
+7. **Terminology discipline with a bounded exception** - "Funding access" keeps the gating platform in the same vocabulary as funding plans, and rules out a third term ("entitlement") for the same concept. `SubscriptionRequiredError` is grandfathered rather than renamed because it is an observable wire contract; confining the exception to the wire keeps the collision with ActivityPub "subscription" out of everything new.
 
 ## Consequences
 
@@ -52,9 +63,14 @@ The community funding model was chosen because:
 - Users complete payment without leaving the site
 - Clear terminology boundary between funding plans and ActivityPub subscriptions
 - Instance owners maintain direct Stripe relationship and full control over their payment configuration
+- A single supported provider means one payment lifecycle to validate before enabling live funds
+- The provider adapter abstraction survives the descope, so finishing PayPal later is additive
 
 **Negative:**
 - Instance administrators must create and configure their own Stripe account
+- Instances that would prefer PayPal have no option in v1, and Stripe availability varies by country
 - API keys must be stored securely (encrypted at rest) adding operational complexity
 - Funding plan management adds UI and backend complexity to the calendar domain
 - Per-calendar funding configuration requires calendar owners to understand pricing options
+- Inert PayPal scaffolding remains in the tree, so readers must consult this decision to know it is deliberately unreachable rather than merely unfinished
+- `SubscriptionRequiredError` on the wire diverges from the "funding access" vocabulary used everywhere else, which requires the exception to be documented rather than inferred

--- a/agent-os/product/decisions/dec-007-community-funding-model.md
+++ b/agent-os/product/decisions/dec-007-community-funding-model.md
@@ -9,7 +9,33 @@
 
 Pavillion will support optional community funding plans that allow calendar owners to collect contributions from their community to sustain calendar infrastructure. The feature uses Stripe Embedded Checkout for payment processing, with instance administrators entering Stripe API keys directly rather than using Stripe Connect OAuth. The term "funding plan" is used instead of "subscription" throughout the codebase and UI to avoid terminology collision with ActivityPub's use of "subscription" for follow relationships.
 
-**Stripe is the only payment provider in v1.** PayPal is descoped: the scaffolding (adapter, factory branch, admin credential form, config modal, seeded provider row) stays in the tree, inert. The admin funding settings page filters the provider list to Stripe, so PayPal is never offered in the add-provider wizard nor shown as a connected provider, and checkout resolves an enabled Stripe provider only — there is no reachable PayPal payment path. PayPal completion is deferred, not cancelled; when it returns, the descope filter is the single site to change.
+**Stripe is the only payment provider in v1.** PayPal is descoped: the scaffolding stays in the tree, inert. There is no reachable PayPal payment path — checkout resolves an enabled Stripe provider only. PayPal completion is deferred, not cancelled.
+
+### The three sites that encode "Stripe only"
+
+"Stripe only" is **not** enforced in one place. Three independent sites encode it, two of them written before the descope and of opposite polarity (denylist rather than allowlist). Re-enabling PayPal means changing all three; changing only one produces a partially-enabled provider, which is worse than either end state.
+
+| Site | Mechanism | Effect |
+|---|---|---|
+| `src/client/components/admin/funding.vue` — `V1_PROVIDER_TYPES` | Allowlist (`['stripe']`) applied to the provider list on load | Keeps PayPal out of the admin connected-providers list and the add-provider wizard |
+| `src/client/components/account/FundingForm.vue` — `availableProviders` | Denylist (`providerType !== 'paypal'`) applied to `GET /v1/options` | Keeps PayPal out of the purchase form's provider choice. Predates the descope. The file also carries an unreachable `startPayPalCheckout()` stub that only sets a generic error |
+| `src/server/funding/service/funding.ts` — `resolveEnabledStripeProvider()` | Hard-coded query (`provider_type: 'stripe', enabled: true`) | Checkout-session creation can only ever resolve Stripe, whatever the UI offers |
+
+The concrete failure mode of a partial change: flip only the admin allowlist and PayPal becomes connectable and enableable in the admin UI, while `FundingForm.vue`'s denylist still hides it from purchasers — an instance with a configured, enabled, invisible provider. That is precisely the silent-failure mode this descope exists to prevent.
+
+Consolidating these into one shared constant is worthwhile but was deliberately not done here: it touches `src/common/model/funding-plan.ts` and `FundingForm.vue`, both outside the descope's scope and under concurrent change. Until that consolidation lands, this table is the authoritative enumeration.
+
+### Inert scaffolding, and the one reachable piece
+
+Left in place and genuinely unreachable: the PayPal adapter (`service/provider/paypal.ts`), the `paypal` branch of `ProviderFactory.getAdapter`, the admin credential form in `add-provider-wizard.vue`, `paypal-config-modal.vue` (now referenced by nothing), and the unconfigured PayPal row seeded by `ensureDefaultProviders()`.
+
+**Reachable but inert:** `POST /api/funding/v1/admin/providers/paypal/configure` (`api/v1/provider_connection.ts`) and `FundingInterface.configurePayPal` remain live and admin-authenticated. A direct caller — not the UI, which no longer offers the route — can still validate credentials against the PayPal API, encrypt them, and persist them. This is accepted: it is a configuration surface, not a checkout path, it requires instance-admin authority, and the resulting row still cannot produce a checkout session. It is named here so that "inert" is not read as "removed."
+
+### Pre-existing PayPal configurations
+
+An instance that connected PayPal before the descope keeps its row: **pre-existing PayPal configurations are left in place and unmanaged.** The admin allowlist filters the provider list before the connected-providers view derives from it, so those encrypted credentials have no UI to inspect, disable, or disconnect them, and an `enabled` row is still returned by `GET /v1/options` (hidden from purchasers only by `FundingForm.vue`'s unrelated denylist).
+
+No migration is written for this. Completing a PayPal checkout was never possible, so a production instance in this state is unlikely; dev and staging instances that experimented with PayPal are the realistic case. **Operators who did configure PayPal should disconnect it before upgrading**, while the UI can still reach the row. Recovery after upgrade is a direct `DELETE /api/funding/v1/admin/providers/paypal` call or a database change.
 
 ### Terminology
 
@@ -42,6 +68,20 @@ Multi-provider support was designed in early (a provider adapter interface, a fa
    - Pros: Simpler codebase, no payment complexity
    - Cons: No sustainable funding path for community infrastructure, instance operators bear all costs
 
+On the PayPal descope specifically:
+
+5. **Hide PayPal, keep the scaffolding** (Selected)
+   - Pros: No reachable half-finished payment path; the adapter abstraction survives, so finishing PayPal later is additive rather than a rewrite; smallest diff, no migration, nothing to un-delete
+   - Cons: Dead code stays in the tree and must be documented as deliberately unreachable (this decision); "Stripe only" ends up encoded in three sites rather than one; pre-existing PayPal rows become unmanaged
+
+6. **Remove the PayPal scaffolding entirely**
+   - Pros: No dead code, no ambiguity about what is supported, only one place left encoding "Stripe only"
+   - Cons: Discards a working provider-adapter abstraction that cost real effort and whose only defect is unfinished lifecycle handling; reinstating PayPal becomes a rewrite rather than a completion, which makes the deferral read as a cancellation; deleting the seeded row and the admin route needs a migration and a wider blast radius than the descope warrants
+
+7. **Show PayPal with a "not available" badge**
+   - Pros: Honest about the roadmap; reuses the existing status-badge pattern; sets expectations for operators who want PayPal (the acceptance criteria permitted this treatment)
+   - Cons: Adds translated UI copy and a badge state for a provider nobody can use, which has to be maintained and re-translated until PayPal ships; advertises a capability with no committed date; "coming soon" in an admin settings page is a support-question generator. Hiding costs nothing today because no instance has ever been able to complete a PayPal checkout
+
 ## Rationale
 
 The community funding model was chosen because:
@@ -73,4 +113,7 @@ The community funding model was chosen because:
 - Funding plan management adds UI and backend complexity to the calendar domain
 - Per-calendar funding configuration requires calendar owners to understand pricing options
 - Inert PayPal scaffolding remains in the tree, so readers must consult this decision to know it is deliberately unreachable rather than merely unfinished
+- "Stripe only" is enforced at three uncoordinated sites of mixed polarity, so re-enabling PayPal is an all-three change and a partial change produces a configured-but-invisible provider. The enumeration table above is the mitigation; a shared constant is the real fix and remains outstanding
+- The admin PayPal configure route stays live to direct callers, so an instance admin can still persist credentials that nothing will ever use
+- Pre-existing PayPal configurations become unmanageable through the UI after upgrade, with no migration to clean them up
 - `SubscriptionRequiredError` on the wire diverges from the "funding access" vocabulary used everywhere else, which requires the exception to be documented rather than inferred

--- a/src/client/components/admin/funding.vue
+++ b/src/client/components/admin/funding.vue
@@ -85,9 +85,20 @@ const currencyOptions = [
  * PayPal is descoped for v1: the backend seeds an unconfigured PayPal provider row
  * and the adapter/wizard/modal scaffolding remains in the tree, but checkout is
  * Stripe-only, so PayPal must never be offered or shown as connected. Filtering
- * here is the single hide site — it keeps PayPal out of both the connected list
- * and the add-provider wizard. See DEC-007
- * (agent-os/product/decisions/dec-007-community-funding-model.md).
+ * here keeps it out of both the connected-providers list and the add-provider
+ * wizard.
+ *
+ * This is NOT the only place "Stripe only" is encoded. Re-enabling PayPal means
+ * changing all three of these together — changing only one leaves a provider that
+ * is configurable but invisible to purchasers:
+ *   1. this allowlist;
+ *   2. src/client/components/account/FundingForm.vue — availableProviders, a
+ *      pre-existing denylist (providerType !== 'paypal') over GET /v1/options;
+ *   3. src/server/funding/service/funding.ts — resolveEnabledStripeProvider(),
+ *      which hard-codes provider_type: 'stripe' for checkout sessions.
+ *
+ * See DEC-007 (agent-os/product/decisions/dec-007-community-funding-model.md),
+ * which enumerates these sites and the disposition of pre-existing PayPal rows.
  */
 const V1_PROVIDER_TYPES = ['stripe'];
 

--- a/src/client/components/admin/funding.vue
+++ b/src/client/components/admin/funding.vue
@@ -5,7 +5,6 @@ import { ref, computed, reactive, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useToast } from '@/client/composables/useToast';
 import FundingService from '@/client/service/funding';
-import PayPalConfigModal from './paypal-config-modal.vue';
 import ConfirmDisconnectModal from './confirm-disconnect-modal.vue';
 import AddProviderWizard from './add-provider-wizard.vue';
 import GrantForm from './grant-form.vue';
@@ -47,7 +46,6 @@ const fieldErrors = reactive<Record<string, string>>({});
 const providers = ref([]);
 const providersLoading = ref(false);
 const connectingProvider = ref(null); // Track which provider is currently connecting
-const showPayPalModal = ref(false); // Control PayPal configuration modal visibility
 const showDisconnectModal = ref(false); // Control disconnect confirmation modal visibility
 const disconnectModalData = ref({
   providerType: '',
@@ -80,6 +78,18 @@ const currencyOptions = [
   { value: 'CAD', label: 'CAD - Canadian Dollar' },
   { value: 'AUD', label: 'AUD - Australian Dollar' },
 ];
+
+/**
+ * Payment providers offered by this release.
+ *
+ * PayPal is descoped for v1: the backend seeds an unconfigured PayPal provider row
+ * and the adapter/wizard/modal scaffolding remains in the tree, but checkout is
+ * Stripe-only, so PayPal must never be offered or shown as connected. Filtering
+ * here is the single hide site — it keeps PayPal out of both the connected list
+ * and the add-provider wizard. See DEC-007
+ * (agent-os/product/decisions/dec-007-community-funding-model.md).
+ */
+const V1_PROVIDER_TYPES = ['stripe'];
 
 // Computed property to check if any payment provider is configured
 const hasConfiguredProvider = computed(() => {
@@ -130,7 +140,8 @@ async function loadSettings() {
 async function loadProviders() {
   try {
     providersLoading.value = true;
-    providers.value = await fundingService.getProviders();
+    const allProviders = await fundingService.getProviders() ?? [];
+    providers.value = allProviders.filter(provider => V1_PROVIDER_TYPES.includes(provider.provider_type));
   }
   catch (error) {
     console.error('Failed to load providers:', error);
@@ -1132,12 +1143,6 @@ onMounted(async () => {
         </div>
       </section>
     </template>
-
-    <!-- PayPal Configuration Modal -->
-    <PayPalConfigModal
-      :show="showPayPalModal"
-      @close="showPayPalModal = false"
-    />
 
     <!-- Disconnect Confirmation Modal -->
     <ConfirmDisconnectModal

--- a/src/client/test/components/admin/funding_provider_ui.test.ts
+++ b/src/client/test/components/admin/funding_provider_ui.test.ts
@@ -19,7 +19,7 @@ const routes: RouteRecordRaw[] = [
  *
  * Tests cover:
  * - Provider connection status display (connected vs not connected)
- * - PayPal configure button opens credential form modal
+ * - PayPal is never surfaced in the admin UI (descoped for v1 — see DEC-007)
  * - Disconnection warning dialog with confirmation checkbox
  * - Error message display from query parameters
  */
@@ -166,8 +166,10 @@ describe('Funding Provider UI Components', () => {
     await nextTick();
     await new Promise(resolve => setTimeout(resolve, 100)); // Wait for async data loading
 
+    // Only Stripe is supported in v1 (DEC-007), so PayPal is filtered out even
+    // though the API reports it as configured.
     const providerItems = wrapper.findAll('.provider-item');
-    expect(providerItems).toHaveLength(2);
+    expect(providerItems).toHaveLength(1);
 
     // Check Stripe shows "Connected" badge and "Disconnect" button
     const stripeItem = providerItems[0];
@@ -175,12 +177,40 @@ describe('Funding Provider UI Components', () => {
     expect(stripeItem.find('.connected-badge').exists()).toBe(true);
     expect(stripeItem.find('.connected-badge').text()).toBe('Connected');
     expect(stripeItem.findAll('button').some(b => b.text().includes('Disconnect'))).toBe(true);
+  });
 
-    // Check PayPal shows "Connected" badge and "Disconnect" button
-    const paypalItem = providerItems[1];
-    expect(paypalItem.find('.provider-info h3').text()).toContain('PayPal');
-    expect(paypalItem.find('.connected-badge').exists()).toBe(true);
-    expect(paypalItem.findAll('button').some(b => b.text().includes('Disconnect'))).toBe(true);
+  /**
+   * Test 1b: PayPal is descoped for v1 (DEC-007) — it must never reach the UI,
+   * whether the API reports it configured or unconfigured.
+   */
+  it('never renders PayPal as a provider option', async () => {
+    mockService.getProviders.mockResolvedValue([
+      {
+        id: 'provider-1',
+        provider_type: 'stripe',
+        enabled: true,
+        display_name: 'Stripe',
+        configured: true,
+      },
+      {
+        id: 'provider-2',
+        provider_type: 'paypal',
+        enabled: false,
+        display_name: 'PayPal',
+        configured: false,
+      },
+    ]);
+
+    wrapper = mountFunding();
+    await nextTick();
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(wrapper.text()).not.toContain('PayPal');
+
+    // Stripe is the only provider left, so the wizard has nothing to offer.
+    const addProviderButton = wrapper.findAll('button.btn-text-orange')
+      .find(b => b.text().includes('Add Provider'));
+    expect(addProviderButton?.attributes('disabled')).toBeDefined();
   });
 
   /**

--- a/src/client/test/components/admin/funding_wizard_integration.test.ts
+++ b/src/client/test/components/admin/funding_wizard_integration.test.ts
@@ -92,7 +92,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
           AddProviderWizard: true,
         },
@@ -139,7 +138,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
           AddProviderWizard: true,
         },
@@ -185,7 +183,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
         },
       },
@@ -214,10 +211,10 @@ describe('Funding Page Wizard Integration', () => {
     expect(wizardComponent.exists()).toBe(true);
     expect(wizardComponent.props('show')).toBe(true);
 
+    // PayPal is descoped for v1 (DEC-007), so the wizard only ever offers Stripe.
     const unconfiguredProviders = wizardComponent.props('unconfiguredProviders');
-    expect(unconfiguredProviders).toHaveLength(2);
+    expect(unconfiguredProviders).toHaveLength(1);
     expect(unconfiguredProviders[0].provider_type).toBe('stripe');
-    expect(unconfiguredProviders[1].provider_type).toBe('paypal');
   });
 
   it('updates provider list after successful wizard completion', async () => {
@@ -267,7 +264,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
         },
       },
@@ -293,7 +289,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
           AddProviderWizard: true,
         },
@@ -313,7 +308,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
         },
       },
@@ -380,7 +374,6 @@ describe('Funding Page Wizard Integration', () => {
     wrapper = mountWithI18n({
       global: {
         stubs: {
-          PayPalConfigModal: true,
           ConfirmDisconnectModal: true,
         },
       },
@@ -425,7 +418,6 @@ describe('Funding Page Wizard Integration', () => {
         global: {
           plugins: [[I18NextVue, { i18next }]],
           stubs: {
-            PayPalConfigModal: true,
             ConfirmDisconnectModal: true,
             AddProviderWizard: true,
             GrantForm: true,


### PR DESCRIPTION
## Motivation

PayPal was half-wired: an adapter, a factory branch, an admin credential form, a config modal, and a seeded provider row all existed, but checkout was never completable. An admin could connect PayPal and reach a dead end. v1 ships one payment provider.

## Approach

A `V1_PROVIDER_TYPES = ['stripe']` allowlist filters the provider list in the admin funding component. Because the connected list and the add-provider wizard both derive from that filtered array, one filter covers both surfaces. The unreferenced config-modal wiring is removed; the component file itself stays in the tree.

Scaffolding stays inert rather than deleted, and the funding decision record is amended in place to say so — including which pieces are genuinely unreachable and which remain reachable-but-inert (the admin configure route still validates and persists credentials against a dead path).

The decision also enumerates the three independent places that encode "Stripe only" — this new client allowlist, a pre-existing denylist of opposite polarity in the purchase form, and the server-side checkout resolver. An earlier draft claimed the new filter was the single site to change; that was wrong, and correcting it matters because someone re-enabling PayPal by flipping only the allowlist would ship a provider that is configurable and enabled but invisible to purchasers.

Terminology is frozen in the same record: the access-gating platform is "funding access", with the existing 402 error name retained as the one legacy wire exception.

## Validation

Lint clean. Unit 8681 (one added test), integration 696, both matching the measured `main` baseline. Build clean. E2E ran four times; the only failures were a load-dependent admin login timeout and a deterministic ICS import-sources failure, both reproduced on clean `main`.

Tests assert the product rule rather than the mechanism: PayPal is filtered even when the API reports it as configured, and the add-provider button is disabled. A reviewer verified non-vacuousness by mutation — reverting the filter fails both tests.

Consolidating the three enforcement sites behind one shared constant is tracked separately; it touches files under concurrent change.