### PR TITLE
fix(funding): read current Stripe payload shapes in webhook parsing

### DIFF
--- a/src/server/funding/service/provider/stripe.ts
+++ b/src/server/funding/service/provider/stripe.ts
@@ -325,35 +325,67 @@ export class StripeAdapter implements PaymentProviderAdapter {
    * which the instance administrator sets independently of this adapter's
    * pin, so the legacy field is still honoured as a fallback.
    *
+   * The resolved id is used downstream as a lookup and authorization key for
+   * the local funding plan, so it is returned only after being confirmed to
+   * be a non-empty string.
+   *
    * @param invoice - Invoice object from a webhook payload
    * @param event - Enclosing event, used for diagnostic markers only
    * @returns Subscription ID, or undefined for an invoice with no subscription
    * @private
    */
   private extractInvoiceSubscriptionId(invoice: Stripe.Invoice, event: Stripe.Event): string | undefined {
-    const current = invoice.parent?.subscription_details?.subscription;
-    if (current) {
-      return typeof current === 'string' ? current : current.id;
+    const parentReference = invoice.parent?.subscription_details?.subscription;
+    const legacyReference = (invoice as unknown as {
+      subscription?: string | Stripe.Subscription;
+    }).subscription;
+
+    // The parent shape wins whenever it is present, so resolution stays
+    // deterministic for payloads that carry both.
+    const reference = parentReference ?? legacyReference;
+
+    if (reference === undefined || reference === null) {
+      if (invoice.parent?.type === 'subscription_details') {
+        // The parent claims a subscription but carries no reference: drift.
+        logger.warn({
+          eventId: event.id,
+          eventType: event.type,
+        }, 'Stripe invoice parent claims a subscription but carries no reference');
+      }
+      else {
+        // No parent, or a parent of some other kind: an ordinary one-off or
+        // quote invoice, not a signal worth raising.
+        logger.debug({
+          eventId: event.id,
+          eventType: event.type,
+          parentType: invoice.parent?.type,
+        }, 'Stripe invoice webhook has no subscription parent');
+      }
+      return undefined;
     }
 
-    const legacy = (invoice as unknown as { subscription?: string | Stripe.Subscription }).subscription;
-    if (legacy) {
-      const subscriptionId = typeof legacy === 'string' ? legacy : legacy.id;
+    const subscriptionId = typeof reference === 'string'
+      ? reference
+      : (reference as { id?: unknown }).id;
+
+    if (typeof subscriptionId !== 'string' || subscriptionId.length === 0) {
+      logger.warn({
+        eventId: event.id,
+        eventType: event.type,
+        referenceType: typeof reference,
+      }, 'Stripe invoice subscription reference is not a usable id');
+      return undefined;
+    }
+
+    if (parentReference === undefined || parentReference === null) {
       logger.debug({
         eventId: event.id,
         eventType: event.type,
         subscriptionId,
       }, 'Stripe invoice webhook used the legacy top-level subscription field');
-      return subscriptionId;
     }
 
-    logger.warn({
-      eventId: event.id,
-      eventType: event.type,
-      hasParent: Boolean(invoice.parent),
-      parentType: invoice.parent?.type,
-    }, 'Stripe invoice webhook has no resolvable subscription');
-    return undefined;
+    return subscriptionId;
   }
 
   /**
@@ -364,8 +396,13 @@ export class StripeAdapter implements PaymentProviderAdapter {
    * remain a fallback for webhook payloads serialized with an older API
    * version (see extractInvoiceSubscriptionId).
    *
+   * Both bounds are taken from a single shape. Item-level and
+   * subscription-level anchors are not guaranteed to describe the same
+   * window, and the end bound drives access expiry, so a period spliced from
+   * two shapes could grant entitlement beyond what was paid for.
+   *
    * @param subscription - Stripe subscription object
-   * @returns Billing period, or null when neither shape carries one
+   * @returns Billing period, or null when neither shape carries a whole one
    * @private
    */
   private extractBillingPeriod(subscription: Stripe.Subscription): BillingPeriod | null {
@@ -375,16 +412,29 @@ export class StripeAdapter implements PaymentProviderAdapter {
       current_period_end?: number;
     };
 
-    const start = item?.current_period_start ?? legacy.current_period_start;
-    const end = item?.current_period_end ?? legacy.current_period_end;
+    return this.toBillingPeriod(item?.current_period_start, item?.current_period_end)
+      ?? this.toBillingPeriod(legacy.current_period_start, legacy.current_period_end);
+  }
 
-    if (typeof start !== 'number' || typeof end !== 'number') {
+  /**
+   * Build a billing period from a pair of Stripe epoch-second timestamps
+   *
+   * Rejects anything that is not a finite number, so a malformed bound
+   * becomes an absent period rather than an invalid Date.
+   *
+   * @param start - Period start in epoch seconds
+   * @param end - Period end in epoch seconds
+   * @returns Billing period, or null if either bound is unusable
+   * @private
+   */
+  private toBillingPeriod(start: number | undefined, end: number | undefined): BillingPeriod | null {
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
       return null;
     }
 
     return {
-      start: new Date(start * 1000),
-      end: new Date(end * 1000),
+      start: new Date((start as number) * 1000),
+      end: new Date((end as number) * 1000),
     };
   }
 

--- a/src/server/funding/service/provider/stripe.ts
+++ b/src/server/funding/service/provider/stripe.ts
@@ -9,6 +9,17 @@ import {
   WebhookEvent,
 } from './adapter';
 import { ProviderType } from '@/common/model/funding-plan';
+import { createLogger } from '@/server/common/helper/logger';
+
+const logger = createLogger('funding');
+
+/**
+ * Billing period resolved from a Stripe subscription
+ */
+interface BillingPeriod {
+  start: Date;
+  end: Date;
+}
 
 /**
  * Stripe payment provider adapter
@@ -39,8 +50,11 @@ export class StripeAdapter implements PaymentProviderAdapter {
       throw new Error('Stripe API key is required');
     }
 
+    // Pinned to the version the installed SDK's types describe. Bump this in
+    // lockstep with the stripe dependency, or the API will answer in an older
+    // shape than the field reads below expect.
     this.stripe = new Stripe(apiKey, {
-      apiVersion: '2025-12-15.clover',
+      apiVersion: '2026-02-25.clover',
     });
     this.webhookSecret = webhookSecret;
     this.credentials = credentials;
@@ -254,7 +268,7 @@ export class StripeAdapter implements PaymentProviderAdapter {
       case 'invoice.paid':
       case 'invoice.payment_succeeded': {
         const invoice = event.data.object as Stripe.Invoice;
-        webhookEvent.subscriptionId = invoice.subscription as string;
+        webhookEvent.subscriptionId = this.extractInvoiceSubscriptionId(invoice, event);
         webhookEvent.customerId = invoice.customer as string;
         webhookEvent.status = 'active';
         break;
@@ -262,7 +276,7 @@ export class StripeAdapter implements PaymentProviderAdapter {
 
       case 'invoice.payment_failed': {
         const invoice = event.data.object as Stripe.Invoice;
-        webhookEvent.subscriptionId = invoice.subscription as string;
+        webhookEvent.subscriptionId = this.extractInvoiceSubscriptionId(invoice, event);
         webhookEvent.customerId = invoice.customer as string;
         webhookEvent.status = 'past_due';
         break;
@@ -273,8 +287,20 @@ export class StripeAdapter implements PaymentProviderAdapter {
         webhookEvent.subscriptionId = subscription.id;
         webhookEvent.customerId = subscription.customer as string;
         webhookEvent.status = this.mapStripeStatus(subscription.status);
-        webhookEvent.currentPeriodStart = new Date(subscription.current_period_start * 1000);
-        webhookEvent.currentPeriodEnd = new Date(subscription.current_period_end * 1000);
+
+        const period = this.extractBillingPeriod(subscription);
+        if (period) {
+          webhookEvent.currentPeriodStart = period.start;
+          webhookEvent.currentPeriodEnd = period.end;
+        }
+        else {
+          logger.warn({
+            eventId: event.id,
+            eventType: event.type,
+            subscriptionId: subscription.id,
+            itemCount: subscription.items?.data?.length ?? 0,
+          }, 'Stripe subscription webhook has no resolvable billing period');
+        }
         break;
       }
 
@@ -288,6 +314,78 @@ export class StripeAdapter implements PaymentProviderAdapter {
     }
 
     return webhookEvent;
+  }
+
+  /**
+   * Resolve the subscription that generated an invoice
+   *
+   * Stripe moved this link from the top-level `subscription` field to
+   * `parent.subscription_details.subscription` in the Basil API. Webhook
+   * payloads are serialized with the API version configured on the endpoint,
+   * which the instance administrator sets independently of this adapter's
+   * pin, so the legacy field is still honoured as a fallback.
+   *
+   * @param invoice - Invoice object from a webhook payload
+   * @param event - Enclosing event, used for diagnostic markers only
+   * @returns Subscription ID, or undefined for an invoice with no subscription
+   * @private
+   */
+  private extractInvoiceSubscriptionId(invoice: Stripe.Invoice, event: Stripe.Event): string | undefined {
+    const current = invoice.parent?.subscription_details?.subscription;
+    if (current) {
+      return typeof current === 'string' ? current : current.id;
+    }
+
+    const legacy = (invoice as unknown as { subscription?: string | Stripe.Subscription }).subscription;
+    if (legacy) {
+      const subscriptionId = typeof legacy === 'string' ? legacy : legacy.id;
+      logger.debug({
+        eventId: event.id,
+        eventType: event.type,
+        subscriptionId,
+      }, 'Stripe invoice webhook used the legacy top-level subscription field');
+      return subscriptionId;
+    }
+
+    logger.warn({
+      eventId: event.id,
+      eventType: event.type,
+      hasParent: Boolean(invoice.parent),
+      parentType: invoice.parent?.type,
+    }, 'Stripe invoice webhook has no resolvable subscription');
+    return undefined;
+  }
+
+  /**
+   * Resolve the current billing period of a subscription
+   *
+   * Stripe moved `current_period_start` / `current_period_end` from the
+   * subscription to its items in the Basil API. The legacy top-level fields
+   * remain a fallback for webhook payloads serialized with an older API
+   * version (see extractInvoiceSubscriptionId).
+   *
+   * @param subscription - Stripe subscription object
+   * @returns Billing period, or null when neither shape carries one
+   * @private
+   */
+  private extractBillingPeriod(subscription: Stripe.Subscription): BillingPeriod | null {
+    const item = subscription.items?.data?.[0];
+    const legacy = subscription as unknown as {
+      current_period_start?: number;
+      current_period_end?: number;
+    };
+
+    const start = item?.current_period_start ?? legacy.current_period_start;
+    const end = item?.current_period_end ?? legacy.current_period_end;
+
+    if (typeof start !== 'number' || typeof end !== 'number') {
+      return null;
+    }
+
+    return {
+      start: new Date(start * 1000),
+      end: new Date(end * 1000),
+    };
   }
 
   /**
@@ -404,18 +502,26 @@ export class StripeAdapter implements PaymentProviderAdapter {
    *
    * @param subscription - Stripe subscription object
    * @returns Standardized subscription data
+   * @throws Error if the subscription carries no billing period
    * @private
    */
   private convertStripeSubscription(subscription: Stripe.Subscription): ProviderSubscription {
     // Get amount from first subscription item
     const amount = subscription.items.data[0]?.price?.unit_amount || 0;
 
+    const period = this.extractBillingPeriod(subscription);
+    if (!period) {
+      // A period is required by ProviderSubscription; persisting an invalid
+      // date would silently corrupt the local funding plan instead.
+      throw new Error(`Stripe subscription ${subscription.id} has no billing period`);
+    }
+
     return {
       providerSubscriptionId: subscription.id,
       providerCustomerId: subscription.customer as string,
       status: this.mapStripeStatus(subscription.status),
-      currentPeriodStart: new Date(subscription.current_period_start * 1000),
-      currentPeriodEnd: new Date(subscription.current_period_end * 1000),
+      currentPeriodStart: period.start,
+      currentPeriodEnd: period.end,
       amount: amount * 1000, // Convert cents to millicents
       currency: subscription.items.data[0]?.price?.currency?.toUpperCase() || 'USD',
     };

--- a/src/server/funding/test/adapter.test.ts
+++ b/src/server/funding/test/adapter.test.ts
@@ -401,6 +401,81 @@ describe('Payment Provider Adapters', () => {
         expect(event.status).toBe('active');
       });
 
+      it('should prefer the parent subscription when both shapes are present', () => {
+        // The resolved id is an authorization key downstream, so precedence
+        // between the two shapes must never silently invert.
+        const payload = JSON.stringify({
+          id: 'evt_inv_both_shapes',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              subscription: 'sub_legacy_shape',
+              customer: 'cus_both_shapes',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: 'sub_modern_shape',
+                  metadata: null,
+                },
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_modern_shape');
+      });
+
+      it('should leave subscriptionId undefined when the subscription reference has no id', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_malformed',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_malformed',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: { object: 'subscription' },
+                  metadata: null,
+                },
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBeUndefined();
+      });
+
+      it('should leave subscriptionId undefined when the subscription id is not a string', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_nonstring_id',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_nonstring_id',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: { id: 12345, object: 'subscription' },
+                  metadata: null,
+                },
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBeUndefined();
+      });
+
       it('should leave subscriptionId undefined for an invoice with no subscription parent', () => {
         const payload = JSON.stringify({
           id: 'evt_inv_one_off',
@@ -493,6 +568,40 @@ describe('Payment Provider Adapters', () => {
         expect(event.currentPeriodEnd).toEqual(new Date(periodEnd * 1000));
       });
 
+      it('should not splice a period from the item and legacy shapes', () => {
+        // Item-level and subscription-level anchors need not describe the same
+        // window, and the end bound drives access expiry, so a half-populated
+        // payload must yield no period rather than a mixed one.
+        const now = Math.floor(Date.now() / 1000);
+        const payload = JSON.stringify({
+          id: 'evt_sub_mixed_shapes',
+          type: 'customer.subscription.updated',
+          data: {
+            object: {
+              id: 'sub_mixed_shapes',
+              customer: 'cus_mixed_shapes',
+              status: 'active',
+              current_period_end: now + 90 * 24 * 60 * 60,
+              items: {
+                object: 'list',
+                data: [
+                  {
+                    id: 'si_mixed_shapes',
+                    current_period_start: now,
+                  },
+                ],
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_mixed_shapes');
+        expect(event.currentPeriodStart).toBeUndefined();
+        expect(event.currentPeriodEnd).toBeUndefined();
+      });
+
       it('should omit period dates when no billing period can be resolved', () => {
         const payload = JSON.stringify({
           id: 'evt_sub_no_period',
@@ -545,6 +654,27 @@ describe('Payment Provider Adapters', () => {
         expect(subscription.currentPeriodEnd).toEqual(new Date(end * 1000));
         expect(subscription.amount).toBe(1500000);
         expect(subscription.currency).toBe('USD');
+      });
+
+      it('should throw rather than build an invalid date from a non-finite bound', async () => {
+        mockStripe.subscriptions.retrieve.resolves({
+          id: 'sub_nan_period',
+          customer: 'cus_nan_period',
+          status: 'active',
+          items: {
+            data: [
+              {
+                id: 'si_nan_period',
+                current_period_start: Number.NaN,
+                current_period_end: Number.POSITIVE_INFINITY,
+              },
+            ],
+          },
+        });
+
+        await expect(stripeAdapter.getSubscription('sub_nan_period')).rejects.toThrow(
+          'has no billing period',
+        );
       });
 
       it('should throw when the subscription has no resolvable billing period', async () => {

--- a/src/server/funding/test/adapter.test.ts
+++ b/src/server/funding/test/adapter.test.ts
@@ -1,6 +1,34 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import sinon from 'sinon';
 import Stripe from 'stripe';
+
+// Intercept the shared logger so the webhook-parsing tests can assert the
+// level a diagnostic lands at. The adapter warns only on genuine API-shape
+// drift; ordinary invoices that carry no subscription must stay at debug or
+// the warning stops meaning anything. vi.hoisted lets the stubs be shared
+// between the mock factory and the assertions.
+const { warnStub, debugStub } = vi.hoisted(() => {
+  return {
+    warnStub: vi.fn(),
+    debugStub: vi.fn(),
+  };
+});
+
+vi.mock('@/server/common/helper/logger', () => ({
+  createLogger: () => ({
+    warn: warnStub,
+    debug: debugStub,
+    info: vi.fn(),
+    error: vi.fn(),
+  }),
+  default: {
+    warn: warnStub,
+    debug: debugStub,
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 import { StripeAdapter } from '../service/provider/stripe';
 import { PayPalAdapter } from '../service/provider/paypal';
 import { MockStripeAdapter, MockPayPalAdapter } from '../service/provider/mock_adapters';
@@ -99,6 +127,9 @@ describe('Payment Provider Adapters', () => {
           retrieve: sandbox.stub(),
         },
       };
+
+      warnStub.mockClear();
+      debugStub.mockClear();
 
       // Create adapter
       const credentials = { apiKey: 'sk_test_123' };
@@ -476,6 +507,55 @@ describe('Payment Provider Adapters', () => {
         expect(event.subscriptionId).toBeUndefined();
       });
 
+      it('should not warn for a quote invoice, which carries no subscription by design', () => {
+        // A quote-backed invoice legitimately has no subscription. Warning on
+        // it would drown the warning that exists to surface real shape drift.
+        const payload = JSON.stringify({
+          id: 'evt_inv_quote',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_quote',
+              parent: {
+                type: 'quote_details',
+                quote_details: { quote: 'qt_quote_123' },
+                subscription_details: null,
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBeUndefined();
+        expect(warnStub).not.toHaveBeenCalled();
+        expect(debugStub).toHaveBeenCalled();
+      });
+
+      it('should warn when a subscription parent carries no subscription reference', () => {
+        // The inverse of the quote case: the parent claims a subscription but
+        // has none, which is the drift the warning is reserved for.
+        const payload = JSON.stringify({
+          id: 'evt_inv_empty_parent',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_empty_parent',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: null,
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBeUndefined();
+        expect(warnStub).toHaveBeenCalled();
+      });
+
       it('should leave subscriptionId undefined for an invoice with no subscription parent', () => {
         const payload = JSON.stringify({
           id: 'evt_inv_one_off',
@@ -492,6 +572,7 @@ describe('Payment Provider Adapters', () => {
 
         expect(event.subscriptionId).toBeUndefined();
         expect(event.customerId).toBe('cus_one_off');
+        expect(warnStub).not.toHaveBeenCalled();
       });
 
       it('should parse customer.subscription.deleted event', () => {

--- a/src/server/funding/test/adapter.test.ts
+++ b/src/server/funding/test/adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import sinon from 'sinon';
+import Stripe from 'stripe';
 import { StripeAdapter } from '../service/provider/stripe';
 import { PayPalAdapter } from '../service/provider/paypal';
 import { MockStripeAdapter, MockPayPalAdapter } from '../service/provider/mock_adapters';
@@ -106,6 +107,15 @@ describe('Payment Provider Adapters', () => {
 
       // Replace the Stripe instance with our mock
       (stripeAdapter as any).stripe = mockStripe;
+    });
+
+    it('should pin the Stripe API version to the version the installed SDK types describe', () => {
+      // A drifted pin makes Stripe serialize responses in an older shape than
+      // the SDK types (and this adapter's field reads) expect.
+      const adapter = new StripeAdapter({ apiKey: 'sk_test_123' }, 'whsec_test');
+      const client = (adapter as any).stripe;
+
+      expect(client.getApiField('version')).toBe(Stripe.API_VERSION);
     });
 
     describe('validateCredentials', () => {
@@ -274,8 +284,15 @@ describe('Payment Provider Adapters', () => {
           type: 'invoice.paid',
           data: {
             object: {
-              subscription: 'sub_inv_123',
               customer: 'cus_inv_123',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: 'sub_inv_123',
+                  metadata: null,
+                },
+              },
             },
           },
         });
@@ -291,21 +308,115 @@ describe('Payment Provider Adapters', () => {
         expect(event.calendarIds).toBeUndefined();
       });
 
-      it('should parse invoice.payment_failed event', () => {
+      it('should parse invoice.payment_succeeded event', () => {
         const payload = JSON.stringify({
-          id: 'evt_inv_failed',
-          type: 'invoice.payment_failed',
+          id: 'evt_invoice_succeeded',
+          type: 'invoice.payment_succeeded',
           data: {
             object: {
-              subscription: 'sub_fail_123',
-              customer: 'cus_fail_123',
+              customer: 'cus_succ_123',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: 'sub_succ_123',
+                  metadata: null,
+                },
+              },
             },
           },
         });
 
         const event = stripeAdapter.parseWebhookEvent(payload);
 
+        expect(event.subscriptionId).toBe('sub_succ_123');
+        expect(event.status).toBe('active');
+      });
+
+      it('should parse invoice.payment_failed event', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_failed',
+          type: 'invoice.payment_failed',
+          data: {
+            object: {
+              customer: 'cus_fail_123',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: 'sub_fail_123',
+                  metadata: null,
+                },
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_fail_123');
+        expect(event.customerId).toBe('cus_fail_123');
         expect(event.status).toBe('past_due');
+      });
+
+      it('should resolve the invoice subscription when it is expanded to an object', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_expanded',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_expanded',
+              parent: {
+                type: 'subscription_details',
+                quote_details: null,
+                subscription_details: {
+                  subscription: { id: 'sub_expanded_123', object: 'subscription' },
+                  metadata: null,
+                },
+              },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_expanded_123');
+      });
+
+      it('should fall back to the legacy top-level invoice subscription field', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_legacy',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              subscription: 'sub_legacy_123',
+              customer: 'cus_legacy_123',
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_legacy_123');
+        expect(event.status).toBe('active');
+      });
+
+      it('should leave subscriptionId undefined for an invoice with no subscription parent', () => {
+        const payload = JSON.stringify({
+          id: 'evt_inv_one_off',
+          type: 'invoice.paid',
+          data: {
+            object: {
+              customer: 'cus_one_off',
+              parent: null,
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBeUndefined();
+        expect(event.customerId).toBe('cus_one_off');
       });
 
       it('should parse customer.subscription.deleted event', () => {
@@ -328,6 +439,7 @@ describe('Payment Provider Adapters', () => {
 
       it('should parse customer.subscription.updated with status mapping', () => {
         const now = Math.floor(Date.now() / 1000);
+        const periodEnd = now + 30 * 24 * 60 * 60;
         const payload = JSON.stringify({
           id: 'evt_sub_updated',
           type: 'customer.subscription.updated',
@@ -336,8 +448,16 @@ describe('Payment Provider Adapters', () => {
               id: 'sub_upd_123',
               customer: 'cus_upd_123',
               status: 'past_due',
-              current_period_start: now,
-              current_period_end: now + 30 * 24 * 60 * 60,
+              items: {
+                object: 'list',
+                data: [
+                  {
+                    id: 'si_upd_123',
+                    current_period_start: now,
+                    current_period_end: periodEnd,
+                  },
+                ],
+              },
             },
           },
         });
@@ -346,8 +466,98 @@ describe('Payment Provider Adapters', () => {
 
         expect(event.subscriptionId).toBe('sub_upd_123');
         expect(event.status).toBe('past_due');
-        expect(event.currentPeriodStart).toBeInstanceOf(Date);
-        expect(event.currentPeriodEnd).toBeInstanceOf(Date);
+        expect(event.currentPeriodStart).toEqual(new Date(now * 1000));
+        expect(event.currentPeriodEnd).toEqual(new Date(periodEnd * 1000));
+      });
+
+      it('should fall back to legacy top-level subscription period fields', () => {
+        const now = Math.floor(Date.now() / 1000);
+        const periodEnd = now + 30 * 24 * 60 * 60;
+        const payload = JSON.stringify({
+          id: 'evt_sub_updated_legacy',
+          type: 'customer.subscription.updated',
+          data: {
+            object: {
+              id: 'sub_upd_legacy',
+              customer: 'cus_upd_legacy',
+              status: 'active',
+              current_period_start: now,
+              current_period_end: periodEnd,
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.currentPeriodStart).toEqual(new Date(now * 1000));
+        expect(event.currentPeriodEnd).toEqual(new Date(periodEnd * 1000));
+      });
+
+      it('should omit period dates when no billing period can be resolved', () => {
+        const payload = JSON.stringify({
+          id: 'evt_sub_no_period',
+          type: 'customer.subscription.updated',
+          data: {
+            object: {
+              id: 'sub_no_period',
+              customer: 'cus_no_period',
+              status: 'active',
+              items: { object: 'list', data: [] },
+            },
+          },
+        });
+
+        const event = stripeAdapter.parseWebhookEvent(payload);
+
+        expect(event.subscriptionId).toBe('sub_no_period');
+        expect(event.status).toBe('active');
+        expect(event.currentPeriodStart).toBeUndefined();
+        expect(event.currentPeriodEnd).toBeUndefined();
+      });
+    });
+
+    describe('getSubscription', () => {
+      it('should read the billing period from the first subscription item', async () => {
+        const start = Math.floor(Date.now() / 1000);
+        const end = start + 30 * 24 * 60 * 60;
+        mockStripe.subscriptions.retrieve.resolves({
+          id: 'sub_conv_123',
+          customer: 'cus_conv_123',
+          status: 'active',
+          items: {
+            data: [
+              {
+                id: 'si_conv_123',
+                current_period_start: start,
+                current_period_end: end,
+                price: { unit_amount: 1500, currency: 'usd' },
+              },
+            ],
+          },
+        });
+
+        const subscription = await stripeAdapter.getSubscription('sub_conv_123');
+
+        expect(subscription.providerSubscriptionId).toBe('sub_conv_123');
+        expect(subscription.providerCustomerId).toBe('cus_conv_123');
+        expect(subscription.status).toBe('active');
+        expect(subscription.currentPeriodStart).toEqual(new Date(start * 1000));
+        expect(subscription.currentPeriodEnd).toEqual(new Date(end * 1000));
+        expect(subscription.amount).toBe(1500000);
+        expect(subscription.currency).toBe('USD');
+      });
+
+      it('should throw when the subscription has no resolvable billing period', async () => {
+        mockStripe.subscriptions.retrieve.resolves({
+          id: 'sub_no_period',
+          customer: 'cus_no_period',
+          status: 'active',
+          items: { data: [] },
+        });
+
+        await expect(stripeAdapter.getSubscription('sub_no_period')).rejects.toThrow(
+          'has no billing period',
+        );
       });
     });
 


### PR DESCRIPTION
## Motivation

The Stripe adapter was written against a pre-Basil payload shape but runs on SDK v20. `invoice.subscription` and `subscription.current_period_*` no longer exist where the code read them, so **renewals and payment failures silently no-opped** — the parser returned `undefined` and downstream handling did nothing. The tests passed only because the fixtures encoded the same stale shape, so the suite was confirming the bug rather than catching it.

## Approach

The `apiVersion` pin moves to the SDK's current version, and the pin is now asserted against the SDK's own `API_VERSION` constant rather than a duplicated string literal — so a future SDK bump without a pin bump fails a test instead of silently drifting. That converts the class of defect that caused this bug into a build failure.

Invoice events read the subscription id from `invoice.parent.subscription_details.subscription`; subscription events and conversion read the period from `items.data[0]`. Both keep a tolerant fallback to the legacy shape, because webhook payload serialization follows the API version configured on the endpoint by the instance admin, independently of this adapter's pin — a drifted endpoint is a live possibility, not a hypothetical.

Hardening after review:

- Billing periods resolve **atomically** — a shape contributes both bounds or neither. Resolving `start` and `end` independently could splice a window from two anchors, and the end bound is what gets written as the access-expiry date, so a spliced value could extend entitlement past what was paid for.
- `Number.isFinite` on both bounds, so `NaN`/`Infinity` cannot reconstitute the `Invalid Date` this change exists to eliminate.
- The resolved subscription id is validated as a non-empty string before return. It becomes a query predicate and an authorization key downstream, and the previous cast could return a non-string at runtime.
- Conversion now throws rather than persisting `Invalid Date`. The throw lands before the transaction and before the dedupe row, so there are no partial writes and the provider's retry is not swallowed.
- Diagnostic logging carries structural markers only — event id, event type, key-path presence — never the payload object graph. Log levels distinguish genuine shape drift from ordinary one-off and quote invoices.

## Validation

Lint clean. Unit 8696 (16 added), integration 696, build clean — all against a measured `main` baseline of 8680/696. E2E matched baseline.

Reviewers verified the fix by replay rather than by reading it: reverting the parser to its pre-fix state fails exactly the tests claimed, for the right reasons (undefined subscription ids, `Date { NaN }`, a promise resolving where it should reject). Three of the hardening tests bite against the pre-fix code; two are characterization locks on precedence and shape.

Known gap, tracked separately: the webhook test fixtures still carry pre-Basil shapes and now pass only via the legacy fallback, so they no longer exercise the modern path. Replacing them requires real captured test-mode payloads, which are not available in this environment. Two adapter tests deliberately retain the legacy shape as back-compat coverage and should survive that rewrite.