### PR TITLE
feat(funding): add funding-gated feature registry

### DIFF
--- a/agent-os/product/decisions/dec-011-federated-value-boundary.md
+++ b/agent-os/product/decisions/dec-011-federated-value-boundary.md
@@ -17,6 +17,12 @@ Three connected scope decisions:
 
 3. **Advanced ICS sync (background polling, hosted-provider OAuth, mirror mode) remains funding-gated, but the rationale is rewritten.** DEC-009 framed this as operational-cost gating. This decision regates it under the *federated value boundary principle*: features that maintain ongoing integrations with non-federated systems — inbound (Google Calendar OAuth, Outlook/M365, iCloud, ICS polling of non-federated sources) or outbound (ICS feed export, third-party read API, advanced widget embedding) — are platform-bridge services, structurally distinct from in-network features. Operational cost remains a secondary contributing concern but is no longer the primary justification.
 
+## Implementation Surface
+
+The boundary's implementation surface is the funding-gated feature registry, `FUNDING_GATED_FEATURES` in `src/common/model/funding-plan.ts`. Every funding-gated feature is an entry in that const map, and every entry carries a `boundaryRationale` naming which side of this boundary the feature sits on and why. The registry is the single place where the in-network/platform-bridge classification is recorded in code, so an unclassifiable feature cannot be gated by accident: a key with no defensible boundary rationale does not belong in the map.
+
+The funding domain owns both the gate decision and the vocabulary of feature keys. Feature domains declare nothing about funding, hold no plan state, and read none — they pass a registry key to `FundingInterface` and act on the answer ([DEC-003](dec-003-domain-driven-architecture.md)). Gating a new feature is therefore one registry entry plus one call, never funding logic grown inside the feature's own domain.
+
 ## Context
 
 DEC-009 was written when Facebook event import was the planned vector for community aggregation from non-federated platforms. Subsequent investigation has confirmed Facebook import is infeasible due to platform constraints Facebook has imposed. This invalidates DEC-009's comparative framing, which positioned ICS import (free, personal migration) against Facebook import (funding-gated, community aggregation) as two ends of a use-case spectrum. With Facebook removed, that spectrum collapses, and the curator aggregation model needs to be restated without reference to non-federated platforms.
@@ -59,6 +65,7 @@ Three reasons drove this revision:
 - ICS import scope is clear: organizer migration tool, full stop — no aggregation use case attached
 - Roadmap v5 Phase 1 has a defensible decision-level foundation
 - The boundary principle gives every future inbound/outbound feature a deterministic free/gated classification, reducing future scope debates
+- The classification is recorded in code per feature (registry `boundaryRationale`), so the boundary stays reviewable in diffs rather than living only in this document
 
 **Negative:**
 - Reading DEC-009 now requires also reading DEC-011 to understand which paragraphs are superseded (standard cost of the supersession convention)

--- a/src/common/model/funding-plan.ts
+++ b/src/common/model/funding-plan.ts
@@ -21,6 +21,40 @@ export type ProviderType = 'stripe' | 'paypal';
 export type FundingStatus = 'admin-exempt' | 'grant' | 'funded' | 'unfunded';
 
 /**
+ * The features whose availability depends on funding access.
+ *
+ * This registry is the implementation surface of the DEC-011 federated value
+ * boundary: in-network features are free, and features that bridge to
+ * non-federated systems — inbound or outbound — are funding-gated. Every entry
+ * records which side of that boundary its feature sits on and why. A feature
+ * that cannot state a boundary rationale does not belong here.
+ *
+ * Ownership (DEC-003): the funding domain owns both the decision to gate a
+ * feature and the vocabulary of keys used to name one. Feature domains declare
+ * nothing, hold no plan state, and read none — they pass a key from this
+ * registry to FundingInterface and act on the answer. Gating a new feature is
+ * therefore an entry here plus a call, never funding logic grown inside the
+ * feature's own domain.
+ */
+export const FUNDING_GATED_FEATURES = {
+  widget_embedding: {
+    boundaryRationale:
+      'Outside the network. A widget publishes calendar content into non-federated '
+      + 'web properties, which is an outbound platform bridge rather than participation '
+      + 'in the federated network. Following, reposting, and curating between Pavillion '
+      + 'and other ActivityPub event platforms stay free because they are in-network.',
+  },
+} as const;
+
+/**
+ * Key identifying a funding-gated feature.
+ *
+ * Derived from the registry so the union cannot drift from the entries that
+ * carry the boundary rationales.
+ */
+export type FundingGatedFeature = keyof typeof FUNDING_GATED_FEATURES;
+
+/**
  * Instance-wide funding settings
  */
 export class FundingSettings extends PrimaryModel {


### PR DESCRIPTION
## Motivation

Funding-gated features had no shared mechanism. The single gated feature (widget embedding) was enforced by a ~12-line block duplicated at two call sites in the calendar service, with no feature-key vocabulary and nothing recording *why* a given feature sits on the paid side of the federated value boundary.

This adds the registry that later gating work builds on, and makes the boundary classification reviewable in a diff rather than inferred from a roadmap principle.

## Approach

`FUNDING_GATED_FEATURES` is a `const` map in the shared client/server model, with `FundingGatedFeature` derived via `keyof typeof` so the union can never drift from the entries. Each entry carries a `boundaryRationale` naming which side of the federated value boundary the feature sits on and why — a feature that cannot state one does not belong in the registry.

Deliberately inert: one entry (`widget_embedding`, matching the string already on the wire), no lookup helper, no consumers. The existing widget call sites are untouched; migrating them is separate work.

The federated-value-boundary decision record is amended in place to name the registry as its implementation surface, per the decisions-index convention (current-state editing, no changelog section).

## Validation

Lint clean. Unit and integration suites measured against a clean `main` baseline: 8680 unit / 696 integration, identical on this branch. Build clean. E2E 143 passed / 2 failed, both failures reproduced on clean `main` (a load-dependent admin-accounts login timeout and a deterministic ICS import-sources failure).

No tests were added: the registry is a compile-time construct with no runtime surface, and a test asserting a literal back at itself would pass unconditionally. A reviewer confirmed no runtime consumer exists yet; the first one will need full unit coverage.

Reviewed by architecture, consistency, complexity, and testing passes. Two documentation follow-ups were recorded rather than fixed here: the amended decision asserts a domain-ownership state that only becomes true once the widget call sites migrate, and the `widget_embedding` rationale does not yet record how the gate interacts with the anonymous-public-access decision.