### PR TITLE
feat(funding): add a single funding-access decision with four ordered invariants

### DIFF
--- a/agent-os/product/decisions.md
+++ b/agent-os/product/decisions.md
@@ -53,7 +53,7 @@ Supersession is the exception, because it retires a decision rather than refinin
 - **File:** [decisions/dec-011-federated-value-boundary.md](decisions/dec-011-federated-value-boundary.md)
 - **Date:** 2026-05-16 · **Status:** Accepted
 - **Decision:** (1) ICS import is exclusively organizer migration tooling — not a curator aggregation surface. (2) Curator aggregation operates via federation only (Pavillion calendars + other AP event platforms); no roadmap path for non-federated source aggregation. (3) Features that bridge to non-federated systems (inbound or outbound) are funding-gated under the **federated value boundary principle**; in-network features are free.
-- **Consult when:** Classifying any feature as free vs funding-gated; designing aggregation features; ICS import scope work; questions about what curators do in Pavillion's model; deciding whether an inbound/outbound integration is in-network or platform-bridge; any feature touching outbound feeds, third-party APIs, or hosted-provider integrations.
+- **Consult when:** Classifying any feature as free vs funding-gated; adding an entry to the funding-gated feature registry (`FUNDING_GATED_FEATURES`); designing aggregation features; ICS import scope work; questions about what curators do in Pavillion's model; deciding whether an inbound/outbound integration is in-network or platform-bridge; any feature touching outbound feeds, third-party APIs, or hosted-provider integrations.
 
 ---
 

--- a/src/server/funding/entity/funding_plan.ts
+++ b/src/server/funding/entity/funding_plan.ts
@@ -126,6 +126,13 @@ class FundingPlanEntity extends Model {
     if (newStatus === 'active' && previousStatus === 'suspended') {
       instance.suspended_at = null;
     }
+
+    // Clear cancelled_at when resubscribing. A stale cancellation marker on a
+    // plan that is active again reads as a lapsed plan to the funding-access
+    // check, which would deny a customer who is paying.
+    if (newStatus === 'active' && previousStatus === 'cancelled') {
+      instance.cancelled_at = null;
+    }
   }
 }
 

--- a/src/server/funding/interface/index.ts
+++ b/src/server/funding/interface/index.ts
@@ -46,6 +46,11 @@ export default class FundingInterface {
   /**
    * Check if a calendar has an active funding plan
    *
+   * @deprecated Use {@link checkFundingAccess}. This reports only the plan's
+   * status, so it keeps granting access to a plan whose cancellation was never
+   * reported to us, and it knows nothing about instance-level funding settings
+   * or admin exemption. Retired at the widget-gate migration.
+   *
    * @param calendarId - Calendar ID to check
    * @returns True if calendar has active funding plan, false otherwise
    */
@@ -56,6 +61,11 @@ export default class FundingInterface {
   /**
    * Check if a calendar has access to funded features
    * (either via active funding plan or complimentary grant)
+   *
+   * @deprecated Use {@link checkFundingAccess}. This answers only the
+   * grant-or-plan half of a gate decision, leaving every caller to remember
+   * the instance-enabled and admin-exemption checks for itself, and it applies
+   * no cancellation boundary. Retired at the widget-gate migration.
    *
    * @param calendarId - Calendar ID to check
    * @returns True if calendar has funding access, false otherwise
@@ -71,6 +81,16 @@ export default class FundingInterface {
    * FUNDING_GATED_FEATURES and act on the answer, holding no funding state of
    * their own. See FundingService.checkFundingAccess for the four invariants
    * that produce the decision.
+   *
+   * This answers a funding question and nothing else. It is NOT an
+   * authorization check: when funding is not enabled on the instance it
+   * returns true for any well-formed UUID, including calendars that do not
+   * exist and calendars the caller has no business touching. Compose it only
+   * AFTER authentication, ownership and existence checks have run.
+   *
+   * A false is not always "unfunded" either — an unreadable instance funding
+   * state also denies. That case is a server-side failure and must surface as
+   * a server error, never as 402 / SubscriptionRequiredError.
    *
    * @param calendarId - Calendar the feature would be used on
    * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature

--- a/src/server/funding/interface/index.ts
+++ b/src/server/funding/interface/index.ts
@@ -8,7 +8,7 @@ import {
   type ProviderStatus,
   type DisconnectionResult,
 } from '@/server/funding/service/provider_connection';
-import { FundingPlan, FundingSettings, ProviderConfig, FundingStatus, BillingCycle, ProviderType } from '@/common/model/funding-plan';
+import { FundingPlan, FundingSettings, ProviderConfig, FundingStatus, BillingCycle, ProviderType, FundingGatedFeature } from '@/common/model/funding-plan';
 import type { ProviderInfo } from '@/server/funding/service/funding';
 import type { ProviderCredentials } from '@/server/funding/service/provider/adapter';
 import { ComplimentaryGrant } from '@/common/model/complimentary_grant';
@@ -62,6 +62,22 @@ export default class FundingInterface {
    */
   async hasFundingAccess(calendarId: string): Promise<boolean> {
     return this.fundingService.hasFundingAccess(calendarId);
+  }
+
+  /**
+   * Decide whether a calendar may use a funding-gated feature.
+   *
+   * The single entry point for funding gates: feature domains pass a key from
+   * FUNDING_GATED_FEATURES and act on the answer, holding no funding state of
+   * their own. See FundingService.checkFundingAccess for the four invariants
+   * that produce the decision.
+   *
+   * @param calendarId - Calendar the feature would be used on
+   * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature
+   * @returns True if the gate is open for this calendar
+   */
+  async checkFundingAccess(calendarId: string, feature: FundingGatedFeature): Promise<boolean> {
+    return this.fundingService.checkFundingAccess(calendarId, feature);
   }
 
   /**

--- a/src/server/funding/service/funding.ts
+++ b/src/server/funding/service/funding.ts
@@ -1651,19 +1651,32 @@ export default class FundingService {
    *     operator who has not turned funding on runs an instance with no paid
    *     tier, so no feature may be withheld (DEC-001 instance autonomy).
    *  2. The calendar's owner is an instance admin -> open.
-   *  3. An active complimentary grant or an active funding plan allocation ->
-   *     open, unless the plan's cancellation boundary has already passed. That
-   *     boundary is read from the plan itself rather than from its
-   *     webhook-driven status, so a missed customer.subscription.deleted
-   *     cannot grant access indefinitely.
+   *  3. An active complimentary grant, or a funding plan allocation that has
+   *     not passed its access boundary -> open. The boundary comes from the
+   *     plan's own dates rather than its webhook-driven status, so a missed
+   *     customer.subscription.deleted cannot grant access indefinitely.
    *  4. Funding is enabled but the answer is indeterminate (database error,
    *     credential decrypt failure, provider unreachable) -> CLOSED. "Cannot
-   *     tell" is not "entitled".
+   *     tell" is not "has access".
    *
    * Note the deliberate split in invariants 1 and 4: a *known* absence of
    * funding opens gates, an *unknown* funding state closes them. Neither is
    * the ambiguous "fail-secure" the earlier hasFundingAccess implemented,
    * which had no notion of an instance with funding switched off.
+   *
+   * Where invariants 3 and 4 meet, the tie-break is: **a determinate allow
+   * beats an indeterminate sibling read.** The admin, grant and plan checks
+   * are read independently; one of them failing means "unknown from that
+   * source", never a denial of what another source can still answer. A
+   * complimentary-grant table that is unreadable must not deny a calendar with
+   * a healthy paid allocation. The gate closes only when no source produced an
+   * allow.
+   *
+   * Constraint on consumers (middleware, API handlers, upsell UI): a denial
+   * from this method is not always "unfunded". When the instance-level funding
+   * state itself could not be read, the denial is a server-side failure and
+   * must surface as a server error — never as 402 / SubscriptionRequiredError,
+   * which would tell an operator to buy something to fix our outage.
    *
    * The feature key carries no policy of its own today — every gated feature
    * is decided the same way — but it is validated against the registry so an
@@ -1686,56 +1699,99 @@ export default class FundingService {
     }
 
     // Invariant 1: funding not enabled on this instance -> all gates open.
-    let fundingEnabled: boolean;
+    let settings: FundingSettings;
     try {
-      fundingEnabled = (await this.getSettings()).enabled;
+      settings = await this.getSettings();
     }
     catch (error) {
-      // Invariant 4: we cannot establish that funding is switched off, so we
-      // cannot open the gate on that basis either.
+      // Invariant 4, instance scope: we cannot establish that funding is
+      // switched off, so we cannot open the gate on that basis either. This is
+      // the denial that consumers must report as a server error.
       logError(error, 'checkFundingAccess: instance funding settings unreadable, closing gate');
       return false;
     }
 
-    if (!fundingEnabled) {
+    if (!settings.enabled) {
       return true;
     }
 
+    // Invariant 2: admin-owned calendars are exempt.
+    if (await this.readAccessSource(
+      () => this.isCalendarOwnerAdmin(calendarId),
+      'checkFundingAccess: calendar owner admin check unreadable',
+    )) {
+      return true;
+    }
+
+    // Invariant 3: an active grant, or a plan allocation still inside its
+    // access boundary.
+    if (await this.readAccessSource(
+      () => this.hasActiveGrant(calendarId),
+      'checkFundingAccess: complimentary grant lookup unreadable',
+    )) {
+      return true;
+    }
+
+    return this.readAccessSource(
+      () => this.hasQualifyingFundingPlan(calendarId, settings.gracePeriodDays),
+      'checkFundingAccess: funding plan lookup unreadable',
+    );
+  }
+
+  /**
+   * Read one source of funding access, treating a failure as "this source
+   * cannot answer" rather than as a denial.
+   *
+   * Keeping each source independent is what implements the tie-break rule in
+   * checkFundingAccess: an unreadable source contributes no allow, but it also
+   * never suppresses the allow a sibling source can still produce. With no
+   * allow from any source the gate closes, so a failure can only ever cost
+   * access it was not able to justify.
+   *
+   * @param read - The access check to run
+   * @param context - Log context describing which source failed
+   * @returns The check's answer, or false if it could not be read
+   */
+  private async readAccessSource(read: () => Promise<boolean>, context: string): Promise<boolean> {
     try {
-      // Invariant 2: admin-owned calendars are exempt.
-      const ownerId = this.calendarInterface
-        ? await this.calendarInterface.getCalendarOwnerAccountId(calendarId)
-        : null;
-
-      if (ownerId && await this.isAccountAdmin(ownerId)) {
-        return true;
-      }
-
-      // Invariant 3: an active grant or a still-entitling funding plan.
-      if (await this.hasActiveGrant(calendarId)) {
-        return true;
-      }
-
-      return await this.hasEntitlingFundingPlan(calendarId);
+      return await read();
     }
     catch (error) {
-      // Invariant 4: indeterminate funding status -> closed.
-      logError(error, 'checkFundingAccess: funding status indeterminate, closing gate');
+      logError(error, context);
       return false;
     }
   }
 
   /**
-   * Check whether the calendar has a funding plan allocation that still
-   * entitles it, i.e. an active allocation on an active plan that has not
-   * passed its cancellation boundary.
-   *
-   * Stricter than hasActiveFundingPlan, which trusts the plan's status alone.
+   * Check whether a calendar's owner is an instance admin.
    *
    * @param calendarId - Calendar ID to check
-   * @returns True if a funding plan allocation currently entitles the calendar
+   * @returns True if the calendar has a resolvable owner holding the admin role
    */
-  private async hasEntitlingFundingPlan(calendarId: string): Promise<boolean> {
+  private async isCalendarOwnerAdmin(calendarId: string): Promise<boolean> {
+    if (!this.calendarInterface) {
+      return false;
+    }
+
+    const ownerId = await this.calendarInterface.getCalendarOwnerAccountId(calendarId);
+
+    return ownerId ? this.isAccountAdmin(ownerId) : false;
+  }
+
+  /**
+   * Check whether the calendar has a funding plan allocation that still grants
+   * access: an active allocation, on an active plan, inside the plan's access
+   * boundary.
+   *
+   * Stricter than hasActiveFundingPlan, which trusts the plan's status alone
+   * and therefore keeps granting access to a plan whose ending was never
+   * reported to us.
+   *
+   * @param calendarId - Calendar ID to check
+   * @param gracePeriodDays - Instance grace period applied after the paid-through date
+   * @returns True if a funding plan allocation currently grants access
+   */
+  private async hasQualifyingFundingPlan(calendarId: string, gracePeriodDays: number): Promise<boolean> {
     const allocation = await CalendarFundingPlanEntity.findOne({
       where: {
         calendar_id: calendarId,
@@ -1755,30 +1811,48 @@ export default class FundingService {
       return false;
     }
 
-    const expiry = this.planEntitlementExpiry(allocation.fundingPlan);
+    const expiry = this.planAccessExpiry(allocation.fundingPlan, gracePeriodDays);
 
     return expiry === null || Date.now() < expiry.getTime();
   }
 
   /**
-   * The instant at which a funding plan stops entitling its calendars, or null
-   * if it has no scheduled end.
+   * The instant at which a funding plan stops granting access to its
+   * calendars, or null if nothing on the plan sets an end.
    *
-   * A plan cancelled at period end keeps entitling until its current period
-   * runs out, and then stops on the clock rather than on the webhook that
-   * reports the cancellation. cancelled_at is the cancellation marker the plan
-   * entity carries today; pv-jdot.3.1 introduces an explicit cancel_at for
-   * cancel-at-period-end plans, and this helper is where it gets read.
+   * Two candidate boundaries are considered and the EARLIEST wins, because a
+   * gate helper must never round permissive:
+   *
+   *  - cancelled_at, the recorded cancellation. An immediate cancellation ends
+   *    access when it happens, even though the interrupted billing period may
+   *    still have weeks to run. pv-jdot.3.1 adds an explicit cancel_at for
+   *    cancel-at-period-end plans, and this is where it joins the list.
+   *  - current_period_end plus the instance grace period. This is the boundary
+   *    written on the happy path, on every renewal, so it is the one that
+   *    still applies when a cancellation is never reported to us at all — the
+   *    silent-renewal-failure and missed-deletion cases. The grace period is
+   *    the same window suspendExpiredFundingPlans uses, so a customer in
+   *    dunning is not cut off before the instance's own policy says so.
    *
    * @param plan - Funding plan the allocation belongs to
-   * @returns Entitlement expiry instant, or null if the plan has none
+   * @param gracePeriodDays - Instance grace period applied after the paid-through date
+   * @returns Access expiry instant, or null if the plan sets none
    */
-  private planEntitlementExpiry(plan: FundingPlanEntity): Date | null {
-    if (!plan.cancelled_at) {
+  private planAccessExpiry(plan: FundingPlanEntity, gracePeriodDays: number): Date | null {
+    const graceMs = Math.max(gracePeriodDays, 0) * 24 * 60 * 60 * 1000;
+
+    const boundaries = [
+      plan.cancelled_at,
+      plan.current_period_end
+        ? new Date(plan.current_period_end.getTime() + graceMs)
+        : null,
+    ].filter((boundary): boundary is Date => boundary instanceof Date);
+
+    if (boundaries.length === 0) {
       return null;
     }
 
-    return plan.current_period_end ?? plan.cancelled_at;
+    return boundaries.reduce((earliest, boundary) => boundary < earliest ? boundary : earliest);
   }
 
   /**

--- a/src/server/funding/service/funding.ts
+++ b/src/server/funding/service/funding.ts
@@ -9,6 +9,8 @@ import {
   ProviderType,
   BillingCycle,
   FundingStatus,
+  FUNDING_GATED_FEATURES,
+  FundingGatedFeature,
 } from '@/common/model/funding-plan';
 import { ComplimentaryGrant } from '@/common/model/complimentary_grant';
 import { FundingSettingsEntity } from '@/server/funding/entity/funding_settings';
@@ -44,6 +46,7 @@ import {
 } from '@/common/exceptions/funding';
 import { ValidationError } from '@/common/exceptions/base';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
+import { logError } from '@/server/common/helper/error-logger';
 import type CalendarInterface from '@/server/calendar/interface';
 
 // UUID v4 validation regex
@@ -392,6 +395,23 @@ export default class FundingService {
   }
 
   /**
+   * Check whether an account holds the instance admin role.
+   *
+   * @param accountId - Account ID to check
+   * @returns True if the account is an instance admin
+   */
+  private async isAccountAdmin(accountId: string): Promise<boolean> {
+    const adminRole = await AccountRoleEntity.findOne({
+      where: {
+        account_id: accountId,
+        role: 'admin',
+      },
+    });
+
+    return !!adminRole;
+  }
+
+  /**
    * Validates that a return URL origin matches the configured instance domain.
    * Defense in depth: prevents open redirect attacks by ensuring the return URL
    * points back to this Pavillion instance.
@@ -723,14 +743,7 @@ export default class FundingService {
     }
 
     // Check if owner is admin
-    const adminRole = await AccountRoleEntity.findOne({
-      where: {
-        account_id: ownerId,
-        role: 'admin',
-      },
-    });
-
-    if (adminRole) {
+    if (await this.isAccountAdmin(ownerId)) {
       return 'admin-exempt';
     }
 
@@ -1626,6 +1639,146 @@ export default class FundingService {
       // Fail-secure: deny access on funding plan check error
       return false;
     }
+  }
+
+  /**
+   * Decide whether a calendar may use a funding-gated feature.
+   *
+   * This is the single access decision behind every funding gate. It applies
+   * four invariants, in this order:
+   *
+   *  1. Funding is not enabled on this instance -> the gate is OPEN. An
+   *     operator who has not turned funding on runs an instance with no paid
+   *     tier, so no feature may be withheld (DEC-001 instance autonomy).
+   *  2. The calendar's owner is an instance admin -> open.
+   *  3. An active complimentary grant or an active funding plan allocation ->
+   *     open, unless the plan's cancellation boundary has already passed. That
+   *     boundary is read from the plan itself rather than from its
+   *     webhook-driven status, so a missed customer.subscription.deleted
+   *     cannot grant access indefinitely.
+   *  4. Funding is enabled but the answer is indeterminate (database error,
+   *     credential decrypt failure, provider unreachable) -> CLOSED. "Cannot
+   *     tell" is not "entitled".
+   *
+   * Note the deliberate split in invariants 1 and 4: a *known* absence of
+   * funding opens gates, an *unknown* funding state closes them. Neither is
+   * the ambiguous "fail-secure" the earlier hasFundingAccess implemented,
+   * which had no notion of an instance with funding switched off.
+   *
+   * The feature key carries no policy of its own today — every gated feature
+   * is decided the same way — but it is validated against the registry so an
+   * unregistered key can never be answered, and so per-feature policy has a
+   * place to live if it is ever needed.
+   *
+   * @param calendarId - Calendar the feature would be used on
+   * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature
+   * @returns True if the gate is open for this calendar
+   * @throws ValidationError if calendarId is not a UUID or feature is not a
+   *   registered funding-gated feature
+   */
+  async checkFundingAccess(calendarId: string, feature: FundingGatedFeature): Promise<boolean> {
+    if (!isValidUUID(calendarId)) {
+      throw new ValidationError('Invalid calendarId: must be a valid UUID');
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(FUNDING_GATED_FEATURES, feature)) {
+      throw new ValidationError('Unknown funding-gated feature');
+    }
+
+    // Invariant 1: funding not enabled on this instance -> all gates open.
+    let fundingEnabled: boolean;
+    try {
+      fundingEnabled = (await this.getSettings()).enabled;
+    }
+    catch (error) {
+      // Invariant 4: we cannot establish that funding is switched off, so we
+      // cannot open the gate on that basis either.
+      logError(error, 'checkFundingAccess: instance funding settings unreadable, closing gate');
+      return false;
+    }
+
+    if (!fundingEnabled) {
+      return true;
+    }
+
+    try {
+      // Invariant 2: admin-owned calendars are exempt.
+      const ownerId = this.calendarInterface
+        ? await this.calendarInterface.getCalendarOwnerAccountId(calendarId)
+        : null;
+
+      if (ownerId && await this.isAccountAdmin(ownerId)) {
+        return true;
+      }
+
+      // Invariant 3: an active grant or a still-entitling funding plan.
+      if (await this.hasActiveGrant(calendarId)) {
+        return true;
+      }
+
+      return await this.hasEntitlingFundingPlan(calendarId);
+    }
+    catch (error) {
+      // Invariant 4: indeterminate funding status -> closed.
+      logError(error, 'checkFundingAccess: funding status indeterminate, closing gate');
+      return false;
+    }
+  }
+
+  /**
+   * Check whether the calendar has a funding plan allocation that still
+   * entitles it, i.e. an active allocation on an active plan that has not
+   * passed its cancellation boundary.
+   *
+   * Stricter than hasActiveFundingPlan, which trusts the plan's status alone.
+   *
+   * @param calendarId - Calendar ID to check
+   * @returns True if a funding plan allocation currently entitles the calendar
+   */
+  private async hasEntitlingFundingPlan(calendarId: string): Promise<boolean> {
+    const allocation = await CalendarFundingPlanEntity.findOne({
+      where: {
+        calendar_id: calendarId,
+        [Op.or]: [
+          { end_time: { [Op.is]: null as any } },
+          { end_time: { [Op.gt]: new Date() } },
+        ],
+      },
+      include: [{
+        model: FundingPlanEntity,
+        where: { status: 'active' },
+        required: true,
+      }],
+    });
+
+    if (!allocation?.fundingPlan) {
+      return false;
+    }
+
+    const expiry = this.planEntitlementExpiry(allocation.fundingPlan);
+
+    return expiry === null || Date.now() < expiry.getTime();
+  }
+
+  /**
+   * The instant at which a funding plan stops entitling its calendars, or null
+   * if it has no scheduled end.
+   *
+   * A plan cancelled at period end keeps entitling until its current period
+   * runs out, and then stops on the clock rather than on the webhook that
+   * reports the cancellation. cancelled_at is the cancellation marker the plan
+   * entity carries today; pv-jdot.3.1 introduces an explicit cancel_at for
+   * cancel-at-period-end plans, and this helper is where it gets read.
+   *
+   * @param plan - Funding plan the allocation belongs to
+   * @returns Entitlement expiry instant, or null if the plan has none
+   */
+  private planEntitlementExpiry(plan: FundingPlanEntity): Date | null {
+    if (!plan.cancelled_at) {
+      return null;
+    }
+
+    return plan.current_period_end ?? plan.cancelled_at;
   }
 
   /**

--- a/src/server/funding/service/funding.ts
+++ b/src/server/funding/service/funding.ts
@@ -1820,19 +1820,34 @@ export default class FundingService {
    * The instant at which a funding plan stops granting access to its
    * calendars, or null if nothing on the plan sets an end.
    *
+   * These dates never widen access: the caller has already required
+   * status 'active', so a plan Stripe moved to past_due or suspended is
+   * denied by the join before any date is read. The boundaries only
+   * discriminate among plans that still claim to be active.
+   *
    * Two candidate boundaries are considered and the EARLIEST wins, because a
    * gate helper must never round permissive:
    *
    *  - cancelled_at, the recorded cancellation. An immediate cancellation ends
    *    access when it happens, even though the interrupted billing period may
-   *    still have weeks to run. pv-jdot.3.1 adds an explicit cancel_at for
-   *    cancel-at-period-end plans, and this is where it joins the list.
+   *    still have weeks to run.
    *  - current_period_end plus the instance grace period. This is the boundary
    *    written on the happy path, on every renewal, so it is the one that
    *    still applies when a cancellation is never reported to us at all — the
-   *    silent-renewal-failure and missed-deletion cases. The grace period is
-   *    the same window suspendExpiredFundingPlans uses, so a customer in
-   *    dunning is not cut off before the instance's own policy says so.
+   *    silent-renewal-failure and missed-deletion cases. The grace window
+   *    exists for the plan that is still 'active' with a renewal webhook in
+   *    flight or lost: it keeps a paying customer from being cut off the
+   *    instant their period rolls over. It is not the dunning window —
+   *    suspendExpiredFundingPlans measures its own grace from updatedAt on
+   *    past_due rows, and those rows never reach this helper.
+   *
+   * pv-jdot.3.1 adds cancel_at for cancel-at-period-end plans. Adding it here
+   * is not the whole of that work: by then there are three markers that can
+   * end access (cancelled_at, cancel_at, current_period_end) against four
+   * predicates that read them (this helper, hasActiveFundingPlan,
+   * getFundingStatusForCalendar, getPlanStatusForCalendars), and which marker
+   * governs which predicate needs one ruling recorded on that bead rather than
+   * a fifth reading invented at this call site.
    *
    * @param plan - Funding plan the allocation belongs to
    * @param gracePeriodDays - Instance grace period applied after the paid-through date

--- a/src/server/funding/test/admin_api.test.ts
+++ b/src/server/funding/test/admin_api.test.ts
@@ -6,6 +6,8 @@ import FundingInterface from '@/server/funding/interface';
 import AdminRoutes from '@/server/funding/api/v1/admin';
 import { FundingSettings, ProviderConfig } from '@/common/model/funding-plan';
 import { testApp } from '@/server/common/test/lib/express';
+import ExpressHelper from '@/server/common/helper/express';
+import { Account } from '@/common/model/account';
 
 describe('Admin Funding API', () => {
   let router: express.Router;
@@ -181,6 +183,70 @@ describe('Admin Funding API', () => {
 
       expect(response.body.error).toContain('payWhatYouCanYearlyDiscount must be a number between 0 and 100');
       expect(response.body.errorName).toBe('ValidationError');
+    });
+  });
+
+  /**
+   * settings.enabled is an instance-level switch: it decides whether funding
+   * gates apply at all (checkFundingAccess invariant 1), so the only path that
+   * may write it is the admin-gated POST /api/funding/v1/admin/settings.
+   *
+   * The passport arm of ExpressHelper.adminOnly is captured at module load and
+   * cannot be restubbed, so authorization is covered in two parts, following
+   * the pattern in src/server/calendar/test/admin.integration.test.ts:
+   * registration wires the whole adminOnly chain, and the role-check arm
+   * rejects a non-admin.
+   */
+  describe('instance settings write authorization', () => {
+    it('registers the settings routes behind the full adminOnly chain', () => {
+      const app = express();
+      adminHandlers.installHandlers(app, '/api/funding/v1');
+
+      const settingsLayers = (app as any)._router.stack
+        .filter((layer: any) => layer.name === 'router')
+        .flatMap((layer: any) => layer.handle.stack)
+        .filter((layer: any) => layer.route?.path === '/admin/settings');
+
+      expect(settingsLayers.length).toBe(2); // GET and POST
+
+      for (const layer of settingsLayers) {
+        const handlers = layer.route.stack.map((l: any) => l.handle);
+        for (const guard of ExpressHelper.adminOnly) {
+          expect(handlers).toContain(guard);
+        }
+      }
+    });
+
+    it('rejects a non-admin attempt to write settings.enabled', async () => {
+      const updateStub = sandbox.stub(service, 'updateSettings').resolves();
+      const nonAdmin = new Account('user-uuid', 'user', 'user@example.com');
+      nonAdmin.roles = [];
+
+      router.use((req, _res, next) => {
+        req.user = nonAdmin;
+        next();
+      });
+      // Reuse the production role-check arm; only the passport arm is skipped.
+      router.post(
+        '/admin/settings',
+        ExpressHelper.adminOnly[1],
+        adminHandlers.updateSettings.bind(adminHandlers),
+      );
+
+      await request(testApp(router))
+        .post('/admin/settings')
+        .send({
+          enabled: true,
+          monthlyPrice: 1000000,
+          yearlyPrice: 10000000,
+          currency: 'USD',
+          payWhatYouCan: false,
+          gracePeriodDays: 7,
+          payWhatYouCanYearlyDiscount: 0,
+        })
+        .expect(403);
+
+      expect(updateStub.called).toBe(false);
     });
   });
 

--- a/src/server/funding/test/admin_api.test.ts
+++ b/src/server/funding/test/admin_api.test.ts
@@ -9,6 +9,10 @@ import { testApp } from '@/server/common/test/lib/express';
 import ExpressHelper from '@/server/common/helper/express';
 import { Account } from '@/common/model/account';
 
+// Snapshot at module load: other suites stub ExpressHelper.adminOnly onto
+// their own middleware, and these tests must compare against the real chain.
+const ADMIN_ONLY_CHAIN = [...ExpressHelper.adminOnly];
+
 describe('Admin Funding API', () => {
   let router: express.Router;
   let service: FundingInterface;
@@ -198,7 +202,7 @@ describe('Admin Funding API', () => {
    * rejects a non-admin.
    */
   describe('instance settings write authorization', () => {
-    it('registers the settings routes behind the full adminOnly chain', () => {
+    it('should register the settings routes behind the full adminOnly chain', () => {
       const app = express();
       adminHandlers.installHandlers(app, '/api/funding/v1');
 
@@ -211,13 +215,13 @@ describe('Admin Funding API', () => {
 
       for (const layer of settingsLayers) {
         const handlers = layer.route.stack.map((l: any) => l.handle);
-        for (const guard of ExpressHelper.adminOnly) {
+        for (const guard of ADMIN_ONLY_CHAIN) {
           expect(handlers).toContain(guard);
         }
       }
     });
 
-    it('rejects a non-admin attempt to write settings.enabled', async () => {
+    it('should reject a non-admin attempt to write settings.enabled', async () => {
       const updateStub = sandbox.stub(service, 'updateSettings').resolves();
       const nonAdmin = new Account('user-uuid', 'user', 'user@example.com');
       nonAdmin.roles = [];
@@ -229,7 +233,7 @@ describe('Admin Funding API', () => {
       // Reuse the production role-check arm; only the passport arm is skipped.
       router.post(
         '/admin/settings',
-        ExpressHelper.adminOnly[1],
+        ADMIN_ONLY_CHAIN[1],
         adminHandlers.updateSettings.bind(adminHandlers),
       );
 

--- a/src/server/funding/test/entity.test.ts
+++ b/src/server/funding/test/entity.test.ts
@@ -113,6 +113,64 @@ describe('Subscription Entities', () => {
       expect(newEntity.get('status')).toBe('active');
       expect(newEntity.get('billing_cycle')).toBe('monthly');
     });
+
+    describe('status transition hook', () => {
+      /**
+       * Builds a persisted-looking plan in the given status, with both
+       * lifecycle markers set, so a transition can be driven through the hook
+       * and its clean-up observed. isNewRecord: false is what makes
+       * instance.previous('status') report the stored status, as it does for
+       * a row loaded from the database and then updated.
+       */
+      function buildPlan(status: 'active' | 'past_due' | 'suspended' | 'cancelled'): FundingPlanEntity {
+        return FundingPlanEntity.build({
+          id: 'sub-id',
+          account_id: 'account-id',
+          provider_config_id: 'provider-id',
+          provider_subscription_id: 'sub_123',
+          provider_customer_id: 'cus_123',
+          status,
+          billing_cycle: 'monthly' as const,
+          amount: 1000000,
+          currency: 'USD',
+          current_period_start: new Date(),
+          current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+          cancelled_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          suspended_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        }, { isNewRecord: false });
+      }
+
+      it('should clear cancelled_at when a cancelled plan is resubscribed', () => {
+        const entity = buildPlan('cancelled');
+
+        entity.status = 'active';
+        FundingPlanEntity.validateStatusTransition(entity);
+
+        // A stale cancellation marker on a paying plan would read as an
+        // expired plan to the funding-access check
+        expect(entity.cancelled_at).toBeNull();
+      });
+
+      it('should clear suspended_at when a suspended plan is reactivated', () => {
+        const entity = buildPlan('suspended');
+
+        entity.status = 'active';
+        FundingPlanEntity.validateStatusTransition(entity);
+
+        expect(entity.suspended_at).toBeNull();
+      });
+
+      it('should set cancelled_at when a plan is cancelled', () => {
+        const entity = buildPlan('active');
+        entity.cancelled_at = null;
+
+        entity.status = 'cancelled';
+        FundingPlanEntity.validateStatusTransition(entity);
+
+        expect(entity.cancelled_at).toBeInstanceOf(Date);
+      });
+
+    });
   });
 
   describe('FundingEventEntity', () => {

--- a/src/server/funding/test/entity.test.ts
+++ b/src/server/funding/test/entity.test.ts
@@ -115,29 +115,29 @@ describe('Subscription Entities', () => {
     });
 
     describe('status transition hook', () => {
+      const planRow = (status: 'active' | 'past_due' | 'suspended' | 'cancelled') => ({
+        id: 'sub-id',
+        account_id: 'account-id',
+        provider_config_id: 'provider-id',
+        provider_subscription_id: 'sub_123',
+        provider_customer_id: 'cus_123',
+        status,
+        billing_cycle: 'monthly' as const,
+        amount: 1000000,
+        currency: 'USD',
+        current_period_start: new Date(),
+        current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        cancelled_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        suspended_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+
       /**
-       * Builds a persisted-looking plan in the given status, with both
-       * lifecycle markers set, so a transition can be driven through the hook
-       * and its clean-up observed. isNewRecord: false is what makes
-       * instance.previous('status') report the stored status, as it does for
-       * a row loaded from the database and then updated.
+       * Builds a plan in the given status, with both lifecycle markers set, for
+       * tests that then reassign .status. That reassignment is what populates
+       * previous('status'), so these instances need no further ceremony.
        */
       function buildPlan(status: 'active' | 'past_due' | 'suspended' | 'cancelled'): FundingPlanEntity {
-        return FundingPlanEntity.build({
-          id: 'sub-id',
-          account_id: 'account-id',
-          provider_config_id: 'provider-id',
-          provider_subscription_id: 'sub_123',
-          provider_customer_id: 'cus_123',
-          status,
-          billing_cycle: 'monthly' as const,
-          amount: 1000000,
-          currency: 'USD',
-          current_period_start: new Date(),
-          current_period_end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-          cancelled_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
-          suspended_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
-        }, { isNewRecord: false });
+        return FundingPlanEntity.build(planRow(status));
       }
 
       it('should clear cancelled_at when a cancelled plan is resubscribed', () => {
@@ -170,6 +170,21 @@ describe('Subscription Entities', () => {
         expect(entity.cancelled_at).toBeInstanceOf(Date);
       });
 
+      it('should leave both markers untouched when the status does not change', () => {
+        // A save that touches some other column must not restamp the lifecycle
+        // markers. raw: true seeds previous() from the row without any
+        // reassignment, which is what a loaded-then-resaved record looks like
+        // when status is not among the columns being updated.
+        const row = planRow('cancelled');
+        const entity = FundingPlanEntity.build(row, { isNewRecord: false, raw: true });
+
+        expect(entity.previous('status')).toBe('cancelled');
+
+        FundingPlanEntity.validateStatusTransition(entity);
+
+        expect(entity.cancelled_at).toBe(row.cancelled_at);
+        expect(entity.suspended_at).toBe(row.suspended_at);
+      });
     });
   });
 

--- a/src/server/funding/test/service.test.ts
+++ b/src/server/funding/test/service.test.ts
@@ -943,6 +943,7 @@ describe('FundingService', () => {
   describe('checkFundingAccess', () => {
     const feature = 'widget_embedding';
     const HOUR = 60 * 60 * 1000;
+    const DAY = 24 * HOUR;
     let calendarId: string;
     let ownerId: string;
 
@@ -1006,14 +1007,14 @@ describe('FundingService', () => {
         fundingPlan: {
           status: 'active',
           cancelled_at: null,
-          current_period_end: new Date(Date.now() + 30 * 24 * HOUR),
+          current_period_end: new Date(Date.now() + 30 * DAY),
           ...plan,
         },
       } as any);
     }
 
     describe('invariant 1: funding not enabled on the instance', () => {
-      it('opens the gate without consulting any plan state', async () => {
+      it('should open the gate without consulting any funding state', async () => {
         stubFundingEnabled(false);
         const grantStub = stubGrant(false);
         const allocationStub = stubAllocation(null);
@@ -1031,7 +1032,7 @@ describe('FundingService', () => {
     });
 
     describe('invariant 2: admin-exempt', () => {
-      it('opens the gate for a calendar owned by an admin', async () => {
+      it('should open the gate for a calendar owned by an admin', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(true);
         const grantStub = stubGrant(false);
@@ -1045,7 +1046,7 @@ describe('FundingService', () => {
         expect(allocationStub.called).toBe(false);
       });
 
-      it('falls through to funding state when the owner is not an admin', async () => {
+      it('should fall through to funding state when the owner is not an admin', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
@@ -1057,7 +1058,7 @@ describe('FundingService', () => {
         expect(allocationStub.called).toBe(true);
       });
 
-      it('falls through to funding state when the calendar has no resolvable owner', async () => {
+      it('should fall through to funding state when the calendar has no resolvable owner', async () => {
         stubFundingEnabled(true);
         mockCalendarInterface.getCalendarOwnerAccountId.resolves(null);
         const adminStub = stubOwnerIsAdmin(true);
@@ -1071,7 +1072,7 @@ describe('FundingService', () => {
     });
 
     describe('invariant 3: active plan or grant', () => {
-      it('opens the gate for an active complimentary grant', async () => {
+      it('should open the gate for an active complimentary grant', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(true);
@@ -1083,7 +1084,7 @@ describe('FundingService', () => {
         expect(allocationStub.called).toBe(false);
       });
 
-      it('opens the gate for an active funding plan allocation', async () => {
+      it('should open the gate for an active funding plan allocation', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
@@ -1094,7 +1095,7 @@ describe('FundingService', () => {
         expect(allowed).toBe(true);
       });
 
-      it('closes the gate with neither a grant nor a funding plan allocation', async () => {
+      it('should close the gate with neither a grant nor a funding plan allocation', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
@@ -1105,14 +1106,35 @@ describe('FundingService', () => {
         expect(allowed).toBe(false);
       });
 
-      it('keeps the gate open for a plan cancelled at period end until the period ends', async () => {
+      it('should close the gate once the paid-through period and its grace window have passed', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
+        // The plan the missed-webhook case actually produces: a deletion that
+        // never arrived leaves status 'active' and no cancellation marker at
+        // all, so only the paid-through date can end access.
         stubAllocation({
           status: 'active',
-          cancelled_at: new Date(Date.now() - HOUR),
-          current_period_end: new Date(Date.now() + HOUR),
+          cancelled_at: null,
+          current_period_end: new Date(Date.now() - 30 * DAY),
+        });
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('should keep the gate open inside the grace window after the paid-through date', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        // Two days past the period end with a 7-day grace window: a customer
+        // mid-dunning, or a renewal whose webhook has not landed yet, keeps
+        // access until the instance's own grace period runs out.
+        stubAllocation({
+          status: 'active',
+          cancelled_at: null,
+          current_period_end: new Date(Date.now() - 2 * DAY),
         });
 
         const allowed = await service.checkFundingAccess(calendarId, feature);
@@ -1120,16 +1142,46 @@ describe('FundingService', () => {
         expect(allowed).toBe(true);
       });
 
-      it('closes the gate once the cancellation boundary has passed, regardless of webhook-driven status', async () => {
+      it('should close the gate once a recorded cancellation has passed, however long the period runs', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
-        // A missed customer.subscription.deleted leaves status 'active' locally;
-        // the clock, not the webhook, decides that entitlement has lapsed.
+        // An immediate cancellation ends access when it is recorded, even
+        // though the billing period it interrupted still has weeks to run.
         stubAllocation({
           status: 'active',
-          cancelled_at: new Date(Date.now() - 40 * 24 * HOUR),
-          current_period_end: new Date(Date.now() - HOUR),
+          cancelled_at: new Date(Date.now() - HOUR),
+          current_period_end: new Date(Date.now() + 30 * DAY),
+        });
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('should keep the gate open until a scheduled cancellation is reached', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        stubAllocation({
+          status: 'active',
+          cancelled_at: new Date(Date.now() + HOUR),
+          current_period_end: null,
+        });
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+      });
+
+      it('should close the gate on a passed cancellation with no period end recorded', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        stubAllocation({
+          status: 'active',
+          cancelled_at: new Date(Date.now() - HOUR),
+          current_period_end: null,
         });
 
         const allowed = await service.checkFundingAccess(calendarId, feature);
@@ -1138,8 +1190,8 @@ describe('FundingService', () => {
       });
     });
 
-    describe('invariant 4: indeterminate status', () => {
-      it('closes the gate when the instance settings cannot be read', async () => {
+    describe('invariant 4: indeterminate reads', () => {
+      it('should close every gate when the instance funding settings cannot be read', async () => {
         sandbox.stub(FundingSettingsEntity, 'findOne').rejects(new Error('DB error'));
         stubOwnerIsAdmin(false);
         stubGrant(true);
@@ -1149,27 +1201,27 @@ describe('FundingService', () => {
         expect(allowed).toBe(false);
       });
 
-      it('closes the gate when the owner admin-role lookup fails', async () => {
+      it('should open the gate on a determinate grant when the owner admin-role lookup fails', async () => {
         stubFundingEnabled(true);
         sandbox.stub(AccountRoleEntity, 'findOne').rejects(new Error('DB error'));
         stubGrant(true);
 
         const allowed = await service.checkFundingAccess(calendarId, feature);
 
-        expect(allowed).toBe(false);
+        expect(allowed).toBe(true);
       });
 
-      it('closes the gate when the owner lookup fails', async () => {
+      it('should open the gate on a determinate grant when the owner lookup fails', async () => {
         stubFundingEnabled(true);
         mockCalendarInterface.getCalendarOwnerAccountId.rejects(new Error('Calendar domain unavailable'));
         stubGrant(true);
 
         const allowed = await service.checkFundingAccess(calendarId, feature);
 
-        expect(allowed).toBe(false);
+        expect(allowed).toBe(true);
       });
 
-      it('closes the gate when the grant lookup fails, without falling through to the plan check', async () => {
+      it('should open the gate on a determinate plan allocation when the grant lookup fails', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         sandbox.stub(ComplimentaryGrantEntity, 'findOne').rejects(new Error('DB error'));
@@ -1177,11 +1229,24 @@ describe('FundingService', () => {
 
         const allowed = await service.checkFundingAccess(calendarId, feature);
 
-        expect(allowed).toBe(false);
-        expect(allocationStub.called).toBe(false);
+        // A grant read that fell over says nothing about the paid allocation
+        // sitting right next to it
+        expect(allowed).toBe(true);
+        expect(allocationStub.called).toBe(true);
       });
 
-      it('closes the gate when the funding plan lookup fails', async () => {
+      it('should close the gate when the grant lookup fails and there is no plan allocation', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        sandbox.stub(ComplimentaryGrantEntity, 'findOne').rejects(new Error('DB error'));
+        stubAllocation(null);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('should close the gate when the funding plan lookup fails', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
         stubGrant(false);
@@ -1191,21 +1256,68 @@ describe('FundingService', () => {
 
         expect(allowed).toBe(false);
       });
+
+      it('should close the gate when every funding read fails', async () => {
+        stubFundingEnabled(true);
+        sandbox.stub(AccountRoleEntity, 'findOne').rejects(new Error('DB error'));
+        sandbox.stub(ComplimentaryGrantEntity, 'findOne').rejects(new Error('DB error'));
+        sandbox.stub(CalendarFundingPlanEntity, 'findOne').rejects(new Error('DB error'));
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
     });
 
     describe('input validation', () => {
-      it('rejects a calendarId that is not a UUID', async () => {
+      it('should reject a calendarId that is not a UUID', async () => {
         await expect(service.checkFundingAccess('not-a-uuid', feature))
           .rejects.toThrow(ValidationError);
       });
 
-      it('rejects a feature key that is not in the registry', async () => {
+      it('should reject a feature key that is not in the registry', async () => {
         await expect(service.checkFundingAccess(calendarId, 'made_up_feature' as any))
           .rejects.toThrow(ValidationError);
       });
     });
 
     describe('parity with the legacy status vocabularies', () => {
+      /**
+       * Builds the funding plan a resubscribe leaves behind, by driving a real
+       * entity through the production status-transition hook rather than
+       * asserting what we imagine that hook writes.
+       */
+      function buildReactivatedPlan(): { status: string; cancelled_at: Date | null; current_period_end: Date | null } {
+        const plan = FundingPlanEntity.build({
+          id: uuidv4(),
+          account_id: uuidv4(),
+          provider_config_id: uuidv4(),
+          provider_subscription_id: 'sub_test',
+          provider_customer_id: 'cus_test',
+          status: 'cancelled',
+          billing_cycle: 'monthly',
+          amount: 1000000,
+          currency: 'USD',
+          current_period_start: new Date(Date.now() - DAY),
+          current_period_end: new Date(Date.now() + 30 * DAY),
+          cancelled_at: new Date(Date.now() - 10 * DAY),
+          suspended_at: null,
+        }, { isNewRecord: false });
+
+        plan.status = 'active';
+        FundingPlanEntity.validateStatusTransition(plan);
+
+        return {
+          status: plan.status,
+          cancelled_at: plan.cancelled_at,
+          current_period_end: plan.current_period_end,
+        };
+      }
+
+      function planFor(world: { reactivated: boolean }): Record<string, unknown> {
+        return world.reactivated ? buildReactivatedPlan() : {};
+      }
+
       /**
        * Each world is a database state that produces one value of each legacy
        * vocabulary. checkFundingAccess must reach the same allow/deny outcome
@@ -1218,6 +1330,7 @@ describe('FundingService', () => {
           isAdmin: true,
           hasGrant: false,
           hasAllocation: false,
+          reactivated: false,
           legacyCalendarStatus: 'admin-exempt',
           legacyPlanStatus: undefined,
           allowed: true,
@@ -1227,6 +1340,7 @@ describe('FundingService', () => {
           isAdmin: false,
           hasGrant: true,
           hasAllocation: false,
+          reactivated: false,
           legacyCalendarStatus: 'grant',
           legacyPlanStatus: 'grant',
           allowed: true,
@@ -1236,6 +1350,20 @@ describe('FundingService', () => {
           isAdmin: false,
           hasGrant: false,
           hasAllocation: true,
+          reactivated: false,
+          legacyCalendarStatus: 'funded',
+          legacyPlanStatus: 'subscribed',
+          allowed: true,
+        },
+        {
+          // A plan resubscribed after cancellation. The status-transition hook
+          // clears cancelled_at on cancelled -> active, so no stale
+          // cancellation marker can deny a customer who is paying again.
+          name: 'calendar whose funding plan was reactivated after cancellation',
+          isAdmin: false,
+          hasGrant: false,
+          hasAllocation: true,
+          reactivated: true,
           legacyCalendarStatus: 'funded',
           legacyPlanStatus: 'subscribed',
           allowed: true,
@@ -1245,6 +1373,7 @@ describe('FundingService', () => {
           isAdmin: false,
           hasGrant: false,
           hasAllocation: false,
+          reactivated: false,
           legacyCalendarStatus: 'unfunded',
           legacyPlanStatus: undefined,
           allowed: false,
@@ -1252,11 +1381,11 @@ describe('FundingService', () => {
       ] as const;
 
       for (const world of worlds) {
-        it(`decides identically to the legacy vocabularies for a ${world.name}`, async () => {
+        it(`should decide identically to the legacy vocabularies for a ${world.name}`, async () => {
           stubFundingEnabled(true);
           stubOwnerIsAdmin(world.isAdmin);
           stubGrant(world.hasGrant);
-          stubAllocation(world.hasAllocation ? {} : null);
+          stubAllocation(world.hasAllocation ? planFor(world) : null);
           mockCalendarInterface.isCalendarOwnerById.resolves(true);
           sandbox.stub(ComplimentaryGrantEntity, 'findAll').resolves(
             world.hasGrant ? [{ calendar_id: calendarId } as any] : [],

--- a/src/server/funding/test/service.test.ts
+++ b/src/server/funding/test/service.test.ts
@@ -1142,6 +1142,15 @@ describe('FundingService', () => {
         expect(allowed).toBe(true);
       });
 
+      /**
+       * The three cases below pair a past or future cancelled_at with an
+       * active status to characterise planAccessExpiry as a pure function of
+       * the plan's dates. That combination is not reachable through today's
+       * writers — cancel() and the status-transition hook only ever write
+       * cancelled_at together with status 'cancelled' — so these pin the
+       * helper's arithmetic, not a live path. They become live when
+       * pv-jdot.3.1 lands a cancellation marker that leaves the plan active.
+       */
       it('should close the gate once a recorded cancellation has passed, however long the period runs', async () => {
         stubFundingEnabled(true);
         stubOwnerIsAdmin(false);
@@ -1285,7 +1294,8 @@ describe('FundingService', () => {
       /**
        * Builds the funding plan a resubscribe leaves behind, by driving a real
        * entity through the production status-transition hook rather than
-       * asserting what we imagine that hook writes.
+       * asserting what we imagine that hook writes. Assigning .status is what
+       * populates previous('status'), which is what the hook reads.
        */
       function buildReactivatedPlan(): { status: string; cancelled_at: Date | null; current_period_end: Date | null } {
         const plan = FundingPlanEntity.build({
@@ -1302,7 +1312,7 @@ describe('FundingService', () => {
           current_period_end: new Date(Date.now() + 30 * DAY),
           cancelled_at: new Date(Date.now() - 10 * DAY),
           suspended_at: null,
-        }, { isNewRecord: false });
+        });
 
         plan.status = 'active';
         FundingPlanEntity.validateStatusTransition(plan);

--- a/src/server/funding/test/service.test.ts
+++ b/src/server/funding/test/service.test.ts
@@ -9,6 +9,7 @@ import { FundingPlanEntity } from '@/server/funding/entity/funding_plan';
 import { FundingEventEntity } from '@/server/funding/entity/funding_event';
 import { ComplimentaryGrantEntity } from '@/server/funding/entity/complimentary_grant';
 import { CalendarFundingPlanEntity } from '@/server/funding/entity/calendar_funding_plan';
+import { AccountRoleEntity } from '@/server/common/entity/account';
 import { ProviderFactory } from '@/server/funding/service/provider/factory';
 import { FundingSettings, ProviderConfig, FundingPlan } from '@/common/model/funding-plan';
 import { ComplimentaryGrant } from '@/common/model/complimentary_grant';
@@ -936,6 +937,349 @@ describe('FundingService', () => {
       await service.hasFundingAccess(calendarId);
 
       expect(subStub.called).toBe(false);
+    });
+  });
+
+  describe('checkFundingAccess', () => {
+    const feature = 'widget_embedding';
+    const HOUR = 60 * 60 * 1000;
+    let calendarId: string;
+    let ownerId: string;
+
+    beforeEach(() => {
+      calendarId = uuidv4();
+      ownerId = uuidv4();
+      mockCalendarInterface.getCalendarOwnerAccountId.resolves(ownerId);
+    });
+
+    /** Stub the single instance funding-settings row. */
+    function stubFundingEnabled(enabled: boolean): sinon.SinonStub {
+      return sandbox.stub(FundingSettingsEntity, 'findOne').resolves({
+        id: uuidv4(),
+        enabled,
+        monthly_price: 1000000,
+        yearly_price: 10000000,
+        currency: 'USD',
+        pay_what_you_can: false,
+        grace_period_days: 7,
+        toModel: function() {
+          const settings = new FundingSettings(this.id);
+          settings.enabled = this.enabled;
+          settings.monthlyPrice = this.monthly_price;
+          settings.yearlyPrice = this.yearly_price;
+          settings.currency = this.currency;
+          settings.payWhatYouCan = this.pay_what_you_can;
+          settings.gracePeriodDays = this.grace_period_days;
+          return settings;
+        },
+      } as any);
+    }
+
+    /** Stub the admin-role lookup for the calendar owner. */
+    function stubOwnerIsAdmin(isAdmin: boolean): sinon.SinonStub {
+      return sandbox.stub(AccountRoleEntity, 'findOne').resolves(
+        isAdmin ? { account_id: ownerId, role: 'admin' } as any : null,
+      );
+    }
+
+    /** Stub the active complimentary grant lookup for the calendar. */
+    function stubGrant(hasGrant: boolean): sinon.SinonStub {
+      return sandbox.stub(ComplimentaryGrantEntity, 'findOne').resolves(
+        hasGrant ? { calendar_id: calendarId, revoked_at: null, expires_at: null } as any : null,
+      );
+    }
+
+    /**
+     * Stub the calendar's funding-plan allocation. Pass null for no allocation,
+     * or plan overrides to shape the funding plan the allocation belongs to.
+     */
+    function stubAllocation(
+      plan: { status?: string; cancelled_at?: Date | null; current_period_end?: Date | null } | null,
+    ): sinon.SinonStub {
+      if (plan === null) {
+        return sandbox.stub(CalendarFundingPlanEntity, 'findOne').resolves(null);
+      }
+
+      return sandbox.stub(CalendarFundingPlanEntity, 'findOne').resolves({
+        calendar_id: calendarId,
+        end_time: null,
+        fundingPlan: {
+          status: 'active',
+          cancelled_at: null,
+          current_period_end: new Date(Date.now() + 30 * 24 * HOUR),
+          ...plan,
+        },
+      } as any);
+    }
+
+    describe('invariant 1: funding not enabled on the instance', () => {
+      it('opens the gate without consulting any plan state', async () => {
+        stubFundingEnabled(false);
+        const grantStub = stubGrant(false);
+        const allocationStub = stubAllocation(null);
+        const adminStub = stubOwnerIsAdmin(false);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+        // Instance autonomy (DEC-001): a calendar's funding state is irrelevant
+        // when the instance operator has not turned funding on at all.
+        expect(grantStub.called).toBe(false);
+        expect(allocationStub.called).toBe(false);
+        expect(adminStub.called).toBe(false);
+      });
+    });
+
+    describe('invariant 2: admin-exempt', () => {
+      it('opens the gate for a calendar owned by an admin', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(true);
+        const grantStub = stubGrant(false);
+        const allocationStub = stubAllocation(null);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+        // Admin exemption is decided before any funding state is read
+        expect(grantStub.called).toBe(false);
+        expect(allocationStub.called).toBe(false);
+      });
+
+      it('falls through to funding state when the owner is not an admin', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        const allocationStub = stubAllocation(null);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+        expect(allocationStub.called).toBe(true);
+      });
+
+      it('falls through to funding state when the calendar has no resolvable owner', async () => {
+        stubFundingEnabled(true);
+        mockCalendarInterface.getCalendarOwnerAccountId.resolves(null);
+        const adminStub = stubOwnerIsAdmin(true);
+        stubGrant(true);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+        expect(adminStub.called).toBe(false);
+      });
+    });
+
+    describe('invariant 3: active plan or grant', () => {
+      it('opens the gate for an active complimentary grant', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(true);
+        const allocationStub = stubAllocation(null);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+        expect(allocationStub.called).toBe(false);
+      });
+
+      it('opens the gate for an active funding plan allocation', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        stubAllocation({});
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+      });
+
+      it('closes the gate with neither a grant nor a funding plan allocation', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        stubAllocation(null);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('keeps the gate open for a plan cancelled at period end until the period ends', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        stubAllocation({
+          status: 'active',
+          cancelled_at: new Date(Date.now() - HOUR),
+          current_period_end: new Date(Date.now() + HOUR),
+        });
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(true);
+      });
+
+      it('closes the gate once the cancellation boundary has passed, regardless of webhook-driven status', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        // A missed customer.subscription.deleted leaves status 'active' locally;
+        // the clock, not the webhook, decides that entitlement has lapsed.
+        stubAllocation({
+          status: 'active',
+          cancelled_at: new Date(Date.now() - 40 * 24 * HOUR),
+          current_period_end: new Date(Date.now() - HOUR),
+        });
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+    });
+
+    describe('invariant 4: indeterminate status', () => {
+      it('closes the gate when the instance settings cannot be read', async () => {
+        sandbox.stub(FundingSettingsEntity, 'findOne').rejects(new Error('DB error'));
+        stubOwnerIsAdmin(false);
+        stubGrant(true);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('closes the gate when the owner admin-role lookup fails', async () => {
+        stubFundingEnabled(true);
+        sandbox.stub(AccountRoleEntity, 'findOne').rejects(new Error('DB error'));
+        stubGrant(true);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('closes the gate when the owner lookup fails', async () => {
+        stubFundingEnabled(true);
+        mockCalendarInterface.getCalendarOwnerAccountId.rejects(new Error('Calendar domain unavailable'));
+        stubGrant(true);
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+
+      it('closes the gate when the grant lookup fails, without falling through to the plan check', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        sandbox.stub(ComplimentaryGrantEntity, 'findOne').rejects(new Error('DB error'));
+        const allocationStub = stubAllocation({});
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+        expect(allocationStub.called).toBe(false);
+      });
+
+      it('closes the gate when the funding plan lookup fails', async () => {
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(false);
+        stubGrant(false);
+        sandbox.stub(CalendarFundingPlanEntity, 'findOne').rejects(new Error('DB error'));
+
+        const allowed = await service.checkFundingAccess(calendarId, feature);
+
+        expect(allowed).toBe(false);
+      });
+    });
+
+    describe('input validation', () => {
+      it('rejects a calendarId that is not a UUID', async () => {
+        await expect(service.checkFundingAccess('not-a-uuid', feature))
+          .rejects.toThrow(ValidationError);
+      });
+
+      it('rejects a feature key that is not in the registry', async () => {
+        await expect(service.checkFundingAccess(calendarId, 'made_up_feature' as any))
+          .rejects.toThrow(ValidationError);
+      });
+    });
+
+    describe('parity with the legacy status vocabularies', () => {
+      /**
+       * Each world is a database state that produces one value of each legacy
+       * vocabulary. checkFundingAccess must reach the same allow/deny outcome
+       * the legacy widget gate reached for that state, where the legacy gate is
+       * the composite: instance enabled -> admin bypass -> hasFundingAccess.
+       */
+      const worlds = [
+        {
+          name: 'admin-owned calendar with no funding state',
+          isAdmin: true,
+          hasGrant: false,
+          hasAllocation: false,
+          legacyCalendarStatus: 'admin-exempt',
+          legacyPlanStatus: undefined,
+          allowed: true,
+        },
+        {
+          name: 'calendar with an active complimentary grant',
+          isAdmin: false,
+          hasGrant: true,
+          hasAllocation: false,
+          legacyCalendarStatus: 'grant',
+          legacyPlanStatus: 'grant',
+          allowed: true,
+        },
+        {
+          name: 'calendar with an active funding plan allocation',
+          isAdmin: false,
+          hasGrant: false,
+          hasAllocation: true,
+          legacyCalendarStatus: 'funded',
+          legacyPlanStatus: 'subscribed',
+          allowed: true,
+        },
+        {
+          name: 'calendar with no funding state at all',
+          isAdmin: false,
+          hasGrant: false,
+          hasAllocation: false,
+          legacyCalendarStatus: 'unfunded',
+          legacyPlanStatus: undefined,
+          allowed: false,
+        },
+      ] as const;
+
+      for (const world of worlds) {
+        it(`decides identically to the legacy vocabularies for a ${world.name}`, async () => {
+          stubFundingEnabled(true);
+          stubOwnerIsAdmin(world.isAdmin);
+          stubGrant(world.hasGrant);
+          stubAllocation(world.hasAllocation ? {} : null);
+          mockCalendarInterface.isCalendarOwnerById.resolves(true);
+          sandbox.stub(ComplimentaryGrantEntity, 'findAll').resolves(
+            world.hasGrant ? [{ calendar_id: calendarId } as any] : [],
+          );
+          sandbox.stub(CalendarFundingPlanEntity, 'findAll').resolves(
+            world.hasAllocation ? [{ calendar_id: calendarId } as any] : [],
+          );
+
+          // Legacy vocabulary 1: single-calendar status
+          expect(await service.getFundingStatusForCalendar(ownerId, calendarId))
+            .toBe(world.legacyCalendarStatus);
+
+          // Legacy vocabulary 2: bulk plan status ('none' is an absent key)
+          const bulk = await service.getPlanStatusForCalendars([calendarId]);
+          expect(bulk.get(calendarId)).toBe(world.legacyPlanStatus);
+
+          // Legacy composite gate decision (calendar.ts widget gate)
+          const legacyDecision = world.isAdmin || await service.hasFundingAccess(calendarId);
+          expect(legacyDecision).toBe(world.allowed);
+
+          expect(await service.checkFundingAccess(calendarId, feature)).toBe(world.allowed);
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## Motivation

Funding gates had no shared decision behind them. The one gated feature (widget embedding) was enforced by a ~12-line block duplicated at two call sites, and the helper it leaned on, `hasFundingAccess`, returned a bare boolean that could not distinguish a calendar we know is unfunded from a calendar whose funding state we could not determine. Those two cases have to be decided differently: an instance that never switched funding on should open every gate, while an instance that cannot read its own funding state should close them.

Two further defects were found while building the decision and are fixed here rather than left for a follow-up:

- **The cancellation boundary could never fire.** The check that was supposed to catch a cancellation we were never told about compared `now()` against `cancelled_at`, but nothing writes `cancelled_at` without also writing status `cancelled`, and the plan query requires an active status. The two conditions were mutually exclusive, so a missed `customer.subscription.deleted` granted access indefinitely — precisely the case the check existed to catch.
- **A failed sibling read denied a healthy calendar.** The admin, grant and plan lookups shared one `try` block, so an error reading complimentary grants denied a calendar holding a perfectly good paid allocation.

## Approach

`FundingService.checkFundingAccess` becomes the single decision behind every funding gate, with `FundingInterface.checkFundingAccess` as a thin delegate. It applies four ordered invariants:

1. Funding not enabled on this instance → all gates open (instance autonomy, DEC-001).
2. Admin-owned calendar → exempt.
3. An active grant or a still-entitling plan allocation → open.
4. Funding enabled but the state is indeterminate → closed.

**Entitlement is read from the plan's own boundary, not from its webhook-driven status.** The boundary now derives from `current_period_end`, which every renewal writes, extended by the instance grace period so a customer mid-dunning is not cut off early. A recorded cancellation stays a second, earlier boundary, and the earliest of the two wins — a gate helper must never round permissive.

Each source is now read independently, under the rule that **a determinate allow beats an indeterminate sibling read**: the gate closes only when no source produced an allow. That rule is recorded on `checkFundingAccess` itself, together with the constraint that a denial caused by unreadable *instance* settings must surface as a server error and never as a request to pay. An operator whose self-hosted instance never enabled funding must not be told during a database outage that their community owes money.

The status-transition hook now clears `cancelled_at` when a cancelled plan is resubscribed, symmetric with the existing `suspended_at` handling. Without it a reactivated plan carried a stale cancellation marker and its owner would have been denied while paying.

Two notes on scope and naming:

- **This is not an authorization check, and the interface now says so.** When funding is disabled, `checkFundingAccess` returns `true` for any UUID, including calendars that do not exist and calendars the caller does not own. It composes after auth and ownership middleware; it never substitutes for them.
- **The new helpers are named in "funding access" vocabulary rather than "entitlement".** The gating platform deliberately reuses the funding-plan vocabulary instead of introducing a third term for the same concept. DEC-007 as merged today only records the older rule — that "funding plan" is used in place of "subscription", to avoid colliding with ActivityPub's sense of that word. The matching Terminology section naming `funding access` and ruling out `Entitlement*` identifiers lands with #440; this branch's commit message overstates the current state of DEC-007 on that point.

`hasFundingAccess` and `hasActiveFundingPlan` are deprecated on the interface. Their call sites are retired in a later branch in this series; the tags are documentation-only for now, since no `no-deprecated` lint rule is configured.

Adding `cancel_at` is not the whole of cancel-at-period-end. Three end-of-access markers now exist against four predicates that read them, and that needs one ruling rather than an interpretation invented per call site; the code records this where the boundary is computed.

## Validation

- Unit tests cover every branch of the decision, with the disabled-instance and indeterminate paths as their own cases.
- A parity table asserts the new decision matches both legacy status vocabularies outcome-for-outcome, so nothing silently changes allow/deny for an existing calendar.
- Route-registration and role-check coverage proves `settings.enabled` is writable only through the admin-gated settings route, never through calendar-settings updates or a mass-assignment merge.
- Entity tests cover the resubscribe path that clears `cancelled_at`, and the no-op-save assertion is rebuilt on a fixture that seeds `previous()` from the row rather than from a reassignment, so it now covers what the earlier version intended. The three active-plus-cancelled cases are marked as characterisation of the expiry helper rather than reachable states.
- Full local gate on this branch at its stack position: lint, unit, integration, typecheck, build and e2e.