### PR TITLE
feat(funding): add the requireFundingAccess route gate

### DIFF
--- a/src/common/exceptions/funding.ts
+++ b/src/common/exceptions/funding.ts
@@ -121,6 +121,29 @@ export class InvalidSessionIdError extends ValidationError {
   }
 }
 
+/**
+ * Thrown when a funding gate cannot establish whether the instance charges for
+ * anything at all — the instance-level funding settings could not be read.
+ *
+ * This is the one denial from checkFundingAccess that is NOT "this calendar is
+ * unfunded". It is our outage, not the caller's unpaid bill, and it must reach
+ * the client as a server error. Answering it with 402 /
+ * SubscriptionRequiredError would tell an operator whose instance never
+ * enabled funding that their community owes money to fix our database
+ * problem — the failure mode DEC-001 is most pointed about avoiding.
+ *
+ * The throw is still fail-closed: it denies access, it just refuses to blame
+ * the caller for the denial. A consumer that wants to degrade some other way
+ * can catch it.
+ */
+export class FundingAccessIndeterminateError extends Error {
+  constructor(message?: string) {
+    super(message || 'Funding access could not be determined');
+    this.name = 'FundingAccessIndeterminateError';
+    Object.setPrototypeOf(this, FundingAccessIndeterminateError.prototype);
+  }
+}
+
 export class WebhookSignatureError extends Error {
   constructor(message?: string) {
     super(message || 'Webhook signature verification failed');

--- a/src/server/funding/api/middleware.ts
+++ b/src/server/funding/api/middleware.ts
@@ -1,0 +1,151 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { FUNDING_GATED_FEATURES, type FundingGatedFeature } from '@/common/model/funding-plan';
+import { SubscriptionRequiredError } from '@/common/exceptions/subscription';
+import ExpressHelper from '@/server/common/helper/express';
+import { logError } from '@/server/common/helper/error-logger';
+import type FundingInterface from '@/server/funding/interface';
+
+/**
+ * An Express handler produced by {@link requireFundingAccess}, tagged with the
+ * feature it gates.
+ *
+ * The tag is not decoration. "Which routes are funding-gated?" is a question
+ * the product needs to be able to answer mechanically — DEC-004 commits us to
+ * never gating anonymous public reads, and a commitment that can only be
+ * checked by reading route files by hand is one that drifts. Tagging the
+ * handler makes any router tree inspectable for gates.
+ */
+export interface FundingAccessGate extends RequestHandler {
+  readonly fundingGatedFeature: FundingGatedFeature;
+}
+
+/**
+ * Whether a value is a funding gate built by {@link requireFundingAccess}.
+ *
+ * @param handler - Candidate Express handler, typically pulled off a router layer
+ * @returns True if the handler is a funding gate
+ */
+export function isFundingAccessGate(handler: unknown): handler is FundingAccessGate {
+  return typeof handler === 'function'
+    && typeof (handler as Partial<FundingAccessGate>).fundingGatedFeature === 'string';
+}
+
+/**
+ * Build Express middleware that refuses a request unless the calendar it
+ * targets may use a funding-gated feature.
+ *
+ * ## Composition contract
+ *
+ * **This is not an authorization check and never substitutes for one.** It
+ * answers a funding question only. When funding is switched off on the
+ * instance, {@link FundingInterface.checkFundingAccess} returns true for any
+ * well-formed UUID — including calendars that do not exist and calendars the
+ * caller has no business touching. Mount it strictly AFTER:
+ *
+ *  1. authentication (`ExpressHelper.loggedInOnly` or equivalent), and
+ *  2. the route's calendar-ownership / editor-permission check, which is also
+ *     what establishes that the calendar exists.
+ *
+ * The calendar comes from `req.params[calendarIdParam]` and from nowhere else
+ * — never the body, never the query string. That is the only source the
+ * ownership middleware above has already validated and authorised; a body
+ * field is caller-controlled and would let a request be judged against a
+ * calendar nobody checked. If the named param is absent or is not a UUID, the
+ * gate treats it as a broken composition and fails the request as a server
+ * error rather than guessing.
+ *
+ * The feature key is likewise fixed here, at route registration, as a
+ * compile-time literal. Nothing about the request can influence which gate is
+ * being asked about. The key is checked against the registry when the gate is
+ * built, so an unregistered key fails at boot rather than per request.
+ *
+ * ## Responses
+ *
+ *  - open      -> `next()`
+ *  - unfunded  -> 402 with `errorName: 'SubscriptionRequiredError'`. A
+ *    documented DEC-007 legacy exception to the usual status mapping, kept
+ *    because it is the wire contract the widget clients already speak. That
+ *    includes an anonymous visitor loading an unfunded widget: they get the
+ *    same 402 the widget routes return today. Preserved, not introduced —
+ *    DEC-011 classes embedding into a non-federated web property as an
+ *    outbound platform bridge, so unlike the public `/api/public/v1` surface
+ *    (which DEC-004 keeps ungated for anonymous readers, always) the widget
+ *    is a legitimate place for a gate to face an anonymous caller.
+ *  - anything else -> 500. Critically, this includes the case where the
+ *    *instance* funding settings could not be read
+ *    (`FundingAccessIndeterminateError`). That denial is our outage, not the
+ *    caller's unpaid bill: telling an operator whose instance never enabled
+ *    funding that their community owes money would be exactly the extraction
+ *    DEC-001 rejects. Indeterminate never becomes 402.
+ *
+ * @param fundingInterface - The funding domain's interface
+ * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature
+ * @param calendarIdParam - Route param holding the calendar's UUID
+ * @returns Express middleware enforcing the gate
+ * @throws Error at registration time if `feature` is not in the registry
+ *
+ * @example
+ * router.post(
+ *   '/calendars/:calendarId/widget/domain',
+ *   ...ExpressHelper.loggedInOnly,
+ *   requireCalendarOwner,
+ *   requireFundingAccess(fundingInterface, 'widget_embedding'),
+ *   this.setDomain.bind(this),
+ * );
+ */
+export function requireFundingAccess(
+  fundingInterface: FundingInterface,
+  feature: FundingGatedFeature,
+  calendarIdParam: string = 'calendarId',
+): FundingAccessGate {
+  if (!Object.prototype.hasOwnProperty.call(FUNDING_GATED_FEATURES, feature)) {
+    throw new Error(`requireFundingAccess: '${feature}' is not a registered funding-gated feature`);
+  }
+
+  const gate = async function fundingAccessGate(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    const calendarId = req.params?.[calendarIdParam];
+
+    if (typeof calendarId !== 'string' || !ExpressHelper.isValidUUID(calendarId)) {
+      logError(
+        new Error(`Route param '${calendarIdParam}' is absent or not a UUID`),
+        `Funding gate for '${feature}' is mounted on a route that cannot supply a validated calendar`,
+      );
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+
+    let allowed: boolean;
+    try {
+      allowed = await fundingInterface.checkFundingAccess(calendarId, feature);
+    }
+    catch (error) {
+      // Every throw lands here, and every throw is a 5xx. The one we must not
+      // get wrong — FundingAccessIndeterminateError — is indistinguishable
+      // from a genuine bug in what it licenses us to tell the caller: we do
+      // not know whether they owe us anything, so we do not ask.
+      logError(error, `Funding gate for '${feature}' could not determine access`);
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+
+    if (allowed) {
+      next();
+      return;
+    }
+
+    const denial = new SubscriptionRequiredError(feature);
+    res.status(402).json({
+      error: 'subscription_required',
+      errorName: denial.name,
+      message: denial.message,
+      feature,
+    });
+  };
+
+  return Object.assign(gate, { fundingGatedFeature: feature } as const);
+}

--- a/src/server/funding/interface/index.ts
+++ b/src/server/funding/interface/index.ts
@@ -88,13 +88,21 @@ export default class FundingInterface {
    * exist and calendars the caller has no business touching. Compose it only
    * AFTER authentication, ownership and existence checks have run.
    *
-   * A false is not always "unfunded" either — an unreadable instance funding
-   * state also denies. That case is a server-side failure and must surface as
-   * a server error, never as 402 / SubscriptionRequiredError.
+   * Three outcomes, not two: `true` opens the gate, `false` is a determinate
+   * "this calendar is unfunded" that may be answered commercially, and a
+   * thrown {@link FundingAccessIndeterminateError} is a denial caused by an
+   * unreadable instance funding state — a server-side failure that must
+   * surface as a server error, never as 402 / SubscriptionRequiredError.
+   *
+   * HTTP consumers should not hand-roll that mapping: use
+   * {@link requireFundingAccess} from `@/server/funding/api/middleware`.
    *
    * @param calendarId - Calendar the feature would be used on
    * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature
-   * @returns True if the gate is open for this calendar
+   * @returns True if the gate is open for this calendar, false if this
+   *   calendar is determinately unfunded
+   * @throws FundingAccessIndeterminateError if the instance funding settings
+   *   could not be read
    */
   async checkFundingAccess(calendarId: string, feature: FundingGatedFeature): Promise<boolean> {
     return this.fundingService.checkFundingAccess(calendarId, feature);

--- a/src/server/funding/service/funding.ts
+++ b/src/server/funding/service/funding.ts
@@ -43,6 +43,7 @@ import {
   ProviderNotConfiguredError,
   InvalidSessionIdError,
   WebhookSignatureError,
+  FundingAccessIndeterminateError,
 } from '@/common/exceptions/funding';
 import { ValidationError } from '@/common/exceptions/base';
 import { CalendarNotFoundError } from '@/common/exceptions/calendar';
@@ -1379,6 +1380,11 @@ export default class FundingService {
    * Queries CalendarFundingPlanEntity for the given calendarId where the linked
    * funding plan is active and the allocation has not ended (end_time IS NULL or end_time > NOW()).
    *
+   * @deprecated Use {@link checkFundingAccess}. This reports only the plan's
+   * status, so it keeps granting access to a plan whose cancellation was never
+   * reported to us, and it knows nothing about instance-level funding settings
+   * or admin exemption. Retired at the widget-gate migration.
+   *
    * @param calendarId - Calendar ID to check
    * @returns True if calendar has an active funding plan allocation
    */
@@ -1619,6 +1625,11 @@ export default class FundingService {
    * Uses fail-secure error handling: if checks throw errors, access is denied.
    * Grant check runs first (smaller table); funding plan check runs second.
    *
+   * @deprecated Use {@link checkFundingAccess}. This answers only the
+   * grant-or-plan half of a gate decision, leaving every caller to remember
+   * the instance-enabled and admin-exemption checks for itself, and it applies
+   * no cancellation boundary. Retired at the widget-gate migration.
+   *
    * @param calendarId - Calendar ID to check
    * @returns True if calendar has an active grant or active funding plan
    */
@@ -1657,7 +1668,9 @@ export default class FundingService {
    *     customer.subscription.deleted cannot grant access indefinitely.
    *  4. Funding is enabled but the answer is indeterminate (database error,
    *     credential decrypt failure, provider unreachable) -> CLOSED. "Cannot
-   *     tell" is not "has access".
+   *     tell" is not "has access". Where the indeterminate read is the
+   *     instance-level settings themselves, the closure is signalled by
+   *     throwing rather than returning false — see the return contract below.
    *
    * Note the deliberate split in invariants 1 and 4: a *known* absence of
    * funding opens gates, an *unknown* funding state closes them. Neither is
@@ -1672,11 +1685,26 @@ export default class FundingService {
    * a healthy paid allocation. The gate closes only when no source produced an
    * allow.
    *
-   * Constraint on consumers (middleware, API handlers, upsell UI): a denial
-   * from this method is not always "unfunded". When the instance-level funding
-   * state itself could not be read, the denial is a server-side failure and
-   * must surface as a server error — never as 402 / SubscriptionRequiredError,
-   * which would tell an operator to buy something to fix our outage.
+   * The return contract carries three outcomes, not two, because a denial from
+   * this method is not always "unfunded":
+   *
+   *  - `true`  — the gate is open.
+   *  - `false` — a determinate denial. This calendar is unfunded on an
+   *    instance that does charge. Consumers may answer it commercially
+   *    (402 / SubscriptionRequiredError, an upsell prompt).
+   *  - throws {@link FundingAccessIndeterminateError} — the instance-level
+   *    funding state could not be read, so we cannot even say whether this
+   *    instance charges for anything. Still a denial, but a server-side one:
+   *    consumers must surface it as a server error and must NEVER answer it
+   *    with 402 / SubscriptionRequiredError, which would tell an operator to
+   *    buy something to fix our outage.
+   *
+   * The distinction is thrown rather than returned deliberately: a bare
+   * boolean cannot express it, and every consumer that forgets it produces the
+   * exact wrong answer (a bill during an outage). Throwing makes the correct
+   * handling the default — an unhandled throw is a 500, which is what this
+   * case should be — and leaves a consumer that wants to degrade differently
+   * free to catch.
    *
    * The feature key carries no policy of its own today — every gated feature
    * is decided the same way — but it is validated against the registry so an
@@ -1685,9 +1713,12 @@ export default class FundingService {
    *
    * @param calendarId - Calendar the feature would be used on
    * @param feature - Key from FUNDING_GATED_FEATURES naming the gated feature
-   * @returns True if the gate is open for this calendar
+   * @returns True if the gate is open for this calendar, false if this
+   *   calendar is determinately unfunded
    * @throws ValidationError if calendarId is not a UUID or feature is not a
    *   registered funding-gated feature
+   * @throws FundingAccessIndeterminateError if the instance funding settings
+   *   could not be read
    */
   async checkFundingAccess(calendarId: string, feature: FundingGatedFeature): Promise<boolean> {
     if (!isValidUUID(calendarId)) {
@@ -1705,10 +1736,12 @@ export default class FundingService {
     }
     catch (error) {
       // Invariant 4, instance scope: we cannot establish that funding is
-      // switched off, so we cannot open the gate on that basis either. This is
-      // the denial that consumers must report as a server error.
+      // switched off, so we cannot open the gate on that basis either. Thrown
+      // rather than returned so consumers cannot mistake it for "unfunded".
       logError(error, 'checkFundingAccess: instance funding settings unreadable, closing gate');
-      return false;
+      throw new FundingAccessIndeterminateError(
+        'Instance funding settings could not be read',
+      );
     }
 
     if (!settings.enabled) {
@@ -1765,12 +1798,21 @@ export default class FundingService {
   /**
    * Check whether a calendar's owner is an instance admin.
    *
+   * A missing CalendarInterface throws rather than answering false: "nobody
+   * injected the calendar domain" is this source being unable to answer, not
+   * an owner who turned out not to be an admin. Callers run this through
+   * readAccessSource, so the throw produces the same denial a false would have
+   * — with a logged reason instead of silence. Not a production path
+   * (server.ts wires the interface unconditionally); it guards construction
+   * order in tests and future wiring.
+   *
    * @param calendarId - Calendar ID to check
    * @returns True if the calendar has a resolvable owner holding the admin role
+   * @throws Error if no CalendarInterface has been injected
    */
   private async isCalendarOwnerAdmin(calendarId: string): Promise<boolean> {
     if (!this.calendarInterface) {
-      return false;
+      throw new Error('CalendarInterface not injected; calendar owner admin status is unknowable');
     }
 
     const ownerId = await this.calendarInterface.getCalendarOwnerAccountId(calendarId);

--- a/src/server/funding/test/api/middleware.test.ts
+++ b/src/server/funding/test/api/middleware.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import sinon from 'sinon';
+import { v4 as uuidv4 } from 'uuid';
+
+import { requireFundingAccess, isFundingAccessGate } from '@/server/funding/api/middleware';
+import FundingInterface from '@/server/funding/interface';
+import { FundingAccessIndeterminateError } from '@/common/exceptions/funding';
+import { SubscriptionRequiredError } from '@/common/exceptions/subscription';
+import { globalErrorHandler } from '@/server/common/middleware/error-handler';
+
+/**
+ * Tests for the requireFundingAccess Express middleware factory.
+ *
+ * Every case drives a real mounted route through supertest rather than
+ * calling the middleware function directly: the composition contract this
+ * middleware carries is about where it sits in an Express stack, and a
+ * hand-built `req` object cannot fail the way a misconfigured route can.
+ *
+ * The routes here are synthetic because no product route is gated yet — the
+ * widget-embedding call sites migrate onto this mechanism in pv-jdot.1.5. The
+ * app is assembled the way the real server assembles one (scoped
+ * `express.json()` per pv-ufag, router mounted under a prefix, the global
+ * error handler last) so the stack under test matches production.
+ */
+describe('requireFundingAccess', () => {
+  let sandbox: sinon.SinonSandbox;
+  let fundingInterface: sinon.SinonStubbedInstance<FundingInterface>;
+  let calendarId: string;
+  let handlerCalls: number;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    fundingInterface = sandbox.createStubInstance(FundingInterface);
+    calendarId = uuidv4();
+    handlerCalls = 0;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  /**
+   * Mounts a gated route the way a feature domain would: authentication and
+   * ownership would run first (stubbed out here — this middleware is not an
+   * authorization check and never stands in for one), then the gate, then the
+   * handler.
+   */
+  function buildApp(
+    routePath: string = '/calendars/:calendarId/widget',
+    gate: express.RequestHandler = requireFundingAccess(
+      fundingInterface as unknown as FundingInterface,
+      'widget_embedding',
+    ),
+  ): express.Application {
+    const app = express();
+    app.use('/api/test/v1', express.json());
+
+    const router = express.Router();
+    router.post(routePath, gate, (_req, res) => {
+      handlerCalls += 1;
+      res.json({ reached: true });
+    });
+    app.use('/api/test/v1', router);
+    app.use(globalErrorHandler);
+
+    return app;
+  }
+
+  describe('gate open', () => {
+    it('should pass the request through to the handler', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ reached: true });
+      expect(handlerCalls).toBe(1);
+    });
+
+    it('should ask about the calendar in the route param and the registered feature', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+
+      await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(fundingInterface.checkFundingAccess.calledOnceWithExactly(
+        calendarId,
+        'widget_embedding',
+      )).toBe(true);
+    });
+  });
+
+  describe('determinate denial: the calendar is unfunded', () => {
+    it('should answer 402 with the SubscriptionRequiredError wire contract', async () => {
+      fundingInterface.checkFundingAccess.resolves(false);
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.status).toBe(402);
+      // Byte-for-byte the body the widget routes already return, so migrating
+      // an existing gate onto this middleware is invisible to its clients —
+      // including the anonymous embedder of an unfunded widget, whose current
+      // rejection this preserves rather than changes.
+      expect(response.body).toEqual({
+        error: 'subscription_required',
+        errorName: 'SubscriptionRequiredError',
+        message: new SubscriptionRequiredError('widget_embedding').message,
+        feature: 'widget_embedding',
+      });
+    });
+
+    it('should not run the handler', async () => {
+      fundingInterface.checkFundingAccess.resolves(false);
+
+      await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(handlerCalls).toBe(0);
+    });
+  });
+
+  describe('indeterminate denial: the instance funding state is unreadable', () => {
+    /**
+     * The product constraint behind this block: an operator whose instance
+     * never enabled funding must never be told, during a database outage,
+     * that their community owes money (DEC-001). An indeterminate INSTANCE
+     * state is our server error, not a commercial refusal.
+     */
+    it('should answer 5xx, never 402', async () => {
+      fundingInterface.checkFundingAccess.rejects(
+        new FundingAccessIndeterminateError('Instance funding settings could not be read'),
+      );
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.status).toBe(500);
+      expect(response.status).not.toBe(402);
+      expect(handlerCalls).toBe(0);
+    });
+
+    it('should not name a subscription or a price anywhere in the response', async () => {
+      fundingInterface.checkFundingAccess.rejects(
+        new FundingAccessIndeterminateError('Instance funding settings could not be read'),
+      );
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.body.errorName).not.toBe('SubscriptionRequiredError');
+      expect(JSON.stringify(response.body)).not.toMatch(/subscription|funding|payment/i);
+    });
+
+    it('should answer 5xx for any other unexpected failure of the check', async () => {
+      fundingInterface.checkFundingAccess.rejects(new Error('connection reset'));
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.status).toBe(500);
+      expect(handlerCalls).toBe(0);
+    });
+  });
+
+  describe('the feature key is fixed at route registration', () => {
+    it('should ignore a feature supplied in the request body', async () => {
+      fundingInterface.checkFundingAccess.resolves(false);
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({ feature: 'some_other_feature' });
+
+      expect(fundingInterface.checkFundingAccess.calledOnceWithExactly(
+        calendarId,
+        'widget_embedding',
+      )).toBe(true);
+      expect(response.body.feature).toBe('widget_embedding');
+    });
+
+    it('should ignore a feature supplied in the query string', async () => {
+      fundingInterface.checkFundingAccess.resolves(false);
+
+      const response = await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget?feature=some_other_feature`)
+        .send({});
+
+      expect(fundingInterface.checkFundingAccess.calledOnceWithExactly(
+        calendarId,
+        'widget_embedding',
+      )).toBe(true);
+      expect(response.body.feature).toBe('widget_embedding');
+    });
+
+    it('should refuse to build a gate for a key that is not in the registry', () => {
+      expect(() => requireFundingAccess(
+        fundingInterface as unknown as FundingInterface,
+        'made_up_feature' as any,
+      )).toThrow(/registered funding-gated feature/);
+    });
+  });
+
+  describe('the calendar comes from the route param and nowhere else', () => {
+    it('should ignore a calendarId supplied in the request body', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+      const bodyCalendarId = uuidv4();
+
+      await request(buildApp())
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({ calendarId: bodyCalendarId });
+
+      expect(fundingInterface.checkFundingAccess.calledOnceWithExactly(
+        calendarId,
+        'widget_embedding',
+      )).toBe(true);
+    });
+
+    it('should fail the request as a server error when the route has no such param', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+
+      const response = await request(buildApp('/widget'))
+        .post('/api/test/v1/widget')
+        .send({ calendarId: uuidv4() });
+
+      // A gate mounted on a route that cannot supply its calendar is our
+      // misconfiguration, not the caller's unpaid bill.
+      expect(response.status).toBe(500);
+      expect(fundingInterface.checkFundingAccess.called).toBe(false);
+      expect(handlerCalls).toBe(0);
+    });
+
+    it('should fail as a server error rather than 402 when the param is not a UUID', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+
+      const response = await request(buildApp())
+        .post('/api/test/v1/calendars/not-a-uuid/widget')
+        .send({});
+
+      // The contract is that the param was already UUID-validated upstream, so
+      // reaching here means the composition is broken. Never 402: nothing has
+      // been established about whether this calendar is funded.
+      expect(response.status).toBe(500);
+      expect(fundingInterface.checkFundingAccess.called).toBe(false);
+      expect(handlerCalls).toBe(0);
+    });
+
+    it('should read a differently-named route param when one is configured', async () => {
+      fundingInterface.checkFundingAccess.resolves(true);
+      const gate = requireFundingAccess(
+        fundingInterface as unknown as FundingInterface,
+        'widget_embedding',
+        'calendar',
+      );
+
+      const response = await request(buildApp('/calendars/:calendar/widget', gate))
+        .post(`/api/test/v1/calendars/${calendarId}/widget`)
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(fundingInterface.checkFundingAccess.calledOnceWithExactly(
+        calendarId,
+        'widget_embedding',
+      )).toBe(true);
+    });
+  });
+
+  describe('gate introspection', () => {
+    it('should tag the middleware with the feature it gates', () => {
+      const gate = requireFundingAccess(
+        fundingInterface as unknown as FundingInterface,
+        'widget_embedding',
+      );
+
+      expect(isFundingAccessGate(gate)).toBe(true);
+      expect(gate.fundingGatedFeature).toBe('widget_embedding');
+    });
+
+    it('should not mistake an ordinary handler for a gate', () => {
+      expect(isFundingAccessGate((_req: any, _res: any, next: any) => next())).toBe(false);
+      expect(isFundingAccessGate(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/server/funding/test/api/public_routes_no_funding_gate.test.ts
+++ b/src/server/funding/test/api/public_routes_no_funding_gate.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import { EventEmitter } from 'events';
+
+import PublicCalendarAPI from '@/server/public/api/v1';
+import PublicCalendarInterface from '@/server/public/interface';
+import CalendarInterface from '@/server/calendar/interface';
+import { isFundingAccessGate, requireFundingAccess } from '@/server/funding/api/middleware';
+
+/**
+ * DEC-004 invariant: anonymous access to public event and calendar
+ * information is never funding-gated.
+ *
+ * Full anonymous access to public event information is a product commitment,
+ * not an implementation detail — a visitor reading a community's calendar is
+ * not a customer and cannot be asked to pay, nor can their view of a
+ * community be withheld because that community stopped paying us. This suite
+ * asserts the shape of the public router tree rather than the behaviour of
+ * one endpoint, so it keeps holding as endpoints are added to it.
+ *
+ * The mechanical check is possible because requireFundingAccess tags every
+ * gate it builds; see isFundingAccessGate.
+ *
+ * Scope note: this is about the public API (`/api/public/v1`), the surface
+ * that serves the anonymous `/view/` site. The widget API is a different
+ * surface — DEC-011 classes embedding a calendar into a non-federated web
+ * property as an outbound platform bridge, so the widget's existing 402 to an
+ * anonymous embedder is deliberate and stays as it is.
+ */
+describe('DEC-004: the public router tree carries no funding gate', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const calendarInterface = new CalendarInterface(new EventEmitter());
+    const publicInterface = new PublicCalendarInterface(new EventEmitter(), calendarInterface);
+    PublicCalendarAPI.install(app, publicInterface);
+  });
+
+  /**
+   * Walks an Express application's layer tree and returns every registered
+   * handler, flattening nested routers and per-route handler chains.
+   */
+  function allHandlers(application: express.Application): unknown[] {
+    const handlers: unknown[] = [];
+
+    const walk = (layers: any[]): void => {
+      for (const layer of layers ?? []) {
+        if (layer.route) {
+          walk(layer.route.stack);
+        }
+        else if (layer.handle?.stack) {
+          walk(layer.handle.stack);
+        }
+        else {
+          handlers.push(layer.handle);
+        }
+      }
+    };
+
+    walk((application as any)._router?.stack);
+
+    return handlers;
+  }
+
+  it('should find a gate mounted the same way the public routes are', () => {
+    // Negative control. Without it this suite would keep passing if the walk
+    // stopped descending into routers, or if the tag were dropped — it would
+    // be asserting that it found nothing, having looked nowhere.
+    const gatedApp = express();
+    const router = express.Router();
+    router.get(
+      '/calendar/:calendarId',
+      requireFundingAccess({} as any, 'widget_embedding'),
+      (_req, res) => res.json({}),
+    );
+    gatedApp.use('/api/public/v1', router);
+
+    expect(allHandlers(gatedApp).filter(isFundingAccessGate)).toHaveLength(1);
+  });
+
+  it('should carry no funding gate on any public route', () => {
+    const gated = allHandlers(app).filter(isFundingAccessGate);
+
+    expect(gated.map((gate) => gate.fundingGatedFeature)).toEqual([]);
+    // The public tree really was walked, not skipped.
+    expect(allHandlers(app).length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/funding/test/service.test.ts
+++ b/src/server/funding/test/service.test.ts
@@ -22,6 +22,7 @@ import {
   InvalidSessionIdError,
   WebhookSignatureError,
   FundingPlanNotFoundError,
+  FundingAccessIndeterminateError,
 } from '@/common/exceptions/funding';
 import { ValidationError } from '@/common/exceptions/base';
 import { v4 as uuidv4 } from 'uuid';
@@ -1205,7 +1206,34 @@ describe('FundingService', () => {
         stubOwnerIsAdmin(false);
         stubGrant(true);
 
-        const allowed = await service.checkFundingAccess(calendarId, feature);
+        // Still fail-closed — but signalled by throwing rather than by
+        // returning false, because a consumer that answers this one with 402
+        // tells an operator their community owes money to fix our outage.
+        // A bare boolean cannot carry that distinction.
+        await expect(service.checkFundingAccess(calendarId, feature))
+          .rejects.toThrow(FundingAccessIndeterminateError);
+      });
+
+      it('should name the indeterminate denial distinctly from any other failure', async () => {
+        sandbox.stub(FundingSettingsEntity, 'findOne').rejects(new Error('DB error'));
+
+        // errorName is what crosses the wire, so it is what a consumer can
+        // key on to keep this out of the 402 path.
+        await expect(service.checkFundingAccess(calendarId, feature))
+          .rejects.toMatchObject({ name: 'FundingAccessIndeterminateError' });
+      });
+
+      it('should close the gate rather than exempt an admin when no calendar interface is wired', async () => {
+        const unwiredService = new FundingService(eventBus);
+        stubFundingEnabled(true);
+        stubOwnerIsAdmin(true);
+        stubGrant(false);
+        stubAllocation(null);
+
+        // A construction-order guard, not a production path: the owner really
+        // may be an admin, but with no calendar domain injected this source
+        // cannot answer, and an unanswerable source never grants.
+        const allowed = await unwiredService.checkFundingAccess(calendarId, feature);
 
         expect(allowed).toBe(false);
       });


### PR DESCRIPTION
## Motivation

The funding-access decision existed but nothing could mount it on a route. Gating a feature still meant hand-writing the check at each call site, which is how the widget gate ended up duplicated in two places.

There was also a gap the decision itself could not express. `checkFundingAccess` returned `Promise<boolean>`, so a caller receiving `false` could not tell "this calendar is genuinely unfunded" from "we could not read the instance's funding settings". Those must produce different answers: the first is a commercial refusal, the second is our outage. An operator running a self-hosted instance that never enabled funding must never be told, during a database outage, that their community owes money.

## Approach

**`requireFundingAccess(fundingInterface, feature, calendarIdParam = 'calendarId')`** — an Express middleware factory in the funding domain's api layer.

The calendar comes from `req.params[calendarIdParam]` only, never the body and never the query. The feature key is a compile-time literal captured at registration and validated against the registry **when the gate is built**, so an unregistered key fails at startup rather than on a request-influenced path.

Outcomes: open calls `next()`; determinately unfunded returns 402 with `errorName: 'SubscriptionRequiredError'`, byte-identical to what the existing widget gate returns today; anything else is a 5xx.

**The access check now has three outcomes rather than two.** `checkFundingAccess` returns `true` for open, `false` for determinately unfunded, and throws `FundingAccessIndeterminateError` when the instance funding state cannot be read. It is still fail-closed — an unhandled throw is already a 500 — but the distinction is now expressible in the type, which is what the boolean could not do. Throwing was chosen over a discriminated result precisely because it makes the correct handling the default: a caller has to go out of its way to turn an outage into a payment demand, rather than getting that by accident.

**This is not an authorization check, and the code says so.** When funding is disabled on an instance, the check returns `true` for any UUID — including calendars that do not exist and calendars the caller does not own. The composition contract in the docblock requires mounting strictly after auth and calendar-ownership middleware. Each gate is tagged so the router tree can be introspected.

Two smaller corrections came along with it. `isCalendarOwnerAdmin` now throws when the calendar interface is absent instead of silently returning `false`; it already runs inside the read-source wrapper, so the denial is unchanged but is now logged with a reason rather than being invisible. And the service-level `hasFundingAccess` / `hasActiveFundingPlan` gained the `@deprecated` tags their interface counterparts already carried. No `no-deprecated` lint rule was added — that is a repository-wide config change, so the deprecation stays documentation-only until those methods are retired.

## Validation

- 16 middleware tests, all driving real mounted routes through a production-shaped app (scoped body parsing, prefixed router, global error handler last) rather than calling the middleware directly. They cover the 402 wire contract, the indeterminate path returning 5xx and never 402 (including asserting the response body names neither subscription nor payment), and regression tests that a request-supplied `feature` in body or query cannot override the registered key, and that a body-supplied `calendarId` cannot override the route param.
- A test walks the real installed public router tree and asserts it carries no gate, with a negative control that mounts one the same way and proves the walk detects it — no funding gate may sit on anonymous read access to public calendar or event information.
- The service test for the indeterminate invariant now asserts rejection rather than a `false` return.
- Full local gate at this stack position: lint clean, unit 8732 passed with zero failures, integration 696 passed / 2 skipped exactly matching trunk, typecheck 1554 errors — identical to trunk, zero introduced — and a clean build. Every e2e failure was re-run and cleared: the funding-tab spec passes 5/5 in isolation, the admin specs pass 5/5 and 16/16, and the remainder are the failures that reproduce on unmodified trunk.

No product route is gated by this middleware yet, so its tests mount synthetic routes. The migration of the existing widget call sites is the first real consumer and lands separately.